### PR TITLE
Update mtime when mmap'ed pages become writable

### DIFF
--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -52,6 +52,7 @@ extern long zpl_fallocate_common(struct inode *ip, int mode,
 extern const struct address_space_operations zpl_address_space_operations;
 extern const struct file_operations zpl_file_operations;
 extern const struct file_operations zpl_dir_file_operations;
+extern const struct vm_operations_struct zpl_file_vm_ops;
 
 /* zpl_super.c */
 extern void zpl_prune_sbs(int64_t bytes_to_scan, void *private);


### PR DESCRIPTION
GNU Tar is sensitive to situations where mtimes on open files are
updated to times in the past.

When doing write operations on mmap'ed files, the modification time update
presently occurs during a flush. Observant programs that open such files
shortly after they are closed will observe that modification times
appear to occur in the past. This caused a failure that was observed
during binary package generation on Gentoo where PaX-marking is done on
certain files via mmap almost immediately prior to package generation,
which relies on GNU tar. It can be replicated with a Hello World program
by doing:

gcc hello.c && scanelf -Xxz -r a.out && tar -cf hello.tgz a.out

Brian Behlendorf suggested that we could prevent this by doing mtime
updates in the kernel's page_mkwrite() callback function, which is
invoked whenever a page becomes writeable. We implement that by
replacing the page_mkwrite function with a wrapper function that invokes
zfs_inode_update() after invoking the kernel's generic page_mkwrite. It
would be better to do an mtime update and flush on each close()
operation done from userland on a dirty file, but unfortunately, the
Linux kernel provides us with no way to do that.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
