### PR TITLE
Ignore non DMU_OST_ZFS and DMU_OST_ZVOL types

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -413,6 +413,9 @@ make_dataset_handle_common(zfs_handle_t *zhp, zfs_cmd_t *zc)
 		zhp->zfs_head_type = ZFS_TYPE_VOLUME;
 	else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZFS)
 		zhp->zfs_head_type = ZFS_TYPE_FILESYSTEM;
+	else if (zhp->zfs_dmustats.dds_type == DMU_OST_OTHER)
+		return (-1); /* zpios' and other testing datasets are
+		                of this type, ignore if encountered */
 	else
 		abort();
 


### PR DESCRIPTION
If a dataset is successfully opened with the zpool or zfs commands, and
it is found to have a dds_type of neither DMU_OST_ZFS nor DMU_OST_ZVOL,
the command will abort(). This patch changes that behavior. Rather than
calling abort(), now, the dataset in question is simply ignored.

Signed-off-by: Prakash Surya surya1@llnl.gov
Closes #536
