### PR TITLE
Increase default udev wait time

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1207,7 +1207,7 @@ make_disks(zpool_handle_t *zhp, nvlist_t *nv)
 			    strrchr(devpath, '/') + 1) == -1)
 				return (-1);
 
-			ret = zpool_label_disk_wait(udevpath, 1000);
+			ret = zpool_label_disk_wait(udevpath, DISK_LABEL_WAIT);
 			if (ret) {
 				(void) fprintf(stderr, gettext("cannot "
 				    "resolve path '%s': %d\n"), udevpath, ret);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -57,6 +57,11 @@ extern "C" {
 #define	DISK_ROOT		"/dev"
 #define	UDISK_ROOT		"/dev/disk"
 
+/*
+ * Default wait time for a device name to be created.
+ */
+#define	DISK_LABEL_WAIT		(30 * 1000)  /* 30 seconds */
+
 #define	DEFAULT_IMPORT_PATH_SIZE	7
 extern char *zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE];
 

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -4080,10 +4080,10 @@ zvol_create_link_common(libzfs_handle_t *hdl, const char *dataset, int ifexists)
 	}
 
 	/*
-	 * Wait up to 10 seconds for udev to create the device.
+	 * Wait for udev to create the device.
 	 */
 	(void) snprintf(path, sizeof (path), "%s/%s", ZVOL_DIR, dataset);
-	error = zpool_label_disk_wait(path, 10000);
+	error = zpool_label_disk_wait(path, DISK_LABEL_WAIT);
 	if (error)
 		(void) printf(gettext("%s may not be immediately "
 		    "available\n"), path);


### PR DESCRIPTION
When creating a new pool, or adding/replacing a disk in an existing
pool, partition tables will be automatically created on the devices.
Under normal circumstances it will take less than a second for udev
to create the expected device files under /dev/.  However, it has
been observed that if the system is doing heavy IO concurrently udev
may take far longer.  If you also throw in some cheap dodgy hardware
it may take even longer.

To prevent zpool commands from failing due to this the default wait
time for udev is being increased to 30 seconds.  This will have no
impact on normal usage, the increase timeout should only be noticed
if your udev rules are incorrectly configured.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1646
