### PR TITLE
Fixed a NULL pointer dereference bug in zfs_preumount

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1231,7 +1231,7 @@ zfs_preumount(struct super_block *sb)
 {
 	zfs_sb_t *zsb = sb->s_fs_info;
 
-	if (zsb->z_ctldir != NULL)
+	if (zsb != NULL && zsb->z_ctldir != NULL)
 		zfsctl_destroy(zsb);
 }
 EXPORT_SYMBOL(zfs_preumount);


### PR DESCRIPTION
When zpl_fill_super -> zfs_domount fails (e.g. because the dataset
was destroyed before it could be successfully mounted) the subsequent
call to zpl_kill_sb -> zfs_preumount would derefence a NULL pointer.

This bug can be reproduced using this shell script:

 #!/bin/sh
 (
 while true; do
    zfs create -o mountpoint=legacz tank/bar
    zfs destroy tank/bar
 done
 ) &

 (
 while true; do
    mount -t zfs tank/bar /mnt
    umount /mnt
 done
 ) &
