### PR TITLE
Create fsck.zfs, splat, and zhack man pages.

### DIFF
--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,4 +1,4 @@
-man_MANS = zpios.1 ztest.1
+man_MANS = splat.1 zhack.1 zpios.1 ztest.1
 EXTRA_DIST = $(man_MANS)
 
 install-data-local:

--- a/man/man1/splat.1
+++ b/man/man1/splat.1
@@ -1,0 +1,114 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
+.\"
+.TH zpios 1 "2013 MAR 16" "ZFS on Linux" "User Commands"
+
+.SH NAME
+splat \- Solaris Porting LAyer Tests
+.SH SYNOPSIS
+.LP
+.BI "splat [\-chvx] < \-\-all | \-\-list | \-\-test " "subsystem" ":" "test" " [...] >"
+
+.SH DESCRIPTION
+This utility uses the splat.ko kernel module to test the spl.ko kernel
+module. Run "modprobe splat" before invoking \fBsplat\fR.
+
+.SH OPTIONS
+.HP
+.BI "\-a" "" ", \-\-all" ""
+.IP
+Run all available tests on all subsystems.
+.HP
+.BI "\-c" "" ", \-\-nocolor" ""
+.IP
+Disable output highlighting. By default, "Fail" is printed in red text
+and "Pass" is printed in green text.
+.HP
+.BI "\-h" "" ", \-\-help" ""
+.IP
+Print the usage message.
+.HP
+.BI "\-l" "" ", \-\-list" ""
+.IP
+For each spl.ko subsystem, print all available test names and
+hexidecimal identifiers with a short description.
+.HP
+.BI "\-t" " subsystem" ":" "test" ", \-\-test" " subsystem" ":" "test"
+.HP
+.BI "\-t" " subsystem" ":all" "" ", \-\-test" " subsystem" ":all" ""
+.IP
+Run the \fItest\fR diagnostic routine for the spl.ko \fIsubsystem\fR.
+Specify this option more than once to run multiple tests.
+
+The \fItest\fR and \fIsubsystem\fR parameters are the names or
+hexidecimal identifiers returned by the \fBsplat --list\fR command.
+
+If \fIsubsystem\fR is a name and not a hexidecimal identifier, then the
+\fBall\fR keyword can be used to run all available \fIsubsystem\fR
+tests.
+
+.HP
+.BI "\-v" "" ", \-\-verbose" ""
+.HP
+.IP
+Increase verbosity.
+.HP
+.BI "\-x" "" ", \-\-exit" ""
+.IP
+Stop running tests after the first failure.
+
+.SH "EXAMPLES"
+.LP
+Test everything in the spl.ko kernel module:
+.IP
+# splat --all --verbose
+.LP
+Test the entire kernel memory subsystem:
+.IP
+# splat --test kmem:all
+.LP
+Test the kernel compression and queue waiting facilities:
+.IP
+# splat --test zlib:compress/uncompress --test taskq:wait
+.LP
+This is the same as the previous command, except that the subsystems
+and tests are referenced by hexidecimal identifier instead of by name:
+.IP
+# splat -t 0x0f00:0x0f01 -t 0x0200:0x0204 
+
+.SH "NOTES"
+All tests always return a green "Pass" result on a healthy system. Any
+red "Fail" result should be investigated or reported.
+
+.SH "BUGS"
+Some tests can deadlock the kernel if an X11 desktop is running,
+especially if a proprietary blob driver is loaded for the video
+hardware.
+
+.SH "AUTHORS"
+This man page was written by Darik Horn <dajhorn@vanadac.com>.
+
+.SH "SEE ALSO"
+.BR zpios (1),
+.BR ztest (1)

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -1,0 +1,99 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
+.\"
+.TH zpios 1 "2013 MAR 16" "ZFS on Linux" "User Commands"
+.SH NAME
+.BR zhack " \- libzpool debugging tool"
+.SH DESCRIPTION
+This utility pokes configuration changes directly into a ZFS pool,
+which is dangerous and can cause data corruption.
+.SH SYNOPSIS
+.LP
+.BI "zhack [\-c " "cachefile" "] [\-d " "dir" "] <" "subcommand" "> [" "arguments" "]"
+.SH OPTIONS
+.HP
+.BI "\-c" " cachefile"
+.IP
+Read the \fIpool\fR configuration from the \fIcachefile\fR, which is
+/etc/zfs/zpool.cache by default.
+.HP
+.BI "\-d" " dir"
+.IP
+Search for \fIpool\fR members in the \fIdir\fR path. Can be specified
+more than once.
+.SH SUBCOMMANDS
+.LP
+.BI "feature stat " "pool"
+.IP
+List feature flags.
+.LP
+.BI "feature enable [\-d " "description" "] [\-r] " "pool guid"
+.IP
+Add a new feature to \fIpool\fR that is uniquely identified by
+\fIguid\fR, which is specified in the same form as a zfs(8) user
+property.
+.IP
+The \fIdescription\fR is a short human readable explanation of the new
+feature.
+.IP
+The \fB\-r\fR switch indicates that \fIpool\fR can be safely opened
+in read-only mode by a system that does not have the \fIguid\fR
+feature.
+.LP
+.BI "feature ref [\-d|\-m] " "pool guid"
+.IP
+Increment the reference count of the \fIguid\fR feature in \fIpool\fR.
+.IP
+The \fB\-d\fR switch decrements the reference count of the \fIguid\fR
+feature in \fIpool\fR.
+.IP
+The \fB\-m\fR switch indicates that the \fIguid\fR feature is now
+required to read the pool MOS.  
+.SH EXAMPLES
+.LP
+.nf
+# zhack feature stat tank
+
+for_read_obj:
+	org.illumos:lz4_compress = 0
+for_write_obj:
+	com.delphix:async_destroy = 0
+	com.delphix:empty_bpobj = 0
+descriptions_obj:
+	com.delphix:async_destroy = Destroy filesystems asynchronously.
+	com.delphix:empty_bpobj = Snapshots use less space.
+	org.illumos:lz4_compress = LZ4 compression algorithm support.
+.LP
+# zhack feature enable -d 'Predict future disk failures.' \\
+    tank com.example:clairvoyance
+.LP
+# zhack feature ref tank com.example:clairvoyance
+.SH AUTHORS
+This man page was written by Darik Horn <dajhorn@vanadac.com>.
+.SH SEE ALSO
+.BR splat (1),
+.BR zfs (8),
+.BR zpios (1),
+.BR zpool-features (5),
+.BR ztest (1)

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -1,4 +1,13 @@
-man_MANS = mount.zfs.8 vdev_id.8 zdb.8 zfs.8 zinject.8 zpool.8 zstreamdump.8
+man_MANS = \
+	fsck.zfs.8 \
+	mount.zfs.8 \
+	vdev_id.8 \
+	zdb.8 \
+	zfs.8 \
+	zinject.8 \
+	zpool.8 \
+	zstreamdump.8
+
 EXTRA_DIST = $(man_MANS)
 
 install-data-local:

