### PR TITLE
Support IEC base-2 prefixes

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1186,11 +1186,14 @@ str2shift(libzfs_handle_t *hdl, const char *buf)
 	}
 
 	/*
-	 * We want to allow trailing 'b' characters for 'GB' or 'Mb'.  But don't
-	 * allow 'BB' - that's just weird.
+	 * Allow 'G' = 'GB' = 'GiB', case-insensitively.
+	 * However, 'BB' and 'BiB' are disallowed.
 	 */
-	if (buf[1] == '\0' || (toupper(buf[1]) == 'B' && buf[2] == '\0' &&
-	    toupper(buf[0]) != 'B'))
+	if (buf[1] == '\0' ||
+	    (toupper(buf[0]) != 'B' &&
+	     ((toupper(buf[1]) == 'B' && buf[2] == '\0') ||
+	      (toupper(buf[1]) == 'I' && toupper(buf[2]) == 'B' &&
+	       buf[3] == '\0'))))
 		return (10*i);
 
 	zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,


### PR DESCRIPTION
This allows one to specify units like KiB in addition to K and KB for numeric properties. The existing prefixes are still parsed as base-2 prefixes for compatibility.
