### PR TITLE
Allow /etc/init.d/zfs to be started at boot by Debian systems

### DIFF
--- a/etc/init.d/zfs.lsb
+++ b/etc/init.d/zfs.lsb
@@ -13,6 +13,8 @@
 # Provides: zfs
 # Required-Start: $local_fs
 # Required-Stop: $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Should-Stop:
 # Short-Description: Mount/umount the zfs filesystems
 # Description: ZFS is an advanced filesystem designed to simplify managing


### PR DESCRIPTION
This change allows Debian system administrators to mount zfs filesystems at boot by issuing the command

<pre># update-rc.d zfs defaults</pre>
