### PR TITLE
Fix compile warning on 32-bit systems

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -485,6 +485,6 @@ blk_queue_discard_granularity(struct request_queue *q, unsigned int dg)
  * user space processes which don't pass this value will get EBUSY.  This is
  * currently required for the correct operation of hot spares.
  */
-#define VDEV_HOLDER			((void *)0x2f5401de7)
+#define VDEV_HOLDER			((void *)0x2401de7)
 
 #endif /* _ZFS_BLKDEV_H */


### PR DESCRIPTION
The definition of zfs_vdev_holder casts VDEV_HOLDER into a function pointer
passing to linux kernel's block layer function blkdev_get_by_path.
However current VDEV_HOLDER is defined to be wider than 32 bits and the compiler
warns about potential overflows. Instead of specifying different values for 32-bit and
64-bit systems using ifdefs, choose the common factor 32-bit addresses.
Redefine VDEV_HOLDER to 0x2401de7("zholder") here.

Signed-off-by: Ying Zhu casualfisher@gmail.com
