### PR TITLE
Fix zdb printf format string for ZIL data blocks

### DIFF
--- a/cmd/zdb/zdb_il.c
+++ b/cmd/zdb/zdb_il.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2012 Cyril Plisko. All rights reserved.
  * Use is subject to license terms.
  */
 
@@ -172,7 +173,7 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		if (isprint(*data))
 			(void) printf("%c ", *data);
 		else
-			(void) printf("%2X", *data);
+			(void) printf("%2hhX", *data);
 		data++;
 	}
 	(void) printf("\n");


### PR DESCRIPTION
Without this fix the zdb printouts of ZIL data blocks look full of FF
due to printf() handling its arguments as int by default.

Here is the output before the fix

```
            TX_WRITE            len   4136, txg 1093817, seq 149231
                    foid 4242, offset 0, length f68
                    G FFFFFF8EFFFFFF87FFFFFF91FFFFFFCC 1c
```

FFFFFFAFFFFFFFC9FFFFFFBAZ FFFFFFC3

And the same after the fix

```
            TX_WRITE            len   4136, txg 1093817, seq 149231
                    foid 4242, offset 0, length f68
                    G 8E8791CC 1cAFC9BAZ C3
```
