### PR TITLE
Register correct handlers in nvlist_alloc()

### DIFF
--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -144,6 +144,7 @@ extern nv_alloc_t *nv_alloc_nosleep;
 
 #if defined(_KERNEL) && !defined(_BOOT)
 extern nv_alloc_t *nv_alloc_sleep;
+extern nv_alloc_t *nv_alloc_pushpage;
 #endif
 
 int nv_alloc_init(nv_alloc_t *, const nv_alloc_ops_t *, /* args */ ...);

--- a/module/nvpair/nvpair_alloc_spl.c
+++ b/module/nvpair/nvpair_alloc_spl.c
@@ -34,6 +34,12 @@ nv_alloc_sleep_spl(nv_alloc_t *nva, size_t size)
 }
 
 static void *
+nv_alloc_pushpage_spl(nv_alloc_t *nva, size_t size)
+{
+	return (kmem_alloc(size, KM_PUSHPAGE | KM_NODEBUG));
+}
+
+static void *
 nv_alloc_nosleep_spl(nv_alloc_t *nva, size_t size)
 {
 	return (kmem_alloc(size, KM_NOSLEEP));
@@ -53,6 +59,14 @@ const nv_alloc_ops_t spl_sleep_ops_def = {
 	NULL                    /* nv_ao_reset() */
 };
 
+const nv_alloc_ops_t spl_pushpage_ops_def = {
+	NULL,                   /* nv_ao_init() */
+	NULL,                   /* nv_ao_fini() */
+	nv_alloc_pushpage_spl,  /* nv_ao_alloc() */
+	nv_free_spl,            /* nv_ao_free() */
+	NULL                    /* nv_ao_reset() */
+};
+
 const nv_alloc_ops_t spl_nosleep_ops_def = {
 	NULL,                   /* nv_ao_init() */
 	NULL,                   /* nv_ao_fini() */
@@ -66,10 +80,16 @@ nv_alloc_t nv_alloc_sleep_def = {
 	NULL
 };
 
+nv_alloc_t nv_alloc_pushpage_def = {
+	&spl_pushpage_ops_def,
+	NULL
+};
+
 nv_alloc_t nv_alloc_nosleep_def = {
 	&spl_nosleep_ops_def,
 	NULL
 };
 
 nv_alloc_t *nv_alloc_sleep = &nv_alloc_sleep_def;
+nv_alloc_t *nv_alloc_pushpage = &nv_alloc_pushpage_def;
 nv_alloc_t *nv_alloc_nosleep = &nv_alloc_nosleep_def;


### PR DESCRIPTION
The non-blocking allocation handlers in nvlist_alloc() would be
mistakenly assigned if any flags other than KM_SLEEP were passed.
This meant that nvlists allocated with KM_PUSHPUSH or other KM_*
debug flags were effectively always using atomic allocations.

While these failures were unlikely it could lead to assertions
because KM_PUSHPAGE allocations in particular are guaranteed to
succeed or block.  They must never fail.

Since the existing API does not allow us to pass allocation
flags to the private allocators the cleanest thing to do is to
add a KM_PUSHPAGE allocator.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Closes zfsonlinux/spl#249
