### PR TITLE
Make ZFS filesystem id persistent across different machines

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -920,6 +920,7 @@ zfs_statvfs(struct dentry *dentry, struct kstatfs *statp)
 {
 	zfs_sb_t *zsb = dentry->d_sb->s_fs_info;
 	uint64_t refdbytes, availbytes, usedobjs, availobjs;
+	uint64_t fsid;
 	uint32_t bshift;
 
 	ZFS_ENTER(zsb);
@@ -927,6 +928,7 @@ zfs_statvfs(struct dentry *dentry, struct kstatfs *statp)
 	dmu_objset_space(zsb->z_os,
 	    &refdbytes, &availbytes, &usedobjs, &availobjs);
 
+	fsid = dmu_objset_fsid_guid(zsb->z_os);
 	/*
 	 * The underlying storage pool actually uses multiple block
 	 * size.  Under Solaris frsize (fragment size) is reported as
@@ -960,8 +962,8 @@ zfs_statvfs(struct dentry *dentry, struct kstatfs *statp)
 	 */
 	statp->f_ffree = MIN(availobjs, availbytes >> DNODE_SHIFT);
 	statp->f_files = statp->f_ffree + usedobjs;
-	statp->f_fsid.val[0] = dentry->d_sb->s_dev;
-	statp->f_fsid.val[1] = 0;
+	statp->f_fsid.val[0] = (uint32_t)fsid;
+	statp->f_fsid.val[1] = (uint32_t)(fsid >> 32);
 	statp->f_type = ZFS_SUPER_MAGIC;
 	statp->f_namelen = ZFS_MAXNAMELEN;
 


### PR DESCRIPTION
Use ZFS dataset fsid guid as a unique file system id, similar to what is
done on Illumos/OpenSolaris.

Issue #888

Signed-off-by: Cyril Plisko cyril.plisko@mountall.com
