### PR TITLE
Fix mount_zfs dependency on libzpool

### DIFF
--- a/cmd/mount_zfs/Makefile.am
+++ b/cmd/mount_zfs/Makefile.am
@@ -16,6 +16,7 @@ mount_zfs_SOURCES = \
 
 mount_zfs_LDADD = \
 	$(top_builddir)/lib/libuutil/libuutil.la \
+	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la
 
 mount_zfs_LDFLAGS = \


### PR DESCRIPTION
mount_zfs depends on libzpool for `zfs_prop_written` since 330d06f90d143b41b276796526a66a1c1fff046d. Unfortunately, the Makefile for mount_zfs has not been modified to reflect this. As a result, libtool doesn't know about the dependency, which may result in the wrong libzpool being used during the build (e.g. the libzpool from the system instead of the libzpool from the build directory).

This patch adds the dependency to fix the issue.

Fixes #909.
