### PR TITLE
Support mutex subclasses in zio_*_child functions

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -254,6 +254,8 @@ extern int mutex_tryenter(kmutex_t *mp);
 extern void *mutex_owner(kmutex_t *mp);
 extern int mutex_held(kmutex_t *mp);
 
+#define mutex_enter_nested(mp, sc) mutex_enter(mp)
+
 /*
  * RW locks
  */


### PR DESCRIPTION
When running ZFS on Linux with CONFIG_LOCK_STAT enabled, lockdep reports
the following warning:

```
vdev_open/1/8480 is trying to acquire lock:
 (&zio->io_lock){+.+...}, at: [<ffffffffa051fac8>] zio_add_child+0x88/0x150 [zfs]

but task is already holding lock:
 (&zio->io_lock){+.+...}, at: [<ffffffffa051faa2>] zio_add_child+0x62/0x150 [zfs]
```

Since this specific lock-chain is valid and nothing to fret about,
lockdep's "nested locking" feature was used to suppress the warning.

Signed-off-by: Prakash Surya surya1@llnl.gov
Issue: #488
