### PR TITLE
Add the zpool and filesystem versions to the printk loading message.

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5178,8 +5178,10 @@ _init(void)
 	mutex_init(&zfs_share_lock, NULL, MUTEX_DEFAULT, NULL);
 #endif /* HAVE_SHARE */
 
-	printk(KERN_NOTICE "ZFS: Loaded ZFS Filesystem v%s%s\n",
-	       ZFS_META_VERSION, ZFS_DEBUG_STR);
+	printk(KERN_NOTICE "ZFS: Loaded module v%s%s, "
+	       "ZFS pool version %s, ZFS filesystem version %s\n",
+	       ZFS_META_VERSION, ZFS_DEBUG_STR,
+	       SPA_VERSION_STRING, ZPL_VERSION_STRING);
 
 	return (0);
 
@@ -5214,7 +5216,7 @@ _fini(void)
 	tsd_destroy(&zfs_fsyncer_key);
 	tsd_destroy(&rrw_tsd_key);
 
-	printk(KERN_NOTICE "ZFS: Unloaded ZFS Filesystem v%s%s\n",
+	printk(KERN_NOTICE "ZFS: Unloaded module v%s%s\n",
 	       ZFS_META_VERSION, ZFS_DEBUG_STR);
 
 	return (0);


### PR DESCRIPTION
This is a cosmetic patch that results in these dmesg lines:

  ZFS: Loaded module v0.6.0, ZFS pool version 28, ZFS filesystem version 5  
  ZFS: Unloaded module v0.6.0

This change removes an ambiguity and adds information that system administrators care about.  The phrase "ZFS pool version %s" is the same as `zpool upgrade -v` so that the operator is familiar with the message.
