### PR TITLE
In autoconf v2.68, AC_LANG_PROGRAM must be quoted

### DIFF
--- a/config/always-no-unused-but-set-variable.m4
+++ b/config/always-no-unused-but-set-variable.m4
@@ -12,7 +12,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_NO_UNUSED_BUT_SET_VARIABLE], [
 	saved_flags="$CFLAGS"
 	CFLAGS="$CFLAGS -Wunused-but-set-variable"
 
-	AC_RUN_IFELSE(AC_LANG_PROGRAM( [], []),
+	AC_RUN_IFELSE([AC_LANG_PROGRAM([], [])],
 	[
 		NO_UNUSED_BUT_SET_VARIABLE=-Wno-unused-but-set-variable
 		AC_MSG_RESULT([yes])

--- a/config/user-frame-larger-than.m4
+++ b/config/user-frame-larger-than.m4
@@ -7,7 +7,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_FRAME_LARGER_THAN], [
 	saved_flags="$CFLAGS"
 	CFLAGS="$CFLAGS -Wframe-larger-than=1024"
 
-	AC_RUN_IFELSE(AC_LANG_PROGRAM( [], []),
+	AC_RUN_IFELSE([AC_LANG_PROGRAM([], [])],
 	[
 		FRAME_LARGER_THAN=-Wframe-larger-than=1024
 		AC_MSG_RESULT([yes])

--- a/config/user-libblkid.m4
+++ b/config/user-libblkid.m4
@@ -39,7 +39,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 			saved_LDFLAGS="$LDFLAGS"
 			LDFLAGS="-lblkid"
 
-			AC_RUN_IFELSE(AC_LANG_PROGRAM(
+			AC_RUN_IFELSE([AC_LANG_PROGRAM(
 			[
 				#include <stdio.h>
 				#include <blkid/blkid.h>
@@ -66,7 +66,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 
 				free(value);
 				blkid_put_cache(cache);
-			]),
+			])],
 			[
 				rm -f $ZFS_DEV
 				AC_MSG_RESULT([yes])

--- a/config/user-nptl_guard_within_stack.m4
+++ b/config/user-nptl_guard_within_stack.m4
@@ -12,7 +12,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_STACK_GUARD], [
 	saved_LDFLAGS="$LDFLAGS"
 	LDFLAGS="-lpthread"
 
-	AC_RUN_IFELSE(AC_LANG_PROGRAM(
+	AC_RUN_IFELSE([AC_LANG_PROGRAM(
 	[
 		#include <pthread.h>
 		#include <sys/resource.h>
@@ -41,7 +41,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_STACK_GUARD], [
 		pthread_attr_setguardsize(&attr, PAGESIZE);
 		pthread_create(&tid, &attr, func, NULL);
 		pthread_join(tid, NULL);
-	]),
+	])],
 	[
 		AC_MSG_RESULT([no])
 	],


### PR DESCRIPTION
This change updates the AC_LANG_PROGRAM autoconf macro invocations to be
wrapped in quotes. As of autoconf version 2.68, the quotes are necessary
to prevent warnings from appearing. Specifically, the autoconf v2.68
Forward Porting Notes specifies:

```
    It is important to note that you need to ensure that the call to
    AC_LANG_SOURCE is quoted and not expanded, otherwise that will
    cause the warning to appear nonetheless.
```
