### PR TITLE
Allow 'zpool replace' to use short device names

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -54,22 +54,11 @@ extern "C" {
 /*
  * Default device paths
  */
+#define	DISK_ROOT		"/dev"
+#define	UDISK_ROOT		"/dev/disk"
 
-#if defined(__sun__) || defined(__sun)
-#define	DISK_ROOT	"/dev/dsk"
-#define	RDISK_ROOT	"/dev/rdsk"
-#define	UDISK_ROOT	RDISK_ROOT
-#define	FIRST_SLICE	"s0"
-#define	BACKUP_SLICE	"s2"
-#endif
-
-#ifdef __linux__
-#define	DISK_ROOT	"/dev"
-#define	RDISK_ROOT	DISK_ROOT
-#define	UDISK_ROOT	"/dev/disk"
-#define	FIRST_SLICE	"1"
-#define	BACKUP_SLICE	""
-#endif
+#define	DEFAULT_IMPORT_PATH_SIZE	8
+extern char *zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE];
 
 /*
  * libzfs errors
@@ -658,8 +647,9 @@ extern zfs_handle_t *zfs_path_to_zhandle(libzfs_handle_t *, char *, zfs_type_t);
 extern boolean_t zfs_dataset_exists(libzfs_handle_t *, const char *,
     zfs_type_t);
 extern int zfs_spa_version(zfs_handle_t *, int *);
-extern void zfs_append_partition(const char *path, char *buf, size_t buflen);
+extern int zfs_append_partition(char *path, size_t max_len);
 extern int zfs_resolve_shortname(const char *name, char *path, size_t pathlen);
+extern int zfs_strcmp_pathname(char *name, char *cmp_name, int wholedisk);
 
 /*
  * Mount support functions.

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -984,9 +984,7 @@ err_blkid1:
 }
 #endif /* HAVE_LIBBLKID */
 
-#define DEFAULT_IMPORT_PATH_SIZE	8
-
-static char *
+char *
 zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
 	"/dev/disk/by-vdev",	/* Custom rules, use first if they exist */
 	"/dev/disk/zpool",	/* Custom rules, use first if they exist */

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -800,56 +800,165 @@ zfs_path_to_zhandle(libzfs_handle_t *hdl, char *path, zfs_type_t argtype)
 }
 
 /*
- * Given a shorthand device name, check if a file by that name exists in a list
- * of directories under /dev.  If one is found, store its full path in the
- * buffer pointed to by the path argument and return 0, else return -1.  The
- * path buffer must be allocated by the caller.
+ * Append partition suffix to an otherwise fully qualified device path.
+ * This is used to generate the name the full path as its stored in
+ * ZPOOL_CONFIG_PATH for whole disk devices.  On success the new length
+ * of 'path' will be returned on error a negative value is returned.
  */
 int
