### PR TITLE
Support "sync=always" for ZVOLs

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -555,7 +555,7 @@ zvol_write(void *arg)
 	dmu_tx_commit(tx);
 	zfs_range_unlock(rl);
 
-	if (rq_is_sync(req))
+	if (rq_is_sync(req) || zv->zv_objset->os_sync == ZFS_SYNC_ALWAYS)
 		zil_commit(zv->zv_zilog, ZVOL_OBJ);
 
 	blk_end_request(req, -error, size);


### PR DESCRIPTION
Currently the "sync=always" property works for regular ZFS datasets, but not for ZVOLs. This patch remedies that.

Fixes #374.

Note: #383 was the original pull request for this, but I made a new one since I seriously messed up the branch by doing unwanted merges. I'll try to be more careful this time.
