### PR TITLE
Illumos #1661: ZFS bug in sa_find_sizes() that can lead to panic

### DIFF
--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2011 iXsystems, Inc
  */
 
 #include <sys/zfs_context.h>
@@ -625,14 +626,14 @@ sa_find_sizes(sa_os_t *sa, sa_bulk_attr_t *attr_desc, int attr_count,
 		 * and spill buffer.
 		 */
 		if (buftype == SA_BONUS && *index == -1 &&
-		    (*total + P2ROUNDUP(hdrsize, 8)) >
+		    *total + (P2ROUNDUP(hdrsize, 8)) >
 		    (full_space - sizeof (blkptr_t))) {
 			*index = i;
 			done = B_TRUE;
 		}
 
 next:
-		if ((*total + P2ROUNDUP(hdrsize, 8)) > full_space &&
+		if (*total + (P2ROUNDUP(hdrsize, 8)) > full_space &&
 		    buftype == SA_BONUS)
 			*will_spill = B_TRUE;
 	}

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2011 Martin Matuska
  */
 
 #include <sys/zfs_context.h>


### PR DESCRIPTION
1313 Integer overflow in txg_delay() (fix copyright)
Reviewed by: Matthew Ahrens matt@delphix.com
Reviewed by: Dan McDonald danmcd@nexenta.com
Approved by: Gordon Ross gwr@nexenta.com
