### PR TITLE
Linux 3.11 compat: Rename LZ4 symbols

### DIFF
--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -74,9 +74,9 @@ extern size_t zle_compress(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
 extern int zle_decompress(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
-extern size_t lz4_compress(void *src, void *dst, size_t s_len, size_t d_len,
+extern size_t lz4_compress_zfs(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
-extern int lz4_decompress(void *src, void *dst, size_t s_len, size_t d_len,
+extern int lz4_decompress_zfs(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
 
 /*

--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -47,7 +47,7 @@ static kmem_cache_t *lz4_cache;
 
 /*ARGSUSED*/
 size_t
-lz4_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
+lz4_compress_zfs(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
 	uint32_t bufsiz;
 	char *dest = d_start;
@@ -74,7 +74,7 @@ lz4_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 
 /*ARGSUSED*/
 int
-lz4_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
+lz4_decompress_zfs(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
 	const char *src = s_start;
 	uint32_t bufsiz = BE_IN32(src);

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -53,7 +53,7 @@ zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 	{gzip_compress,		gzip_decompress,	8,	"gzip-8"},
 	{gzip_compress,		gzip_decompress,	9,	"gzip-9"},
 	{zle_compress,		zle_decompress,		64,	"zle"},
-	{lz4_compress,		lz4_decompress,		0,	"lz4"},
+	{lz4_compress_zfs,	lz4_decompress_zfs,	0,	"lz4"},
 };
 
 enum zio_compress


### PR DESCRIPTION
Linus Torvalds merged LZ4 into Linux 3.11. This causes a conflict
whenever CONFIG_LZ4_DECOMPRESS=y or CONFIG_LZ4_COMPRESS=y are set in the
kernel's .config. We rename the symbols to avoid the conflict.

Signed-off-by: Richard Yao ryao@gentoo.org
