### PR TITLE
Make Gentoo initscript use modinfo

### DIFF
--- a/etc/init.d/zfs.gentoo.in
+++ b/etc/init.d/zfs.gentoo.in
@@ -19,7 +19,7 @@ ZFS_MODULE=zfs
 checksystem() {
 	if [ ! -c /dev/zfs ]; then
 		einfo "Checking if ZFS modules present"
-		if [ "x$(modprobe -l  $ZFS_MODULE | grep $ZFS_MODULE)" == "x" ]; then
+		if ! modinfo zfs > /dev/null 2>&1 ; then
 			eerror "$ZFS_MODULE not found. Is the ZFS package installed?"
 			return 1
 		fi


### PR DESCRIPTION
The -l parameter to modprobe has been removed from the latest upstream
code and this change has entered Gentoo. Using modinfo as a substitute
addresses this.
