### PR TITLE
fzap_cursor_move_to_key() should drop l_rwlock

### DIFF
--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1257,13 +1257,13 @@ fzap_cursor_move_to_key(zap_cursor_t *zc, zap_name_t *zn)
 		return (err);
 
 	err = zap_leaf_lookup(l, zn, &zeh);
-	if (err != 0)
-		return (err);
+	if (err == 0) {
+		zc->zc_leaf = l;
+		zc->zc_hash = zeh.zeh_hash;
+		zc->zc_cd = zeh.zeh_cd;
+	}
 
-	zc->zc_leaf = l;
-	zc->zc_hash = zeh.zeh_hash;
-	zc->zc_cd = zeh.zeh_cd;
-
+	rw_exit(&l->l_rwlock);
 	return (err);
 }
 


### PR DESCRIPTION
Callers of zap_deref_leaf() must be careful to drop leaf->l_rwlock
since that function returns with the lock held on success.  All other
callers drop the lock correctly but it seems fzap_cursor_move_to_key()
does not.  This may block writers or cause VERIFY failures when the
lock is freed.

Fixes #1215
Fixes zfsonlinux/spl#143
Fixes zfsonlinux/spl#97
