### PR TITLE
Fix configure tests to play nice with GCC 4.6

### DIFF
--- a/config/kernel-bdev-block-device-operations.m4
+++ b/config/kernel-bdev-block-device-operations.m4
@@ -3,6 +3,8 @@ dnl # 2.6.x API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BDEV_BLOCK_DEVICE_OPERATIONS], [
 	AC_MSG_CHECKING([block device operation prototypes])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -30,4 +32,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BDEV_BLOCK_DEVICE_OPERATIONS], [
 	],[
 		AC_MSG_RESULT(struct inode)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-bdev-logical-size.m4
+++ b/config/kernel-bdev-logical-size.m4
@@ -7,6 +7,8 @@ dnl # it explicit.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BDEV_LOGICAL_BLOCK_SIZE], [
 	AC_MSG_CHECKING([whether bdev_logical_block_size() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -19,4 +21,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BDEV_LOGICAL_BLOCK_SIZE], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-end-request.m4
+++ b/config/kernel-blk-end-request.m4
@@ -5,6 +5,8 @@ dnl # changed in 2.6.31 so it may be used by non-GPL modules.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_END_REQUEST], [
 	AC_MSG_CHECKING([whether blk_end_request() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -34,4 +36,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_END_REQUEST], [
 		AC_DEFINE(HAVE_BLK_END_REQUEST_GPL_ONLY, 1,
 		          [blk_end_request() is GPL-only])
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-fetch-request.m4
+++ b/config/kernel-blk-fetch-request.m4
@@ -7,6 +7,8 @@ dnl # next available request and removed it from the request queue.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_FETCH_REQUEST], [
 	AC_MSG_CHECKING([whether blk_fetch_request() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -19,4 +21,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_FETCH_REQUEST], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-requeue-request.m4
+++ b/config/kernel-blk-requeue-request.m4
@@ -6,6 +6,8 @@ dnl # blk_requeue_request() function.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_REQUEUE_REQUEST], [
 	AC_MSG_CHECKING([whether blk_requeue_request() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -19,4 +21,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_REQUEUE_REQUEST], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-rq-bytes.m4
+++ b/config/kernel-blk-rq-bytes.m4
@@ -6,6 +6,8 @@ dnl blk_rq_bytes() helper was changed to a static inline which we can use.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_BYTES], [
 	AC_MSG_CHECKING([whether blk_rq_bytes() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -35,4 +37,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_BYTES], [
 		AC_DEFINE(HAVE_BLK_RQ_BYTES_GPL_ONLY, 1,
 		          [blk_rq_bytes() is GPL-only])
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-rq-pos.m4
+++ b/config/kernel-blk-rq-pos.m4
@@ -3,6 +3,8 @@ dnl # 2.6.31 API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_POS], [
 	AC_MSG_CHECKING([whether blk_rq_pos() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -15,4 +17,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_POS], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-blk-rq-sectors.m4
+++ b/config/kernel-blk-rq-sectors.m4
@@ -3,6 +3,8 @@ dnl # 2.6.31 API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_SECTORS], [
 	AC_MSG_CHECKING([whether blk_rq_sectors() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -15,4 +17,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_RQ_SECTORS], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-get-disk-ro.m4
+++ b/config/kernel-get-disk-ro.m4
@@ -3,6 +3,8 @@ dnl # 2.6.x API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_GET_DISK_RO], [
 	AC_MSG_CHECKING([whether get_disk_ro() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -15,4 +17,5 @@ AC_DEFUN([ZFS_AC_KERNEL_GET_DISK_RO], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-rq-for-each_segment.m4
+++ b/config/kernel-rq-for-each_segment.m4
@@ -3,6 +3,8 @@ dnl # 2.6.x API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_RQ_FOR_EACH_SEGMENT], [
 	AC_MSG_CHECKING([whether rq_for_each_segment() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -17,4 +19,5 @@ AC_DEFUN([ZFS_AC_KERNEL_RQ_FOR_EACH_SEGMENT], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/config/kernel-rq-is_sync.m4
+++ b/config/kernel-rq-is_sync.m4
@@ -3,6 +3,8 @@ dnl # 2.6.x API change
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_RQ_IS_SYNC], [
 	AC_MSG_CHECKING([whether rq_is_sync() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-but-set-variable"
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/blkdev.h>
 	],[
@@ -15,4 +17,5 @@ AC_DEFUN([ZFS_AC_KERNEL_RQ_IS_SYNC], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])


### PR DESCRIPTION
As of GCC 4.6, specific kernel 2.6.32 header files do not compile
cleanly without warnings. One specific example of this is the
arch/x86/include/asm/percpu.h file. Thus, a few of the configure tests
were getting hung up on this and the '-Wno-unsued-but-set-variables'
compile option had to be introduced.

Signed-off-by: Prakash Surya surya1@llnl.gov
Closes #459
