### PR TITLE
Remove zvol device node

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3163,6 +3163,7 @@ zfs_ioc_destroy_snaps_nvl(zfs_cmd_t *zc)
 		}
 
 		(void) zfs_unmount_snap(name, NULL);
+		(void) zvol_remove_minor(name);
 	}
 
 	err = dmu_snapshots_destroy_nvl(nvl, zc->zc_defer_destroy,


### PR DESCRIPTION
The 'zfs destroy' changes in 330d06f disrupted how zvol devices
get removed on ZoL.  However, it basically boils down to the
fact that we are no longer reliably calling zvol_remove_minor()
via zfs_ioc_destroy_snaps().

Therefore we add the missing call and handle things similarly
to the existing zfs_unmount_snap() case.  Ideally we would check
if this is of type DMU_OST_ZFS or DMU_OST_ZVOL and just do the
right thing as in zfs_ioc_destroy().  However, it looks like
it would be fairly expensive to get the type, and it's harmless
to simply attempt the umount and minor removal.

It's not exactly clear to me why this wasn't an issue for the
upstream Illumos code.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #903
