### PR TITLE
Add kstat for monitoring dmu_tx_try_assign failure

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -90,6 +90,7 @@ typedef struct dsl_pool {
 	struct taskq *dp_iput_taskq;
 	kstat_t *dp_txg_kstat;
 	kstat_t *dp_tx_assign_kstat;
+	kstat_t *dp_tx_try_assign_kstat;
 
 	/* No lock needed - sync context only */
 	blkptr_t dp_meta_rootbp;
@@ -114,6 +115,8 @@ typedef struct dsl_pool {
 	list_t dp_txg_history;
 	uint64_t dp_tx_assign_size;
 	kstat_named_t *dp_tx_assign_buckets;
+	uint64_t dp_tx_try_assign_size;
+	kstat_named_t *dp_tx_try_assign_buckets;
 
 
 	/* Has its own locking */
@@ -165,6 +168,7 @@ extern int dsl_pool_user_release(dsl_pool_t *dp, uint64_t dsobj,
 extern void dsl_pool_clean_tmp_userrefs(dsl_pool_t *dp);
 int dsl_pool_open_special_dir(dsl_pool_t *dp, const char *name, dsl_dir_t **);
 
+void dsl_pool_tx_try_assign_add(dsl_pool_t *dp, uint64_t count);
 void dsl_pool_tx_assign_add_usecs(dsl_pool_t *dp, uint64_t usecs);
 
 txg_history_t *dsl_pool_txg_history_add(dsl_pool_t *dp, uint64_t txg);

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1090,6 +1090,7 @@ int
 dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 {
 	hrtime_t before, after;
+	uint64_t try_count = 0;
 	int err;
 
 	ASSERT(tx->tx_txg == 0);
@@ -1104,6 +1105,8 @@ dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 		if (err != ERESTART || txg_how != TXG_WAIT)
 			return (err);
 
+		try_count++;
+
 		dmu_tx_wait(tx);
 	}
 
@@ -1113,6 +1116,8 @@ dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 
 	dsl_pool_tx_assign_add_usecs(tx->tx_pool,
 	    (after - before) / NSEC_PER_USEC);
+
+	dsl_pool_tx_try_assign_add(tx->tx_pool, try_count);
 
 	return (0);
 }

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -59,9 +59,69 @@ kmutex_t zfs_write_limit_lock;
 static pgcnt_t old_physmem = 0;
 
 static void
+dsl_pool_tx_try_assign_init(dsl_pool_t *dp, unsigned int ndata)
+{
+	kstat_t *ks;
+	kstat_named_t *ksn;
+	char name[KSTAT_STRLEN];
+	int i, data_size = ndata * sizeof(kstat_named_t);
+
+	(void) snprintf(name, KSTAT_STRLEN, "dmu_tx_try_assign-%s",
+			spa_name(dp->dp_spa));
+
+	dp->dp_tx_try_assign_size = ndata;
+
+	if (data_size)
+		dp->dp_tx_try_assign_buckets = kmem_alloc(data_size, KM_SLEEP);
+	else
+		dp->dp_tx_try_assign_buckets = NULL;
+
+	for (i = 0; i < dp->dp_tx_try_assign_size; i++) {
+		ksn = &dp->dp_tx_try_assign_buckets[i];
+		ksn->data_type = KSTAT_DATA_UINT64;
+		ksn->value.ui64 = 0;
+		(void) snprintf(ksn->name, KSTAT_STRLEN, "%u", i);
+	}
+
+	dp->dp_tx_try_assign_kstat = kstat_create("zfs", 0, name, "misc",
+	    KSTAT_TYPE_NAMED, 0, KSTAT_FLAG_VIRTUAL);
+
+	if (dp->dp_tx_try_assign_kstat) {
+		ks = dp->dp_tx_try_assign_kstat;
+		ks->ks_data = dp->dp_tx_try_assign_buckets;
+		ks->ks_ndata = dp->dp_tx_try_assign_size;
+		ks->ks_data_size = data_size;
+		kstat_install(ks);
+	}
+}
+
+static void
+dsl_pool_tx_try_assign_destroy(dsl_pool_t *dp)
+{
+	if (dp->dp_tx_try_assign_buckets)
+		kmem_free(dp->dp_tx_try_assign_buckets,
+			  dp->dp_tx_try_assign_size * sizeof(kstat_named_t));
+
+	if (dp->dp_tx_try_assign_kstat)
+		kstat_delete(dp->dp_tx_try_assign_kstat);
+}
+
+void
+dsl_pool_tx_try_assign_add(dsl_pool_t *dp, uint64_t count)
+{
+	uint64_t idx = 0;
+
+	while ((idx < count) && (idx < dp->dp_tx_try_assign_size - 1))
+		idx++;
+
+	atomic_inc_64(&dp->dp_tx_try_assign_buckets[idx].value.ui64);
+}
+
+static void
 dsl_pool_tx_assign_init(dsl_pool_t *dp, unsigned int ndata)
 {
-	kstat_named_t *ks;
+	kstat_t *ks;
+	kstat_named_t *ksn;
 	char name[KSTAT_STRLEN];
 	int i, data_size = ndata * sizeof(kstat_named_t);
 
@@ -76,20 +136,21 @@ dsl_pool_tx_assign_init(dsl_pool_t *dp, unsigned int ndata)
 		dp->dp_tx_assign_buckets = NULL;
 
 	for (i = 0; i < dp->dp_tx_assign_size; i++) {
-		ks = &dp->dp_tx_assign_buckets[i];
-		ks->data_type = KSTAT_DATA_UINT64;
-		ks->value.ui64 = 0;
-		(void) snprintf(ks->name, KSTAT_STRLEN, "%u us", 1 << i);
+		ksn = &dp->dp_tx_assign_buckets[i];
+		ksn->data_type = KSTAT_DATA_UINT64;
+		ksn->value.ui64 = 0;
+		(void) snprintf(ksn->name, KSTAT_STRLEN, "%u us", 1 << i);
 	}
 
 	dp->dp_tx_assign_kstat = kstat_create("zfs", 0, name, "misc",
 	    KSTAT_TYPE_NAMED, 0, KSTAT_FLAG_VIRTUAL);
 
 	if (dp->dp_tx_assign_kstat) {
-		dp->dp_tx_assign_kstat->ks_data = dp->dp_tx_assign_buckets;
-		dp->dp_tx_assign_kstat->ks_ndata = dp->dp_tx_assign_size;
-		dp->dp_tx_assign_kstat->ks_data_size = data_size;
-		kstat_install(dp->dp_tx_assign_kstat);
+		ks = dp->dp_tx_assign_kstat;
+		ks->ks_data = dp->dp_tx_assign_buckets;
+		ks->ks_ndata = dp->dp_tx_assign_size;
+		ks->ks_data_size = data_size;
+		kstat_install(ks);
 	}
 }
 
@@ -296,6 +357,7 @@ dsl_pool_open_impl(spa_t *spa, uint64_t txg)
 
 	dsl_pool_txg_history_init(dp, txg);
 	dsl_pool_tx_assign_init(dp, 32);
+	dsl_pool_tx_try_assign_init(dp, 32);
 
 	return (dp);
 }
@@ -437,6 +499,7 @@ dsl_pool_close(dsl_pool_t *dp)
 	arc_flush(dp->dp_spa);
 	txg_fini(dp);
 	dsl_scan_fini(dp);
+	dsl_pool_tx_try_assign_destroy(dp);
 	dsl_pool_tx_assign_destroy(dp);
 	dsl_pool_txg_history_destroy(dp);
 	rw_destroy(&dp->dp_config_rwlock);


### PR DESCRIPTION
This change adds a new kstat to gain some visibility into the number of
dmu_tx_try_assign failures per each call to dmu_tx_assign. If TXG_WAIT
is used, dmu_tx_try_assign may be called repeated inside dmu_tx_assign.
The assumption is that if dmu_tx_try_assign fails, it will succeed on
the next iteration. This change is needed to gain some visibility into
whether this assumption is being met or not.

To interpret the newly exported information, let's consider the
following example:

```
$ cat /proc/spl/kstat/zfs/dmu_tx_try_assign-lustre-ost2
24 1 0x01 32 1536 3664740347397 3786787884701
name                            type data
0                               4    430
1                               4    43
2                               4    21
3                               4    31
4                               4    0
5                               4    0
6                               4    0
7                               4    0
8                               4    0
9                               4    0
10                              4    0
11                              4    0
12                              4    0
13                              4    0
14                              4    0
15                              4    0
16                              4    0
17                              4    0
18                              4    0
19                              4    0
20                              4    0
21                              4    0
22                              4    0
23                              4    0
24                              4    0
25                              4    0
26                              4    0
27                              4    0
28                              4    0
29                              4    0
30                              4    0
31                              4    0
```

In this example, most successful calls to dmu_tx_assign did not suffer
from a dmu_tx_try_assign failure; but some did. Specifically, 31 of the
calls to dmu_tx_assign resulted in 3 failed calls to dmu_tx_try_assign.
The other rows can be interpreted the same way (21 calls had 2 failures,
and 43 calls had 1 failure).

Signed-off-by: Prakash Surya surya1@llnl.gov
