### PR TITLE
Fix zfs_write_limit_max integer size mismatch on 32-bit systems

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -148,7 +148,7 @@ static kcondvar_t	arc_reclaim_thr_cv;	/* used to signal reclaim thr */
 static uint8_t		arc_thread_exit;
 
 extern int zfs_write_limit_shift;
-extern uint64_t zfs_write_limit_max;
+extern unsigned long zfs_write_limit_max;
 extern kmutex_t zfs_write_limit_lock;
 
 /* number of bytes to prune from caches when at arc_meta_limit is reached */


### PR DESCRIPTION
Commit c409e4647f221ab724a0bd10c480ac95447203c3 introduced a number of
module parameters. Of these, ARC unconditionally expected
zfs_write_limit_max to be 64-bit. Unfortunately, the largest size
integer module parameter that Linux supports is unsigned
long, which varies in size depending on the host system's native word
size. The effect was that on 32-bit systems, ARC incorrectly performed
64-bit operations on a 32-bit value by reading the neighboring 32 bits
as the upper 32 bits of the 64-bit value. We correct that by changing
the extern declaration to use the unsigned long type. This should make
ARC correctly treat zfs_write_limit_max as a 32-bit value on 32-bit
systems.

Closes zfsonlinux/zfs#749

Reported-by: Jorgen Lundman lundman@lundman.net
Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
