### PR TITLE
-x shouldn't warn about old on-disk format or unavailable features

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3970,7 +3970,10 @@ status_callback(zpool_handle_t *zhp, void *data)
 	 * If we were given 'zpool status -x', only report those pools with
 	 * problems.
 	 */
-	if (reason == ZPOOL_STATUS_OK && cbp->cb_explain) {
+	if (cbp->cb_explain &&
+            (reason == ZPOOL_STATUS_OK ||
+             reason == ZPOOL_STATUS_VERSION_OLDER ||
+             reason == ZPOOL_STATUS_FEAT_DISABLED)) {
 		if (!cbp->cb_allpools) {
 			(void) printf(gettext("pool '%s' is healthy\n"),
 			    zpool_get_name(zhp));

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1604,7 +1604,7 @@ If a scrub or resilver is in progress, this command reports the percentage done 
 .ad
 .RS 6n
 .rt  
-Only display status for pools that are exhibiting errors or are otherwise unavailable.
+Only display status for pools that are exhibiting errors or are otherwise unavailable. Warnings about pools not using the latest on-disk format will not be included.
 .RE
 
 .sp


### PR DESCRIPTION
`zpool status -x` should only flag errors or where the pool is
unavailable.  If it imported fine but isn't using the latest features
available in the code, that's not an error.
