### PR TITLE
Don't store rdev in SA for FIFOs and sockets

### DIFF
--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -85,6 +85,13 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, int mode, dev_t rdev)
 	vattr_t *vap;
 	int error;
 
+	/*
+	 * We currently expect Linux to supply rdev=0 for all sockets
+	 * and fifos, but we want to know if this behavior ever changes.
+	 */
+	if (S_ISSOCK(mode) || S_ISFIFO(mode))
+		ASSERT(rdev == 0);
+
 	crhold(cr);
 	vap = kmem_zalloc(sizeof(vattr_t), KM_SLEEP);
 	vap->va_mode = mode;


### PR DESCRIPTION
Update the handling of named pipes and sockets to be consistent with
other platforms with regard to the rdev attribute.  While all ZFS
ipmlementations store the rdev for device files in a system attribute
(SA), this is not the case for FIFOs and sockets.  Indeed, Linux always
passes rdev=0 to mknod() for FIFOs and sockets, so the value is not
needed.  Add an ASSERT that rdev==0 for FIFOs and sockets to detect if
the expected behavior ever changes.

Closes #216
