### PR TITLE
Don't validate cache/spares for readonly pools

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3946,14 +3946,16 @@ spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 		spa_load_l2cache(spa);
 	}
 
-	VERIFY(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
-	    &nvroot) == 0);
-	if (error == 0)
-		error = spa_validate_aux(spa, nvroot, -1ULL,
-		    VDEV_ALLOC_SPARE);
-	if (error == 0)
-		error = spa_validate_aux(spa, nvroot, -1ULL,
-		    VDEV_ALLOC_L2CACHE);
+	if (spa_writeable(spa)) {
+		VERIFY(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
+		    &nvroot) == 0);
+		if (error == 0)
+			error = spa_validate_aux(spa, nvroot, -1ULL,
+			    VDEV_ALLOC_SPARE);
+		if (error == 0)
+			error = spa_validate_aux(spa, nvroot, -1ULL,
+			    VDEV_ALLOC_L2CACHE);
+	}
 	spa_config_exit(spa, SCL_ALL, FTAG);
 
 	if (props != NULL)


### PR DESCRIPTION
When a pool is imported read-only avoid validating any hot spare
and l2arc vdevs.  The validation process can result in the vdev
being reinitialized and a new label being written.  Since the pool
must never be written to the unexpected write IO correctly triggers
a VERIFY in the IO pipeline.

  zpool import -o readonly <pool>
  ...
  VERIFY(zio->io_type != ZIO_TYPE_WRITE || spa_writeable(spa)) failed
  SPLError: 9415:0:(zio.c:2613:zio_vdev_io_start()) SPL PANIC

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1863
