### PR TITLE
Update zfs.gentoo init script

### DIFF
--- a/etc/init.d/zfs.gentoo
+++ b/etc/init.d/zfs.gentoo
@@ -6,7 +6,7 @@
 depend()
 {
 	before net
-	after udev
+	after udev localmount
 	keyword -lxc -openvz -prefix -vserver
 }
 


### PR DESCRIPTION
If rc_parallel="YES" 'zfs' starts before 'localmount', which leads to "No such file or directory" error on systems with /usr on a separate partition.
