### PR TITLE
Check kernel source directory for SPL

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -302,6 +302,13 @@ AC_DEFUN([ZFS_AC_SPL], [
 			sourcelink=../spl
 		])
 
+		dnl #
+		dnl # Look in the kernel directory
+		dnl #
+		AS_IF([test -z "$sourcelink" || test ! -e $sourcelink/spl_config.h], [
+			sourcelink="$LINUX"
+		])
+
 		AS_IF([test -e $sourcelink/spl_config.h], [
 			splsrc=`readlink -f ${sourcelink}`
 		], [


### PR DESCRIPTION
ZFS fails to build when SPL is built into the kernel on unless
--with-spl=/path/to/kernel/sources is specified. We fallback to the
kernel sources directory when SPL is not found elsewhere to resolve
that.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
