### PR TITLE
Export symbols dsl_pool_config_{enter,exit}

### DIFF
--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -1229,6 +1229,9 @@ dsl_pool_config_held(dsl_pool_t *dp)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+EXPORT_SYMBOL(dsl_pool_config_enter);
+EXPORT_SYMBOL(dsl_pool_config_exit);
+
 module_param(zfs_no_write_throttle, int, 0644);
 MODULE_PARM_DESC(zfs_no_write_throttle, "Disable write throttling");
 


### PR DESCRIPTION
These are needed by consumers (i.e. Lustre) who wish to use the
dsl_prop_register() interface to register callbacks when pool
properties of interest change.  This interface requires that the
DSL pool configuration lock is held when called.
