### PR TITLE
Fix module probe failure on 32-bit systems

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -920,7 +920,7 @@ spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
 	if (tqs->stqs_count == 1) {
 		tq = tqs->stqs_taskq[0];
 	} else {
-		tq = tqs->stqs_taskq[gethrtime() % tqs->stqs_count];
+		tq = tqs->stqs_taskq[((uint64_t)gethrtime()) % tqs->stqs_count];
 	}
 
 	taskq_dispatch_ent(tq, func, arg, flags, ent);
@@ -943,7 +943,7 @@ spa_taskq_dispatch_sync(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
 	if (tqs->stqs_count == 1) {
 		tq = tqs->stqs_taskq[0];
 	} else {
-		tq = tqs->stqs_taskq[gethrtime() % tqs->stqs_count];
+		tq = tqs->stqs_taskq[((uint64_t)gethrtime()) % tqs->stqs_count];
 	}
 
 	id = taskq_dispatch(tq, func, arg, flags);


### PR DESCRIPTION
Previous commit 7ef5e54e2e28884a04dc800657967b891239e933 caused
module probe failure on 32-bit systems, dmesg showed
Unknown symbol __moddi3
The problem was caused by the modulo operation gethrtime() % tqs->stqs_count
in the committed code, instead of implementing __moddi3 for all 32-bit systems,
advised by Behlendorf, we can just cast the return value of gethrtime() into
a uint64_t, since gethrtime does not return negative value on all circumstances
we need not care about the potential overflow.

Signed-off-by: Ying Zhu casualfisher@gmail.com
