### PR TITLE
New tunable parameters

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3236,4 +3236,16 @@ MODULE_PARM_DESC(zio_delay_max, "Max zio millisec delay before posting event");
 
 module_param(zio_requeue_io_start_cut_in_line, int, 0644);
 MODULE_PARM_DESC(zio_requeue_io_start_cut_in_line, "Prioritize requeued I/O");
+
+module_param(zfs_sync_pass_deferred_free, int, 0644);
+MODULE_PARM_DESC(zfs_sync_pass_deferred_free,
+    "defer frees starting in this pass");
+
+module_param(zfs_sync_pass_dont_compress, int, 0644);
+MODULE_PARM_DESC(zfs_sync_pass_dont_compress,
+    "don't compress starting in this pass");
+
+module_param(zfs_sync_pass_rewrite, int, 0644);
+MODULE_PARM_DESC(zfs_sync_pass_rewrite,
+    "rewrite new bps starting in this pass");
 #endif


### PR DESCRIPTION
While the new tunables are not intended for day-to-day tweak, it is the question of parity with Illumos - if the need to tinker with these variable ever arise the Linux way of doing so is module parameter.

Commit 55d85d5a8c45c4559a4a0e675c37b0c3afb19c2f (backport of the upstream changes)
replaced three hardcoded constants:

```
#define SYNC_PASS_DEFERRED_FREE 2 /* defer frees after this pass */
#define SYNC_PASS_DONT_COMPRESS 4 /* don't compress after this pass */
#define SYNC_PASS_REWRITE       1 /* rewrite new bps after this pass */
```

with a tunable parameters:

```
int zfs_sync_pass_deferred_free = 2; /* defer frees starting in this pass */
int zfs_sync_pass_dont_compress = 5; /* don't compress starting in this pass */
int zfs_sync_pass_rewrite = 2;       /* rewrite new bps starting in this pass */
```

This commit makes these tunables available as module parameters in Linux.
