### PR TITLE
use io_schedule() for zio

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -322,6 +322,7 @@ extern void cv_signal(kcondvar_t *cv);
 extern void cv_broadcast(kcondvar_t *cv);
 #define cv_timedwait_interruptible(cv, mp, at)	cv_timedwait(cv, mp, at)
 #define cv_wait_interruptible(cv, mp)		cv_wait(cv, mp)
+#define cv_wait_io(cv, mp)		cv_wait(cv, mp)
 
 /*
  * kstat creation, installation and deletion

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1316,7 +1316,7 @@ zio_wait(zio_t *zio)
 
 	mutex_enter(&zio->io_lock);
 	while (zio->io_executor != NULL)
-		cv_wait(&zio->io_cv, &zio->io_lock);
+		cv_wait_io(&zio->io_cv, &zio->io_lock);
 	mutex_exit(&zio->io_lock);
 
 	error = zio->io_error;


### PR DESCRIPTION
This will make zfs show up in kernel iowait percentage time, see https://github.com/zfsonlinux/zfs/issues/1158. Requires patch https://github.com/zfsonlinux/spl/pull/206
