### PR TITLE
Implement Support for 8KB SSD page sizes

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -443,7 +443,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				goto error;
 			}
 
-			if (intval != 0 && (intval < 9 || intval > 12)) {
+			if (intval != 0 && (intval < 9 || intval > 13)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "property '%s' number %d is invalid."),
 				    propname, intval);

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -89,7 +89,7 @@ zpool_prop_init(void)
 
 	/* readonly onetime number properties */
 	zprop_register_number(ZPOOL_PROP_ASHIFT, "ashift", 0, PROP_ONETIME,
-	    ZFS_TYPE_POOL, "<ashift, 9-12, or 0=default>", "ASHIFT");
+	    ZFS_TYPE_POOL, "<ashift, 9-13, or 0=default>", "ASHIFT");
 
 	/* default number properties */
 	zprop_register_number(ZPOOL_PROP_VERSION, "version", SPA_VERSION,


### PR DESCRIPTION
This enables the use of ashift=13 so that writes on SSDs that use an 8KB page size are more efficient.

This closes  #565.
