### PR TITLE
Fix minor typos and update marketing copy.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Brian Behlendorf is the principle developer of the ZFS on Linux port.
+Brian Behlendorf is the principal developer of the ZFS on Linux port.
 He works full time as a computer scientist at Lawrence Livermore
 National Laboratory on the ZFS and Lustre filesystems.  However,
 this port would not have been possible without the help of many

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -16,7 +16,7 @@ services by trade name, trademark, manufacturer or otherwise does
 not necessarily constitute or imply its endorsement, recommendation,
 or favoring by the United States Government or Lawrence Livermore
 National Security, LLC.  The views and opinions of authors expressed
-herein do not necessarily state or reflect those of the Untied States
+herein do not necessarily state or reflect those of the United States
 Government or Lawrence Livermore National Security, LLC, and shall
 not be used for advertising or product endorsement purposes.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,17 +1,10 @@
-Native ZFS for Linux! ZFS is an advanced file system and volume manager
-which was originally developed for Solaris. It has been successfully 
-ported to FreeBSD and now there is a functional Linux ZFS kernel port
-too. The port currently includes a fully functional and stable SPA, DMU,
-and ZVOL with a ZFS Posix Layer (ZPL) on the way!
+Native ZFS for Linux!
 
-    $ ./configure
-    $ make pkg
+ZFS is an advanced file system and volume manager which was originally
+developed for Solaris and is now maintained by the Illumos community.
 
-To copy the kernel code inside your kernel source tree for builtin
-compilation:
+ZFS on Linux, which is also known as ZoL, is currently feature complete.  It
+includes fully functional and stable SPA, DMU, ZVOL, and ZPL layers.
 
-    $ ./configure --enable-linux-builtin --with-linux=/usr/src/linux-...
-    $ ./copy-builtin /usr/src/linux-...
-
-Full documentation for building, configuring, and using ZFS can be
-found at: <http://zfsonlinux.org>
+Full documentation for installing ZoL on your favorite Linux distribution can
+be found at: <http://zfsonlinux.org>


### PR DESCRIPTION
Correct spelling mistakes in the AUTHORS and DISCLAIMER files, and
update the README.markdown file to credit Illumos and mention that
the ZPL is finished.

The README.markdown file is also the first impression for a handful
of new users that discover ZoL through a web search because it
doubles as the splash page for the Github repository. The build blurbs
are therefore removed because these people should be encouraged to
visit the regular home page before installing the product.
