### PR TITLE
Fix NULL pointer dereference on PaX/GRSecurity patched Linux 3.3 and lat...

### DIFF
--- a/config/kernel-show-options.m4
+++ b/config/kernel-show-options.m4
@@ -6,11 +6,12 @@ AC_DEFUN([ZFS_AC_KERNEL_SHOW_OPTIONS], [
 
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
-	],[
-		int (*show_options) (struct seq_file *, struct dentry *) = NULL;
-		struct super_operations sops __attribute__ ((unused));
 
-		sops.show_options = show_options;
+		int show_options (struct seq_file * x, struct dentry * y) { return 0; };
+		static struct super_operations sops __attribute__ ((unused)) = {
+			.show_options = show_options,
+		};
+	],[
 	],[
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(HAVE_SHOW_OPTIONS_WITH_DENTRY, 1,


### PR DESCRIPTION
...er kernels

Support for PaX/GRSecurity patched kernels was developed against Linux
3.2.  Unfortunately, an autotools check introduced for a Linux 3.3 API
fails on PaX/GRSecurity patched kernels. This causes the module to be
built against the Linux 3.2 ABI, which results in a NULL pointer
dereference at runtime.

Closes zfsonlinux/zfs#794 and zfsonlinux/zfs#809

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
