### PR TITLE
Allow GPT+EFI vdev replacement in boot pools.

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -490,6 +490,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			verify(nvlist_lookup_nvlist(zpool_get_config(zhp, NULL),
 			    ZPOOL_CONFIG_VDEV_TREE, &nvroot) == 0);
 
+#if defined(__sun__) || defined(__sun)
 			/*
 			 * bootfs property cannot be set on a disk which has
 			 * been EFI labeled.
@@ -502,6 +503,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				zpool_close(zhp);
 				goto error;
 			}
+#endif
 			zpool_close(zhp);
 			break;
 


### PR DESCRIPTION
Commit zfsonlinux/zfs@57a4eddc4d5e1e6c10d8d7dcf87a9fc27398adcd
allows the bootfs property to be set on any pool, but does not
accommodate subsequent vdev changes. For example:

```
# zpool replace rpool /dev/sda /dev/sdb
operation not supported on this type of pool
property 'bootfs' is not supported on EFI labeled devices
```

For non-Solaris builds, disable the check that emits this error.
