### PR TITLE
Refresh links to web site

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -17,7 +17,7 @@ kernel test code also remains licensed under the GPLv2.
 The latest stable and development versions of this port can be downloaded
 from the official ZFS on Linux site located at:
 
-http://github.com/behlendorf/zfs/
+http://zfsonlinux.org/
 
 This ZFS on Linux port was produced at the Lawrence Livermore National
 Laboratory (LLNL) under Contract No. DE-AC52-07NA27344 (Contract 44)

--- a/cmd/zpios/zpios.h
+++ b/cmd/zpios/zpios.h
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/cmd/zpios/zpios_main.c
+++ b/cmd/zpios/zpios_main.c
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/cmd/zpios/zpios_util.c
+++ b/cmd/zpios/zpios_util.c
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/zpios-internal.h
+++ b/include/zpios-internal.h
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/zpios/pios.c
+++ b/module/zpios/pios.c
@@ -15,7 +15,7 @@
  *             Milind Dumbare <milind@clusterfs.com>
  *
  *  This file is part of ZFS on Linux.
- *  For details, see <http://github.com/behlendorf/zfs/>.
+ *  For details, see <http://zfsonlinux.org/>.
  *
  *  ZPIOS is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the


### PR DESCRIPTION
A few files still refer to @behlendorf's private fork on
github.  Use the primary web site URL instead.
