### PR TITLE
Use MAXPATHLEN instead of sizeof in snprintf

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -2581,7 +2581,7 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		zs->zs_vdev_aux = 0;
 		for (;;) {
 			int c;
-			(void) snprintf(path, sizeof (path), ztest_aux_template,
+			(void) snprintf(path, MAXPATHLEN, ztest_aux_template,
 			    ztest_opts.zo_dir, ztest_opts.zo_pool, aux,
 			    zs->zs_vdev_aux);
 			for (c = 0; c < sav->sav_count; c++)


### PR DESCRIPTION
This silences a GCC 4.8.0 warning by fixing a programming error caught by
static analysis:

../../cmd/ztest/ztest.c: In function ‘ztest_vdev_aux_add_remove’:
../../cmd/ztest/ztest.c:2584:33: error: argument to ‘sizeof’ in ‘snprintf’ call is the same expression as the destination; did you mean to provide an explicit length? [-Werror=sizeof-pointer-memaccess](void) snprintf(path, sizeof (path), ztest_aux_template,
                                 ^

Closes zfsonlinux/zfs#1480

Signed-off-by: Richard Yao ryao@gentoo.org
