### PR TITLE
Fix function relocations in libzpool

### DIFF
--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -93,7 +93,8 @@ libzpool_la_SOURCES = \
 
 libzpool_la_LIBADD = \
 	$(top_builddir)/lib/libunicode/libunicode.la \
-	$(top_builddir)/lib/libuutil/libuutil.la
+	$(top_builddir)/lib/libuutil/libuutil.la \
+	$(top_builddir)/lib/libnvpair/libnvpair.la
 
 libzpool_la_LDFLAGS = -pthread -version-info 1:1:0
 


### PR DESCRIPTION
binutils 2.23.1 fails in situations that generate function relocations
on PowerPC and possibly other architectures. This causes linking of
libzpool to fail because it depends on libnvpair. We add a dependency on
libnvpair to lib/libzpool/Makefile.am to correct that.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
