### PR TITLE
Dedup-related documentation additions for zpool and zdb.

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -256,7 +256,7 @@ get_usage(zpool_help_t idx) {
 	case HELP_SCRUB:
 		return (gettext("\tscrub [-s] <pool> ...\n"));
 	case HELP_STATUS:
-		return (gettext("\tstatus [-vx] [-T d|u] [pool] ... [interval "
+		return (gettext("\tstatus [-vxD] [-T d|u] [pool] ... [interval "
 		    "[count]]\n"));
 	case HELP_UPGRADE:
 		return (gettext("\tupgrade\n"

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -133,6 +133,12 @@ compression ratio (compress), inflation due to the zfs copies property
 If specified twice, display a histogram of deduplication statistics, showing
 the allocated (physically present on disk) and referenced (logically
 referenced in the pool) block counts and sizes by reference count.
+.sp
+If specified a third time, display the statistics independently for each deduplication table.
+.sp
+If specified a fourth time, dump the contents of the deduplication tables describing duplicate blocks.
+.sp
+If specified a fifth time, also dump the contents of the deduplication tables describing unique blocks.
 .RE
 
 .sp

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -89,7 +89,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool iostat\fR [\fB-T\fR u | d ] [\fB-v\fR] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]
+\fBzpool iostat\fR [\fB-T\fR d | u ] [\fB-v\fR] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]
 .fi
 
 .LP
@@ -99,7 +99,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool list\fR [\fB-T\fR u | d ] [\fB-Hv\fR] [\fB-o\fR \fIproperty\fR[,...]] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]
+\fBzpool list\fR [\fB-T\fR d | u ] [\fB-Hv\fR] [\fB-o\fR \fIproperty\fR[,...]] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]
 .fi
 
 .LP
@@ -149,7 +149,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool status\fR [\fB-xv\fR] [\fIpool\fR] ...
+\fBzpool status\fR [\fB-xvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .fi
 
 .LP
@@ -1400,7 +1400,7 @@ Allows a pool to import when there is a missing log device.
 .ne 2
 .mk
 .na
-\fB\fBzpool iostat\fR [\fB-T\fR \fBu\fR | \fBd\fR] [\fB-v\fR] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]\fR
+\fB\fBzpool iostat\fR [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-v\fR] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]\fR
 .ad
 .sp .6
 .RS 4n
@@ -1457,7 +1457,7 @@ Treat exported or foreign devices as inactive.
 .ne 2
 .mk
 .na
-\fB\fBzpool list\fR [\fB-T\fR \fBu\fR | \fBd\fR] [\fB-Hv\fR] [\fB-o\fR \fIprops\fR[,...]] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]\fR
+\fB\fBzpool list\fR [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-Hv\fR] [\fB-o\fR \fIprops\fR[,...]] [\fIpool\fR] ... [\fIinterval\fR[\fIcount\fR]]\fR
 .ad
 .sp .6
 .RS 4n
@@ -1476,7 +1476,7 @@ Scripted mode. Do not display headers, and separate fields by a single tab inste
 .ne 2
 .mk
 .na
-\fB\fB-T\fR \fBu\fR | \fBd\fR\fR
+\fB\fB-T\fR \fBd\fR | \fBu\fR\fR
 .ad
 .RS 12n
 .rt  
@@ -1701,7 +1701,7 @@ Sets the specified property for \fInewpool\fR. See the “Properties” section 
 .ne 2
 .mk
 .na
-\fB\fBzpool status\fR [\fB-xv\fR] [\fIpool\fR] ...\fR
+\fBzpool status\fR [\fB-xvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .ad
 .sp .6
 .RS 4n
@@ -1714,7 +1714,7 @@ If a scrub or resilver is in progress, this command reports the percentage done 
 .na
 \fB\fB-x\fR\fR
 .ad
-.RS 6n
+.RS 12n
 .rt  
 Only display status for pools that are exhibiting errors or are otherwise unavailable. Warnings about pools not using the latest on-disk format will not be included.
 .RE
@@ -1725,11 +1725,34 @@ Only display status for pools that are exhibiting errors or are otherwise unavai
 .na
 \fB\fB-v\fR\fR
 .ad
-.RS 6n
+.RS 12n
 .rt  
 Displays verbose data error information, printing out a complete list of all data errors since the last complete pool scrub.
 .RE
 
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-D\fR\fR
+.ad
+.RS 12n
+.rt  
+Display a histogram of deduplication statistics, showing the allocated (physically present on disk) and
+referenced (logically referenced in the pool) block counts and sizes by reference count.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-T\fR \fBd\fR | \fBu\fR\fR
+.ad
+.RS 12n
+.rt  
+Display a time stamp.
+.sp
+Specify \fBu\fR for a printed representation of the internal representation of time. See \fBtime\fR(2). Specify \fBd\fR for standard date format. See \fBdate\fR(1).
 .RE
 
 .sp


### PR DESCRIPTION
Document the "-D" and "-T" options and the optional interval and count or
"zpool status".

Also for zpool's man page, use a consistent order for the various "-T"
options to match the program's help output.

Document the effect of additional "-D" options for zdb.
