### PR TITLE
Fix man page installation path

### DIFF
--- a/zfs.spec.in
+++ b/zfs.spec.in
@@ -5,6 +5,7 @@
 %define _prefix          /
 %define _libexecdir      /usr/libexec
 %define _datadir         /usr/share
+%define _mandir          %{_datadir}/man
 %define _includedir      /usr/include
 %define _udevdir         /lib/udev
 


### PR DESCRIPTION
RPM versions 4.8 and 4.9 differ in the definition of macro %_mandir:

$ rpm --version ; rpm --showrc | grep ^-14:._mandir
RPM version 4.9.0
-14: _mandir    %{_prefix}/share/man

$ rpm --version ; rpm --showrc | grep ^-14:._mandir
RPM version 4.8.0
-14: _mandir    /usr/share/man

zfs.spec.in defines %_prefix as /, so man pages end up getting
installed in /share/man on RPM 4.9 systems.  To fix this, define
%_mandir relative to %_datadir in the spec file.

Issue #353
