### PR TITLE
OS-682: ARC minimum is set too high, potentially blocking VM creation

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3774,9 +3774,6 @@ arc_init(void)
 	if (zfs_arc_meta_limit > 0 && zfs_arc_meta_limit <= arc_c_max)
 		arc_meta_limit = zfs_arc_meta_limit;
 
-	if (arc_c_min < arc_meta_limit / 2 && zfs_arc_min == 0)
-		arc_c_min = arc_meta_limit / 2;
-
 	if (zfs_arc_grow_retry > 0)
 		arc_grow_retry = zfs_arc_grow_retry;
 


### PR DESCRIPTION
The lines that this commit deletes caused issues for adeel when he tried using ZFS on 32-bit Linux. If I recall correctly, he had to comment them out. Upon seeing that SmartOS has removed them, it might be wise to follow suit.
