### PR TITLE
Turn the init.d scripts into autoconf config files so that @sbindir@ can be expanded

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,12 @@ AC_CONFIG_FILES([
 	etc/udev/Makefile
 	etc/udev/rules.d/Makefile
 	etc/init.d/Makefile
+	etc/init.d/zfs.arch
+	etc/init.d/zfs.gentoo
+	etc/init.d/zfs.lunar
+	etc/init.d/zfs.fedora
+	etc/init.d/zfs.lsb
+	etc/init.d/zfs.redhat
 	etc/zfs/Makefile
 	man/Makefile
 	man/man8/Makefile

--- a/etc/init.d/zfs.arch.in
+++ b/etc/init.d/zfs.arch.in
@@ -3,6 +3,10 @@
 . /etc/rc.conf
 . /etc/rc.d/functions
 
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
+
 case "$1" in
   start)
     stat_busy "Starting zfs"
@@ -16,8 +20,8 @@ case "$1" in
     fi
 
     # Import ZFS pools (via cache file)
-    if [ -f /etc/zfs/zpool.cache ]; then
-      /usr/sbin/zpool import -c /etc/zfs/zpool.cache -aN 2>/dev/null
+    if [ -f $ZPOOL_CACHE ]; then
+      $ZPOOL import -c $ZPOOL_CACHE -aN 2>/dev/null
       if [ $? -ne 0 ]; then
         stat_fail
         exit 1
@@ -25,14 +29,14 @@ case "$1" in
     fi
 
     # Mount ZFS filesystems
-    /usr/sbin/zfs mount -a
+    $ZFS mount -a
     if [ $? -ne 0 ]; then
         stat_fail
         exit 1
     fi
 
     # Export ZFS flesystems
-    /usr/sbin/zfs share -a
+    $ZFS share -a
     if [ $? -ne 0 ]; then
         stat_fail
         exit 1
@@ -43,7 +47,7 @@ case "$1" in
     ;;
   stop)
     stat_busy "Stopping zfs"
-    zfs umount -a
+    $ZFS umount -a
     rm_daemon zfs
     stat_done
     ;;

--- a/etc/init.d/zfs.fedora.in
+++ b/etc/init.d/zfs.fedora.in
@@ -30,8 +30,9 @@ export PATH=/usr/local/sbin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 # script variables
 RETVAL=0
-ZPOOL=zpool
-ZFS=zfs
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 servicename=zfs
 LOCKFILE=/var/lock/subsys/$servicename
 
@@ -143,10 +144,10 @@ start()
 		fi
 	fi
 
-        if [ -f /etc/zfs/zpool.cache ] ; then
+        if [ -f $ZPOOL_CACHE ] ; then
 	
 		echo -n $"Importing ZFS pools not yet imported: "
-		$ZPOOL import -c /etc/zfs/zpool.cache -aN || true # stupid zpool will fail if all pools are already imported
+		$ZPOOL import -c $ZPOOL_CACHE -aN || true # stupid zpool will fail if all pools are already imported
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
 			failure "Importing ZFS pools not yet imported: "

--- a/etc/init.d/zfs.gentoo.in
+++ b/etc/init.d/zfs.gentoo.in
@@ -11,9 +11,9 @@ depend()
 	keyword -lxc -openvz -prefix -vserver
 }
 
-CACHEFILE=/etc/zfs/zpool.cache
-ZPOOL=/sbin/zpool
-ZFS=/sbin/zfs
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 ZFS_MODULE=zfs
 
 checksystem() {
@@ -55,11 +55,11 @@ start() {
 
 	# Import all pools described by the cache file, and then mount
 	# all filesystem based on their properties.
-	if [ -f $CACHEFILE ]; then
+	if [ -f $ZPOOL_CACHE ]; then
 		einfo "Importing ZFS pools"
 		# as per fedora script, import can fail if all pools are already imported
 		# The check for $rv makes no sense...but someday, it will work right.
-		$ZPOOL import -c $CACHEFILE -aN 2>/dev/null || true
+		$ZPOOL import -c $ZPOOL_CACHE -aN 2>/dev/null || true
 		rv=$?
 		if [ $rv -ne 0 ]; then
 			eerror "Failed to import not-yet imported pools."

--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -31,9 +31,9 @@
 RETVAL=0
 
 LOCKFILE=/var/lock/zfs
-CACHEFILE=/etc/zfs/zpool.cache
-ZPOOL=/sbin/zpool
-ZFS=/sbin/zfs
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 
 [ -x $ZPOOL ] || exit 1
 [ -x $ZFS ] || exit 2
@@ -66,9 +66,9 @@ start()
 
 	# Import all pools described by the cache file, and then mount
 	# all filesystem based on their properties.
-	if [ -f $CACHEFILE ] ; then
+	if [ -f $ZPOOL_CACHE ] ; then
 		log_begin_msg "Importing ZFS pools"
-		$ZPOOL import -c $CACHEFILE -aN 2>/dev/null
+		$ZPOOL import -c $ZPOOL_CACHE -aN 2>/dev/null
 		log_end_msg $?
 
 		log_begin_msg "Mounting ZFS filesystems"

--- a/etc/init.d/zfs.lunar.in
+++ b/etc/init.d/zfs.lunar.in
@@ -10,6 +10,10 @@
 #              using SPL (Solaris Porting Layer) by zfsonlinux.org.
 # probe: true
 
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
+
 case $1 in
   start)  echo "$1ing ZFS filesystems"
 
@@ -35,16 +39,16 @@ case $1 in
     while IFS= read -r -d $'\n' dev; do
       mdev=$(echo "$dev" | awk '{ print $1; }')
       echo -n "mounting $mdev..."
-      if zfs mount $mdev; then
+      if $ZFS mount $mdev; then
         echo -e "done";
       else
         echo -e "failed";
       fi
-    done < <(zfs list -H);
+    done < <($ZFS list -H);
 
     # export the filesystems
     echo -n "exporting ZFS filesystems..."
-    if zfs share -a; then
+    if $ZFS share -a; then
       echo -e "done";
     else
       echo -e "failed";
@@ -60,14 +64,14 @@ case $1 in
       while IFS= read -r -d $'\n' dev; do
         mdev=$(echo "$dev" | awk '{ print $1 }');
         echo -n "umounting $mdev...";
-        if zfs umount $mdev; then
+        if $ZFS umount $mdev; then
           echo -e "done";
         else
           echo -e "failed";
         fi
         # the next line is, because i have to reverse the
         # output, otherwise it wouldn't work as it should
-      done < <(zfs list -H | tac);
+      done < <($ZFS list -H | tac);
 
       # and finally let's rmmod the module
       rmmod zfs

--- a/etc/init.d/zfs.redhat.in
+++ b/etc/init.d/zfs.redhat.in
@@ -30,8 +30,9 @@ export PATH=/usr/local/sbin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 # script variables
 RETVAL=0
-ZPOOL=zpool
-ZFS=zfs
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 servicename=zfs
 LOCKFILE=/var/lock/subsys/$servicename
 


### PR DESCRIPTION
I am adding this as a pull request for extra discussion.

```
configure:exec_prefix=NONE
configure:# These are left unexpanded so users can "make install exec_prefix=/foo"
configure:# and all the variables that are supposed to be based on exec_prefix
```

Because of the above, this will now leave ${exec_prefix} in some of the init.d scripts. I can't see what use make install exec_prefix would be, ./configure --exec-prefix should be used. Could this be removed so that the init.d scripts can follow binder and sysconfdir?

Note: Like my previous pull request, I did not include changes made by autogen.sh to my commit. Since I have a different autoconf version this results in lots of changes.
