### PR TITLE
Return positive error number in zfsctl_shares_lookup.

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -952,7 +952,7 @@ zfsctl_shares_lookup(struct inode *dip, char *name, struct inode **ipp,
 
 	if (zsb->z_shares_dir == 0) {
 		ZFS_EXIT(zsb);
-		return (-ENOTSUP);
+		return (ENOTSUP);
 	}
 
 	error = zfs_zget(zsb, zsb->z_shares_dir, &dzp);


### PR DESCRIPTION
Otherwise it will cause zpl_shares_lookup to return a invalid pointer
when an error occurs.
