### PR TITLE
Smbfs fixes

### DIFF
--- a/lib/libshare/smb.c
+++ b/lib/libshare/smb.c
@@ -423,7 +423,15 @@ static const sa_share_ops_t smb_shareops = {
 static boolean_t
 smb_available(void)
 {
-	/* TODO: Sanity check NET_CMD_PATH and SHARE_DIR */
+	struct stat statbuf;
+
+	if (lstat(SHARE_DIR, &statbuf) != 0 ||
+	    !S_ISDIR(statbuf.st_mode))
+		return B_FALSE;
+
+	if (access(NET_CMD_PATH, F_OK) != 0)
+		return B_FALSE;
+
 	return B_TRUE;
 }
 

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1042,7 +1042,17 @@ Because \fBSMB\fR shares requires a resource name, a unique resource name is con
 .sp
 If the \fBsharesmb\fR property is set to \fBoff\fR, the file systems are unshared.
 .sp
-In Linux, the share is created with the acl "Everyone:F" by default, meaning that everyone have read access. This however isn't the full truth: Any access control on the underlaying filesystem supersedes this.
+In Linux, the share is created with the ACL (Access Control List) "Everyone:F" ("F" stands for "full permissions", ie. read and write permissions) and no guest access (which means samba must be able to authenticate a real user, system passwd/shadow, ldap or smbpasswd based) by default. This means that any additional access control (dissalow specific user specific access etc) must be done on the underlaying filesystem.
+.sp
+.in +2
+Example to mount a SMB filesystem shared through ZFS (share/tmp):
+.mk
+Note that a user and his/her password \fBmust\fR be given!
+.sp
+.in +2
+smbmount //127.0.0.1/share_tmp /mnt/tmp -o user=workgroup/turbo,password=obrut,uid=1000
+.in -2
+.in -2
 .sp
 .ne 2
 .mk
@@ -1052,7 +1062,9 @@ In Linux, the share is created with the acl "Everyone:F" by default, meaning tha
 .in +2
 * Samba will need to listen to 'localhost' (127.0.0.1) for the zfs utilities to communitate with samba.  This is the default behavior for most Linux distributions.
 .sp
-* See the \fBUSERSHARE\fR section of the \fBsmb.conf\fR(5) man page for all configuration options.
+* Samba must be able to authenticate a user. This can be done in a number of ways, depending on if using the system password file, LDAP or the Samba specific smbpasswd file. How to do this is outside the scope of this manual. Please refer to the smb.conf(5) manpage for more information.
+.sp
+* See the \fBUSERSHARE\fR section of the \fBsmb.conf\fR(5) man page for all configuration options in case you need to modify any options to the share afterwards. Do note that any changes done with the 'net' command will be undone if the share is every unshared (such as at a reboot etc). In the future, ZoL will be able to set specific options directly using sharesmb=<option>.
 .sp
 .in -2
 .RE


### PR DESCRIPTION
Closes: #1124 (CIFS Sanity checks), #1181 (CIFS share documentation lacking).
