### PR TITLE
Update ARC memory limits to account for SLUB internal fragmentation

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3747,11 +3747,7 @@ arc_init(void)
 
 	/* set min cache to 1/32 of all memory, or 64MB, whichever is more */
 	arc_c_min = MAX(arc_c / 4, 64<<20);
-	/* set max to 1/2 of all memory, or all but 4GB, whichever is more */
-	if (arc_c * 8 >= ((uint64_t)4<<30))
-		arc_c_max = (arc_c * 8) - ((uint64_t)4<<30);
-	else
-		arc_c_max = arc_c_min;
+	/* set max to 1/2 of all memory */
 	arc_c_max = MAX(arc_c * 4, arc_c_max);
 
 	/*


### PR DESCRIPTION
23bdb07d4e4c435205d25d3efdb5fef2d089ce5e updated the ARC memory limits
to be 1/2 of memory or all but 4GB. Unfortunately, these values assume
zero internal fragmentation in the SLUB allocator, when in reality, the
internal fragmentation could be as high as 50%, effectively doubling
memory usage. This poses clear safety issues, because it permits the
size of ARC to exceed system memory.

This patch changes this so that the default value of arc_c_max is always
1/2 of system memory. This effectively limits the ARC to the memory that
the system has physically installed.
