### PR TITLE
Call udevadm trigger more safely

### DIFF
--- a/cmd/zpool_layout/zpool_layout
+++ b/cmd/zpool_layout/zpool_layout
@@ -153,7 +153,7 @@ exec 1>&8 8>&-
 popd >/dev/null
 
 if [ ${TRIGGER} = "yes" ]; then
-	udevadm trigger
+	udevadm trigger --action=change --subsystem-match=block
 	udevadm settle
 fi
 

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -430,7 +430,7 @@ scsi_rescan() {
 #
 udev_trigger() {
 	if [ -f ${UDEVADM} ]; then
-		${UDEVADM} trigger
+		${UDEVADM} trigger --action=change --subsystem-match=block
 		${UDEVADM} settle
 	else
 		/sbin/udevtrigger


### PR DESCRIPTION
Some udev hooks are not designed to be idempotent, so calling udevadm
trigger outside of the distribution's initialization scripts can have
unexpected (and potentially dangerous) side effects.  For example, the
system time may change or devices may appear multiple times.  See Ubuntu
launchpad bug 320200 and this mailing list post for more details:

https://lists.ubuntu.com/archives/ubuntu-devel/2009-January/027260.html

To avoid these problems we call udevadm trigger with --action=change
--subsystem-match=block.  The first argument tells udev just to refresh
devices, and make sure everything's as it should be.  The second
argument limits the scope to block devices, so devices belonging to
other subsystems cannot be affected.

This doesn't fix the problem on older udev implementations that don't
provide udevadm but instead have udevtrigger as a standalone program.
In this case the above options aren't available so there's no way to
call call udevtrigger safely.  But we can live with that since this
issue only exists in optional test and helper scripts, and most
zfs-on-linux users are running newer systems anyways.
