### PR TITLE
Make libzfs_init into a singleton

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -673,7 +673,10 @@ libzfs_load_module(const char *module)
 libzfs_handle_t *
 libzfs_init(void)
 {
-	libzfs_handle_t *hdl;
+	static libzfs_handle_t *hdl = NULL;
+
+	if (hdl)
+		return hdl;
 
 	if (libzfs_load_module("zfs") != 0) {
 		(void) fprintf(stderr, gettext("Failed to load ZFS module "


### PR DESCRIPTION
libzfs_init opens a file descriptor to /dev/zfs. This fails when run as
a non-root user on ZFSOnLinux for lack of delegation support. The
failures revealed that libzfs_init is run twice. Once by the dynamic
loader and a second time by zdb's main function. The purpose of the
second invocation is to obtain a libzfs_handle_t. Since multiple
invocations do not make sense, make libzfs_init return a singleton.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
