### PR TITLE
Improve CONFIG_DEBUG_LOCK_ALLOC error message

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -374,8 +374,9 @@ AC_DEFUN([ZFS_AC_KERNEL_CONFIG_DEBUG_LOCK_ALLOC], [
 			AC_MSG_RESULT(yes)
 			AC_MSG_ERROR([
 	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
-	*** with the CDDL license.  You must rebuild your kernel without
-	*** this option enabled.])
+	*** with the CDDL license and will prevent the module linking stage
+	*** from succeeding.  You must rebuild your kernel without this
+	*** option enabled.])
 		])
 		EXTRA_KCFLAGS="$tmp_flags"
 	], [])

--- a/configure
+++ b/configure
@@ -12587,12 +12587,14 @@ sed 's/^/| /' conftest.$ac_ext >&5
 $as_echo "yes" >&6; }
 			{ { $as_echo "$as_me:$LINENO: error:
 	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
-	*** with the CDDL license.  You must rebuild your kernel without
-	*** this option enabled." >&5
+	*** with the CDDL license and will prevent the module linking stage
+	*** from succeeding.  You must rebuild your kernel without this
+	*** option enabled." >&5
 $as_echo "$as_me: error:
 	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
-	*** with the CDDL license.  You must rebuild your kernel without
-	*** this option enabled." >&2;}
+	*** with the CDDL license and will prevent the module linking stage
+	*** from succeeding.  You must rebuild your kernel without this
+	*** option enabled." >&2;}
    { (exit 1); exit 1; }; }
 
 
@@ -18680,12 +18682,14 @@ sed 's/^/| /' conftest.$ac_ext >&5
 $as_echo "yes" >&6; }
 			{ { $as_echo "$as_me:$LINENO: error:
 	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
-	*** with the CDDL license.  You must rebuild your kernel without
-	*** this option enabled." >&5
+	*** with the CDDL license and will prevent the module linking stage
+	*** from succeeding.  You must rebuild your kernel without this
+	*** option enabled." >&5
 $as_echo "$as_me: error:
 	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
-	*** with the CDDL license.  You must rebuild your kernel without
-	*** this option enabled." >&2;}
+	*** with the CDDL license and will prevent the module linking stage
+	*** from succeeding.  You must rebuild your kernel without this
+	*** option enabled." >&2;}
    { (exit 1); exit 1; }; }
 
 


### PR DESCRIPTION
The configure script error message for kernels built with
CONFIG_DEBUG_LOCK_ALLOC may give the impression that the issue is
strictly with license compliance.  To avoid confusion add some words
indicating that the linking stage will fail if the build continues.
