### PR TITLE
Register correct handlers in nvlist_alloc()

### DIFF
--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -271,7 +271,7 @@ nvlist_alloc(nvlist_t **nvlp, uint_t nvflag, int kmflag)
 {
 #if defined(_KERNEL) && !defined(_BOOT)
 	return (nvlist_xalloc(nvlp, nvflag,
-	    (kmflag == KM_SLEEP ? nv_alloc_sleep : nv_alloc_nosleep)));
+	    (kmflag & __GFP_WAIT ? nv_alloc_sleep : nv_alloc_nosleep)));
 #else
 	return (nvlist_xalloc(nvlp, nvflag, nv_alloc_nosleep));
 #endif


### PR DESCRIPTION
The non-blocking allocation handlers in nvlist_alloc() would be
mistakenly assigned if any flags other than KM_SLEEP were passed.
This meant that nvlists allocated with KM_PUSHPUSH or other KM_*
debug flags were effectively always using atomic allocations.

While these failures were unlikely it could lead to assertions
because KM_PUSHPAGE allocation in particular are guaranteed to
succeed or block.  They must never fail.

Since this code is already wrapped in a _KERNEL define the
cleanest fix is to check the __GFP_HIGH bit.  When set the
caller is signaling it is safe for the allocation to block,
when it's clear atomic allocations must be used.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/spl#249
