### PR TITLE
Enable setting/getting users/groups in quota properties through numeric identifier

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -2532,29 +2532,29 @@ userquota_propname_decode(const char *propname, boolean_t zoned,
 		return (ENOSYS);
 #endif /* HAVE_IDMAP */
 	} else {
-#ifdef HAVE_IDMAP
 		/* It's a user/group ID (eg "12345"). */
 		uid_t id;
-		idmap_rid_t rid;
-		char *mapdomain;
 		char *end;
-
 		id = strtoul(cp, &end, 10);
 		if (*end != '\0')
 			return (EINVAL);
 		if (id > MAXUID) {
+#ifdef HAVE_IDMAP
 			/* It's an ephemeral ID. */
+			idmap_rid_t rid;
+			char *mapdomain;
+
 			if (idmap_id_to_numeric_domain_rid(id, isuser,
 			    &mapdomain, &rid) != 0)
 				return (ENOENT);
 			(void) strlcpy(domain, mapdomain, domainlen);
 			*ridp = rid;
+#else
+			return (ENOSYS);
+#endif /* HAVE_IDMAP */
 		} else {
 			*ridp = id;
 		}
-#else
-		return (ENOSYS);
-#endif /* HAVE_IDMAP */
 	}
 
 	return (0);


### PR DESCRIPTION
Obtained by moving #ifdef HAVE_IDMAP to exclude only the part of code that really needs IDMAP.
Now zfs (get|set) (user|group)quota@1000 works as expected.

Issue #1147
