### PR TITLE
Fix zfs_rename to update symlinks under /dev (Fixes #408)

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3358,6 +3358,20 @@ zfs_create_link_cb(zfs_handle_t *zhp, void *arg)
 	return (ret);
 }
 
+static int
+zfs_create_link_snapvol(zfs_handle_t *zhp, void *arg)
+{
+	(void) zvol_create_link_common(zhp->zfs_hdl, zhp->zfs_name, B_TRUE);
+	return (0);
+}
+
+static int
+zfs_remove_link_snapvol(zfs_handle_t *zhp, void *arg)
+{
+	(void) zvol_remove_link(zhp->zfs_hdl, zhp->zfs_name);
+	return (0);
+}
+
 /*
  * Takes a snapshot of the given dataset.
  */
@@ -3735,21 +3749,24 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive)
 		return (zfs_error(hdl, EZFS_ZONED, errbuf));
 	}
 
+	parentname = zfs_strdup(zhp->zfs_hdl, zhp->zfs_name);
+	if (parentname == NULL) {
+		ret = -1;
+		goto error;
+	}
+	delim = strchr(parentname, '@');
+	if (delim != NULL) {
+		*delim = '\0';
+	}
+	zhrp = zfs_open(zhp->zfs_hdl, parentname, ZFS_TYPE_DATASET);
+	if (zhrp == NULL) {
+		ret = -1;
+		printf("zhrp is NULL\n");
+		goto error;
+	}
+
 	if (recursive) {
 		struct destroydata dd;
-
-		parentname = zfs_strdup(zhp->zfs_hdl, zhp->zfs_name);
-		if (parentname == NULL) {
-			ret = -1;
-			goto error;
-		}
-		delim = strchr(parentname, '@');
-		*delim = '\0';
-		zhrp = zfs_open(zhp->zfs_hdl, parentname, ZFS_TYPE_DATASET);
-		if (zhrp == NULL) {
-			ret = -1;
-			goto error;
-		}
 
 		dd.snapname = delim + 1;
 		dd.gotone = B_FALSE;
@@ -3777,10 +3794,13 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive)
 			goto error;
 	}
 
-	if (ZFS_IS_VOLUME(zhp))
+	if (ZFS_IS_VOLUME(zhp)) {
 		zc.zc_objset_type = DMU_OST_ZVOL;
-	else
-		zc.zc_objset_type = DMU_OST_ZFS;
+		/* remove udev links */
+		(void) zfs_iter_snapshots(zhrp, zfs_remove_link_snapvol, NULL);
+	} else {
+	        zc.zc_objset_type = DMU_OST_ZFS;
+	}
 
 	(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
 	(void) strlcpy(zc.zc_value, target, sizeof (zc.zc_value));
@@ -3817,6 +3837,11 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive)
 			(void) zfs_iter_filesystems(zhrp, zfs_create_link_cb,
 			    &cd);
 		} else {
+			if (ZFS_IS_VOLUME(zhp)) {
+				/* restore old udev links back */
+				(void) zfs_iter_snapshots(zhrp,
+				    zfs_create_link_snapvol, NULL);
+			}
 			(void) changelist_postfix(cl);
 		}
 	} else {
@@ -3829,6 +3854,17 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive)
 			ret = zfs_iter_filesystems(zhrp, zfs_create_link_cb,
 			    &cd);
 		} else {
+			if (ZFS_IS_VOLUME(zhp)) {
+				/* create new udev links */
+				zhrp = zfs_open(zhp->zfs_hdl, target,
+				    ZFS_TYPE_DATASET);
+				if (zhrp == NULL) {
+					ret = -1;
+					goto error;
+				}
+				(void) zfs_iter_snapshots(zhrp,
+				    zfs_create_link_snapvol, NULL);
+			}
 			changelist_rename(cl, zfs_get_name(zhp), target);
 			ret = changelist_postfix(cl);
 		}


### PR DESCRIPTION
When a zvol consisting of snapshots is renamed, the symlinks under
/dev for snapshots are not renamed at all. Exporting and reimporting
the zpool updates the link properly but that is not desirable to
do. We need to update udev in zfs_rename to update these symlinks as
part of zfs rename.

I've update the zfs_rename function to remove symlinks prior to
renaming the volume and create new links upon success or restore old
links upon failure. Also, I've moved parentname and zhrp variable
asignments up towards the beginning as they are needed for both
recursive and volume rename cases. I've also added supporting
functions zfs_create_link_snapvol and zfs_remove_link_snapvol to be
used as callbacks for zfs_iter_snapshots
