### PR TITLE
Simplify reclaim

### DIFF
--- a/module/zfs/zpl_super.c
+++ b/module/zfs/zpl_super.c
@@ -275,7 +275,6 @@ zpl_prune_sbs(int64_t bytes_to_scan, void *private)
 	unsigned long nr_to_scan = (bytes_to_scan / sizeof(znode_t));
 
 	iterate_supers_type(&zpl_fs_type, zpl_prune_sb, &nr_to_scan);
-	kmem_reap();
 }
 #else
 /*
@@ -293,7 +292,6 @@ zpl_prune_sbs(int64_t bytes_to_scan, void *private)
 
         shrink_dcache_memory(nr_to_scan, GFP_KERNEL);
         shrink_icache_memory(nr_to_scan, GFP_KERNEL);
-        kmem_reap();
 }
 #endif /* HAVE_SHRINK */
 


### PR DESCRIPTION
I have been testing a revival of arc_reclaim where I make direct reclaim kick the arc_reclaim thread and block until either 1 second passes or it completes. It seems to work well and brings us more in line with other implementations.

I am opening this pull request for review. The manner in which the commits are split needs to be revisited before it is merged, but the end result seems sane to me.
