### PR TITLE
Silence "setting dataset to sync always" message in ztest

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -2923,7 +2923,8 @@ ztest_dataset_create(char *dsname)
 	if (err || zilset < 80)
 		return (err);
 
-	(void) printf("Setting dataset %s to sync always\n", dsname);
+	if (zopt_verbose >= 5)
+		(void) printf("Setting dataset %s to sync always\n", dsname);
 	return (ztest_dsl_prop_set_uint64(dsname, ZFS_PROP_SYNC,
 	    ZFS_SYNC_ALWAYS, B_FALSE));
 }


### PR DESCRIPTION
ztest outputs a message when testing `sync=always` no matter what the verbosity level is. There is no point outputting this message for low verbosity levels.

With this patch the message is only displayed at verbosity level 5 or above. The result is less output pollution.
