### PR TITLE
Return success from check_slice() if device doesn't exist    

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -188,19 +188,10 @@ check_error(int err)
 static int
 check_slice(const char *path, blkid_cache cache, int force, boolean_t isspare)
 {
-	struct stat64 statbuf;
 	int err;
 #ifdef HAVE_LIBBLKID
 	char *value;
-#endif /* HAVE_LIBBLKID */
 
-	if (stat64(path, &statbuf) != 0) {
-		vdev_error(gettext("cannot stat %s: %s\n"),
-		           path, strerror(errno));
-		return (-1);
-	}
-
-#ifdef HAVE_LIBBLKID
 	/* No valid type detected device is safe to use */
 	value = blkid_get_tag_value(cache, "TYPE", path);
 	if (value == NULL)


### PR DESCRIPTION
When creating a new pool, make_root_vdev() calls check_in_use() to  
ensure that none of the consituent disks are in use.  If the disk
contains a valid vdev label it is read to retrieve the list of its 
child vdevs and these are checked recursively.  However, the
partitions stored in the vdev label my no longer exist, for example
if the partition table has since been altered.  In any such case we  
would want the pool creation to proceed, so this change removes the
check from check_slice() that returns an error if the device doesn't
exist.  As an added assurance, the Solaris implementation also
returns sucess on ENOENT.
