### PR TITLE
Add visibility into arc_read through a new kstat

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -51,6 +51,8 @@ typedef struct zilog zilog_t;
 typedef struct spa_aux_vdev spa_aux_vdev_t;
 typedef struct ddt ddt_t;
 typedef struct ddt_entry ddt_entry_t;
+typedef struct zbookmark zbookmark_t;
+
 struct dsl_pool;
 
 /*
@@ -532,6 +534,12 @@ extern boolean_t spa_refcount_zero(spa_t *spa);
 #define	SCL_LOCKS	7
 #define	SCL_ALL		((1 << SCL_LOCKS) - 1)
 #define	SCL_STATE_ALL	(SCL_STATE | SCL_L2ARC | SCL_ZIO)
+
+/* Pool read history statistics */
+extern void spa_read_history_init(spa_t *spa);
+extern void spa_read_history_destroy(spa_t *spa);
+extern void spa_read_history_add(spa_t *spa, const zbookmark_t *zb,
+    uint32_t aflags);
 
 /* Pool configuration locks */
 extern int spa_config_tryenter(spa_t *spa, int locks, void *tag, krw_t rw);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -236,6 +236,12 @@ struct spa {
 	uint64_t	spa_deadman_calls;	/* number of deadman calls */
 	uint64_t	spa_sync_starttime;	/* starting time fo spa_sync */
 	uint64_t	spa_deadman_synctime;	/* deadman expiration timer */
+	kmutex_t	spa_read_history_lock;	/* read history list lock */
+	uint64_t	spa_read_history_count;	/* running count of # of reads */
+	uint64_t	spa_read_history_size;	/* read history list size */
+	kstat_t		*spa_read_history_kstat;/* read history list kstat */
+	list_t		spa_read_history;	/* read history list */
+
 	/*
 	 * spa_refcnt & spa_config_lock must be the last elements
 	 * because refcount_t changes size based on compilation options.

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -212,6 +212,7 @@ typedef struct kthread {
 #define	tsd_get(key)			pthread_getspecific(key)
 #define	tsd_set(key, val)		pthread_setspecific(key, val)
 #define	curthread			zk_thread_current()
+#define	getcomm()			"unknown"
 #define	thread_exit			zk_thread_exit
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
 	zk_thread_create(stk, stksize, (thread_func_t)func, arg,	\

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -256,12 +256,13 @@ extern char *zio_type_name[ZIO_TYPES];
  * Therefore it must not change size or alignment between 32/64 bit
  * compilation options.
  */
-typedef struct zbookmark {
+struct zbookmark {
 	uint64_t	zb_objset;
 	uint64_t	zb_object;
 	int64_t		zb_level;
 	uint64_t	zb_blkid;
-} zbookmark_t;
+	char *		zb_func;
+};
 
 #define	SET_BOOKMARK(zb, objset, object, level, blkid)  \
 {                                                       \
@@ -269,6 +270,7 @@ typedef struct zbookmark {
 	(zb)->zb_object = object;                       \
 	(zb)->zb_level = level;                         \
 	(zb)->zb_blkid = blkid;                         \
+	(zb)->zb_func = FTAG;                           \
 }
 
 #define	ZB_DESTROYED_OBJSET	(-1ULL)

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -60,6 +60,7 @@ libzpool_la_SOURCES = \
 	$(top_srcdir)/module/zfs/spa_errlog.c \
 	$(top_srcdir)/module/zfs/spa_history.c \
 	$(top_srcdir)/module/zfs/spa_misc.c \
+	$(top_srcdir)/module/zfs/spa_stats.c \
 	$(top_srcdir)/module/zfs/space_map.c \
 	$(top_srcdir)/module/zfs/txg.c \
 	$(top_srcdir)/module/zfs/uberblock.c \

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -239,6 +239,14 @@ void
 kstat_delete(kstat_t *ksp)
 {}
 
+/*ARGSUSED*/
+void
+kstat_set_raw_ops(kstat_t *ksp,
+		  void  (*headers)(char *buf, size_t size),
+		  void  (*data)(char *buf, size_t size, void *data),
+		  void* (*addr)(kstat_t *ksp, loff_t index))
+{}
+
 /*
  * =========================================================================
  * mutexes

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -44,6 +44,7 @@ $(MODULE)-objs += @top_srcdir@/module/zfs/spa_config.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/spa_errlog.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/spa_history.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/spa_misc.o
+$(MODULE)-objs += @top_srcdir@/module/zfs/spa_stats.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/space_map.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/txg.o
 $(MODULE)-objs += @top_srcdir@/module/zfs/uberblock.o

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -48,6 +48,7 @@
 #include <sys/metaslab_impl.h>
 #include <sys/arc.h>
 #include <sys/ddt.h>
+#include <sys/kstat.h>
 #include "zfs_prop.h"
 #include "zfeature_common.h"
 
@@ -252,7 +253,6 @@ unsigned long zfs_deadman_synctime = 1000ULL;
  * By default the deadman is enabled.
  */
 int zfs_deadman_enabled = 1;
-
 
 /*
  * ==========================================================================
@@ -499,6 +499,8 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	refcount_create(&spa->spa_refcount);
 	spa_config_lock_init(spa);
 
+	spa_read_history_init(spa);
+
 	avl_add(&spa_namespace_avl, spa);
 
 	/*
@@ -580,6 +582,8 @@ spa_remove(spa_t *spa)
 	spa_config_set(spa, NULL);
 
 	refcount_destroy(&spa->spa_refcount);
+
+	spa_read_history_destroy(spa);
 
 	spa_config_lock_destroy(spa);
 

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -1,0 +1,230 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+#include <sys/zfs_context.h>
+#include <sys/spa_impl.h>
+
+/*
+ * Keeps stats on last N reads per spa_t, disabled by default.
+ */
+int zfs_read_history = 0;
+
+/*
+ * ==========================================================================
+ * SPA Read History Routines
+ * ==========================================================================
+ */
+
+/*
+ * Read statistics - Information exported regarding each arc_read call
+ */
+typedef struct kstat_read {
+	uint64_t	uid;		/* unique identifier */
+	hrtime_t	start;		/* time read completed */
+	uint64_t	objset;		/* read from this objset */
+	uint64_t	object;		/* read of this object number */
+	uint64_t	level;		/* block's indirection level */
+	uint64_t	blkid;		/* read of this block id */
+	char		origin[24];	/* read originated from here */
+	uint32_t	aflags;		/* ARC flags (cached, prefetch, etc.) */
+	pid_t		pid;		/* PID of task doing read */
+	char		comm[16];	/* command name of task doing read */
+} kstat_read_t;
+
+typedef struct spa_read_history {
+	kstat_read_t	srh_kstat;
+	list_node_t	srh_link;
+} spa_read_history_t;
+
+void
+spa_read_history_headers(char *buf, size_t size)
+{
+	snprintf(buf, size, "%-8s %-18s %-8s %-8s %-8s %-8s %-10s "
+		 "%-24s %-8s %-16s\n", "UID", "start", "objset", "object",
+		 "level", "blkid", "aflags", "origin", "pid", "command");
+	buf[size-1] = '\0';
+}
+
+void
+spa_read_history_data(char *buf, size_t size, void *data)
+{
+	kstat_read_t *krp = (kstat_read_t *)data;
+
+	snprintf(buf, size, "%-8llu %-18llu 0x%-6llx %-8lli %-8lli %-8lli "
+		 "0x%-6x %-24s %-8i %-16s\n", (u_longlong_t)krp->uid, krp->start,
+		 (longlong_t)krp->objset, (longlong_t)krp->object,
+		 (longlong_t)krp->level, (longlong_t)krp->blkid,
+		 krp->aflags, krp->origin, krp->pid, krp->comm);
+	buf[size-1] = '\0';
+}
+
+void *
+spa_read_history_addr(kstat_t *ksp, loff_t index)
+{
+	return ksp->ks_data + index * sizeof(kstat_read_t);
+}
+
+static int
+spa_read_history_update(kstat_t *ksp, int rw)
+{
+	spa_t *spa = ksp->ks_private;
+	spa_read_history_t *srh;
+	int i = 0;
+
+	if (rw == KSTAT_WRITE)
+		return (EACCES);
+
+	if (ksp->ks_data) {
+		vmem_free(ksp->ks_data, ksp->ks_data_size);
+		ksp->ks_data = NULL;
+	}
+
+	mutex_enter(&spa->spa_read_history_lock);
+
+	ksp->ks_ndata = spa->spa_read_history_size;
+	ksp->ks_data_size = spa->spa_read_history_size * sizeof(kstat_read_t);
+
+	if (ksp->ks_data_size > 0)
+		ksp->ks_data = vmem_alloc(ksp->ks_data_size, KM_PUSHPAGE);
+
+	for (srh = list_tail(&spa->spa_read_history); srh != NULL;
+	     srh = list_prev(&spa->spa_read_history, srh)) {
+		ASSERT3S(i + sizeof(kstat_read_t), <=, ksp->ks_data_size);
+		memcpy(ksp->ks_data + i, &srh->srh_kstat, sizeof(kstat_read_t));
+		i += sizeof(kstat_read_t);
+	}
+
+	mutex_exit(&spa->spa_read_history_lock);
+
+	return (0);
+}
+
+void
+spa_read_history_init(spa_t *spa)
+{
+	char name[KSTAT_STRLEN];
+	kstat_t *ksp;
+
+	mutex_init(&spa->spa_read_history_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	list_create(&spa->spa_read_history, sizeof (spa_read_history_t),
+	    offsetof(spa_read_history_t, srh_link));
+
+	spa->spa_read_history_count = 0;
+	spa->spa_read_history_size = 0;
+
+	(void) snprintf(name, KSTAT_STRLEN, "reads-%s", spa_name(spa));
+	name[KSTAT_STRLEN-1] = '\0';
+
+	ksp = kstat_create("zfs", 0, name, "misc",
+	    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
+
+	spa->spa_read_history_kstat = ksp;
+
+	if (ksp) {
+		ksp->ks_data = NULL;
+		ksp->ks_private = spa;
+		ksp->ks_update = spa_read_history_update;
+		kstat_set_raw_ops(ksp, spa_read_history_headers,
+				       spa_read_history_data,
+				       spa_read_history_addr);
+		kstat_install(ksp);
+	}
+}
+
+void
+spa_read_history_destroy(spa_t *spa)
+{
+	spa_read_history_t *srh;
+	kstat_t *ksp;
+
+	ksp = spa->spa_read_history_kstat;
+	if (ksp) {
+		if (ksp->ks_data)
+			vmem_free(ksp->ks_data, ksp->ks_data_size);
+
+		kstat_delete(ksp);
+	}
+
+	mutex_enter(&spa->spa_read_history_lock);
+	while ((srh = list_remove_head(&spa->spa_read_history))) {
+		spa->spa_read_history_size--;
+		kmem_free(srh, sizeof(spa_read_history_t));
+	}
+
+	ASSERT3U(spa->spa_read_history_size, ==, 0);
+	list_destroy(&spa->spa_read_history);
+	mutex_exit(&spa->spa_read_history_lock);
+
+	mutex_destroy(&spa->spa_read_history_lock);
+}
+
+void
+spa_read_history_add(spa_t *spa, const zbookmark_t *zb, uint32_t aflags)
+{
+	spa_read_history_t *srh, *rm;
+	unsigned int size;
+
+	ASSERT3P(spa, !=, NULL);
+	ASSERT3P(zb,  !=, NULL);
+
+	/* Must also check history_size in case we need to clear the list */
+	if (zfs_read_history == 0 && spa->spa_read_history_size == 0)
+		return;
+
+	srh = kmem_zalloc(sizeof(spa_read_history_t), KM_PUSHPAGE);
+
+	size = sizeof(srh->srh_kstat.origin);
+	strncpy(srh->srh_kstat.origin, zb->zb_func, size);
+	srh->srh_kstat.origin[size-1] = '\0';
+
+	srh->srh_kstat.start  = gethrtime();
+	srh->srh_kstat.objset = zb->zb_objset;
+	srh->srh_kstat.object = zb->zb_object;
+	srh->srh_kstat.level  = zb->zb_level;
+	srh->srh_kstat.blkid  = zb->zb_blkid;
+	srh->srh_kstat.aflags = aflags;
+
+	srh->srh_kstat.pid    = getpid();
+	size = sizeof(srh->srh_kstat.comm);
+	strncpy(srh->srh_kstat.comm, getcomm(), size);
+	srh->srh_kstat.comm[size-1] = '\0';
+
+	mutex_enter(&spa->spa_read_history_lock);
+
+	srh->srh_kstat.uid = spa->spa_read_history_count++;
+
+	list_insert_head(&spa->spa_read_history, srh);
+	spa->spa_read_history_size++;
+
+	while (spa->spa_read_history_size > zfs_read_history) {
+		spa->spa_read_history_size--;
+		rm = list_remove_tail(&spa->spa_read_history);
+		kmem_free(rm, sizeof(spa_read_history_t));
+	}
+
+	mutex_exit(&spa->spa_read_history_lock);
+}
+
+#if defined(_KERNEL) && defined(HAVE_SPL)
+module_param(zfs_read_history, int, 0644);
+MODULE_PARM_DESC(zfs_read_history, "Historic statistics for the last N reads");
+#endif


### PR DESCRIPTION
This change is an attempt to add visibility into the arc_read calls
occurring on a system, in real time. To do this, a list was added to the
in memory SPA data structure for a pool, with each element on the list
corresponding to a call to arc_read. These entries are then exported
through the kstat interface, which can then be interpreted in userspace.

For each arc_read call, the following information is exported:
- A unique identifier (uint64_t)
- The time the entry was added to the list (hrtime_t)
  (_not_ wall clock time; relative to the other entries on the list)
- The objset ID (uint64_t)
- The object number (uint64_t)
- The indirection level (uint64_t)
- The block ID (uint64_t)
- The name of the function originating the arc_read call (char[24])
- The arc_flags from the arc_read call (uint32_t)
- The PID of the reading thread (pid_t)
- The command or name of thread originating read (char[16])

From this exported information one can see, in real time, exactly what
is being read, what function is generating the read, and whether or not
the read was found to be already cached.

There is still some work to be done, but this should serve as a good
starting point.

Specifically, dbuf_read's are not accounted for in the currently
exported information. Thus, a follow up patch should probably be added
to export these calls that never call into arc_read (they only hit the
dbuf hash table). In addition, it might be nice to create a utility
similar to "arcstat.py" to digest the exported information and display
it in a more readable format. Or perhaps, log the information and allow
for it to be "replayed" at a later time.

Signed-off-by: Prakash Surya surya1@llnl.gov
