### PR TITLE
Fix for #724

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -30,6 +30,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <libzfs.h>
+#include <locale.h>
 #ifdef HAVE_LIBSELINUX
 #include <selinux/selinux.h>
 #endif /* HAVE_LIBSELINUX */


### PR DESCRIPTION
Trivial fix to avoid "undeclared LC_ALL" error when compiling with CFLAGS=-O0
Fixes #724
