### PR TITLE
Don't leak mount flags into kernel

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -131,15 +131,6 @@ parse_option(char *mntopt, unsigned long *mntflags,
 		if (strncmp(name, opt->name, strlen(name)) == 0) {
 			*mntflags |= opt->mntmask;
 			*zfsflags |= opt->zfsmask;
-
-			/* MS_USERS implies default user options */
-			if (opt->mntmask & (MS_USERS))
-				*mntflags |= (MS_NOEXEC|MS_NOSUID|MS_NODEV);
-
-			/* MS_OWNER|MS_GROUP imply default owner options */
-			if (opt->mntmask & (MS_OWNER | MS_GROUP))
-				*mntflags |= (MS_NOSUID|MS_NODEV);
-
 			error = 0;
 			goto out;
 		}

--- a/lib/libspl/include/sys/mount.h
+++ b/lib/libspl/include/sys/mount.h
@@ -51,10 +51,10 @@
 #define MS_DIRSYNC		S_WRITE
 #endif
 
-#define	MS_USERS	0x40000000
-#define	MS_OWNER	0x10000000
-#define	MS_GROUP	0x08000000
-#define	MS_COMMENT	0x02000000
+#define	MS_USERS	(MS_NOEXEC|MS_NOSUID|MS_NODEV)
+#define	MS_OWNER	(MS_NOSUID|MS_NODEV)
+#define	MS_GROUP	(MS_NOSUID|MS_NODEV)
+#define	MS_COMMENT	0
 
 /*
  * Older glibc <sys/mount.h> headers did not define all the available


### PR DESCRIPTION
When calling mount(), care must be taken to avoid passing in flags
that are used only by the user space utilities.  Otherwise we may
stomp on flags that are reserved for other purposes in the kernel.

In particular, openSUSE 12.3 kernels have added a new MS_RICHACL
super-block flag whose value conflicts with our MS_COMMENT flag. This
causes incorrect behavior such as the umask being ignored.  The
MS_COMMENT flag essentially serves as a placeholder in the option_map
data structure of zfs_mount.c, but its value is never used. Therefore
we can avoid the conflict by defining it to 0.

The MS_USERS, MS_OWNER, and MS_GROUP flags also conflict with reserved
flags in the kernel. While this is not known to have caused any
problems, it is nevertheless incorrect.  For the purposes of the
mount.zfs helper, the "users", "owner", and "group" options just serve
as hints to set additional implied options.  Therefore we now define
their associated mount flags in terms of the options that they imply
rather than giving them unique values.

Closes #1457
