### PR TITLE
Fix PaX/GrSecurity runtime error regression

### DIFF
--- a/config/kernel-dirty-inode.m4
+++ b/config/kernel-dirty-inode.m4
@@ -8,11 +8,11 @@ AC_DEFUN([ZFS_AC_KERNEL_DIRTY_INODE_WITH_FLAGS], [
 	AC_MSG_CHECKING([whether sops->dirty_inode() wants flags])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
+		void dirty_inode (struct inode * a, int b) { return; }
+		static struct super_operations sops __attribute__ ((unused)) = {
+			.dirty_inode = dirty_inode,
+		};
 	],[
-		void (*dirty_inode) (struct inode *, int) = NULL;
-		struct super_operations sops __attribute__ ((unused));
-
-		sops.dirty_inode = dirty_inode;
 	],[
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(HAVE_DIRTY_INODE_WITH_FLAGS, 1,


### PR DESCRIPTION
Commit 8780c53961e668211682d40ad36946294c3145d8 reintroduced an
autotools check that is incompatible with the PaX/GrSecurity dialect of
C. This caused autotools checks to exhibit silent failures that
manifested as NULL pointer exceptions during runtime. A bug report
involving this was submitted to the gentoo bug tracker:

https://bugs.gentoo.org/show_bug.cgi?id=457176

This patch adapts the dirty inode check reintroduced by commit
8780c53961e668211682d40ad36946294c3145d8 to be semantically valid in the
PaX/GrSecurity dialect of C.

Reported-by: Marcin Mirosław bug@mejor.pl
Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
