### PR TITLE
Fix libblkid support

### DIFF
--- a/config/user-libblkid.m4
+++ b/config/user-libblkid.m4
@@ -22,18 +22,37 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 		[with_blkid=check])
 
 	LIBBLKID=
-	AS_IF([test "x$with_blkid" != xno],
+	AS_IF([test "x$with_blkid" = xyes],
+	[
+		AC_SUBST([LIBBLKID], ["-lblkid"])
+		AC_DEFINE([HAVE_LIBBLKID], 1,
+			[Define if you have libblkid])
+	])
+
+	AS_IF([test "x$with_blkid" = xcheck],
 	[
 		AC_CHECK_LIB([blkid], [blkid_get_cache],
 		[
 			AC_MSG_CHECKING([for blkid zfs support])
 
 			ZFS_DEV=`mktemp`
-			dd if=/dev/zero of=$ZFS_DEV bs=1024k count=8 \
+			dd if=/dev/zero of=$ZFS_DEV bs=1024k count=64 \
+				>/dev/null 2>/dev/null
+			echo -en "\x0c\xb1\xba\0\0\0\0\0" | \
+				dd of=$ZFS_DEV bs=1k count=8 \
+				seek=128 conv=notrunc &>/dev/null \
 				>/dev/null 2>/dev/null
 			echo -en "\x0c\xb1\xba\0\0\0\0\0" | \
 				dd of=$ZFS_DEV bs=1k count=8 \
 				seek=132 conv=notrunc &>/dev/null \
+				>/dev/null 2>/dev/null
+			echo -en "\x0c\xb1\xba\0\0\0\0\0" | \
+				dd of=$ZFS_DEV bs=1k count=8 \
+				seek=136 conv=notrunc &>/dev/null \
+				>/dev/null 2>/dev/null
+			echo -en "\x0c\xb1\xba\0\0\0\0\0" | \
+				dd of=$ZFS_DEV bs=1k count=8 \
+				seek=140 conv=notrunc &>/dev/null \
 				>/dev/null 2>/dev/null
 
 			saved_LDFLAGS="$LDFLAGS"
@@ -42,6 +61,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 			AC_RUN_IFELSE([AC_LANG_PROGRAM(
 			[
 				#include <stdio.h>
+				#include <stdlib.h>
 				#include <blkid/blkid.h>
 			],
 			[
@@ -58,10 +78,10 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 					return 2;
 				}
 
-				if (strcmp(value, "zfs")) {
+				if (strcmp(value, "zfs_member")) {
 					free(value);
 					blkid_put_cache(cache);
-					return 3;
+					return 0;
 				}
 
 				free(value);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -965,7 +965,7 @@ zpool_find_import_blkid(libzfs_handle_t *hdl, pool_list_t *pools)
 		goto err_blkid2;
 	}
 
-	err = blkid_dev_set_search(iter, "TYPE", "zfs");
+	err = blkid_dev_set_search(iter, "TYPE", "zfs_member");
 	if (err != 0) {
 		(void) zfs_error_fmt(hdl, EZFS_BADCACHE,
 		    dgettext(TEXT_DOMAIN, "blkid_dev_set_search() %d"), err);


### PR DESCRIPTION
libblkid support is dormant because the autotools check is broken and
liblkid identifies ZFS vdevs as "zfs_member", not "zfs". We fix that
with a few changes:

First, we fix the libblkid autotools check to do a few things:
1. Make a 64MB file, which is the minimum size ZFS permits.
2. Make 4 fake uberblock entries to make libblkid's check succeed.
3. Return 0 upon success to make autotools use the success case.
4. Include stdlib.h to avoid implicit declration of free().
5. Check for "zfs_member", not "zfs"
6. Make --with-blkid disable autotools check (avoids Gentoo sandbox violation)

Second, we change the libblkid support to scan for "zfs_member", not
"zfs".

This makes --with-blkid work on Gentoo.

Signed-off-by: Richard Yao ryao@gentoo.org
