### PR TITLE
Fix hard coded path in 60-vdev.rules.in

### DIFF
--- a/udev/rules.d/60-vdev.rules.in
+++ b/udev/rules.d/60-vdev.rules.in
@@ -2,7 +2,7 @@
 # /lib/udev/rules.d/60-vdev.rules
 #
 
-ENV{DEVTYPE}=="disk", IMPORT{program}="/lib/udev/vdev_id -d %k"
+ENV{DEVTYPE}=="disk", IMPORT{program}="@udevdir@/vdev_id -d %k"
 
 KERNEL=="*[!0-9]", ENV{SUBSYSTEM}=="block", ENV{ID_VDEV}=="?*", SYMLINK+="$env{ID_VDEV_PATH}"
 KERNEL=="*[0-9]", ENV{SUBSYSTEM}=="block", ENV{DEVTYPE}=="partition", ENV{ID_VDEV}=="?*", SYMLINK+="$env{ID_VDEV_PATH}-part%n"


### PR DESCRIPTION
The udev data directory was hard coded in 60-vdev.rules.in. That causes
a problem when a distribution changes the location of the directory.
This was not an issue in the past because virtually all distributions
used the same path, but that is beginning to change following a decision
by the systemd developers to change the directory location to reflect
their take-over of udev maintainership. The testing branch of Gentoo
Linux adopted this change, which enabled the hardcoded directory
location to trigger a regression.

Closes zfsonlinux/zfs#1085

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
