### PR TITLE
Handle concurrent snapshot automounts failing due to EBUSY.

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -528,7 +528,7 @@ main(int argc, char **argv)
 			case EBUSY:
 				(void) fprintf(stderr, gettext("filesystem "
 				    "'%s' is already mounted\n"), dataset);
-				return (MOUNT_SYSERR);
+				return (MOUNT_BUSY);
 			default:
 				(void) fprintf(stderr, gettext("filesystem "
 				    "'%s' can not be mounted due to error "

--- a/lib/libspl/include/sys/mntent.h
+++ b/lib/libspl/include/sys/mntent.h
@@ -39,6 +39,7 @@
 #define	MOUNT_FILEIO	0x10		/* Error updating/locking /etc/mtab */
 #define	MOUNT_FAIL	0x20		/* Mount failed */
 #define	MOUNT_SOMEOK	0x40		/* At least on mount succeeded */
+#define MOUNT_BUSY	0x80		/* Mount failed due to EBUSY */
 
 #define	MNTOPT_ASYNC	"async"		/* all I/O is asynchronous */
 #define	MNTOPT_ATIME	"atime"		/* update atime for files */

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -292,6 +292,8 @@ do_mount(const char *src, const char *mntpt, char *opts)
 			return EINTR;
 		if (rc & MOUNT_SOFTWARE)
 			return EPIPE;
+		if (rc & MOUNT_BUSY)
+			return EBUSY;
 		if (rc & MOUNT_SYSERR)
 			return EAGAIN;
 		if (rc & MOUNT_USAGE)


### PR DESCRIPTION
In the current snapshot automount implementation, it is possible for
multiple mounts to attempted concurrently.  Only one of the mounts will
succeed and the other will fail.  The failed mounts will cause an EREMOTE
to be propagated back to the application.

This commit works around the problem by adding a new exit status,
MOUNT_BUSY to the mount.zfs program which is used when the underlying
mount(2) call returns EBUSY.  The zfs code detects this condition and
treats it as if the mount had succeeded.

Fixes #1819
