### PR TITLE
Change fsync(2) optimization to per-file

### DIFF
--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -150,8 +150,6 @@ typedef struct zfid_long {
 #define	SHORT_FID_LEN	(sizeof (zfid_short_t) - sizeof (uint16_t))
 #define	LONG_FID_LEN	(sizeof (zfid_long_t) - sizeof (uint16_t))
 
-extern uint_t zfs_fsyncer_key;
-
 extern int zfs_suspend_fs(zfs_sb_t *zsb);
 extern int zfs_resume_fs(zfs_sb_t *zsb, const char *osname);
 extern int zfs_userspace_one(zfs_sb_t *zsb, zfs_userquota_prop_t type,

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -205,6 +205,7 @@ typedef struct znode {
 	uint64_t	z_gid;		/* gid fuid (cached) */
 	mode_t		z_mode;		/* mode (cached) */
 	uint32_t	z_sync_cnt;	/* synchronous open count */
+	uint32_t	z_fsync_cnt;	/* synchronous fsync count */
 	kmutex_t	z_acl_lock;	/* acl data lock */
 	zfs_acl_t	*z_acl_cached;	/* cached acl */
 	krwlock_t	z_xattr_lock;	/* xattr data lock */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -193,6 +193,7 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_gid = 0;
 	zp->z_mode = 0;
 	zp->z_sync_cnt = 0;
+	zp->z_fsync_cnt = 0;
 	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_TRUE;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5187,7 +5187,6 @@ zfs_detach(void)
 	list_destroy(&zfsdev_state_list);
 }
 
-uint_t zfs_fsyncer_key;
 extern uint_t rrw_tsd_key;
 
 #ifdef DEBUG
@@ -5210,7 +5209,6 @@ _init(void)
 	if ((error = zfs_attach()) != 0)
 		goto out2;
 
-	tsd_create(&zfs_fsyncer_key, NULL);
 	tsd_create(&rrw_tsd_key, NULL);
 
 	printk(KERN_NOTICE "ZFS: Loaded module v%s-%s%s, "
@@ -5240,7 +5238,6 @@ _fini(void)
 	zfs_fini();
 	spa_fini();
 
-	tsd_destroy(&zfs_fsyncer_key);
 	tsd_destroy(&rrw_tsd_key);
 
 	printk(KERN_NOTICE "ZFS: Unloaded module v%s-%s%s\n",

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -475,9 +475,8 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	else
 		write_state = WR_NEED_COPY;
 
-	if ((fsync_cnt = (uintptr_t)tsd_get(zfs_fsyncer_key)) != 0) {
-		(void) tsd_set(zfs_fsyncer_key, (void *)(fsync_cnt - 1));
-	}
+	if ((fsync_cnt = zp->z_fsync_cnt) != 0)
+		zp->z_fsync_cnt--;
 
 	while (resid) {
 		itx_t *itx;

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -376,6 +376,7 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 	zp->z_blksz = blksz;
 	zp->z_seq = 0x7A4653;
 	zp->z_sync_cnt = 0;
+	zp->z_fsync_cnt = 0;
 	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_FALSE;


### PR DESCRIPTION
The zfs_fsyncer_key TSD was added as a performance optimization
to reduce contention on the zl_lock from zil_commit().  This
issue manifested itself as very long (100+ms) system call
times for fsync(2) heavy workloads.

However, we'd like to eliminate the usage of TSD in ZoL while
keeping this optimization.  There is no native Linux kernel
equivilant of TSD and the SPLs implementation is primitive.
It would simply be best to remove all the TSD consumers.

To achieve this the zfs_fsyncer_key TSD counter has been
reworked to be per-file instead of per-thread.  This is not
expected to behave significantly differently than the original
implementation for real workloads.

This just leaves one small ZFS TSD consumer.  If it can be
cleanly removed from the code we'll be able to shed the SPL
TSD implementation entirely.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/spl#174
