### PR TITLE
Add make rule for building Arch Linux packages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 include $(top_srcdir)/config/rpm.am
 include $(top_srcdir)/config/deb.am
 include $(top_srcdir)/config/tgz.am
+include $(top_srcdir)/config/arch.am
 
 if CONFIG_USER
 USER_DIR = dracut udev etc man scripts lib cmd

--- a/PKGBUILD-zfs-modules.in
+++ b/PKGBUILD-zfs-modules.in
@@ -1,0 +1,24 @@
+# Maintainer: Prakash Surya <surya1@llnl.gov>
+pkgname=@ZFS_META_NAME@-modules
+pkgver=@ZFS_META_VERSION@
+pkgrel=@ZFS_META_RELEASE@
+pkgdesc="Contains kernel modules and support utilities for the zfs file system."
+arch=(x86_64)
+url="git://github.com/zfsonlinux/zfs.git"
+license=(@ZFS_META_LICENSE@)
+depends=('spl-modules')
+source=(@ZFS_META_NAME@-@ZFS_META_VERSION@.tar.gz)
+
+build() {
+	cd $srcdir/@ZFS_META_NAME@-@ZFS_META_VERSION@
+	./configure --with-config=kernel \
+	            --prefix=/usr \
+	            --sysconfdir=/etc \
+	            --libexecdir=/usr/lib
+	make
+}
+
+package() {
+	cd $srcdir/@ZFS_META_NAME@-@ZFS_META_VERSION@
+	make DESTDIR=$pkgdir install
+}

--- a/PKGBUILD-zfs.in
+++ b/PKGBUILD-zfs.in
@@ -1,0 +1,25 @@
+# Maintainer: Prakash Surya <surya1@llnl.gov>
+pkgname=@ZFS_META_NAME@
+pkgver=@ZFS_META_VERSION@
+pkgrel=@ZFS_META_RELEASE@
+pkgdesc="Contains the libzfs library and support utilities for the zfs file system."
+arch=(x86_64)
+url="git://github.com/zfsonlinux/zfs.git"
+license=(@ZFS_META_LICENSE@)
+depends=('spl' 'zlib' 'e2fsprogs')
+backup=('etc/zfs/zdev.conf')
+source=(@ZFS_META_NAME@-@ZFS_META_VERSION@.tar.gz)
+
+build() {
+	cd $srcdir/@ZFS_META_NAME@-@ZFS_META_VERSION@
+	./configure --with-config=user \
+	            --prefix=/usr \
+	            --sysconfdir=/etc \
+	            --libexecdir=/usr/lib
+	make
+}
+
+package() {
+	cd $srcdir/@ZFS_META_NAME@-@ZFS_META_VERSION@
+	make DESTDIR=$pkgdir install
+}

--- a/config/arch.am
+++ b/config/arch.am
@@ -1,0 +1,40 @@
+###############################################################################
+# Written by Prakash Surya <surya1@llnl.gov>
+###############################################################################
+# Build targets for RPM packages.
+###############################################################################
+
+sarch-modules:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" sarch-common
+
+sarch-utils:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" sarch-common
+
+sarch: sarch-modules sarch-utils
+
+arch-modules:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" arch-common
+
+arch-utils:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" arch-common
+
+arch: arch-modules arch-utils
+
+arch-local:
+	@(if test "${HAVE_MAKEPKG}" = "no"; then \
+		echo -e "\n" \
+	"*** Required util ${MAKEPKG} missing.  Please install the\n" \
+	"*** package for your distribution which provides ${MAKEPKG},\n" \
+	"*** re-run configure, and try again.\n"; \
+		exit 1; \
+	fi;)
+
+sarch-common: dist
+	pkgbuild=PKGBUILD-$(pkg); \
+	$(MAKE) $(AM_MAKEFLAGS) arch-local || exit 1; \
+	$(MAKEPKG) --allsource --skipinteg --nodeps -p $$pkgbuild || exit 1;
+
+arch-common: dist
+	pkgbuild=PKGBUILD-$(pkg); \
+	$(MAKE) $(AM_MAKEFLAGS) arch-local || exit 1; \
+	$(MAKEPKG) --skipinteg -p $$pkgbuild || exit 1;

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -175,6 +175,48 @@ AC_DEFUN([ZFS_AC_ALIEN], [
 ])
 
 dnl #
