### PR TITLE
Add explicit MAXNAMELEN check

### DIFF
--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -41,6 +41,9 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 	struct inode *ip;
 	int error;
 
+	if (dlen(dentry) > ZFS_MAXNAMELEN)
+		return ERR_PTR(-ENAMETOOLONG);
+
 	crhold(cr);
 	error = -zfs_lookup(dir, dname(dentry), &ip, 0, cr, NULL, NULL);
 	ASSERT3S(error, <=, 0);


### PR DESCRIPTION
It turns out that the Linux VFS doesn't strictly handle all cases
where a component path name exceeds MAXNAMELEN.  It does however
appear to correctly handle MAXPATHLEN for us.

The right way to handle this appears to be to add an explicit
check to the zpl_lookup() function.  Several in-tree filesystems
handle this case the same way.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1279
