### PR TITLE
Ensure that zfs diff prints unicode safely.

### DIFF
--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -141,7 +141,7 @@ stream_bytes(FILE *fp, const char *string)
 		if (*string > ' ' && *string != '\\' && *string < '\177')
 			(void) fprintf(fp, "%c", *string++);
 		else
-			(void) fprintf(fp, "\\%03o", *string++);
+			(void) fprintf(fp, "\\%03o", (unsigned char)*string++);
 	}
 }
 


### PR DESCRIPTION
In the stream_bytes() library function used by `zfs diff`, explicitly
cast each byte in the input string to an unsigned character so that the
Linux fprintf() correctly escapes to octal and does not mangle the output.

Closes: #1172
