### PR TITLE
Add missing dependencies to ./copy-builtin

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -61,6 +61,9 @@ cat > "$KERNEL_DIR/fs/zfs/Kconfig" <<"EOF"
 config ZFS
 	tristate "ZFS"
 	depends on SPL
+	depends on EFI_PARTITION
+	select ZLIB_INFLATE
+	select ZLIB_DEFLATE
 	help
 	  This is the ZFS filesystem from the ZFS On Linux project.
 


### PR DESCRIPTION
ZFS depends on EFI_PARTITION, ZLIB_DEFLATE and ZLIB_INFLATE, but when
ZFS is integrated with the kernel source tree, menuconfig does not
enforce these dependencies. This can cause build failures in the case of
ZLIB_DEFLATE and ZLIB_INFLATE where symbols are not found. This can also
cause runtime failures in the case of EFI_PARTITION, where the kernel
will not understand GPT partitions when creating pools from raw disks.
We solve this by making menuconfig aware of these dependencies.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
