### PR TITLE
Fixed the default checksum algorithm in the manpage.

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -723,7 +723,7 @@ This property is not inherited.
 .ad
 .sp .6
 .RS 4n
-Controls the checksum used to verify data integrity. The default value is \fBon\fR, which automatically selects an appropriate algorithm (currently, \fBfletcher2\fR, but this may change in future releases). The value \fBoff\fR disables integrity checking on user data. Disabling checksums is \fBNOT\fR a recommended practice.
+Controls the checksum used to verify data integrity. The default value is \fBon\fR, which automatically selects an appropriate algorithm (currently, \fBfletcher4\fR, but this may change in future releases). The value \fBoff\fR disables integrity checking on user data. Disabling checksums is \fBNOT\fR a recommended practice.
 .sp
 Changing this property affects only newly-written data.
 .RE


### PR DESCRIPTION
I've noticed a mismatch between the man page and the source code about the default algorithm for checksum=on.
The manpage reports fletcher2, but zio.h (https://github.com/zfsonlinux/zfs/blob/master/include/sys/zio.h#L85) says it's fletcher4.
