### PR TITLE
dmu_tx: Fix possible NULL pointer dereference

### DIFF
--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1320,6 +1320,8 @@ dmu_tx_hold_spill(dmu_tx_t *tx, uint64_t object)
 
 	txh = dmu_tx_hold_object_impl(tx, tx->tx_objset, object,
 	    THT_SPILL, 0, 0);
+	if (txh == NULL)
+		return;
 
 	dn = txh->txh_dnode;
 


### PR DESCRIPTION
dmu_tx_hold_object_impl can return NULL on error.  Check or this condition prior to dereferencing pointer.

Signed-off-by: Nathaniel Clark Nathaniel.Clark@misrule.us
