### PR TITLE
Switch KM_SLEEP to KM_PUSHPAGE

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1672,7 +1672,7 @@ dmu_objset_find_spa(spa_t *spa, const char *name,
 	}
 
 	thisobj = dd->dd_phys->dd_head_dataset_obj;
-	attr = kmem_alloc(sizeof (zap_attribute_t), KM_SLEEP);
+	attr = kmem_alloc(sizeof (zap_attribute_t), KM_PUSHPAGE);
 	dp = dd->dd_pool;
 
 	/*

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -295,7 +295,7 @@ getcomponent(const char *path, char *component, const char **nextp)
 }
 
 /*
- * same as dsl_open_dir, ignore the first component of name and use the
+ * same as dsl_dir_open, ignore the first component of name and use the
  * spa instead
  */
 int
@@ -312,7 +312,7 @@ dsl_dir_open_spa(spa_t *spa, const char *name, void *tag,
 
 	dprintf("%s\n", name);
 
-	buf = kmem_alloc(MAXNAMELEN, KM_SLEEP);
+	buf = kmem_alloc(MAXNAMELEN, KM_PUSHPAGE);
 	err = getcomponent(name, buf, &next);
 	if (err)
 		goto error;


### PR DESCRIPTION
Two more locations where KM_SLEEP was used in a call which must use
KM_PUSHPAGE were found while using the zpool upgrade command.
See commit b8d06fc for additional details.

Also make a small correction to the comment block above
dsl_dir_open_spa().

Closes #1268
