### PR TITLE
Improve ZVOL queue behavior

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1164,6 +1164,13 @@ __zvol_create_minor(const char *name)
 
 	set_capacity(zv->zv_disk, zv->zv_volsize >> 9);
 
+	blk_queue_max_hw_sectors(zv->zv_queue, UINT_MAX);
+	blk_queue_max_segments(zv->zv_queue, USHRT_MAX);
+	blk_queue_max_segment_size(zv->zv_queue, UINT_MAX);
+	blk_queue_physical_block_size(zv->zv_queue, zv->zv_volblocksize);
+	blk_queue_io_opt(zv->zv_queue, zv->zv_volblocksize);
+	queue_flag_set_unlocked(QUEUE_FLAG_NONROT, zv->zv_queue);
+	
 	if (zil_replay_disable)
 		zil_destroy(dmu_objset_zil(os), B_FALSE);
 	else


### PR DESCRIPTION
The Linux block device queue subsystem exposes a number of configurable settings described in Linux `block/blk-settings.c`. The defaults for these settings are tuned for hard drives, and are not optimized for ZVOLs. Proper configuration of these options would allow upper layers (I/O scheduler) to take better decisions about write merging and ordering.

Detailed rationale:
- `max_hw_sectors` is set to unlimited (`UINT_MAX`). `zvol_write()` is able to handle writes of any size, so there's no reason to impose a limit. Let the upper layer decide.
- `max_segments` and `max_segment_size` are set to unlimited. `zvol_write()` will copy the requests' contents into a dbuf anyway, so the number and size of the segments are irrelevant. Let the upper layer decide.
- `physical_block_size` and `io_opt` are set to the ZVOL's block size. This has the potential to somewhat alleviate issue #361 for ZVOLs, by warning the upper layers that writes smaller than the volume's block size will be slow.
- The `NONROT` flag is set to indicate this isn't a rotational device. Although the backing zpool might be composed of rotational devices, the resulting ZVOL often doesn't exhibit the same behavior due to the COW mechanisms used by ZFS. Setting this flag will prevent upper layers from making useless decisions (such as reordering writes) based on incorrect assumptions about the behavior of the ZVOL.

Note: #389 was the original pull request for this, but I made a new one since I seriously messed up the branch by doing unwanted merges. I'll try to be more careful this time.
