### PR TITLE
Allow setting a lower ashift with -o ashift

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1258,11 +1258,12 @@ vdev_open(vdev_t *vd)
 	if (vd->vdev_asize == 0) {
 		/*
 		 * This is the first-ever open, so use the computed values.
-		 * For testing purposes, a higher ashift can be requested.
+		 * For testing purposes, a different ashift can be requested.
 		 */
 		vd->vdev_asize = asize;
 		vd->vdev_max_asize = max_asize;
-		vd->vdev_ashift = MAX(ashift, vd->vdev_ashift);
+		if (vd->vdev_ashift == 0)
+			vd->vdev_ashift = ashift;
 	} else {
 		/*
 		 * Detect if the alignment requirement has increased.


### PR DESCRIPTION
On our systems we have experienced the following problems:
- the new default ashift value (4k drives) causes an unacceptable increase in space usage (we have many small files) reducing available space down to 30-40%
- we are unable to add new devices to existing pools that use a 512b ashift, even if they are the same disk models as in the pool
