### PR TITLE
Force 4K blocksize when testing ext2 on zvol

### DIFF
--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -342,7 +342,9 @@ format() {
 	local DEVICE=$1
 	local FSTYPE=$2
 
-	/sbin/mkfs.${FSTYPE} -q ${DEVICE} || return 1
+	# Force 4K blocksize, else mkfs.ext2 tries to use 8K, which
+	# won't mount
+	/sbin/mkfs.${FSTYPE} -b 4096 -F -q ${DEVICE} || return 1
 
 	return 0
 }


### PR DESCRIPTION
Currently, mkfs.ext2 on zconfig.sh zvols tries to use a 8K blocksize, probably because by default zvol exposes an optimal I/O size of 8K.

Unfortunately, a ext2 blocksize of 8K is not supported by the kernel, so the resulting filesystem is unmountable.

This patch fixes the issue by making sure the blocksize is 4K. We have to use -F to force it else mkfs.ext2 won't allow us to use a blocksize smaller than the optimal I/O size.
