### PR TITLE
Report bytes reserved in txg history file

### DIFF
--- a/lib/libspl/include/sys/kstat.h
+++ b/lib/libspl/include/sys/kstat.h
@@ -718,6 +718,7 @@ typedef struct kstat_txg {
 	u_longlong_t		nwritten;	/* number of bytes written */
 	uint_t			reads;		/* number of read operations */
 	uint_t			writes;		/* number of write operations */
+	u_longlong_t		nreserved;	/* number of bytes reserved */
 	hrtime_t		open_time;	/* open time */
 	hrtime_t		quiesce_time;	/* quiesce time */
 	hrtime_t		sync_time;	/* sync time */

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -537,6 +537,8 @@ txg_sync_thread(dsl_pool_t *dp)
 
 		th = dsl_pool_txg_history_get(dp, txg);
 		th->th_kstat.state = TXG_STATE_SYNCING;
+		th->th_kstat.nreserved = dp->dp_space_towrite[txg & TXG_MASK]
+		    + dp->dp_tempreserved[txg & TXG_MASK] / 2;
 		vdev_get_stats(spa->spa_root_vdev, &th->th_vs1);
 		dsl_pool_txg_history_put(th);
 


### PR DESCRIPTION
Add a column in the txg history file for reporting the number of bytes
reserved for each txg. This should provide some visibility into the
ratio of reserved space to space actually written for each txg.

Signed-off-by: Prakash Surya surya1@llnl.gov