--- a/man/man8/fsck.zfs.8
+++ b/man/man8/fsck.zfs.8
@@ -1,0 +1,67 @@
+'\" t
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
+.\"
+.TH zpios 8 "2013 MAR 16" "ZFS on Linux" "System Administration Commands"
+
+.SH NAME
+.BR fsck.zfs " \- Dummy ZFS filesystem checker."
+
+.SH SYNOPSIS
+.LP
+.BI "fsck.zfs [" "options" "] <" "dataset" ">"
+
+.SH DESCRIPTION
+.LP
+\fBfsck.zfs\fR is a shell stub that does nothing and always returns
+true. It is installed by ZoL because some Linux distributions expect
+a fsck helper for all filesystems.
+
+.SH OPTIONS
+.HP
+All \fIoptions\fR and the \fIdataset\fR are ignored.
+
+.SH "NOTES"
+.LP
+ZFS datasets are checked by running \fBzpool scrub\fR on the
+containing pool. An individual ZFS dataset is never checked
+independently of its pool, which is unlike a regular filesystem.
+
+.SH "BUGS"
+.LP
+On some systems, if the \fIdataset\fR is in a degraded pool, then it
+might be appropriate for \fBfsck.zfs\fR to return exit code 4 to
+indicate an uncorrected filesystem error.
+.LP
+Similarly, if the \fIdataset\fR is in a faulted pool and has a legacy
+/etc/fstab record, then \fBfsck.zfs\fR should return exit code 8 to
+indicate a fatal operational error.
+
+.SH "AUTHORS"
+.LP
+Darik Horn <dajhorn@vanadac.com>.
+
+.SH "SEE ALSO"
+.BR fsck (8),
+.BR fstab (5),
+.BR zpool (8)


### PR DESCRIPTION
And update the automake templates to install them.

The splat documentation is included here in anticipation of moving
the splat utility from zfsonlinux/spl to zfsonlinux/zfs.

Supplements #518
