### PR TITLE
mount.zfs needs to allow fake mounts to succeed

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -474,7 +474,7 @@ main(int argc, char **argv)
 		return (MOUNT_USAGE);
 	}
 
-	if (!zfsutil && strcmp(legacy, ZFS_MOUNTPOINT_LEGACY) && !remount) {
+	if (!zfsutil && strcmp(legacy, ZFS_MOUNTPOINT_LEGACY) && ! (remount || fake) ) {
 		(void) fprintf(stderr, gettext(
 		    "filesystem '%s' cannot be mounted using 'mount'.\n"
 		    "Use 'zfs set mountpoint=%s' or 'zfs mount %s'.\n"


### PR DESCRIPTION
When using mountall to mount ZFS root's, it will attempt to invoke something like `mount -f -t zfs -o defaults ssdpool/ROOT/mint-13 /` for the root filesystem (which has already been mounted by the initramfs).

This currently fails with mount.zfs, because the zfsutil logic does not allow a fake mount request to succeed (unless it's passed with zfsutil), although it does allow a `-o remount` request to succeed in the same way.

Since fake mounts seem to be an accepted behavior (I really don't know), it seems like they should be allowed to succeed in the same manner so utilities like mountall will work with them.

I've got a rough (untested) commit for what needs to change here: 0f8d8f34633c902909f8fc11d16f3f14e3ebbe14
