### PR TITLE
zpool man page: detach  now suggests the offline command

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1001,7 +1001,7 @@ Forces any active datasets contained within the pool to be unmounted.
 .ad
 .sp .6
 .RS 4n
-Detaches \fIdevice\fR from a mirror. The operation is refused if there are no other valid replicas of the data.
+Detaches \fIdevice\fR from a mirror. The operation is refused if there are no other valid replicas of the data.  If \fIdevice\fR may be re-added to the pool later on then consider the "\fBzpool offline\fR" command instead.
 .RE
 
 .sp


### PR DESCRIPTION
A one-line change to the "detach" section of the zpool man page that suggests "zpool offline" if the device might be re-added to the pool later on
