### PR TITLE
Only check directory xattr on ENOENT

### DIFF
--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -288,7 +288,7 @@ __zpl_xattr_get(struct inode *ip, const char *name, void *value, size_t size,
 
 	if (zsb->z_use_sa && zp->z_is_sa) {
 		error = zpl_xattr_get_sa(ip, name, value, size);
-		if (error >= 0)
+		if (error != -ENOENT)
 			goto out;
 	}
 


### PR DESCRIPTION
When SA xattrs are enabled only fallback to checking the directory
xattrs when the name is not found as a SA xattr.  Otherwise, the SA
error which should be returned to the caller is overwritten by the
directory xattr errors.  Positive return values indicating success
will also be immediately returned.

In the case of #1437 the ERANGE error was being correctly returned
by zpl_xattr_get_sa() only to be overridden with ENOENT which was
returned by the subsequent unnessisary call to zpl_xattr_get_dir().

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1437
