### PR TITLE
Stop doing runtime pointer modifications in additional autotools checks

### DIFF
--- a/config/kernel-bdi.m4
+++ b/config/kernel-bdi.m4
@@ -6,9 +6,12 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI], [
 	AC_MSG_CHECKING([whether super_block has s_bdi])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
+
+		static const struct super_block
+		    sb __attribute__ ((unused)) {
+			.s_bdi = NULL,
+		}
 	],[
-		struct super_block sb __attribute__ ((unused));
-		sb.s_bdi = NULL;
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_BDI, 1, [struct super_block has s_bdi])

--- a/config/kernel-xattr-handler.m4
+++ b/config/kernel-xattr-handler.m4
@@ -18,10 +18,11 @@ AC_DEFUN([ZFS_AC_KERNEL_CONST_XATTR_HANDLER],
 		const struct xattr_handler *xattr_handlers[] = {
 			&xattr_test_handler,
 		};
-	],[
-		struct super_block sb __attribute__ ((unused));
 
-		sb.s_xattr = xattr_handlers;
+		const struct super_block sb __attribute__ ((unused)) = {
+			.s_xattr = xattr_handlers,
+		};
+	],[
 	],[
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(HAVE_CONST_XATTR_HANDLER, 1,
@@ -40,12 +41,14 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_GET], [
 	AC_MSG_CHECKING([whether xattr_handler->get() wants dentry])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/xattr.h>
-	],[
-		int (*get)(struct dentry *dentry, const char *name,
-		    void *buffer, size_t size, int handler_flags) = NULL;
-		struct xattr_handler xops __attribute__ ((unused));
 
-		xops.get = get;
+		int get(struct dentry *dentry, const char *name,
+		    void *buffer, size_t size, int handler_flags) { return 0; }
+		static const struct xattr_handler
+		    xops __attribute__ ((unused)) = {
+			.get = get,
+		};
+	],[
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_DENTRY_XATTR_GET, 1,
@@ -64,13 +67,15 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 	AC_MSG_CHECKING([whether xattr_handler->set() wants dentry])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/xattr.h>
-	],[
-		int (*set)(struct dentry *dentry, const char *name,
-		    const void *buffer, size_t size, int flags,
-		    int handler_flags) = NULL;
-		struct xattr_handler xops __attribute__ ((unused));
 
-		xops.set = set;
+		int set(struct dentry *dentry, const char *name,
+		    const void *buffer, size_t size, int flags,
+		    int handler_flags) { return 0; }
+		static const struct xattr_handler
+		    xops __attribute__ ((unused)) = {
+			.set = set,
+		};
+	],[
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_DENTRY_XATTR_SET, 1,


### PR DESCRIPTION
c38367c73f592ca9729ba0d5e70b5e3bc67e0745 was meant to eliminate runtime
function pointer modifications in autotools checks because they were
prone to false negatives on kernels hardened by the PaX project.
Unfortunately, I missed the xattr_handler and super_block->s_bdi
autotools checks. Recent changes to PaX constified
xattr_handler->get/set, which lead me to discover this oversight.

Closes zfsonlinux/zfs#1433

Signed-off-by: Richard Yao ryao@gentoo.org
