### PR TITLE
Fix ztest vdev file paths

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -4999,7 +4999,7 @@ ztest_run_zdb(char *pool)
 
 	fp = popen(zdb, "r");
 
-	while (fgets(zbuf, sizeof (zbuf), fp) != NULL)
+	while (fgets(zbuf, 1024, fp) != NULL)
 		if (zopt_verbose >= 3)
 			(void) printf("%s", zbuf);
 


### PR DESCRIPTION
Currently, in several instances (but not all), ztest generates vdev file paths using a statement similar to this:

```
snprintf(path, sizeof (path), ztest_dev_template, ...);
```

This worked fine until 40b84e7aec6392187722e61e5a4a853b530bf60f, which changed `path` to be a pointer to the heap instead of an array allocated on the stack. Before this change, `sizeof(path)` would return the size of the array; now, it returns the size of the pointer instead.

As a result, the aforementioned `sprintf` statement uses the wrong size and truncates the vdev file path to the first 4 or 8 bytes (depending on the architecture). Typically, with default settings, the file path will become `/tmp/zt` instead of `/test/ztest.XXX`.

This issue only exists in `ztest_vdev_attach_detach()` and `ztest_fault_inject()`, which explains why ztest doesn't fail right away.
