### PR TITLE
znode: use set_nlink to update inode

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -431,7 +431,7 @@ zfs_inode_update(znode_t *zp)
 	ip->i_generation = zp->z_gen;
 	ip->i_uid = zp->z_uid;
 	ip->i_gid = zp->z_gid;
-	ip->i_nlink = zp->z_links;
+	set_nlink(ip, zp->z_links);
 	ip->i_mode = zp->z_mode;
 	ip->i_blkbits = SPA_MINBLOCKSHIFT;
 	dmu_object_size_from_db(sa_get_db(zp->z_sa_hdl), &blksize,


### PR DESCRIPTION
Since d211858837ff8d8e31942ca7d27e6e08b3b46f5e ("vfs: protect
i_nlink") the i_nlink member in inodes cannot be set directly anymore.
Instead one has to use the set_nlink function.

Signed-off-by: Axel Gembe axel@gembe.net
