### PR TITLE
Ensure that --with-spl-timeout waits for both SPL spl_config.h and symvers files

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -229,54 +229,6 @@ AC_DEFUN([ZFS_AC_KERNEL], [
 	ZFS_AC_MODULE_SYMVERS
 ])
 
-dnl #
-dnl # Detect name used for the additional SPL Module.symvers file.  If one
-dnl # does not exist this is likely because the SPL has been configured
-dnl # but not built.  The '--with-spl-timeout' option can be passed
-dnl # to pause here, waiting for the file to appear from a concurrently
-dnl # building SPL package.  If the file does not appear in time, a good
-dnl # guess is made as to what this file will be named based on what it
-dnl # is named in the kernel build products.  This file will first be
-dnl # used at link time so if the guess is wrong the build will fail
-dnl # then.  This unfortunately means the ZFS package does not contain a
-dnl # reliable mechanism to detect symbols exported by the SPL at
-dnl # configure time.
-dnl #
-AC_DEFUN([ZFS_AC_SPL_MODULE_SYMVERS], [
-	AC_ARG_WITH([spl-timeout],
-		AS_HELP_STRING([--with-spl-timeout=SECS],
-		[Wait SECS for symvers file to appear  @<:@default=0@:>@]),
-		[timeout="$withval"], [timeout=0])
-
-	AC_MSG_CHECKING([spl file name for module symbols])
-	SPL_SYMBOLS=NONE
-
-	while true; do
-		AS_IF([test -r $SPL_OBJ/Module.symvers], [
-			SPL_SYMBOLS=Module.symvers
-		], [test -r $SPL_OBJ/Modules.symvers], [
-			SPL_SYMBOLS=Modules.symvers
-		], [test -r $SPL_OBJ/module/Module.symvers], [
-			SPL_SYMBOLS=Module.symvers
-		], [test -r $SPL_OBJ/module/Modules.symvers], [
-			SPL_SYMBOLS=Modules.symvers
-		])
-
-		AS_IF([test $SPL_SYMBOLS != NONE -o $timeout -le 0], [
-			break;
-		], [
-			sleep 1
-			timeout=$((timeout-1))
-		])
-	done
-
-	AS_IF([test "$SPL_SYMBOLS" = NONE], [
-		SPL_SYMBOLS=$LINUX_SYMBOLS
-	])
-
-	AC_MSG_RESULT([$SPL_SYMBOLS])
-	AC_SUBST(SPL_SYMBOLS)
-])
 
 dnl #
 dnl # Detect the SPL module to be built against
@@ -291,6 +243,11 @@ AC_DEFUN([ZFS_AC_SPL], [
 		AS_HELP_STRING([--with-spl-obj=PATH],
 		[Path to spl build objects]),
 		[splbuild="$withval"])
+
+	AC_ARG_WITH([spl-timeout],
+		AS_HELP_STRING([--with-spl-timeout=SECS],
+		[Wait SECS for SPL header and symver file to appear @<:@default=0@:>@]),
+		[timeout="$withval"], [timeout=0])
 
 	dnl #
 	dnl # The existence of spl.release.in is used to identify a valid
@@ -338,16 +295,28 @@ AC_DEFUN([ZFS_AC_SPL], [
 	dnl # directory are the same, however the objects may also reside
 	dnl # is a subdirectory named after the kernel version.
 	dnl #
+	dnl # This file is supposed to be available after DKMS finish building
+	dnl # the SPL kernel module for the target kernel.
+	dnl # The '--with-spl-timeout' option can be passed to pause here,
+	dnl # waiting for the file to appear from a concurrently building SPL package.
 	AC_MSG_CHECKING([spl build directory])
-	AS_IF([test -z "$splbuild"], [
-		AS_IF([ test -e "${splsrc}/${LINUX_VERSION}/spl_config.h" ], [
-			splbuild="${splsrc}/${LINUX_VERSION}"
-		], [ test -e "${splsrc}/spl_config.h" ], [
-			splbuild="${splsrc}"
-		], [
-			splbuild="[Not found]"
+	while true; do
+		AS_IF([test -z "$splbuild"], [
+			AS_IF([ test -e "${splsrc}/${LINUX_VERSION}/spl_config.h" ], [
+				splbuild="${splsrc}/${LINUX_VERSION}"
+			], [ test -e "${splsrc}/spl_config.h" ], [
+				splbuild="${splsrc}"
+			], [
+				splbuild="[Not found]"
+			])
 		])
-	])
+		AS_IF([test -e "$splbuild/spl_config.h" -o $timeout -le 0], [
+			break;
+		], [
+			sleep 1
+			timeout=$((timeout-1))
+		])
+	done
 
 	AC_MSG_RESULT([$splbuild])
 	AS_IF([ ! test -e "$splbuild/spl_config.h"], [
@@ -385,7 +354,48 @@ AC_DEFUN([ZFS_AC_SPL], [
 	AC_SUBST(SPL_OBJ)
 	AC_SUBST(SPL_VERSION)
 
-	ZFS_AC_SPL_MODULE_SYMVERS
+	dnl #
+	dnl # Detect name used for the additional SPL Module.symvers file.  If one
+	dnl # does not exist this is likely because the SPL has been configured
+	dnl # but not built.  The '--with-spl-timeout' option can be passed
+	dnl # to pause here, waiting for the file to appear from a concurrently
+	dnl # building SPL package.  If the file does not appear in time, a good
+	dnl # guess is made as to what this file will be named based on what it
+	dnl # is named in the kernel build products.  This file will first be
+	dnl # used at link time so if the guess is wrong the build will fail
+	dnl # then.  This unfortunately means the ZFS package does not contain a
+	dnl # reliable mechanism to detect symbols exported by the SPL at
+	dnl # configure time.
+	dnl #
+
+	AC_MSG_CHECKING([spl file name for module symbols])
+	SPL_SYMBOLS=NONE
+
+	while true; do
+		AS_IF([test -r $SPL_OBJ/Module.symvers], [
+			SPL_SYMBOLS=Module.symvers
+		], [test -r $SPL_OBJ/Modules.symvers], [
+			SPL_SYMBOLS=Modules.symvers
+		], [test -r $SPL_OBJ/module/Module.symvers], [
+			SPL_SYMBOLS=Module.symvers
+		], [test -r $SPL_OBJ/module/Modules.symvers], [
+			SPL_SYMBOLS=Modules.symvers
+		])
+
+		AS_IF([test $SPL_SYMBOLS != NONE -o $timeout -le 0], [
+			break;
+		], [
+			sleep 1
+			timeout=$((timeout-1))
+		])
+	done
+
+	AS_IF([test "$SPL_SYMBOLS" = NONE], [
+		SPL_SYMBOLS=$LINUX_SYMBOLS
+	])
+
+	AC_MSG_RESULT([$SPL_SYMBOLS])
+	AC_SUBST(SPL_SYMBOLS)
 ])
 
 dnl #


### PR DESCRIPTION
The previous code was only waiting for the symver file. But the postinst
target of the DKMS script for SPL will not only create the symvers file,
but also the header spl_config.h.

If we are waiting in the configure script of ZFS for the SPL symvers file,
then we also need to wait for spl_config.h. Otherwise the configure script
will abort because the spl_config.h is not yet available.

On top of that, the function ZFS_AC_SPL_MODULE_SYMVERS is moved
to the end of the function ZFS_AC_SPL to allow both checks share the
with-spl-timeout parameter.
