### PR TITLE
Fix various generic kmod RPM spec issues

### DIFF
--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -15,7 +15,7 @@ License:        @ZFS_META_LICENSE@
 URL:            http://zfsonlinux.org/
 Source0:        %{module}-%{version}.tar.gz
 Source10:       kmodtool
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)
 
 # The developments headers will conflict with the dkms packages.
 Conflicts:      %{module}-dkms
@@ -90,12 +90,11 @@ for kernel_version in %{?kernel_versions}; do
         --with-linux="${kernel_version##*___}" \
         --with-linux-obj="${kernel_version##*___}" \
 %else
-        --with-linux=\
-        %(if [ -e /lib/modules/${kernel_version%%___*}/source ]; then \
-            echo "/lib/modules/${kernel_version%%___*}/source" \
+        --with-linux="$(if [ -e "/lib/modules/${kernel_version%%___*}/source" ]; then \
+            echo "/lib/modules/${kernel_version%%___*}/source"; \
         else \
-            echo "/lib/modules/${kernel_version%%___*}/build" \
-        fi) \
+            echo "/lib/modules/${kernel_version%%___*}/build"; \
+        fi)" \
         --with-linux-obj="/lib/modules/${kernel_version%%___*}/build" \
 %endif
         --with-spl="/usr/src/spl-%{version}" \


### PR DESCRIPTION
There are a number of issues with the generic kmod RPM spec in its current state:
- The `%{__id_u}` macro seems to not be available on some systems (e.g. Debian squeeze). It appears it has been deprecated. Use `${__id} -u` instead.
- The way the `--with-linux=` configure option is generated in the non-RHEL/Fedora case is completely wrong with various newline and escaping issues (also, `$kernel_version` is not available in the generator context).

The second issue made the generator shell snippet (almost) silently fail, which under specific circumstances can result in broken builds against the wrong kernel sources.
