### PR TITLE
Switch KM_SLEEP to KM_PUSHPAGE

### DIFF
--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -253,7 +253,7 @@ zfs_range_new_proxy(avl_tree_t *tree, uint64_t off, uint64_t len)
 	rl_t *rl;
 
 	ASSERT(len);
-	rl = kmem_alloc(sizeof (rl_t), KM_SLEEP);
+	rl = kmem_alloc(sizeof (rl_t), KM_PUSHPAGE);
 	rl->r_off = off;
 	rl->r_len = len;
 	rl->r_cnt = 1;


### PR DESCRIPTION
When writes to zvols invoke ZIL, zfs_range_new_proxy() is called, which
allocates memory using KM_SLEEP, triggering a warning. Switch to
KM_PUSHPAGE to silence that warning.

Closes zfsonlinux/zfs#1023
Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
