### PR TITLE
Disable direct reclaim on zvols

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1391,7 +1391,7 @@ zvol_init(void)
 	int error;
 
 	zvol_taskq = taskq_create(ZVOL_DRIVER, zvol_threads, maxclsyspri,
-		                  zvol_threads, INT_MAX, TASKQ_PREPOPULATE);
+		                  zvol_threads, INT_MAX, TASKQ_PREPOPULATE | TASKQ_NORECLAIM);
 	if (zvol_taskq == NULL) {
 		printk(KERN_INFO "ZFS: taskq_create() failed\n");
 		return (-ENOMEM);


### PR DESCRIPTION
Previously, it was possible for the direct reclaim path to be invoked
when a write to a zvol was made. When a zvol is used as a swap device,
this often causes swap requests to depend on additional swap requests,
which deadlocks. We address this by disabling the direct reclaim path
on zvols.

This closes issue #342.
