### PR TITLE
Use automatic variable in Makefile

### DIFF
--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -16,7 +16,7 @@ $(init_SCRIPTS):
 		-e 's,@udevruledir\@,$(udevruledir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		-e 's,@initdir\@,$(initdir),g' \
-		'zfs.$(DEFAULT_INIT_SCRIPT).in' >'$@'
+		'$@.$(DEFAULT_INIT_SCRIPT).in' >'$@'
 
 distclean-local::
 	-$(RM) $(init_SCRIPTS)

--- a/etc/init.d/Makefile.in
+++ b/etc/init.d/Makefile.in
@@ -531,7 +531,7 @@ $(init_SCRIPTS):
 		-e 's,@udevruledir\@,$(udevruledir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		-e 's,@initdir\@,$(initdir),g' \
-		'zfs.$(DEFAULT_INIT_SCRIPT).in' >'$@'
+		'$@.$(DEFAULT_INIT_SCRIPT).in' >'$@'
 
 distclean-local::
 	-$(RM) $(init_SCRIPTS)


### PR DESCRIPTION
As written, the $(init_SCRIPTS) rule in etc/init.d/Makefule.am
would not work as expected if the init_SCRIPTS variable were
to contain any elements other than zfs.  Fix this by replacing
the hard-coded 'zfs' reference with $@.
