### PR TITLE
Fix VOP_CLOSE() in userspace

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -495,7 +495,7 @@ typedef struct vsecattr {
 
 extern int fop_getattr(vnode_t *vp, vattr_t *vap);
 
-#define	VOP_CLOSE(vp, f, c, o, cr, ct)	0
+#define	VOP_CLOSE(vp, f, c, o, cr, ct)	vn_close(vp)
 #define	VOP_PUTPAGE(vp, of, sz, fl, cr, ct)	0
 #define	VOP_GETATTR(vp, vap, fl, cr, ct)  fop_getattr((vp), (vap));
 


### PR DESCRIPTION
Currently, for unknown reasons, `VOP_CLOSE()` is a no-op in userspace. This causes file descriptor leaks. This is especially problematic with long ztest runs, since zpool.cache is opened repeatedly and never closed, resulting in resource exhaustion (`EMFILE` errors).

This patch fixes the issue by making `VOP_CLOSE()` do what it is supposed to do.

See issue #989.
