### PR TITLE
Lock the DSL pool configuration in zpl_snapdir_iterate().

### DIFF
--- a/module/zfs/zpl_ctldir.c
+++ b/module/zfs/zpl_ctldir.c
@@ -261,8 +261,10 @@ zpl_snapdir_iterate(struct file *filp, struct dir_context *ctx)
 		goto out;
 
 	while (error == 0) {
+		dsl_pool_config_enter(dmu_objset_pool(zsb->z_os), FTAG);
 		error = -dmu_snapshot_list_next(zsb->z_os, MAXNAMELEN,
-		    snapname, &id, &(ctx->pos), &case_conflict);
+		    snapname, &id, &ctx->pos, &case_conflict);
+		dsl_pool_config_exit(dmu_objset_pool(zsb->z_os), FTAG);
 		if (error)
 			goto out;
 


### PR DESCRIPTION
The new semantics introduced by the restructured sync task of illumos
3464 require this lock when calling dmu_snapshot_list_next().

Porting note:
  I missed this when doing the original port because ZoL's control
  directory code is Linux-specific and is in a different file than
  in illumos.
