### PR TITLE
/usr/sbin -> /sbin

### DIFF
--- a/etc/init.d/zfs.gentoo
+++ b/etc/init.d/zfs.gentoo
@@ -11,8 +11,8 @@ depend()
 }
 
 CACHEFILE=/etc/zfs/zpool.cache
-ZPOOL=/usr/sbin/zpool
-ZFS=/usr/sbin/zfs
+ZPOOL=/sbin/zpool
+ZFS=/sbin/zfs
 ZFS_MODULE=zfs
 
 checksystem() {

--- a/etc/init.d/zfs.lsb
+++ b/etc/init.d/zfs.lsb
@@ -32,8 +32,8 @@ RETVAL=0
 
 LOCKFILE=/var/lock/zfs
 CACHEFILE=/etc/zfs/zpool.cache
-ZPOOL=/usr/sbin/zpool
-ZFS=/usr/sbin/zfs
+ZPOOL=/sbin/zpool
+ZFS=/sbin/zfs
 
 [ -x $ZPOOL ] || exit 1
 [ -x $ZFS ] || exit 2


### PR DESCRIPTION
need to remove /usr from /sbin in init.d scripts to match new location of zfs and zpool binaries
