### PR TITLE
Add script to fix file names in upstream patches

### DIFF
--- a/scripts/zfs2zol-patch.sed
+++ b/scripts/zfs2zol-patch.sed
@@ -1,0 +1,15 @@
+#!/bin/sed -f
+
+s:usr/src/uts/common/fs/zfs/sys:include/sys:g
+s:usr/src/uts/common/fs/zfs:module/zfs:g
+s:usr/src/lib/libzpool:lib/libzpool:g
+s:usr/src/cmd:cmd:g
+s:usr/src/common/nvpair:module/nvpair:g
+s:usr/src/lib/libzfs/common/libzfs.h:include/libzfs.h:g
+s:usr/src/man/man1m/zfs.1m:man/man8/zfs.8:g
+s:usr/src/uts/common/sys:include/sys:g
+s:usr/src/lib/libzfs_core/common/libzfs_core.h:include/libzfs_core.h:g
+s:usr/src/lib/libzfs/common:lib/libzfs:g
+s:usr/src/lib/libzfs_core/common:lib/libzfs_core:g
+s:lib/libzpool/common/sys:include/sys:g
+s:lib/libzpool/common:lib/libzpool:g


### PR DESCRIPTION
Added a simple perl script to do a search and replace on the Illumos
ZFS file names and replace them with the ZFS on Linux equivalent.

Would a script like this be useful? Currently it only fixes up the file
names found in upstream patches to use the ZFS on Linux file names.
Before I spend any more time adding all of the possible upstream files,
I wanted to see if a script like this would be useful enough to land?

I've only used it on patches created by `git format-patch -k` on the
upstream illumos-gate tree, but there's no reason it can't be updated to
work with patches created by `diff`.

Example usage:

```
    $ ./scripts/zfs2zol-patch.pl < 0001-3537-want-pool-io-kstats.patch > 0001-3537-want-pool-io-kstats.patch.linux
    $ patch -p1 < 0001-3537-want-pool-io-kstats.patch.linux
```
