### PR TITLE
Updating init scripts to have more robust grepping

### DIFF
--- a/etc/init.d/zfs.fedora.in
+++ b/etc/init.d/zfs.fedora.in
@@ -27,7 +27,7 @@ export PATH=/usr/local/sbin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 if [ -z "$init" ]; then
     # Not interactive
-    grep -Eqi 'zfs=off|zfs=no' /proc/cmdline && exit 3
+    grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
 # Source function library & LSB routines

--- a/etc/init.d/zfs.gentoo.in
+++ b/etc/init.d/zfs.gentoo.in
@@ -5,7 +5,7 @@
 
 if [ -z "$init" ]; then
     # Not interactive
-    grep -Eqi 'zfs=off|zfs=no' /proc/cmdline && exit 3
+    grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
 depend()

--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -38,7 +38,7 @@ ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 
 if [ -z "$init" ]; then
     # Not interactive
-    grep -Eqi 'zfs=off|zfs=no' /proc/cmdline && exit 3
+    grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
 start()

--- a/etc/init.d/zfs.lunar.in
+++ b/etc/init.d/zfs.lunar.in
@@ -16,7 +16,7 @@ ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 
 if [ -z "$init" ]; then
     # Not interactive
-    grep -Eqi 'zfs=off|zfs=no' /proc/cmdline && exit 3
+    grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
 case $1 in

--- a/etc/init.d/zfs.redhat.in
+++ b/etc/init.d/zfs.redhat.in
@@ -27,7 +27,7 @@ export PATH=/usr/local/sbin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 if [ -z "$init" ]; then
     # Not interactive
-    grep -Eqi 'zfs=off|zfs=no' /proc/cmdline && exit 3
+    grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
 # Source function library & LSB routines


### PR DESCRIPTION
was previously catching on real_root=ZFS=node02-zp00/ROOT/rootfs because
it matched zfs=no
