### PR TITLE
changes the manpages for sync

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1119,12 +1119,12 @@ Controls whether the \fB\&.zfs\fR directory is hidden or visible in the root of 
 .ne 2
 .mk
 .na
-\fB\fBsync\fR=\fBdefault\fR | \fBalways\fR | \fBdisabled\fR\fR
+\fB\fBsync\fR=\fBstandard\fR | \fBalways\fR | \fBdisabled\fR\fR
 .ad
 .sp .6
 .RS 4n
 Controls the behavior of synchronous requests (e.g. fsync, O_DSYNC).
-\fBdefault\fR is the POSIX specified behavior of ensuring all synchronous
+\fBstandard\fR is the POSIX specified behavior of ensuring all synchronous
 requests are written to stable storage and all devices are flushed to ensure
 data is not cached by device controllers (this is the default). \fBalways\fR
 causes every file system transaction to be written and flushed before its


### PR DESCRIPTION
The help output of for zfs set/get says that sync can be one of

standard | always | disabled

but the man pages claim it can be

sync=default | always | disabled

the accepted value is standard, this changes the manpage to give the
correct values.
