### PR TITLE
Switch KM_SLEEP to KM_PUSHPAGE

### DIFF
--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -62,7 +62,7 @@ ddt_zap_lookup(objset_t *os, uint64_t object, ddt_entry_t *dde)
 	uint64_t one, csize;
 	int error;
 
-	cbuf = kmem_alloc(sizeof (dde->dde_phys) + 1, KM_SLEEP);
+	cbuf = kmem_alloc(sizeof (dde->dde_phys) + 1, KM_PUSHPAGE);
 
 	error = zap_length_uint64(os, object, (uint64_t *)&dde->dde_key,
 	    DDT_KEY_WORDS, &one, &csize);


### PR DESCRIPTION
This warning indicates the incorrect use of KM_SLEEP in a call
path which must use KM_PUSHPAGE to avoid deadlocking in direct
reclaim.  See commit b8d06fc for additional details.

  SPL: Fixing allocation for task txg_sync (6093) which
  used GFP flags 0x297bda7c with PF_NOFS set

Signed-off-by: Chris Dunlop chris@onthe.net.au
