### PR TITLE
Add overlay(-O) mount option support

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -5469,7 +5469,7 @@ share_mount(int op, int argc, char **argv)
 	int flags = 0;
 
 	/* check options */
-	while ((c = getopt(argc, argv, op == OP_MOUNT ? ":avo:" : "a"))
+	while ((c = getopt(argc, argv, op == OP_MOUNT ? ":avo:O" : "a"))
 	    != -1) {
 		switch (c) {
 		case 'a':
@@ -5491,7 +5491,9 @@ share_mount(int op, int argc, char **argv)
 			/* option validation is done later */
 			append_options(options, optarg);
 			break;
-
+		case 'O':
+			flags |= MS_OVERLAY;
+			break;
 		case ':':
 			(void) fprintf(stderr, gettext("missing argument for "
 			    "'%c' option\n"), optopt);

--- a/lib/libspl/include/sys/mount.h
+++ b/lib/libspl/include/sys/mount.h
@@ -73,4 +73,11 @@
 # define MS_DETACH	0x00000002
 #endif /* MNT_DETACH */
 
+/*
+ * Overlay mount is default in Linux, but for solaris/zfs
+ * compatibility, MS_OVERLAY is defined to explicitly have the user
+ * provide a flag (-O) to mount over a non empty directory.
+ */
+#define MS_OVERLAY      0x00000004
+
 #endif /* _LIBSPL_SYS_MOUNT_H */

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -440,9 +440,11 @@ zfs_mount(zfs_handle_t *zhp, const char *options, int flags)
 
 	/*
 	 * Determine if the mountpoint is empty.  If so, refuse to perform the
-	 * mount.  We don't perform this check if 'remount' is specified.
+	 * mount.  We don't perform this check if 'remount' is
+	 * specified or if overlay option(-O) is given
 	 */
-	if (!remount && !dir_is_empty(mountpoint)) {
+	if ((flags & MS_OVERLAY) == 0 && !remount &&
+	    !dir_is_empty(mountpoint)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 		    "directory is not empty"));
 		return (zfs_error_fmt(hdl, EZFS_MOUNTFAILED,


### PR DESCRIPTION
Linux supports mounting over non-empty directories by default. In
Solaris this is not the case and -O option is required for zfs mount
to mount a zfs filesystem over a non-empty directory. For
compatibility, I've added support for -O option to mount zfs
filesystems over non-empty directories if the user wants to, just like
in Solaris.

I've defined MS_OVERLAY to record it in the flags variable if -O
option is supplied. the flags variable passes through a few functions
and its checked before performing the empty directory check in
zfs_mount function. if -O is given, the check is not performed.
