### PR TITLE
Fix zil_commit() deadlock

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1515,7 +1515,6 @@ zil_commit_writer(zilog_t *zilog)
 	 * calling zil_create().
 	 */
 	if (list_head(&zilog->zl_itx_commit_list) == NULL) {
-		mutex_enter(&zilog->zl_lock);
 		return;
 	}
 
@@ -1557,8 +1556,6 @@ zil_commit_writer(zilog_t *zilog)
 
 	if (error || lwb == NULL)
 		txg_wait_synced(zilog->zl_dmu_pool, 0);
-
-	mutex_enter(&zilog->zl_lock);
 
 	/*
 	 * Remember the highest committed log sequence number for ztest.
@@ -1627,8 +1624,6 @@ zil_commit(zilog_t *zilog, uint64_t foid)
 
 	/* wake up all threads waiting for this batch to be committed */
 	cv_broadcast(&zilog->zl_cv_batch[mybatch & 1]);
-
-	mutex_exit(&zilog->zl_lock);
 }
 
 /*


### PR DESCRIPTION
If two threads concurrently enter zil_commit(), one will take the
zilog->zl_lock mutex (lets call this thread A) while the other will
block (lets call this thread B). Thread A will then set a flag saying
that there is a writer and free the mutex. Thread B will get the mutex,
see the flag and enter a condition wait for a signal from thread A that
it finished. Then before thead A sends the signal, it will attempt to
take the mutex. The two threads will then wait on each other ad
infinitum and forward progress on the pool will stop.

We break the deadlock by making thread A stop trying to retake the
mutex. When thinking about safety, there are two cases to consider. The
first is that there is a thread B. In that case, this is safe because
thread B will not act until signaled by thread A, giving thread A
effective control over the mutex. The second is that there is no thread
B. In that case, this is safe because we do not need to worry about
another thread.

Signed-off-by: Richard Yao ryao@gentoo.org
