### PR TITLE
Fixed a bug preventing to boot into zfs root

### DIFF
--- a/dracut/90zfs/parse-zfs.sh.in
+++ b/dracut/90zfs/parse-zfs.sh.in
@@ -48,7 +48,7 @@ esac
 
 # Make sure Dracut is happy that we have a root and will wait for ZFS
 # modules to settle before mounting.
-if [ "${wait_for_zfs}" == "1" ]; then
+if [ "${wait_for_zfs}" = "1" ]; then
 	ln -s /dev/null /dev/root 2>/dev/null
 	echo '[ -e /dev/zfs ]' > $hookdir/initqueue/finished/zfs.sh
 fi


### PR DESCRIPTION
Fixed a bug preventing to boot into zfs root (this caused a simple non-noticable warning but stopped booting onto zfs root: https://picasaweb.google.com/lh/photo/3qfldN8OBimKpH5-xQmsuQ?feat=directlink). 
@see http://stackoverflow.com/questions/2011160/unexpected-operator-error
