### PR TITLE
zpios: Replace current_kernel_time() with getnstimeofday()

### DIFF
--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -177,7 +177,7 @@ zpios_timespec_t zpios_timespec_now(void)
 	zpios_timespec_t zts_now;
 	struct timespec ts_now;
 
-	ts_now = current_kernel_time();
+	getnstimeofday(&ts_now);
 	zts_now.ts_sec  = ts_now.tv_sec;
 	zts_now.ts_nsec = ts_now.tv_nsec;
 


### PR DESCRIPTION
current_kernel_time() is not meant for performance measurement. This
should use getnstimeofday(), which is equivalent to the gethrestime()
function on Solaris.

Signed-off-by: Richard Yao ryao@gentoo.org
