### PR TITLE
Removing unneeded mutex for reading vq->vq_pending_tree->avl_numnodes

### DIFF
--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -92,10 +92,7 @@ vdev_mirror_pending(vdev_t *vd)
 	vdev_queue_t *vq = &vd->vdev_queue;
 	int pending;
 
-	mutex_enter(&vq->vq_lock);
 	pending = avl_numnodes(&vq->vq_pending_tree);
-	mutex_exit(&vq->vq_lock);
-
 	return (pending);
 }
 


### PR DESCRIPTION
locking mutex &vq->vq_lock in vdev_mirror_pending is unneeded:
- no data is modified
- only vq_pending_tree is read
- in case garbage is returned (eg. vq_pending_tree being updated while the read is made) worst case would be that a single read could be queued on a mirror side which more busy than thought

Benefit of this change is streamlining of the codepath, since it is taken for _every_ mirror member on _every_ read.
