### PR TITLE
Add blkdev_compat.h to the DIST rules.

### DIFF
--- a/include/linux/Makefile.am
+++ b/include/linux/Makefile.am
@@ -3,7 +3,8 @@ COMMON_H =
 KERNEL_H = \
 	$(top_srcdir)/include/linux/dcache_compat.h \
 	$(top_srcdir)/include/linux/xattr_compat.h \
-	$(top_srcdir)/include/linux/vfs_compat.h
+	$(top_srcdir)/include/linux/vfs_compat.h \
+	$(top_srcdir)/include/linux/blkdev_compat.h
 
 USER_H =
 

--- a/include/linux/Makefile.in
+++ b/include/linux/Makefile.in
@@ -90,7 +90,8 @@ SOURCES =
 DIST_SOURCES =
 am__kernel_HEADERS_DIST = $(top_srcdir)/include/linux/dcache_compat.h \
 	$(top_srcdir)/include/linux/xattr_compat.h \
-	$(top_srcdir)/include/linux/vfs_compat.h
+	$(top_srcdir)/include/linux/vfs_compat.h \
+	$(top_srcdir)/include/linux/blkdev_compat.h
 am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
 am__vpath_adj = case $$p in \
     $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \


### PR DESCRIPTION
This change is required for `make dist-all` to include the new blkdev_compat.h header in the redistributable archive.