+dnl # Check for pacman+makepkg to build Arch Linux packages.  If these
+dnl # tools are missing it is non-fatal but you will not be able to
+dnl # build Arch Linux packages and will be warned if you try too.
+dnl #
+AC_DEFUN([ZFS_AC_PACMAN], [
+	PACMAN=pacman
+	MAKEPKG=makepkg
+
+	AC_MSG_CHECKING([whether $PACMAN is available])
+	tmp=$($PACMAN --version 2>/dev/null)
+	AS_IF([test -n "$tmp"], [
+		PACMAN_VERSION=$(echo $tmp |
+		                 $AWK '/Pacman/ { print $[3] }' |
+		                 $SED 's/^v//')
+		HAVE_PACMAN=yes
+		AC_MSG_RESULT([$HAVE_PACMAN ($PACMAN_VERSION)])
+	],[
+		HAVE_PACMAN=no
+		AC_MSG_RESULT([$HAVE_PACMAN])
+	])
+
+	AC_MSG_CHECKING([whether $MAKEPKG is available])
+	tmp=$($MAKEPKG --version 2>/dev/null)
+	AS_IF([test -n "$tmp"], [
+		MAKEPKG_VERSION=$(echo $tmp | $AWK '/makepkg/ { print $[3] }')
+		HAVE_MAKEPKG=yes
+		AC_MSG_RESULT([$HAVE_MAKEPKG ($MAKEPKG_VERSION)])
+	],[
+		HAVE_MAKEPKG=no
+		AC_MSG_RESULT([$HAVE_MAKEPKG])
+	])
+
+	AC_SUBST(HAVE_PACMAN)
+	AC_SUBST(PACMAN)
+	AC_SUBST(PACMAN_VERSION)
+
+	AC_SUBST(HAVE_MAKEPKG)
+	AC_SUBST(MAKEPKG)
+	AC_SUBST(MAKEPKG_VERSION)
+])
+
+dnl #
 dnl # Using the VENDOR tag from config.guess set the default
 dnl # package type for 'make pkg': (rpm | deb | tgz)
 dnl #
@@ -214,6 +256,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		slackware)  DEFAULT_PACKAGE=tgz ;;
 		gentoo)     DEFAULT_PACKAGE=tgz ;;
 		lunar)      DEFAULT_PACKAGE=tgz ;;
+		arch)       DEFAULT_PACKAGE=arch;;
 		*)          DEFAULT_PACKAGE=rpm ;;
 	esac
 
@@ -254,5 +297,6 @@ AC_DEFUN([ZFS_AC_PACKAGE], [
 	ZFS_AC_RPM
 	ZFS_AC_DPKG
 	ZFS_AC_ALIEN
+	ZFS_AC_PACMAN
 	ZFS_AC_DEFAULT_PACKAGE
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,8 @@ AC_CONFIG_FILES([
 	scripts/common.sh
 	zfs.spec
 	zfs-modules.spec
+	PKGBUILD-zfs
+	PKGBUILD-zfs-modules
 	zfs-script-config.sh
 ])
 


### PR DESCRIPTION
Added the necessary build infrastructure for building packages
compatible with the Arch Linux distribution. As such, one can now run:

```
$ ./configure
$ make pkg     # Alternatively, one can run 'make arch' as well
```

on the Arch Linux machine to create two binary packages compatible with
the pacman package manager, one for the zfs userland utilities and
another for the zfs kernel modules. The new packages can then be
installed by running:

```
# pacman -U $package.pkg.tar.xz
```

In addition, source-only packages suitable for an Arch Linux chroot
environment or remote builder can also be build using the 'sarch' make
rule.

NOTE: Since the source dist tarball is created on the fly from the head
of the build tree, it's MD5 hash signature will be continually influx.
As a result, the md5sum variable was intentionally omitted from the
PKGBUILD files, and the '--skipinteg' makepkg option is used. This may
or may not have any serious security implications, as the source tarball
is not being downloaded from an outside source.

Signed-off-by: Prakash Surya surya1@llnl.gov
