### PR TITLE
Honor logbias when writing to ZVOLs

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -479,7 +479,7 @@ zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx,
 		 * Unlike zfs_log_write() we can be called with
 		 * up to DMU_MAX_ACCESS/2 (5MB) writes.
 		 */
-		if (blocksize > zvol_immediate_write_sz && !slogging &&
+		if (blocksize > immediate_write_sz && !slogging &&
 		    size >= blocksize && offset % blocksize == 0) {
 			write_state = WR_INDIRECT; /* uses dmu_sync */
 			len = blocksize;


### PR DESCRIPTION
The logbias option is not taken into account when writing to ZVOLs. We fix that by using the same logic as in the zfs filesystem write code (see zfs_log.c).
