### PR TITLE
Explicitly flush output at end of each "zpool events -f" event. 

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5243,6 +5243,7 @@ zpool_do_events_next(ev_opts_t *opts)
 			zpool_do_events_nvprint(nvl, 8);
 			printf(gettext("\n"));
 		}
+                (void) fflush(stdout);
 
 		nvlist_free(nvl);
 	}


### PR DESCRIPTION
Useful for syslog shims or to otherwise trigger maintenance or alerts.

Tested against 0.6.1.
Issue #1568
