### PR TITLE
Fix `make distclean` for `./configure --with-config=user`.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -460,10 +460,7 @@ $(RECURSIVE_CLEAN_TARGETS):
 	  esac; \
 	done; \
 	dot_seen=no; \
-	case "$@" in \
-	  distclean-* | maintainer-clean-*) list='$(DIST_SUBDIRS)' ;; \
-	  *) list='$(SUBDIRS)' ;; \
-	esac; \
+	list='$(SUBDIRS)'; \
 	rev=''; for subdir in $$list; do \
 	  if test "$$subdir" = "."; then :; else \
 	    rev="$$subdir $$rev"; \


### PR DESCRIPTION
Running `make distclean` fails after `./configure --with-config=user` with this error message:

```
Making distclean in module
make[1]: Entering directory `/zfs/module'
make -C  SUBDIRS=`pwd`  clean
make: Entering an unknown directory
make: *** SUBDIRS=/zfs/module: No such file or directory.  Stop.
make: Leaving an unknown directory
make[1]: *** [clean] Error 2
make[1]: Leaving directory `/zfs/module'
make: *** [distclean-recursive] Error 1
```

This happens because the module/ tree uses the kernel build framework, which is unconfigured if CONFIG_KERNEL is unset.

Correcting this is worthwhile because debhelper assumes that all configurations produce a working distclean rule, and the debian/ packaging overlay currently needs a workaround for it.
