### PR TITLE
Fix snapshot automounting with GrSecurity constify plugin.

### DIFF
--- a/config/kernel-automount.m4
+++ b/config/kernel-automount.m4
@@ -9,11 +9,12 @@ AC_DEFUN([ZFS_AC_KERNEL_AUTOMOUNT], [
 	AC_MSG_CHECKING([whether dops->d_automount() exists])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/dcache.h>
-	],[
-		struct vfsmount *(*d_automount) (struct path *) = NULL;
+		struct vfsmount * d_automount(struct path *p){return NULL;}
 		struct dentry_operations dops __attribute__ ((unused)) = {
 			.d_automount = d_automount,
 		};
+
+	],[
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_AUTOMOUNT, 1, [dops->automount() exists])


### PR DESCRIPTION
./configure erroneously detects absence of dops->d_automount when built against a GrSecurity patched kernel.

Error message found in config.log:

configure:24349: checking whether dops->d_automount() exists
configure:24384: cp conftest.c build && make modules -C /mypool/vm/hardenedchroot/kernelsrc/withzfs/linux-3.4.7/ EXTRA_CFLAGS=-Werror-implicit-function-declaration -Werror  M=/mypool/vm/hardenedchroot/kernelsrc/withzfs/zfs/build modpost=true
/mypool/vm/hardenedchroot/kernelsrc/withzfs/zfs/build/conftest.c: In function 'main':
/mypool/vm/hardenedchroot/kernelsrc/withzfs/zfs/build/conftest.c:132:28: error: constified variable 'dops' cannot be local
make[1]: **\* [/mypool/vm/hardenedchroot/kernelsrc/withzfs/zfs/build/conftest.o] Error 1
make: **\* [_module_/mypool/vm/hardenedchroot/kernelsrc/withzfs/zfs/build] Error 2

The "dops" variable cannot be a local variable, so it's moved to the global scope.
