### PR TITLE
Illumos #3639 zpool.cache should skip over readonly pools

### DIFF
--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -225,7 +225,15 @@ spa_config_sync(spa_t *target, boolean_t removing, boolean_t postsysevent)
 		 */
 		nvl = NULL;
 		while ((spa = spa_next(spa)) != NULL) {
-			if (spa == target && removing)
+			/*
+			 * Skip over our own pool if we're about to remove
+			 * ourselves from the spa namespace or any pool that
+			 * is readonly. Since we cannot guarantee that a
+			 * readonly pool would successfully import upon reboot,
+			 * we don't allow them to be written to the cache file.
+			 */
+			if ((spa == target && removing) ||
+			    !spa_writeable(spa))
 				continue;
 
 			mutex_enter(&spa->spa_props_lock);


### PR DESCRIPTION
Normally we don't list pools that are imported read-only in the cache
file, however you can accidentally get one into the cache file by
importing and exporting a read-write pool while a read-only pool is
imported:

$ zpool import -o readonly test1
$ zpool import test2
$ zpool export test2
$ zdb -C

This is a problem because if the machine reboots we import all pools in
the cache file as read-write.

https://www.illumos.org/issues/3639

Reviewed by: Eric Schrock eric.schrock@delphix.com
Reviewed by: Adam Leventhal ahl@delphix.com
Reviewed by: Basil Crow basil.crow@delphix.com
Approved by: Gordon Ross gwr@nexenta.com
Ported-by: Richard Yao ryao@gentoo.org
