### PR TITLE
Fix zdb -R failures with 'Aborted (core dumped)'

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2844,11 +2844,7 @@ zdb_read_block(char *thing, spa_t *spa)
 	psize = size;
 	lsize = size;
 
-#ifdef __linux__
 	pbuf = umem_alloc_aligned(SPA_MAXBLOCKSIZE, 512, UMEM_NOFAIL);
-#else
-	pbuf = umem_alloc(SPA_MAXBLOCKSIZE, UMEM_NOFAIL);
-#endif
 	lbuf = umem_alloc(SPA_MAXBLOCKSIZE, UMEM_NOFAIL);
 
 	BP_ZERO(bp);


### PR DESCRIPTION
Make sure that buffer is aligned to 512 bytes on linux so that
pread call combined with O_DIRECT does not return EINVAL.
