### PR TITLE
Combine libraries: spl, avl, efi, share, unicode.

### DIFF
--- a/cmd/mount_zfs/Makefile.am
+++ b/cmd/mount_zfs/Makefile.am
@@ -15,11 +15,6 @@ mount_zfs_SOURCES = \
 	$(top_srcdir)/cmd/mount_zfs/mount_zfs.c
 
 mount_zfs_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
-	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzfs/libzfs.la
 

--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -11,11 +11,7 @@ zdb_SOURCES = \
 	$(top_srcdir)/cmd/zdb/zdb_il.c
 
 zdb_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/zfs/Makefile.am
+++ b/cmd/zfs/Makefile.am
@@ -13,11 +13,7 @@ zfs_SOURCES = \
 	$(top_srcdir)/cmd/zfs/zfs_util.h
 
 zfs_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/zinject/Makefile.am
+++ b/cmd/zinject/Makefile.am
@@ -12,11 +12,7 @@ zinject_SOURCES = \
 	$(top_srcdir)/cmd/zinject/zinject.h
 
 zinject_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -14,11 +14,7 @@ zpool_SOURCES = \
 	$(top_srcdir)/cmd/zpool/zpool_vdev.c
 
 zpool_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -12,11 +12,7 @@ ztest_SOURCES = \
 	$(top_srcdir)/cmd/ztest/ztest.c
 
 ztest_LDADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libunicode/libunicode.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,2 +1,7 @@
-SUBDIRS  = libspl libavl libefi libnvpair libshare
-SUBDIRS += libunicode libuutil libzpool libzfs
+# NB: GNU Automake Manual, Chapter 8.3.5: Libtool Convenience Libraries
+# These five libraries are intermediary build components.
+SUBDIRS = libspl libavl libefi libshare libunicode 
+
+# These four libraries, which are installed as the final build product,
+# incorporate the five convenience libraries given above.
+SUBDIRS += libnvpair libuutil libzpool libzfs

--- a/lib/libavl/Makefile.am
+++ b/lib/libavl/Makefile.am
@@ -6,9 +6,7 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-lib_LTLIBRARIES = libavl.la
+noinst_LTLIBRARIES = libavl.la
 
 libavl_la_SOURCES = \
 	$(top_srcdir)/module/avl/avl.c
-
-libavl_la_LDFLAGS = -version-info 1:0:0

--- a/lib/libefi/Makefile.am
+++ b/lib/libefi/Makefile.am
@@ -6,9 +6,7 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-lib_LTLIBRARIES = libefi.la
+noinst_LTLIBRARIES = libefi.la
 
 libefi_la_SOURCES = \
 	$(top_srcdir)/lib/libefi/rdwr_efi.c
-
-libefi_la_LDFLAGS = -version-info 1:0:0

--- a/lib/libnvpair/Makefile.am
+++ b/lib/libnvpair/Makefile.am
@@ -14,7 +14,7 @@ libnvpair_la_SOURCES = \
 	$(top_srcdir)/module/nvpair/nvpair_alloc_fixed.c \
 	$(top_srcdir)/module/nvpair/nvpair.c
 
-libnvpair_la_LDFLAGS = -version-info 1:0:0
+libnvpair_la_LDFLAGS = -version-info 1:1:0
 
 EXTRA_DIST = \
 	$(top_srcdir)/module/nvpair/nvpair_alloc_spl.c

--- a/lib/libshare/Makefile.am
+++ b/lib/libshare/Makefile.am
@@ -4,12 +4,10 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-lib_LTLIBRARIES = libshare.la
+noinst_LTLIBRARIES = libshare.la
 
 libshare_la_SOURCES = \
 	$(top_srcdir)/lib/libshare/libshare.c \
 	$(top_srcdir)/lib/libshare/nfs.c \
 	$(top_srcdir)/lib/libshare/libshare_impl.h \
 	$(top_srcdir)/lib/libshare/nfs.h
-
-libshare_la_LDFLAGS = -version-info 1:0:0

--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -11,7 +11,7 @@ DEFAULT_INCLUDES += \
 AM_CCASFLAGS = \
 	-I$(top_srcdir)/lib/libspl/include
 
-lib_LTLIBRARIES = libspl.la
+noinst_LTLIBRARIES = libspl.la
 
 libspl_la_SOURCES = \
 	$(top_srcdir)/lib/libspl/getexecname.c \
@@ -30,4 +30,4 @@ libspl_la_SOURCES = \
 	$(top_srcdir)/lib/libspl/include/sys/list.h \
 	$(top_srcdir)/lib/libspl/include/sys/list_impl.h
 
-libspl_la_LDFLAGS = -lrt -version-info 1:0:0
+libspl_la_LDFLAGS = -lrt

