### PR TITLE
Add 'Provides:' attributes for '-debug' packages

### DIFF
--- a/zfs-modules.spec.in
+++ b/zfs-modules.spec.in
@@ -420,6 +420,7 @@ which use %{name}.
 %package debug
 Summary:         ZFS File System (Debug)
 Group:           Utilities/System
+Provides:        %{name}
 Release:         %{rel_dbug}
 %if %{defined req_dbug}
 Requires:        %{req_dbug}
@@ -442,6 +443,7 @@ utilities for the %{name} file system.
 %package debug-devel
 Summary:         ZFS File System Headers and Symbols (Debug)
 Group:           Development/Libraries
+Provides:        %{name}-devel
 Release:         %{rel_dbug}
 %if %{defined devreq_dbug}
 Requires:        %{devreq_dbug}


### PR DESCRIPTION
The generated '-debug' packages do not set their "Provides" attribute,
causing failed dependencies for packages which depend on "zfs-modules"
or "zfs-modules-devel". For example, with only the zfs-modules-debug
package installed, installing the zfs package will fail its dependency
check because it needs "zfs-modules".

This patch fixes the problem by allowing the zfs-modules-debug and
zfs-modules-debug-devel packages to "Provide" zfs-modules and
zfs-modules-devel respectively.

Signed-off-by: Prakash Surya surya1@llnl.gov
