### PR TITLE
FIX: ensure FC15 boots when zfs isn't being used for boot partition

### DIFF
--- a/dracut/90zfs/parse-zfs.sh.in
+++ b/dracut/90zfs/parse-zfs.sh.in
@@ -22,7 +22,7 @@ case "$root" in
 		# best later on.
 		root="zfs:AUTO"
 		rootok=1
-
+		wait_for_zfs=1
 		info "ZFS: Enabling autodetection of bootfs after udev settles."
 		;;
 
@@ -39,6 +39,7 @@ case "$root" in
 		root="${root#FILESYSTEM=}"
 		root="zfs:${root#ZFS=}"
 		rootok=1
+		wait_for_zfs=1
 
 		info "ZFS: Set ${root} as bootfs."
 		;;
@@ -46,5 +47,7 @@ esac
 
 # Make sure Dracut is happy that we have a root and will wait for ZFS
 # modules to settle before mounting.
-ln -s /dev/null /dev/root 2>/dev/null
-echo '[ -e /dev/zfs ]' > $hookdir/initqueue/finished/zfs.sh
+if [ "${wait_for_zfs}" == "1" ]; then
+	ln -s /dev/null /dev/root 2>/dev/null
+	echo '[ -e /dev/zfs ]' > $hookdir/initqueue/finished/zfs.sh
+fi


### PR DESCRIPTION
It seems that dracut version 009 through 013 won't boot correctly when
the zfs-dracut rpm package has been installed, but 'root=zfs' isn't
used on the boot commandline, for example when the package has been
installed on a system that _doesn't_ boot from a zfs filesystem.
