### PR TITLE
fix tx_sync_thread when create

### DIFF
--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -208,7 +208,7 @@ txg_sync_start(dsl_pool_t *dp)
 	 * 32-bit x86.  This is due in part to nested pools and
 	 * scrub_visitbp() recursion.
 	 */
-	tx->tx_sync_thread = thread_create(NULL, 32<<10, txg_sync_thread,
+	tx->tx_sync_thread = thread_create(NULL, 0, txg_sync_thread,
 	    dp, 0, &p0, TS_RUN, minclsyspri);
 
 	mutex_exit(&tx->tx_sync_lock);
@@ -310,6 +310,7 @@ txg_hold_open(dsl_pool_t *dp, txg_handle_t *th)
 
 	th->th_cpu = tc;
 	th->th_txg = txg;
+
 
 	return (txg);
 }


### PR DESCRIPTION
The sync_thread is a kernel thread created in spl module. When zfs call thread_create in spl, actually,the function thread_create ignore the stacksize when it call thread_create.
