### PR TITLE
Illumos #1946: incorrect formatting when listing output of multiple pool...

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -21,6 +21,9 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2011 by Delphix. All rights reserved.
+ * Copyright (c) 2012 by Frederik Wessels. All rights reserved.
  */
 
 #include <assert.h>
@@ -2206,7 +2209,8 @@ get_namewidth(zpool_handle_t *zhp, void *data)
 		if (!cb->cb_verbose)
 			cb->cb_namewidth = strlen(zpool_get_name(zhp));
 		else
-			cb->cb_namewidth = max_width(zhp, nvroot, 0, 0);
+			cb->cb_namewidth = max_width(zhp, nvroot, 0,
+			    cb->cb_namewidth);
 	}
 
 	/*


### PR DESCRIPTION
...s with zpool iostat -v

Reviewed by: Richard Elling richard.elling@richardelling.com
Reviewed by: Joshua M. Clulow josh@sysmgr.org
Approved by: Richard Lowe richlowe@richlowe.net

Reference to Illumos issue:
    https://www.illumos.org/issues/1946

Ported by: Richard Yao ryao@cs.stonybrook.edu
