### PR TITLE
Relicense zfs.gentoo.in from GPLv2 to 2-clause BSD

### DIFF
--- a/etc/init.d/zfs.gentoo.in
+++ b/etc/init.d/zfs.gentoo.in
@@ -1,6 +1,6 @@
 #!/sbin/runscript
 # Copyright 1999-2011 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
+# Released under the 2-clause BSD license.
 # $Header: /var/cvsroot/gentoo-x86/sys-fs/zfs/files/zfs,v 0.9 2011/04/30 10:13:43 devsk Exp $
 
 depend()


### PR DESCRIPTION
As the Gentoo sys-fs/zfs maintainer, I receive license compatibility
questions and at times, those questions can be harassing. I feel that
the presence of the GPL in Gentoo's package metadata promotes such
questions.  zfs.gentoo.in is the only GPLv2 licensed file in ZFS, so I
have taken the liberty of contacting all contributors to this file to
request permission to relicense it.

All of the contributors to this file have agreed to relicense it under
the 2-clause BSD license. I have added their Signed-offs to this commit,
in order of first contribution. Thankyou everyone for being so
understanding.

Signed-off-by: devsk devsku@gmail.com
Signed-off-by: Alexey Shvetsov alexxy@gentoo.org
Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Signed-off-by: Andrew Tselischev andrewtselischev@gmail.com
Signed-off-by: Zachary Bedell zac@thebedells.org
Signed-off-by: Gunnar Beutner gunnar@beutner.name
Signed-off-by: Kyle Fuller inbox@kylefuller.co.uk
Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