-zfs_resolve_shortname(const char *name, char *path, size_t pathlen)
+zfs_append_partition(char *path, size_t max_len)
 {
-	int i, err;
-	char dirs[6][9] = {"by-id", "by-label", "by-path", "by-uuid", "zpool",
-			   "by-vdev"};
+	int len = strlen(path);
 
-	/* /dev/ */
-	(void) snprintf(path, pathlen, "%s/%s", DISK_ROOT, name);
-	err = access(path, F_OK);
-	if (err == 0)
-		return (err);
+	if (strncmp(path, UDISK_ROOT, strlen(UDISK_ROOT)) == 0) {
+		if (len + 6 >= max_len)
+			return (-1);
 
-	/* /dev/mapper/ */
-	(void) snprintf(path, pathlen, "%s/mapper/%s", DISK_ROOT, name);
-	err = access(path, F_OK);
-	if (err == 0)
-		return (err);
+		(void) strcat(path, "-part1");
+		len += 6;
+	} else {
+		if (len + 2 >= max_len)
+			return (-1);
 
-	/* /dev/disk/<dirs>/ */
-	for (i = 0; i < 6 && err < 0; i++) {
-		(void) snprintf(path, pathlen, "%s/%s/%s",
-		    UDISK_ROOT, dirs[i], name);
-		err = access(path, F_OK);
+		if (isdigit(path[len-1])) {
+			(void) strcat(path, "p1");
+			len += 2;
+		} else {
+			(void) strcat(path, "1");
+			len += 1;
+		}
 	}
 
-	return (err);
+	return (len);
 }
 
 /*
- * Append partition suffix to a device path.  This should be used to generate
- * the name of a whole disk as it is stored in the vdev label.  The
- * user-visible names of whole disks do not contain the partition information.
- * Modifies buf which must be allocated by the caller.
+ * Given a shorthand device name check if a file by that name exists in any
+ * of the 'zpool_default_import_path' or ZPOOL_IMPORT_PATH directories.  If
+ * one is found, store its fully qualified path in the 'path' buffer passed
+ * by the caller and return 0, otherwise return an error.
  */
-void
-zfs_append_partition(const char *path, char *buf, size_t buflen)
+int
+zfs_resolve_shortname(const char *name, char *path, size_t len)
 {
-	if (strncmp(path, UDISK_ROOT, strlen(UDISK_ROOT)) == 0)
-		(void) snprintf(buf, buflen, "%s%s%s", path, "-part",
-			FIRST_SLICE);
-	else
-		(void) snprintf(buf, buflen, "%s%s%s", path,
-			isdigit(path[strlen(path)-1]) ?  "p" : "",
-			FIRST_SLICE);
+	int i, error = -1;
+	char *dir, *env, *envdup;
+
+	env = getenv("ZPOOL_IMPORT_PATH");
+	errno = ENOENT;
+
+	if (env) {
+		envdup = strdup(env);
+		dir = strtok(envdup, ":");
+		while (dir && error) {
+			(void) snprintf(path, len, "%s/%s", dir, name);
+			error = access(path, F_OK);
+			dir = strtok(NULL, ":");
+		}
+		free(envdup);
+	} else {
+		for (i = 0; i < DEFAULT_IMPORT_PATH_SIZE && error < 0; i++) {
+			(void) snprintf(path, len, "%s/%s",
+			    zpool_default_import_path[i], name);
+			error = access(path, F_OK);
+		}
+	}
+
+	return (error ? ENOENT : 0);
+}
+
+/*
+ * Given a shorthand device name look for a match against 'cmp_name'.  This
+ * is done by checking all prefix expansions using either the default
+ * 'zpool_default_import_paths' or the ZPOOL_IMPORT_PATH environment
+ * variable.  Proper partition suffixes will be appended if this is a
+ * whole disk.  When a match is found 0 is returned otherwise ENOENT.
+ */
+static int
+zfs_strcmp_shortname(char *name, char *cmp_name, int wholedisk)
+{
+	int path_len, cmp_len, i = 0, error = ENOENT;
+	char *dir, *env, *envdup = NULL;
+	char path_name[MAXPATHLEN];
+
+	cmp_len = strlen(cmp_name);
+	env = getenv("ZPOOL_IMPORT_PATH");
+
+	if (env) {
+		envdup = strdup(env);
+		dir = strtok(envdup, ":");
+	} else {
+		dir =  zpool_default_import_path[i];
+	}
+
+	while (dir) {
+		/* Trim trailing directory slashes from ZPOOL_IMPORT_PATH */
+		while (dir[strlen(dir)-1] == '/')
+			dir[strlen(dir)-1] = '\0';
+
+		path_len = snprintf(path_name, MAXPATHLEN, "%s/%s", dir, name);
+		if (wholedisk)
+			path_len = zfs_append_partition(path_name, MAXPATHLEN);
+
+		if ((path_len == cmp_len) && !strcmp(path_name, cmp_name)) {
+			error = 0;
+			break;
+		}
+
+		if (env) {
+			dir = strtok(NULL, ":");
+		} else if (++i < DEFAULT_IMPORT_PATH_SIZE) {
+			dir = zpool_default_import_path[i];
+		} else {
+			dir = NULL;
+		}
+	}
+
+	if (env)
+		free(envdup);
+
+	return (error);
+}
+
+/*
+ * Given either a shorthand or fully qualified path name look for a match
+ * against 'cmp'.  The passed name will be expanded as needed for comparison
+ * purposes and redundant slashes stripped to ensure an accurate match.
+ */
+int
+zfs_strcmp_pathname(char *name, char *cmp, int wholedisk)
+{
+	int path_len, cmp_len;
+	char path_name[MAXPATHLEN];
+	char cmp_name[MAXPATHLEN];
+	char *dir;
+
+	/* Strip redundant slashes if one exists due to ZPOOL_IMPORT_PATH */
+	memset(cmp_name, 0, MAXPATHLEN);
+	dir = strtok(cmp, "/");
+	while (dir) {
+		strcat(cmp_name, "/");
+		strcat(cmp_name, dir);
+		dir = strtok(NULL, "/");
+	}
+
+	if (name[0] != '/')
+		return zfs_strcmp_shortname(name, cmp_name, wholedisk);
+
+	strncpy(path_name, name, MAXPATHLEN);
+	path_len = strlen(path_name);
+	cmp_len = strlen(cmp_name);
+
+	if (wholedisk) {
+		path_len = zfs_append_partition(path_name, MAXPATHLEN);
+		if (path_len == -1)
+			return (ENOMEM);
+	}
+
+	if ((path_len != cmp_len) || strcmp(path_name, cmp_name))
+		return (ENOENT);
+
+	return (0);
 }
 
 /*


### PR DESCRIPTION
The 'zpool replace' command would fail when given a short name
because unlike on other platforms the short name cannot be
deterministically expanded to a single path.  Multiple path
prefixes must be checked and in addition the partition suffix
for whole disks is determined by the prefix.

To handle this complexity a zfs_strcmp_pathname() function was
added which takes either a short or fully qualified device name.
Short names will be expanded using the prefixes in the default
import search path, or the ZPOOL_IMPORT_PATH environment variable
if it's defined.  All posible expansions are then compared against
the comparison path.  Care is taken to strip redundant slashes to
ensure legitimate matches are not missed.

In the context of this work the existing zfs_resolve_shortname()
function was extended to consider the ZPOOL_IMPORT_PATH when set.
The zfs_append_partition() interface was also simplified to take
only a single buffer.

The vast majority of these changes rework existing Linux specific
code which was originally written to accomidate udev.  However,
there is some minimal cleanup which removes Illumos specific code.
This was done to improve readability but the basic flow and intent
of the upstream code was maintained.

These changes are the logical conclusion of the previos work to
adjust the 'zpool import' search behavior, see commit 44867b6a.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #544
Issue #976
