### PR TITLE
Align lz4_cache allocations to cache-lines

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -990,7 +990,7 @@ void
 lz4_init(void)
 {
 	lz4_cache = kmem_cache_create("lz4_cache",
-		sizeof (struct refTables), 0, NULL, NULL, NULL, NULL, NULL, 0);
+		sizeof (struct refTables), 64, NULL, NULL, NULL, NULL, NULL, 0);
 }
 
 void


### PR DESCRIPTION
The original LZ4 source code suggests that that the hash table is
intended to fit entirely into the L1 data cache on Intel processors, but
the code makes no attempt to align its allocations to cache-lines. This
is a bug in the original LZ4 code that should be corrected.

The import of the LZ4 code into Illumos retained this feature. However,
the Illumos SLAB allocator is used for its allocations. SLAB allocator
implementations normally pack objects consecutively in virtual
allocations that are page aligned. The consequence is that cache-line
alignment is free. The SPL SLAB allocator implementation interleaves
objects with their metadata, which requires us to explicitly specify
alignment.

We correct this by explicitly forcing 64-byte alignment. This will
guarentee proper alignment on Intel processors, as well as many others.
LZ4 operations appeared in `perf top -U` as being interrupted by about
1% of IRQs on my system prior to this change. It no longer appears on
the list after this change.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
