### PR TITLE
Change WRITE_BARRIER to WRITE_FLUSH_FUA

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -339,6 +339,19 @@ bio_set_flags_failfast(struct block_device *bdev, int *flags)
 #endif
 
 /*
+ * 2.6.37 API change
+ * The WRITE_FLUSH, WRITE_FUA, and WRITE_FLUSH_FUA flags have been
+ * introduced as a replacement for WRITE_BARRIER.  This was done to allow richer
+ * semantics to be expressed to the block layer.  It is the block layers responsibility
+ * to choose the correct way to implement these semantics.
+ */
+#ifdef WRITE_FLUSH_FUA
+# define VDEV_WRITE_FLUSH_FUA WRITE_FLUSH_FUA
+#else
+# define VDEV_WRITE_FLUSH_FUA WRITE_BARRIER
+#endif
+
+/*
  * Default Linux IO Scheduler,
  * Setting the scheduler to noop will allow the Linux IO scheduler to
  * still perform front and back merging, while leaving the request

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -559,7 +559,7 @@ vdev_disk_io_flush(struct block_device *bdev, zio_t *zio)
 	bio->bi_private = zio;
 	bio->bi_bdev = bdev;
 	zio->io_delay = jiffies_64;
-	submit_bio(WRITE_FLUSH_FUA, bio);
+	submit_bio(VDEV_WRITE_FLUSH_FUA, bio);
 
 	return 0;
 }


### PR DESCRIPTION
On EL6 x86_64 (kernel 2.6.32-131.2.1.el6.x86_64), I get the following deprecation warning in the kernel log:

------------[ cut here ]------------
WARNING: at block/blk-core.c:1222 __make_request+0x477/0x500() (Tainted: P           ----------------  )
Hardware name: To be filled by O.E.M.
block: BARRIER is deprecated, use FLUSH/FUA instead
Modules linked in: zfs(P+)(U) zcommon(P)(U) znvpair(P)(U) zavl(P)(U) zunicode(P)(U) spl(U) zlib_deflate r8169 mii xhci_hcd i2c_piix4 i2c_core sg shpchp ext4 mbcache jbd2 sd_mod crc_t10dif usb_storage ata_generic pata_acpi pata_atiixp ahci dm_mod [last unloaded: scsi_wait_scan]
Pid: 1349, comm: z_ioctl_iss/0 Tainted: P           ----------------   2.6.32-131.2.1.el6.x86_64 #1
Call Trace:
 [<ffffffff810670f7>] ? warn_slowpath_common+0x87/0xc0
 [<ffffffff810671e6>] ? warn_slowpath_fmt+0x46/0x50
 [<ffffffff8124a857>] ? __make_request+0x477/0x500
 [<ffffffff81248dbe>] ? generic_make_request+0x21e/0x5b0
 [<ffffffff8106067b>] ? dequeue_task_fair+0x8b/0x90
 [<ffffffff812491df>] ? submit_bio+0x8f/0x120
 [<ffffffffa02730a3>] ? vdev_disk_io_start+0x143/0x1a0 [zfs]
 [<ffffffffa02ab167>] ? zio_vdev_io_start+0xa7/0x2e0 [zfs]
 [<ffffffffa02adbe9>] ? zio_execute+0x99/0xf0 [zfs]
 [<ffffffffa0193b0c>] ? taskq_thread+0x1cc/0x330 [spl]
 [<ffffffff8105dc20>] ? default_wake_function+0x0/0x20
 [<ffffffffa0193940>] ? taskq_thread+0x0/0x330 [spl]
 [<ffffffff8108dd96>] ? kthread+0x96/0xa0
 [<ffffffff8100c1ca>] ? child_rip+0xa/0x20
 [<ffffffff8108dd00>] ? kthread+0x0/0xa0
 [<ffffffff8100c1c0>] ? child_rip+0x0/0x20
---[ end trace 18c0494e1ff34948 ]---

It seems that the WRITE_BARRIER option is just deprecated and replaced by WRITE_FLUSH / WRITE_FLUSH_FUA.

I decided to use WRITE_FLUSH_FUA because it seems to guarantee that the data is written to non-volatile memory (which generally is what ZFS wants). Please correct me if I'm wrong. Maybe WRITE_FLUSH is just enough.
