### PR TITLE
umount incorect clean mtab entry when mount point specified not in canonical form

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -273,7 +273,7 @@ mtab_update(char *dataset, char *mntpoint, char *type, char *mntopts)
 	int error;
 
 	mnt.mnt_fsname = dataset;
-	mnt.mnt_dir = mntpoint;
+	mnt.mnt_dir = canonicalize_file_name(mntpoint);
 	mnt.mnt_type = type;
 	mnt.mnt_opts = mntopts ? mntopts : "";
 	mnt.mnt_freq = 0;


### PR DESCRIPTION
Hi,
When mount point contain garbage characters, it all will be written in mtab.
And when unmount on the canonical path, umount not clean non canonical mtab entry.
Reproduce:
mkdir /mnt/foo
mount -t zfs zpool/foo /mnt/../mnt/foo////
umount /mnt/foo

not removed mtab entry:
zpool/foo /mnt/../mnt/foo//// zfs rw 0 0
