### PR TITLE
Wrap Dracut files to 79 chars

### DIFF
--- a/dracut/90zfs/mount-zfs.sh
+++ b/dracut/90zfs/mount-zfs.sh
@@ -19,12 +19,14 @@ case "$root" in
 			# Might be imported by the kernel module, so try searching before
 			# we import anything.
 			zfsbootfs=`zpool list -H -o bootfs | sed 'q'`
-			if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || [ "$zfsbootfs" = "no pools available" ] ; then
+			if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
+				[ "$zfsbootfs" = "no pools available" ] ; then
 				# Not there, so we need to import everything.
 				info "ZFS: Attempting to import additional pools."
 				zpool import -N -a ${ZPOOL_FORCE}
 				zfsbootfs=`zpool list -H -o bootfs | sed 'q'`
-				if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || [ "$zfsbootfs" = "no pools available" ] ; then
+				if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
+					[ "$zfsbootfs" = "no pools available" ] ; then
 					rootok=0
 					pool=""
 

--- a/dracut/90zfs/parse-zfs.sh
+++ b/dracut/90zfs/parse-zfs.sh
@@ -10,7 +10,8 @@ if [ "${spl_hostid}" != "" ] ; then
 elif [ -f /etc/hostid ] ; then
 	info "ZFS: Using hostid from /etc/hostid: `cat /etc/hostid`"
 else
-	warn "ZFS: No hostid found on kernel command line or /etc/hostid.  ZFS pools may not import correctly."
+	warn "ZFS: No hostid found on kernel command line or /etc/hostid.  "
+	warn "ZFS: Pools may not import correctly."
 fi
 
 case "$root" in

--- a/dracut/README.dracut.markdown
+++ b/dracut/README.dracut.markdown
@@ -33,16 +33,17 @@ Kernel Command Line
 The initramfs' behavior is influenced by the following kernel command line
 parameters passed in from the boot loader:
 
-* `root=...`: If not set, importable pools are searched for a bootfs attribute.
-If an explicitly set root is desired, you may use `root=ZFS:pool/dataset`
+* `root=...`: If not set, importable pools are searched for a bootfs 
+attribute.  If an explicitly set root is desired, you may use 
+`root=ZFS:pool/dataset`
 
 * `zfs_force=0`: If set to 1, the initramfs will run `zpool import -f` when
 attempting to import pools if the required pool isn't automatically imported
-by the zfs module.  This can save you a trip to a bootcd if hostid has changed,
-but is dangerous and can lead to zpool corruption, particularly in cases where
-storage is on a shared fabric such as iSCSI where multiple hosts can access
-storage devices concurrently.  _Please understand the implications of
-force-importing a pool before enabling this option!_
+by the zfs module.  This can save you a trip to a bootcd if hostid has 
+changed, but is dangerous and can lead to zpool corruption, particularly in 
+cases where storage is on a shared fabric such as iSCSI where multiple hosts 
+can access storage devices concurrently.  _Please understand the implications 
+of force-importing a pool before enabling this option!_
 
 * `spl_hostid`: By default, the hostid used by the SPL module is read from
 /etc/hostid inside the initramfs.  This file is placed there from the host


### PR DESCRIPTION
Attached wraps the Dracut stuff at 79 chars.  The Makefile.in files still go over 79, but as they're generated, I didn't change them.
