### PR TITLE
Make spl directory setable when building rpms

### DIFF
--- a/rpm/fedora/zfs-kmod.spec.in
+++ b/rpm/fedora/zfs-kmod.spec.in
@@ -44,7 +44,7 @@ BuildRequires:  spl-devel-kmod = %{version}-%{release}
 # Kmodtool does its magic here.  A patched version of kmodtool is shipped
 # with the source rpm until kmod development packages are supported upstream.
 # https://bugzilla.rpmfusion.org/show_bug.cgi?id=2714
-%{expand:%(sh %{SOURCE10} --target %{_target_cpu} --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(sh %{SOURCE10} --target %{_target_cpu} --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null) }
 
 
 %description
@@ -55,7 +55,7 @@ This package contains the ZFS kernel modules.
 %{?kmodtool_check}
 
 # Print kmodtool output for debugging purposes:
-sh %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+sh %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null
 
 %if %{with debug}
     %define debug --enable-debug
@@ -68,6 +68,28 @@ sh %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --dev
 %else
     %define debug_dmu_tx --disable-debug-dmu-tx
 %endif
+
+#
+# Allow the overriding of spl locations
+#
+%if %{defined require_splver}
+%define splver %{require_splver}
+%else
+%define splver %{version}
+%endif
+
+%if %{defined require_spldir}
+%define spldir %{require_spldir}
+%else
+%define spldir %{_usrdir}/spl-%{splver}
+%endif
+
+%if %{defined require_splobj}
+%define splobj %{require_splobj}
+%else
+%define splobj %{spldir}/${kernel_version%%___*}
+%endif
+
 
 # Leverage VPATH from configure to avoid making multiple copies.
 %define _configure ../%{module}-%{version}/configure
@@ -85,8 +107,8 @@ for kernel_version in %{?kernel_versions}; do
         --with-config=kernel \
         --with-linux="${kernel_version##*___}" \
         --with-linux-obj="${kernel_version##*___}" \
-        --with-spl="/usr/src/spl-%{version}" \
-        --with-spl-obj="/usr/src/spl-%{version}/${kernel_version%%___*}" \
+        --with-spl="%{spldir}" \
+        --with-spl-obj="%{splobj}" \
         %{debug} \
         %{debug_dmu_tx}
     make %{?_smp_mflags}

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -47,7 +47,7 @@ BuildRequires:             spl-devel-kmod = %{version}
 # Kmodtool does its magic here.  A patched version of kmodtool is shipped
 # with the source rpm until kmod development packages are supported upstream.
 # https://bugzilla.rpmfusion.org/show_bug.cgi?id=2714
-%{expand:%(bash %{SOURCE10} --target %{_target_cpu} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(bash %{SOURCE10} --target %{_target_cpu} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null) }
 
 
 %description
@@ -58,7 +58,7 @@ This package contains the ZFS kernel modules.
 %{?kmodtool_check}
 
 # Print kmodtool output for debugging purposes:
-bash %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+bash %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null
 
 %if %{with debug}
     %define debug --enable-debug
@@ -71,6 +71,28 @@ bash %{SOURCE10}  --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --d
 %else
     %define debug_dmu_tx --disable-debug-dmu-tx
 %endif
+
+#
+# Allow the overriding of spl locations
+#
+%if %{defined require_splver}
+%define splver %{require_splver}
+%else
+%define splver %{version}
+%endif
+
+%if %{defined require_spldir}
+%define spldir %{require_spldir}
+%else
+%define spldir %{_usrdir}/spl-%{splver}
+%endif
+
+%if %{defined require_splobj}
+%define splobj %{require_splobj}
+%else
+%define splobj %{spldir}/${kernel_version%%___*}
+%endif
+
 
 # Leverage VPATH from configure to avoid making multiple copies.
 %define _configure ../%{module}-%{version}/configure
@@ -98,8 +120,8 @@ for kernel_version in %{?kernel_versions}; do
         fi)" \
         --with-linux-obj="/lib/modules/${kernel_version%%___*}/build" \
 %endif
-        --with-spl="/usr/src/spl-%{version}" \
-        --with-spl-obj="/usr/src/spl-%{version}/${kernel_version%%___*}" \
+        --with-spl="%{spldir}" \
+        --with-spl-obj="%{splobj}" \
         %{debug} \
         %{debug_dmu_tx}
     make %{?_smp_mflags}

--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -37,6 +37,7 @@ kernel_versions_to_build_for=
 prefix=
 filterfile=
 target=
+buildroot=
 
 error_out()
 {
@@ -305,9 +306,9 @@ print_customrpmtemplate ()
 {
 	for kernel in ${1}
 	do
-		if 	[[ -e "/usr/src/kernels/${kernel}" ]] ; then
+		if [[ -e "${buildroot}/usr/src/kernels/${kernel}" ]] ; then
 			# this looks like a Fedora/RH kernel -- print a normal template (which includes the proper BR) and be happy :)
-			kernel_versions="${kernel_versions}${kernel}___%{_usrsrc}/kernels/${kernel} "
+			kernel_versions="${kernel_versions}${kernel}___${buildroot}%{_usrsrc}/kernels/${kernel} "
 
 			# parse kernel versions string and print template
 			local kernel_verrelarch=${kernel%%${kernels_known_variants}}
@@ -382,7 +383,6 @@ myprog_help ()
 	echo "Usage: $(basename ${0}) [OPTIONS]"
 	echo $'\n'"Creates a template to be used during kmod building"
 	echo $'\n'"Available options:"
-	# FIXME	echo " --datadir <dir>     -- look for our shared files in <dir>"
 	echo " --filterfile <file>  -- filter the results with grep --file <file>"
 	echo " --for-kernels <list> -- created templates only for these kernels"
 	echo " --kmodname <file>    -- name of the kmod (required)"
@@ -390,6 +390,7 @@ myprog_help ()
 	echo " --noakmod            -- no akmod package"
 	echo " --repo <name>        -- use buildsys-build-<name>-kerneldevpkgs"
 	echo " --target <arch>      -- target-arch (required)"
+	echo " --buildroot <dir>    -- Build root (place to look for build files)"
 }
 
 while [ "${1}" ] ; do
@@ -477,6 +478,11 @@ while [ "${1}" ] ; do
 		--current)
 			shift
 			build_kernels="current"
+			;;
+		--buildroot)
+			shift
+			buildroot="${1}"
+			shift
 			;;
 		--help)
 			myprog_help


### PR DESCRIPTION
This adds ability to set the location of spl via defines when building from the spec files.  This is useful for build systems that build spl and zfs together without installing the actual rpms.

This will make integration with Lustre lbuild much easier.

Signed-off-by: Nathaniel Clark Nathaniel.Clark@misrule.us
