### PR TITLE
Only commit the ZIL once in zpl_writepages() (msync() case)

### DIFF
--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -354,7 +354,8 @@ extern void zfs_log_symlink(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 extern void zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
     znode_t *sdzp, char *sname, znode_t *tdzp, char *dname, znode_t *szp);
 extern void zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
-    znode_t *zp, offset_t off, ssize_t len, int ioflag);
+    znode_t *zp, offset_t off, ssize_t len, int ioflag,
+    zil_callback_t callback, void *callback_data);
 extern void zfs_log_truncate(zilog_t *zilog, dmu_tx_t *tx, int txtype,
     znode_t *zp, uint64_t off, uint64_t len);
 extern void zfs_log_setattr(zilog_t *zilog, dmu_tx_t *tx, int txtype,

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -362,11 +362,15 @@ typedef enum {
 	WR_NUM_STATES	/* number of states */
 } itx_wr_state_t;
 
+typedef void (*zil_callback_t)(void *data);
+
 typedef struct itx {
 	list_node_t	itx_node;	/* linkage on zl_itx_list */
 	void		*itx_private;	/* type-specific opaque data */
 	itx_wr_state_t	itx_wr_state;	/* write state */
 	uint8_t		itx_sync;	/* synchronous transaction */
+	zil_callback_t  itx_callback;   /* To be called when the write is on persistent storage */
+	void            *itx_callback_data; /* User data for the callback above */
 	uint64_t	itx_sod;	/* record size on disk */
 	uint64_t	itx_oid;	/* object id */
 	lr_t		itx_lr;		/* common part of log record */

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1182,6 +1182,8 @@ zil_itx_create(uint64_t txtype, size_t lrsize)
 	itx->itx_sod = lrsize; /* if write & WR_NEED_COPY will be increased */
 	itx->itx_lr.lrc_seq = 0;	/* defensive */
 	itx->itx_sync = B_TRUE;		/* default is synchronous */
+	itx->itx_callback = NULL;
+	itx->itx_callback_data = NULL;
 
 	return (itx);
 }
@@ -1207,6 +1209,8 @@ zil_itxg_clean(itxs_t *itxs)
 
 	list = &itxs->i_sync_list;
 	while ((itx = list_head(list)) != NULL) {
+		if (itx->itx_callback != NULL)
+			itx->itx_callback(itx->itx_callback_data);
 		list_remove(list, itx);
 		kmem_free(itx, offsetof(itx_t, itx_lr) +
 		    itx->itx_lr.lrc_reclen);
@@ -1217,6 +1221,8 @@ zil_itxg_clean(itxs_t *itxs)
 	while ((ian = avl_destroy_nodes(t, &cookie)) != NULL) {
 		list = &ian->ia_list;
 		while ((itx = list_head(list)) != NULL) {
+			if (itx->itx_callback != NULL)
+				itx->itx_callback(itx->itx_callback_data);
 			list_remove(list, itx);
 			kmem_free(itx, offsetof(itx_t, itx_lr) +
 			    itx->itx_lr.lrc_reclen);
@@ -1283,6 +1289,8 @@ zil_remove_async(zilog_t *zilog, uint64_t oid)
 		mutex_exit(&itxg->itxg_lock);
 	}
 	while ((itx = list_head(&clean_list)) != NULL) {
+		if (itx->itx_callback != NULL)
+			itx->itx_callback(itx->itx_callback_data);
 		list_remove(&clean_list, itx);
 		kmem_free(itx, offsetof(itx_t, itx_lr) +
 		    itx->itx_lr.lrc_reclen);
@@ -1528,15 +1536,13 @@ zil_commit_writer(zilog_t *zilog)
 	}
 
 	DTRACE_PROBE1(zil__cw1, zilog_t *, zilog);
-	while ((itx = list_head(&zilog->zl_itx_commit_list))) {
+	for (itx = list_head(&zilog->zl_itx_commit_list); itx != NULL;
+	     itx = list_next(&zilog->zl_itx_commit_list, itx)) {
 		txg = itx->itx_lr.lrc_txg;
 		ASSERT(txg);
 
 		if (txg > spa_last_synced_txg(spa) || txg > spa_freeze_txg(spa))
 			lwb = zil_lwb_commit(zilog, itx, lwb);
-		list_remove(&zilog->zl_itx_commit_list, itx);
-		kmem_free(itx, offsetof(itx_t, itx_lr)
-		    + itx->itx_lr.lrc_reclen);
 	}
 	DTRACE_PROBE1(zil__cw2, zilog_t *, zilog);
 
@@ -1558,6 +1564,17 @@ zil_commit_writer(zilog_t *zilog)
 	if (error || lwb == NULL)
 		txg_wait_synced(zilog->zl_dmu_pool, 0);
 
+	while ((itx = list_head(&zilog->zl_itx_commit_list))) {
+		txg = itx->itx_lr.lrc_txg;
+		ASSERT(txg);
+
+		if (itx->itx_callback != NULL)
+			itx->itx_callback(itx->itx_callback_data);
+		list_remove(&zilog->zl_itx_commit_list, itx);
+		kmem_free(itx, offsetof(itx_t, itx_lr)
+		    + itx->itx_lr.lrc_reclen);
+	}
+	
 	mutex_enter(&zilog->zl_lock);
 
 	/*

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -23,6 +23,7 @@
  */
 
 
+#include <sys/dmu_objset.h>
 #include <sys/zfs_vfsops.h>
 #include <sys/zfs_vnops.h>
 #include <sys/zfs_znode.h>
@@ -412,7 +413,43 @@ zpl_putpage(struct page *pp, struct writeback_control *wbc, void *data)
 static int
 zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 {
-	return write_cache_pages(mapping, wbc, zpl_putpage, mapping);
+	znode_t		*zp = ITOZ(mapping->host);
+	zfs_sb_t	*zsb = ITOZSB(mapping->host);
+	enum writeback_sync_modes sync_mode;
+	int result;
+
+	ZFS_ENTER(zsb);
+	if (zsb->z_os->os_sync == ZFS_SYNC_ALWAYS)
+		wbc->sync_mode = WB_SYNC_ALL;
+	ZFS_EXIT(zsb);
+	sync_mode = wbc->sync_mode;
+
+	/*
+	 * We don't want to run write_cache_pages() in SYNC mode here, because
+	 * that would make putpage() wait for a single page to be committed to
+	 * disk every single time, resulting in atrocious performance. Instead
+	 * we run it once in non-SYNC mode so that the ZIL gets all the data,
+	 * and then we commit it all in one go.
+	 */
+	wbc->sync_mode = WB_SYNC_NONE;
+	result = write_cache_pages(mapping, wbc, zpl_putpage, mapping);
+	if (sync_mode != wbc->sync_mode) {
+		ZFS_ENTER(zsb);
+		ZFS_VERIFY_ZP(zp);
+		zil_commit(zsb->z_log, zp->z_id);
+		ZFS_EXIT(zsb);
+
+		/*
+		 * We need to call write_cache_pages() again (we can't just
+		 * return after the commit) because the previous call in
+		 * non-SYNC mode does not guarantee that we got all the dirty
+		 * pages (see the implementation of write_cache_pages() for
+		 * details). That being said, this is a no-op in most cases.
+		 */
+		wbc->sync_mode = sync_mode;
+		result = write_cache_pages(mapping, wbc, zpl_putpage, mapping);
+	}
+	return result;
 }
 
 /*
@@ -424,6 +461,8 @@ zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 static int
 zpl_writepage(struct page *pp, struct writeback_control *wbc)
 {
+	if (ITOZSB(pp->mapping->host)->z_os->os_sync == ZFS_SYNC_ALWAYS)
+		wbc->sync_mode = WB_SYNC_ALL;
 	return zpl_putpage(pp, wbc, pp->mapping);
 }
 


### PR DESCRIPTION
This is a fix for issue #1849, as well as a cleaner fix for issue #907. See the individual commit description for details about the implementation.

Before:

```
msync(         1 bytes)      0.035 seconds
msync(         2 bytes)      0.027 seconds
msync(         4 bytes)      0.009 seconds
msync(         8 bytes)      0.011 seconds
msync(        16 bytes)      0.014 seconds
msync(        32 bytes)      0.009 seconds
msync(        64 bytes)      0.011 seconds
msync(       128 bytes)      0.014 seconds
msync(       256 bytes)      0.009 seconds
msync(       512 bytes)      0.011 seconds
msync(      1024 bytes)      0.014 seconds
msync(      2048 bytes)      0.009 seconds
msync(      4096 bytes)      0.011 seconds
msync(      8192 bytes)      0.023 seconds
msync(     16384 bytes)      0.045 seconds
msync(     32768 bytes)      0.092 seconds
msync(     65536 bytes)      0.183 seconds
msync(    131072 bytes)      0.378 seconds
msync(    262144 bytes)      0.583 seconds
msync(    524288 bytes)      1.413 seconds
msync(   1048576 bytes)      3.105 seconds
msync(   2097152 bytes)      6.242 seconds
msync(   4194304 bytes)     12.117 seconds
msync(   8388608 bytes)     10.331 seconds
msync(  16777216 bytes)     34.966 seconds
msync(  33554432 bytes)     34.901 seconds
```

After:

```
msync(         1 bytes)      0.003 seconds
msync(         2 bytes)      0.003 seconds
msync(         4 bytes)      0.004 seconds
msync(         8 bytes)      0.003 seconds
msync(        16 bytes)      0.003 seconds
msync(        32 bytes)      0.004 seconds
msync(        64 bytes)      0.003 seconds
msync(       128 bytes)      0.003 seconds
msync(       256 bytes)      0.003 seconds
msync(       512 bytes)      0.003 seconds
msync(      1024 bytes)      0.003 seconds
msync(      2048 bytes)      0.002 seconds
msync(      4096 bytes)      0.002 seconds
msync(      8192 bytes)      0.002 seconds
msync(     16384 bytes)      0.003 seconds
msync(     32768 bytes)      0.003 seconds
msync(     65536 bytes)      0.003 seconds
msync(    131072 bytes)      0.003 seconds
msync(    262144 bytes)      0.006 seconds
msync(    524288 bytes)      0.007 seconds
msync(   1048576 bytes)      0.009 seconds
msync(   2097152 bytes)      0.017 seconds
msync(   4194304 bytes)      0.035 seconds
msync(   8388608 bytes)      0.064 seconds
msync(  16777216 bytes)      0.641 seconds
msync(  33554432 bytes)      0.250 seconds
```

And now `aptitude` is much faster. Yay!
