### PR TITLE
Return -1 from arc_shrinker_func()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2380,10 +2380,8 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	 */
 	if (pages > 0) {
 		arc_kmem_reap_now(ARC_RECLAIM_AGGR, ptob(sc->nr_to_scan));
-		pages = btop(arc_evictable_memory());
 	} else {
 		arc_kmem_reap_now(ARC_RECLAIM_CONS, ptob(sc->nr_to_scan));
-		pages = -1;
 	}
 
 	/*
@@ -2403,7 +2401,7 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 
 	mutex_exit(&arc_reclaim_thr_lock);
 
-	return (pages);
+	return (-1);
 }
 SPL_SHRINKER_CALLBACK_WRAPPER(arc_shrinker_func);
 


### PR DESCRIPTION
This is analogous to the following SPL commit:

zfsonlinux/spl@b9b3715346b2748b2e512099862f1eabf076cf51

Closes zfsonlinux/zfs#1579

Signed-off-by: Richard Yao ryao@gentoo.org
