### PR TITLE
Fixes deadlock during import of ZVOLs

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1363,7 +1363,7 @@ __zvol_create_minor(const char *name, boolean_t ignore_snapdev)
 	zv->zv_volsize = volsize;
 	zv->zv_objset = os;
 
-	set_capacity(zv->zv_disk, zv->zv_volsize >> 9);
+	set_capacity(zv->zv_disk, 0);
 
 	blk_queue_max_hw_sectors(zv->zv_queue, UINT_MAX);
 	blk_queue_max_segments(zv->zv_queue, UINT16_MAX);
@@ -1397,6 +1397,12 @@ out:
 	if (error == 0) {
 		zvol_insert(zv);
 		add_disk(zv->zv_disk);
+    /* You must set_capacity() to 0 unless calling setcapacity() *after*
+       you call add_disk(), according to these references:
+         http://osdir.com/ml/linux.enbd.general/2002-10/msg00176.html
+         http://osdir.com/ml/linux.enbd.general/2002-10/msg00177.html
+         http://stackoverflow.com/questions/13518404/add-disk-hangs-on-insmod */ 
+    set_capacity(zv->zv_disk, zv->zv_volsize >> 9);
 	}
 
 	return (error);


### PR DESCRIPTION
Small patch to fix issue https://github.com/zfsonlinux/zfs/issues/1488:

One must set_capacity() to 0 unless calling setcapacity() _after_
       you call add_disk(), according to these references:
         http://osdir.com/ml/linux.enbd.general/2002-10/msg00176.html
         http://osdir.com/ml/linux.enbd.general/2002-10/msg00177.html
         http://stackoverflow.com/questions/13518404/add-disk-hangs-on-insmod */  
