### PR TITLE
Increase the stack space in userspace

### DIFF
--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -159,9 +159,14 @@ zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
 	 *
 	 * We reduce the default stack size in userspace, to ensure
 	 * we observe stack overruns in user space as well as in
-	 * kernel space.  PTHREAD_STACK_MIN is the minimum stack
-	 * required for a NULL procedure in user space and is added
-	 * in to the stack requirements.
+	 * kernel space. In practice we can't set the userspace stack
+	 * size to 8k because differences in stack usage between kernel
+	 * space and userspace could lead to spurious stack overflows
+	 * (especially when debugging is enabled). Nevertheless, we try
+	 * to set it to the lowest value that works (currently 8k*4).
+	 * PTHREAD_STACK_MIN is the minimum stack required for a NULL
+	 * procedure in user space and is added in to the stack
+	 * requirements.
 	 *
 	 * Some buggy NPTL threading implementations include the
 	 * guard area within the stack size allocations.  In
@@ -170,7 +175,7 @@ zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
 	 * on Linux.
 	 */
 
-	stack = PTHREAD_STACK_MIN + MAX(stksize, STACK_SIZE) +
+	stack = PTHREAD_STACK_MIN + MAX(stksize, STACK_SIZE) * 4 +
 			EXTRA_GUARD_BYTES;
 
 	VERIFY3S(pthread_attr_init(&attr), ==, 0);


### PR DESCRIPTION
In 1e33ac1e2677c898a0b5ef6207048c692cb51bf4, the maximum stack size for userspace tools was set to 8k to mimic the available kernel stack size.

Unfortunately, due to differences in how the stack is used in userspace vs kernel space, spurious stack overflows could occur in userspace tools due to the limited stack size. This is especially true in ztest when debugging is enabled.

This patch multiplies the userspace stack size by 4, which fixes the stack overflow issues. This comes at the price of not being able to catch stack size issues in userspace, but the previous solution proved unreliable anyway.

Fixes #934.
