### PR TITLE
call_usermodehelper() should wait for process

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -32,6 +32,7 @@
 #include <sys/fs/zfs.h>
 #include <sys/zio.h>
 #include <sys/sunldi.h>
+#include <linux/kmod.h>
 
 char *zfs_vdev_scheduler = VDEV_SCHEDULER;
 
@@ -159,7 +160,7 @@ vdev_elevator_switch(vdev_t *v, char *elevator)
 		char *envp[] = { NULL };
 
 		argv[2] = kmem_asprintf(SET_SCHEDULER_CMD, device, elevator);
-		error = call_usermodehelper(argv[0], argv, envp, 1);
+		error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 		strfree(argv[2]);
 	}
 #endif /* HAVE_ELEVATOR_CHANGE */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -83,6 +83,7 @@
 #include <sys/dsl_deleg.h>
 #include <sys/mount.h>
 #include <sys/zpl.h>
+#include <linux/kmod.h>
 #include "zfs_namecheck.h"
 
 /*
@@ -696,7 +697,7 @@ __zfsctl_unmount_snapshot(zfs_snapentry_t *sep, int flags)
 
 	argv[2] = kmem_asprintf(SET_UNMOUNT_CMD,
 	    flags & MNT_FORCE ? "-f " : "", sep->se_path);
-	error = call_usermodehelper(argv[0], argv, envp, 1);
+	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	strfree(argv[2]);
 
 	/*
@@ -822,7 +823,7 @@ zfsctl_mount_snapshot(struct path *path, int flags)
 	 * to safely abort the automount.  This should be very rare.
 	 */
 	argv[2] = kmem_asprintf(SET_MOUNT_CMD, full_name, full_path);
-	error = call_usermodehelper(argv[0], argv, envp, 1);
+	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	strfree(argv[2]);
 	if (error) {
 		printk("ZFS: Unable to automount %s at %s: %d\n",

--- a/module/zpios/pios.c
+++ b/module/zpios/pios.c
@@ -35,6 +35,7 @@
 #include <sys/dmu.h>
 #include <sys/txg.h>
 #include <linux/cdev.h>
+#include <linux/kmod.h>
 #include "zpios-internal.h"
 
 
@@ -92,7 +93,7 @@ int zpios_upcall(char *path, char *phase, run_args_t *run_args, int rc)
         envp[2] = "PATH=/sbin:/usr/sbin:/bin:/usr/bin";
         envp[3] = NULL;
 
-        return call_usermodehelper(path, argv, envp, 1);
+        return call_usermodehelper(path, argv, envp, UMH_WAIT_PROC);
 }
 
 static uint64_t


### PR DESCRIPTION
As of Linux 3.4 the UMH_WAIT_\* constants were renumbered.  In
particular, the meaning of "1" changed from UMH_WAIT_PROC (wait for
process to complete), to UMH_WAIT_EXEC (wait for the exec, but not the
process).  A number of call sites used the number 1 instead of the
constant name, so the behavior was not as expected on kernels with this
change.

One visible consequence of this change was that processes accessing
automounted snapshots received an ELOOP error because they failed to
wait for zfs.mount to complete.

Closes #816
