### PR TITLE
Properly handle /dev/vd* devices as whole disks

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -196,6 +196,12 @@ efi_get_info(int fd, struct dk_cinfo *dki_info)
 		rval = sscanf(dev_path, "/dev/%[a-zA-Z0-9]p%hu",
 			      dki_info->dki_dname,
 			      &dki_info->dki_partition);
+	} else if ((strncmp(dev_path, "/dev/vd", 7) == 0)) {
+		strcpy(dki_info->dki_cname, "vd");
+		dki_info->dki_ctype = DKC_MD;
+		rval = sscanf(dev_path, "/dev/%[a-zA-Z]%hu",
+			      dki_info->dki_dname,
+			      &dki_info->dki_partition);
 	} else if ((strncmp(dev_path, "/dev/dm-", 8) == 0)) {
 		strcpy(dki_info->dki_cname, "pseudo");
 		dki_info->dki_ctype = DKC_VBD;


### PR DESCRIPTION
I was doing some ZFS testing with a KVM virtual machine. If I configure the disk as a SCSI disk, it shows up as sda and `zpool create tank sda` creates a GPT disk label, as expected. If I configure the disk as a virtio disk, it shows up as /dev/vda and `zpool create tank vda` does not create a GPT disk label. This commit fixes the vda case to behave like the sda case.
