### PR TITLE
Do not use KERNEL_DIR environment variable in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,13 +3,13 @@ include $(top_srcdir)/config/deb.am
 include $(top_srcdir)/config/tgz.am
 include $(top_srcdir)/config/arch.am
 
+SUBDIRS = include
 if CONFIG_USER
-USER_DIR = dracut udev etc man scripts lib cmd
+SUBDIRS += dracut udev etc man scripts lib cmd
 endif
 if CONFIG_KERNEL
-KERNEL_DIR = module
+SUBDIRS += module
 endif
-SUBDIRS = $(USER_DIR) $(KERNEL_DIR) include
 
 AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST  = autogen.sh zfs.spec.in zfs-modules.spec.in


### PR DESCRIPTION
A Gentoo user reported an issue where the build system would attempt to
recurse into the kernel source tree if KERNEL_DIR is set in the
environment. KERNEL_DIR is an environment variable that is used when the
kernel sources are in a non-standard location, so it is necessary to stop
relying on it to prevent this issue.

https://bugs.gentoo.org/show_bug.cgi?id=433946

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
