### PR TITLE
Run ZFS_AC_PACMAN only if $VENDOR is "arch"

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -294,9 +294,10 @@ dnl #
 dnl # Default ZFS package configuration
 dnl #
 AC_DEFUN([ZFS_AC_PACKAGE], [
+	ZFS_AC_DEFAULT_PACKAGE
 	ZFS_AC_RPM
 	ZFS_AC_DPKG
 	ZFS_AC_ALIEN
-	ZFS_AC_PACMAN
-	ZFS_AC_DEFAULT_PACKAGE
+
+	AS_IF([test "$VENDOR" = "arch"], [ZFS_AC_PACMAN]);
 ])


### PR DESCRIPTION
Unfortunately, Arch's package manager `pacman` shares it's name with a
popular arcade video game. Thus, in order to refrain from executing the
video game when we mean to execute the package manager, ZFS_AC_PACMAN is
now only run when $VENDOR is determined to be "arch".

Signed-off-by: Prakash Surya surya1@llnl.gov
Closes #517
