### PR TITLE
zpool create -o sectorsize=4K

### DIFF
--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -44,7 +44,8 @@ uint_t num_logs(nvlist_t *nv);
  */
 
 nvlist_t *make_root_vdev(zpool_handle_t *zhp, int force, int check_rep,
-    boolean_t replacing, boolean_t dryrun, int argc, char **argv);
+    boolean_t replacing, boolean_t dryrun, int argc, char **argv,
+    uint64_t ashift);
 nvlist_t *split_mirror_vdev(zpool_handle_t *zhp, char *newname,
     nvlist_t *props, splitflags_t flags, int argc, char **argv);
 

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1180,8 +1180,9 @@ str2shift(libzfs_handle_t *hdl, const char *buf)
 			break;
 	}
 	if (i == strlen(ends)) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "invalid numeric suffix '%s'"), buf);
+		if (hdl)
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "invalid numeric suffix '%s'"), buf);
 		return (-1);
 	}
 
@@ -1193,8 +1194,9 @@ str2shift(libzfs_handle_t *hdl, const char *buf)
 	    toupper(buf[0]) != 'B'))
 		return (10*i);
 
-	zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-	    "invalid numeric suffix '%s'"), buf);
+	if (hdl)
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "invalid numeric suffix '%s'"), buf);
 	return (-1);
 }
 

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -504,6 +504,24 @@ Amount of storage space used within the pool.
 These space usage properties report actual physical space available to the storage pool. The physical space can be different from the total amount of space that any contained datasets can actually use. The amount of space used in a \fBraidz\fR configuration depends on the characteristics of the data being written. In addition, \fBZFS\fR reserves some space for internal accounting that the \fBzfs\fR(1M) command takes into account, but the \fBzpool\fR command does not. For non-full pools of a reasonable size, these effects should be invisible. For small pools, or pools that are close to being completely full, these discrepancies may become more noticeable.
 .sp
 .LP
+The following property can be set at creation time:
+.sp
+.ne 2
+.mk
+.na
+\fB\fBsectorsize\fR\fR
+.ad
+.sp .6
+.RS 4n
+Pool sector size (internally referred to as "ashift"). I/O operations will be aligned to the specified size boundaries. Additionally, the minimum (disk) write size will be set to the specified size, so this represents a space vs. performance trade-off. The typical case for setting this property is when performance is important and the underlying disks use 4KiB sectors but report 512B sectors to the OS (for compatibility reasons); in that case, set \fBsectorsize=4K\fR.
+.LP
+The pool sector size must be greater than or equal to the sector size of the underlying disks. Since the property cannot be changed after pool creation, if in a given pool, you \fIever\fR want to use drives that \fIreport\fR 4KiB sectors, you must set \fBsectorsize=4K\fR at pool creation time.
+.LP
+This property is a ZFS on Linux extension, but the internal "ashift" value is not.
+.RE
+
+.sp
+.LP
 The following property can be set at creation time and import time:
 .sp
 .ne 2


### PR DESCRIPTION
I've implemented the (fake) sectorsize property we discussed on zfs-devel. I tried to re-use existing gettext strings. This commit adds it to the zpool manual page as well.
