### PR TITLE
Update spare and cache device names on import

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1144,14 +1144,15 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 
 			if (config != NULL) {
 				boolean_t matched = B_TRUE;
+				char *pname;
 
-				if (iarg->poolname != NULL) {
-					char *pname;
+				if ((iarg->poolname != NULL) &&
+				    (nvlist_lookup_string(config,
+				    ZPOOL_CONFIG_POOL_NAME, &pname) == 0)) {
 
-					matched = nvlist_lookup_string(config,
-					    ZPOOL_CONFIG_POOL_NAME,
-					    &pname) == 0 &&
-					    strcmp(iarg->poolname, pname) == 0;
+					if (strcmp(iarg->poolname, pname))
+					       matched = B_FALSE;
+
 				} else if (iarg->guid != 0) {
 					uint64_t this_guid;
 


### PR DESCRIPTION
During 'zpool import' all ZPOOL_CONFIG_PATH names are supposed
to be updated by fix_paths().  This was not happening for spare
and cache devices because the proper names were getting filtered
out of the pool_list_t->names.  Interestingly, the names were
being filtered because the spare and cache devices do not
contain the pool name in their vdev label.

The fix is to exclude the device path from the list only if:

  1) has a valid ZPOOL_CONFIG_POOL_NAME key in the label, and
  2) that pool name does not match the specified pool name.

Since the label is valid and because it does properly store the
vdev guid it will be correctly assembled without the pool name.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #725
