### PR TITLE
ZFS-kmod.spec: use $SPL passed by --with-spl ..

### DIFF
--- a/rpm/fedora/zfs-kmod.spec.in
+++ b/rpm/fedora/zfs-kmod.spec.in
@@ -85,7 +85,7 @@ for kernel_version in %{?kernel_versions}; do
         --with-config=kernel \
         --with-linux="${kernel_version##*___}" \
         --with-linux-obj="${kernel_version##*___}" \
-        --with-spl="/usr/src/spl-%{version}" \
+        --with-spl="@SPL@" \
         --with-spl-obj="/usr/src/spl-%{version}/${kernel_version%%___*}" \
         %{debug} \
         %{debug_dmu_tx}

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -98,7 +98,7 @@ for kernel_version in %{?kernel_versions}; do
         fi)" \
         --with-linux-obj="/lib/modules/${kernel_version%%___*}/build" \
 %endif
-        --with-spl="/usr/src/spl-%{version}" \
+        --with-spl="@SPL@" \
         --with-spl-obj="/usr/src/spl-%{version}/${kernel_version%%___*}" \
         %{debug} \
         %{debug_dmu_tx}


### PR DESCRIPTION
- use $SPL as @SPL@ passed by "configure --with-spl=/path/to/spl"
- verified to work on Debian Wheezy (7.x)

---

I couldn't figure why "make deb-kmod" was failing, even though I've explicitly ran "./configure --with-spl=/home/anapsix/spl-0.6.1", until I've found spec.in ignored the flag
Why not use $SPL passed from ./configure for spec file generation?
