### PR TITLE
ARCH=ARM changes

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -91,6 +91,10 @@ struct dk_map2  default_vtoc_map[NDKMAP] = {
 	{	V_BOOT,		V_UNMNT	},		/* i - 8 */
 	{	V_ALTSCTR,	0	},		/* j - 9 */
 
+#elif defined(__arm__) 
+
+	/* no boot on arm yet */ 
+
 #else
 #error No VTOC format defined.
 #endif			/* defined(i386) */

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -102,7 +102,18 @@ extern "C" {
 
 #define        _SUNOS_VTOC_16
 
-#else /* Currently only x86_64, i386, and powerpc arches supported */
+#elif defined(__arm) || defined(__arm__) 
+
+ 
+#if defined(__ARMEL__) 
+#define _LITTLE_ENDIAN 
+#else 
+#define _BIG_ENDIAN 
+#endif 
+ 
+#define        _SUNOS_VTOC_16 
+
+#else /* Currently only x86_64, i386, ARM, and powerpc arches supported */
 #error "Unsupported ISA type"
 #endif
 


### PR DESCRIPTION
Required changes for clean compile on ARM.

I ignored "boot" at the moment (Is that supported by other archs?) I only know uboot, and all work would need to go in there.

The final problem is the missing "64bit divide by 64bit";
"__aeabi_ldivmod" 
"__aeabi_uldivmod"

Missing from zcommon.ko, and zfs.ko. (splat.ko)

More specifically used in zcommon.o zprop_common.o zvol.o zpl_super.o zio.o zil.o zfs_replay.o zfs.o zap_leaf.o vdev_raidz.o vdev_mirror.o vdev.o spa_misc.o spa_history.o spa.o metaslab.o dsl_scan.o dsl_pool.o dsl_dir.o dsl_dataset.o dmu_zfetch.o dmu_traverse.o arc.o

One option is to use the assembler supplied by Google, here: http://codereview.chromium.org/5302007/
Add tests to autoconf for its absence, and include it in linking.

Another question is, does ZFS need 64/64 ? Usually 64/32 is sufficient, but I do not know enough to answer that.
