### PR TITLE
Use @ZFS_META LICENSE@ in spec.in files

### DIFF
--- a/zfs-modules.spec.in
+++ b/zfs-modules.spec.in
@@ -212,7 +212,7 @@ Group:           Utilities/System
 Name:            %{name}
 Version:         %{version}
 Release:         %{release}
-License:         @LICENSE@
+License:         @ZFS_META_LICENSE@
 URL:             git://github.com/zfsonlinux/zfs.git
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id} -un)
 Source:          @PACKAGE@-%{version}.tar.gz

--- a/zfs.spec.in
+++ b/zfs.spec.in
@@ -13,7 +13,7 @@ Group:           Utilities/System
 Name:            %{name}
 Version:         %{version}
 Release:         %{release}
-License:         @LICENSE@
+License:         @ZFS_META_LICENSE@
 URL:             git://github.com/zfsonlinux/zfs.git
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id} -un)
 Source:          %{name}-%{version}.tar.gz


### PR DESCRIPTION
zfs.spec.in and zfs-modules.spec.in had the License field incorrectly set to
@LICENSE@, causing generated rpm packages to report an invalid license string.
Fix this by using @ZFS_META_LICENSE@.

Signed-off-by: Ned Bass bass6@llnl.gov
