### PR TITLE
Update Posix ACL patch to be compatible with kernels without Posix ACL.

### DIFF
--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -71,6 +71,7 @@ extern struct file_system_type zpl_fs_type;
 extern ssize_t zpl_xattr_list(struct dentry *dentry, char *buf, size_t size);
 extern int zpl_xattr_security_init(struct inode *ip, struct inode *dip,
     const struct qstr *qstr);
+#if defined(CONFIG_FS_POSIX_ACL)
 extern int zpl_set_acl(struct inode *ip, int type, struct posix_acl *acl);
 extern struct posix_acl *zpl_get_acl(struct inode *ip, int type);
 #if !defined(HAVE_GET_ACL)
@@ -84,6 +85,7 @@ extern int zpl_permission(struct inode *ip, int mask, struct nameidata *nd);
 extern int zpl_permission(struct inode *ip, int mask);
 #endif /*  HAVE_CHECK_ACL | HAVE_PERMISSION */
 #endif /* HAVE_GET_ACL */
+#endif /* CONFIG_FS_POSIX_ACL */
 
 extern int zpl_init_acl(struct inode *ip, struct inode *dir);
 extern int zpl_chmod_acl(struct inode *ip);

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -165,8 +165,13 @@ acltype_changed_cb(void *arg, uint64_t newval)
 		zsb->z_sb->s_flags &= ~MS_POSIXACL;
 		break;
 	case ZFS_ACLTYPE_POSIXACL:
+#ifdef CONFIG_FS_POSIX_ACL
 		zsb->z_acl_type = ZFS_ACLTYPE_POSIXACL;
 		zsb->z_sb->s_flags |= MS_POSIXACL;
+#else
+		zsb->z_acl_type = ZFS_ACLTYPE_OFF;
+		printk(KERN_EMERG "ZFS mounted a filesystem with Posix ACL enabled on a kernel without Posix ACL enabled. Ignoring Posix ACLs\n");
+#endif
 		break;
 	default:
 		break;

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -462,13 +462,14 @@ const struct inode_operations zpl_inode_operations = {
 #ifdef HAVE_INODE_FALLOCATE
 	.fallocate	= zpl_fallocate,
 #endif /* HAVE_INODE_FALLOCATE */
-#if defined(HAVE_GET_ACL)
+#if !defined(CONFIG_FS_POSIX_ACL)
+#elif defined(HAVE_GET_ACL)
 	.get_acl	= zpl_get_acl,
 #elif defined(HAVE_CHECK_ACL)
 	.check_acl	= zpl_check_acl,
 #elif defined(HAVE_PERMISSION)
 	.permission	= zpl_permission,
-#endif /* HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION */
+#endif /* CONFIG_FS_POSIX_ACL & ( HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION ) */
 };
 
 const struct inode_operations zpl_dir_inode_operations = {
@@ -487,13 +488,14 @@ const struct inode_operations zpl_dir_inode_operations = {
 	.getxattr	= generic_getxattr,
 	.removexattr	= generic_removexattr,
 	.listxattr	= zpl_xattr_list,
-#if defined(HAVE_GET_ACL)
+#if !defined(CONFIG_FS_POSIX_ACL)
+#elif defined(HAVE_GET_ACL)
 	.get_acl	= zpl_get_acl,
 #elif defined(HAVE_CHECK_ACL)
 	.check_acl	= zpl_check_acl,
 #elif defined(HAVE_PERMISSION)
 	.permission	= zpl_permission,
-#endif /* HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION */
+#endif /* CONFIG_FS_POSIX_ACL & ( HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION ) */
 };
 
 const struct inode_operations zpl_symlink_inode_operations = {
@@ -515,13 +517,14 @@ const struct inode_operations zpl_special_inode_operations = {
 	.getxattr	= generic_getxattr,
 	.removexattr	= generic_removexattr,
 	.listxattr	= zpl_xattr_list,
-#if defined(HAVE_GET_ACL)
+#if !defined(CONFIG_FS_POSIX_ACL)
+#elif defined(HAVE_GET_ACL)
 	.get_acl	= zpl_get_acl,
 #elif defined(HAVE_CHECK_ACL)
 	.check_acl	= zpl_check_acl,
 #elif defined(HAVE_PERMISSION)
 	.permission	= zpl_permission,
-#endif /* HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION */
+#endif /* CONFIG_FS_POSIX_ACL & ( HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION ) */
 };
 
 dentry_operations_t zpl_dentry_operations = {

--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -722,6 +722,8 @@ xattr_handler_t zpl_xattr_security_handler = {
 	.set	= zpl_xattr_security_set,
 };
 
+#ifdef CONFIG_FS_POSIX_ACL
+
 int
 zpl_set_acl(struct inode *ip, int type, struct posix_acl *acl)
 {
@@ -1187,11 +1189,26 @@ struct xattr_handler zpl_xattr_acl_default_handler =
 #endif /* HAVE_DENTRY_XATTR_LIST */
 };
 
+#else /* CONFIG_FS_POSIX_ACL = n */
+int
+zpl_init_acl(struct inode *ip, struct inode *dir)
+{
+	return 0;
+}
+int
+zpl_chmod_acl(struct inode *ip)
+{
+	return 0;
+}
+#endif /* CONFIG_FS_POSIX_ACL */
+
 xattr_handler_t *zpl_xattr_handlers[] = {
 	&zpl_xattr_security_handler,
 	&zpl_xattr_trusted_handler,
 	&zpl_xattr_user_handler,
+#ifdef CONFIG_FS_POSIX_ACL
 	&zpl_xattr_acl_access_handler,
 	&zpl_xattr_acl_default_handler,
+#endif /* CONFIG_FS_POSIX_ACL */
 	NULL
 };


### PR DESCRIPTION
Removing the acltype property would have needed to rebuild userspace components for different kernels.
So I decided to leave acltype as is, and print a KERN_EMERG message when using a dataset with posixacl enabled on a non-posix-acl-enabled kernel. 
Issue #1825 
