### PR TITLE
Fix build failures on PaX/GRSecurity patched kernels

### DIFF
--- a/config/kernel-evict-inode.m4
+++ b/config/kernel-evict-inode.m4
@@ -7,11 +7,11 @@ AC_DEFUN([ZFS_AC_KERNEL_EVICT_INODE], [
 	AC_MSG_CHECKING([whether sops->evict_inode() exists])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
-	],[
-		void (*evict_inode) (struct inode *) = NULL;
-		struct super_operations sops __attribute__ ((unused)) = {
+		void evict_inode (struct inode * t) { return; }
+		static struct super_operations sops __attribute__ ((unused)) = {
 			.evict_inode = evict_inode,
 		};
+	],[
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_EVICT_INODE, 1, [sops->evict_inode() exists])

--- a/config/kernel-fallocate.m4
+++ b/config/kernel-fallocate.m4
@@ -39,10 +39,31 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_FALLOCATE], [
 ])
 
 dnl #
+dnl # PaX Linux 2.6.38 - 3.x API
+dnl #
+AC_DEFUN([ZFS_AC_PAX_KERNEL_FILE_FALLOCATE], [
+	AC_MSG_CHECKING([whether fops->fallocate() exists])
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		long (*fallocate) (struct file *, int, loff_t, loff_t) = NULL;
+		struct file_operations_no_const fops __attribute__ ((unused)) = {
+			.fallocate = fallocate,
+		};
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_FILE_FALLOCATE, 1, [fops->fallocate() exists])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
 dnl # The fallocate callback was moved from the inode_operations
 dnl # structure to the file_operations structure.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_FALLOCATE], [
 	ZFS_AC_KERNEL_FILE_FALLOCATE
 	ZFS_AC_KERNEL_INODE_FALLOCATE
+	ZFS_AC_PAX_KERNEL_FILE_FALLOCATE
 ])

--- a/config/kernel-fsync.m4
+++ b/config/kernel-fsync.m4
@@ -37,7 +37,7 @@ AC_DEFUN([ZFS_AC_KERNEL_FSYNC_WITHOUT_DENTRY], [
 ])
 
 dnl #
-dnl # Linux 3.1 -x 3.x API
+dnl # Linux 3.1 - 3.x API
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_FSYNC_RANGE], [
 	ZFS_LINUX_TRY_COMPILE([
@@ -55,9 +55,69 @@ AC_DEFUN([ZFS_AC_KERNEL_FSYNC_RANGE], [
 	])
 ])
 
+dnl #
+dnl # PaX Linux 2.6.x - 2.6.34 API
+dnl #
+AC_DEFUN([ZFS_AC_PAX_KERNEL_FSYNC_WITH_DENTRY], [
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		int (*fsync) (struct file *, struct dentry *, int) = NULL;
+		file_operations_no_const fops __attribute__ ((unused));
+
+		fops.fsync = fsync;
+	],[
+		AC_MSG_RESULT([dentry])
+		AC_DEFINE(HAVE_FSYNC_WITH_DENTRY, 1,
+			[fops->fsync() with dentry])
+	],[
+	])
+])
+
+dnl #
+dnl # PaX Linux 2.6.35 - Linux 3.0 API
+dnl #
+AC_DEFUN([ZFS_AC_PAX_KERNEL_FSYNC_WITHOUT_DENTRY], [
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		int (*fsync) (struct file *, int) = NULL;
+		file_operations_no_const fops __attribute__ ((unused));
+
+		fops.fsync = fsync;
+	],[
+		AC_MSG_RESULT([no dentry])
+		AC_DEFINE(HAVE_FSYNC_WITHOUT_DENTRY, 1,
+			[fops->fsync() without dentry])
+	],[
+	])
+])
+
+dnl #
+dnl # PaX Linux 3.1 - 3.x API
+dnl #
+AC_DEFUN([ZFS_AC_PAX_KERNEL_FSYNC_RANGE], [
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		int (*fsync) (struct file *, loff_t, loff_t, int) = NULL;
+		file_operations_no_const fops __attribute__ ((unused));
+
+		fops.fsync = fsync;
+	],[
+		AC_MSG_RESULT([range])
+		AC_DEFINE(HAVE_FSYNC_RANGE, 1,
+			[fops->fsync() with range])
+	],[
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_FSYNC], [
 	AC_MSG_CHECKING([whether fops->fsync() wants])
 	ZFS_AC_KERNEL_FSYNC_WITH_DENTRY
 	ZFS_AC_KERNEL_FSYNC_WITHOUT_DENTRY
 	ZFS_AC_KERNEL_FSYNC_RANGE
+	ZFS_AC_PAX_KERNEL_FSYNC_WITH_DENTRY
+	ZFS_AC_PAX_KERNEL_FSYNC_WITHOUT_DENTRY
+	ZFS_AC_PAX_KERNEL_FSYNC_RANGE
 ])

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -165,7 +165,7 @@ typedef struct zfs_acl {
 	uint64_t	z_hints;	/* ACL hints (ZFS_INHERIT_ACE ...) */
 	zfs_acl_node_t	*z_curr_node;	/* current node iterator is handling */
 	list_t		z_acl;		/* chunks of ACE data */
-	acl_ops_t	z_ops;		/* ACL operations */
+	acl_ops_t	*z_ops;		/* ACL operations */
 } zfs_acl_t;
 
 typedef struct acl_locator_cb {

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -294,9 +294,8 @@ zpl_follow_link(struct dentry *dentry, struct nameidata *nd)
 static void
 zpl_put_link(struct dentry *dentry, struct nameidata *nd, void *ptr)
 {
-	char *link;
+	const char *link = nd_get_link(nd);
 
-	link = nd_get_link(nd);
 	if (!IS_ERR(link))
 		kmem_free(link, MAXPATHLEN);
 }


### PR DESCRIPTION
Gentoo Hardened kernels include the PaX/GRSecurity patches. They use a
dialect of C that relies on a GCC plugin. In particular, struct
file_operations has been marked do_const in the PaX/GRSecurity dialect,
which causes GCC to consider all instances of it as const. This caused
failures in the autotools checks and the ZFS source code.

To address this, we amend the autotools checks to utilize struct
file_operations_no_const and modify the ZFS source code to use memcpy(),
which avoids issues in the PaX/GRSecurity dialect.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
