### PR TITLE
Fix for scripts/common.sh.in not to return a non loop device. 

### DIFF
--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -263,7 +263,7 @@ check_loop_utils() {
 # Find and return an unused loopback device.
 #
 unused_loop_device() {
-	for DEVICE in `ls -1 /dev/loop* 2>/dev/null`; do
+	for DEVICE in `ls -1 /dev/loop[0-9]* 2>/dev/null`; do
 		${LOSETUP} ${DEVICE} &>/dev/null
 		if [ $? -ne 0 ]; then
 			echo ${DEVICE}


### PR DESCRIPTION
This fixes Issue #797 so that zconfig.sh -c runs cleanly on an Ubuntu box (and I assume Debian)

The function unused_loop_device in /usr/libexec/zfs/common.sh returns
/dev/loop-control on the first call. This device is NOT a loop device (see
http://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=commitdiff;h=770fe30a46a12b6fb6b63fbe1737654d28e84844)
but rather a control device. This in turn causes the script zconfig.sh to fail with:

zpool-create.sh: Error 1 creating /tmp/zpool-vdev0 -> /dev/loop-control loopback

The patch makes the function return /dev/loop[0-9]\* which are loop devices
