### PR TITLE
Add zio_ddt_free() error handling

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2250,7 +2250,8 @@ zio_ddt_free(zio_t *zio)
 	ddt_enter(ddt);
 	freedde = dde = ddt_lookup(ddt, bp, B_TRUE);
 	ddp = ddt_phys_select(dde, bp);
-	ddt_phys_decref(ddp);
+	if (ddp)
+		ddt_phys_decref(ddp);
 	ddt_exit(ddt);
 
 	return (ZIO_PIPELINE_CONTINUE);


### PR DESCRIPTION
The assumption here is that ddt_phys_select() must always find
a match.  However, if that fails due to a damaged DDT or some
other reason the code will NULL dereference in ddt_phys_decref().
This needs to be handled more gracefully.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1308
