### PR TITLE
#1404 Stop exporting readdir for files that are not directories.

### DIFF
--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -446,7 +446,6 @@ const struct file_operations zpl_file_operations = {
 	.llseek		= generic_file_llseek,
 	.read		= zpl_read,
 	.write		= zpl_write,
-	.readdir	= zpl_readdir,
 	.mmap		= zpl_mmap,
 	.fsync		= zpl_fsync,
 #ifdef HAVE_FILE_FALLOCATE


### PR DESCRIPTION
see: https://github.com/zfsonlinux/zfs/issues/1404
