### PR TITLE
Always issue synchronous reads

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -693,7 +693,7 @@ vdev_disk_io_start(zio_t *zio)
 		break;
 
 	case ZIO_TYPE_READ:
-		flags = READ;
+		flags = READ_SYNC;
 		break;
 
 	default:


### PR DESCRIPTION
By running blktrace while issuing an 'ls' it was observed that
there are lots of 'unplug due to timer' events occuring.  This
occurs because all read requests are issued asynchronously to
provide the elevator an opportunity to merge requests.

This delay can translate in to a significant performance penalty
for FAT ZAPs which can issue multiple dependant read I/O to
perform a single lookup.  Issuing the I/O immediately reduces
this latency and improves the behavior of ZAPs.

However, it's not clear if this is the optimal behavior for all
workloads.  For example, this may negitively impact sequential
read performance by reducing the window to merge requests.  Or
it may not because ZFS already contains it's own I/O scheduler
which is designed to mitigate this problem.

This patch is designed as a starting point to help quantify the
performance impact of immediately issuing all read I/Os.  This
patch can be further refined to issue a mix of READ, READ_SYNC,
and READA requests based on the zio flags.  However, until we
have some real data I've avoid any premature optimization.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1419