--- a/lib/libunicode/Makefile.am
+++ b/lib/libunicode/Makefile.am
@@ -6,10 +6,8 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-lib_LTLIBRARIES = libunicode.la
+noinst_LTLIBRARIES = libunicode.la
 
 libunicode_la_SOURCES = \
 	$(top_srcdir)/module/unicode/u8_textprep.c \
 	$(top_srcdir)/module/unicode/uconv.c
-
-libunicode_la_LDFLAGS = -version-info 1:0:0

--- a/lib/libuutil/Makefile.am
+++ b/lib/libuutil/Makefile.am
@@ -8,8 +8,6 @@ DEFAULT_INCLUDES += \
 
 lib_LTLIBRARIES = libuutil.la
 
-libuutil_la_LIBADD = $(top_builddir)/lib/libavl/libavl.la
-
 libuutil_la_SOURCES = \
 	$(top_srcdir)/lib/libuutil/uu_alloc.c \
 	$(top_srcdir)/lib/libuutil/uu_avl.c \
@@ -22,4 +20,9 @@ libuutil_la_SOURCES = \
 	$(top_srcdir)/lib/libuutil/uu_string.c \
 	$(top_srcdir)/lib/libuutil/uu_strtoint.c
 
-libuutil_la_LDFLAGS = -version-info 1:0:0
+libuutil_la_LIBADD = \
+	$(top_builddir)/lib/libavl/libavl.la \
+	$(top_builddir)/lib/libspl/libspl.la \
+	$(top_builddir)/lib/libefi/libefi.la
+
+libuutil_la_LDFLAGS = -pthread -version-info 1:1:0

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -6,14 +6,6 @@ DEFAULT_INCLUDES += \
 
 lib_LTLIBRARIES = libzfs.la
 
-libzfs_la_LIBADD = \
-	$(top_builddir)/lib/libspl/libspl.la \
-	$(top_builddir)/lib/libefi/libefi.la \
-	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libshare/libshare.la \
-	$(top_builddir)/lib/libuutil/libuutil.la \
-	$(top_builddir)/lib/libzpool/libzpool.la
-
 libzfs_la_SOURCES = \
 	$(top_srcdir)/lib/libzfs/libzfs_changelist.c \
 	$(top_srcdir)/lib/libzfs/libzfs_config.c \
@@ -28,4 +20,9 @@ libzfs_la_SOURCES = \
 	$(top_srcdir)/lib/libzfs/libzfs_status.c \
 	$(top_srcdir)/lib/libzfs/libzfs_util.c
 
-libzfs_la_LDFLAGS = -lm -ldl $(LIBSELINUX) -version-info 1:0:0
+libzfs_la_LIBADD = \
+	$(top_builddir)/lib/libshare/libshare.la \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzpool/libzpool.la
+
+libzfs_la_LDFLAGS = -lm -ldl -version-info 1:1:0 $(LIBSELINUX)

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -8,11 +8,6 @@ DEFAULT_INCLUDES += \
 
 lib_LTLIBRARIES = libzpool.la
 
-libzpool_la_LIBADD = \
-	$(top_builddir)/lib/libunicode/libunicode.la \
-	$(top_builddir)/lib/libavl/libavl.la \
-	$(top_builddir)/lib/libspl/libspl.la
-
 libzpool_la_SOURCES = \
 	$(top_srcdir)/lib/libzpool/kernel.c \
 	$(top_srcdir)/lib/libzpool/taskq.c \
@@ -93,7 +88,11 @@ libzpool_la_SOURCES = \
 	$(top_srcdir)/module/zfs/zle.c \
 	$(top_srcdir)/module/zfs/zrlock.c
 
-libzpool_la_LDFLAGS = -pthread -version-info 1:0:0
+libzpool_la_LIBADD = \
+	$(top_builddir)/lib/libunicode/libunicode.la \
+	$(top_builddir)/lib/libuutil/libuutil.la
+
+libzpool_la_LDFLAGS = -pthread -version-info 1:1:0
 
 EXTRA_DIST = \
 	$(top_srcdir)/module/zfs/vdev_disk.c \


### PR DESCRIPTION
These libraries, which are an artifact of the ZoL development
process, conflict with packages that are already in distribution:
- libspl: SPL Programming Language
- libavl: AVL for Linux
- libefi: GRUB

And these libraries are potential conflicts:
- libshare: the Linux Mount Manager
- libunicode: Perl and Python

Recompose these five ZoL components into the four libraries that are
conventionally provided by Solaris and FreeBSD systems:
- libnvpair
- libuutil
- libzpool
- libzfs

This change resolves the name conflict, makes ZoL more compatible
with existing software that uses autotools to detect ZFS, and allows
pkg-zfs to better reflect the official Debian kFreeBSD packaging.

Closes: #430
