### PR TITLE
fix for https://github.com/zfsonlinux/zfs/issues/581

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -2834,7 +2834,7 @@ zfs_do_list(int argc, char **argv)
 	zfs_free_sort_columns(sortcol);
 
 	if (ret == 0 && cb.cb_first && !cb.cb_scripted)
-		(void) printf(gettext("no datasets available\n"));
+		(void) fprintf(stderr, gettext("no datasets available\n"));
 
 	return (ret);
 }
@@ -5139,7 +5139,7 @@ zfs_do_holds(int argc, char **argv)
 	print_holds(scripted, cb.cb_max_namelen, cb.cb_max_taglen, nvl);
 
 	if (nvlist_empty(nvl))
-		(void) printf(gettext("no datasets available\n"));
+		(void) fprintf(stderr, gettext("no datasets available\n"));
 
 	nvlist_free(nvl);
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1960,8 +1960,7 @@ zpool_do_import(int argc, char **argv)
 	 * found.
 	 */
 	if (argc == 0 && first)
-		(void) fprintf(stderr,
-		    gettext("no pools available to import\n"));
+		(void) fprintf(stderr, gettext("no pools available to import\n"));
 
 error:
 	nvlist_free(props);
@@ -2358,7 +2357,7 @@ zpool_do_iostat(int argc, char **argv)
 		pool_list_update(list);
 
 		if ((npools = pool_list_count(list)) == 0)
-			(void) printf(gettext("no pools available\n"));
+			(void) fprintf(stderr, gettext("no pools available\n"));
 		else {
 			/*
 			 * Refresh all statistics.  This is done as an
@@ -2599,7 +2598,7 @@ zpool_do_list(int argc, char **argv)
 		    list_callback, &cb);
 
 		if (argc == 0 && cb.cb_first)
-			(void) printf(gettext("no pools available\n"));
+			(void) fprintf(stderr, gettext("no pools available\n"));
 		else if (argc && cb.cb_first) {
 			/* cannot open the given pool */
 			zprop_free_list(cb.cb_proplist);
@@ -3793,7 +3792,7 @@ zpool_do_status(int argc, char **argv)
 		    status_callback, &cb);
 
 		if (argc == 0 && cb.cb_count == 0)
-			(void) printf(gettext("no pools available\n"));
+			(void) fprintf(stderr, gettext("no pools available\n"));
 		else if (cb.cb_explain && cb.cb_first && cb.cb_allpools)
 			(void) printf(gettext("all pools are healthy\n"));
 
@@ -4219,7 +4218,7 @@ zpool_do_history(int argc, char **argv)
 	    &cbdata);
 
 	if (argc == 0 && cbdata.first == B_TRUE) {
-		(void) printf(gettext("no pools available\n"));
+		(void) fprintf(stderr, gettext("no pools available\n"));
 		return (0);
 	}
 


### PR DESCRIPTION
This should direct 'no pools/datasets available' error messages to stderr instead of stdout, simplifying scripting zpool and zfs for the case that no pools are imported.
