### PR TITLE
Add I/O Read/Write Accounting

### DIFF
--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -32,6 +32,7 @@
 #include <linux/exportfs.h>
 #include <linux/writeback.h>
 #include <linux/falloc.h>
+#include <linux/task_io_accounting_ops.h>
 
 /* zpl_inode.c */
 extern void zpl_vap_init(vattr_t *vap, struct inode *dir,

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -170,6 +170,7 @@ zpl_read_common(struct inode *ip, const char *buf, size_t len, loff_t pos,
      uio_seg_t segment, int flags, cred_t *cr)
 {
 	int error;
+	ssize_t read;
 	struct iovec iov;
 	uio_t uio;
 
@@ -187,7 +188,10 @@ zpl_read_common(struct inode *ip, const char *buf, size_t len, loff_t pos,
 	if (error < 0)
 		return (error);
 
-	return (len - uio.uio_resid);
+	read = len - uio.uio_resid;
+	task_io_account_read(read);
+
+	return (read);
 }
 
 static ssize_t
@@ -213,6 +217,7 @@ zpl_write_common(struct inode *ip, const char *buf, size_t len, loff_t pos,
     uio_seg_t segment, int flags, cred_t *cr)
 {
 	int error;
+	ssize_t wrote;
 	struct iovec iov;
 	uio_t uio;
 
@@ -230,7 +235,10 @@ zpl_write_common(struct inode *ip, const char *buf, size_t len, loff_t pos,
 	if (error < 0)
 		return (error);
 
-	return (len - uio.uio_resid);
+	wrote = len - uio.uio_resid;
+	task_io_account_write(wrote);
+
+	return (wrote);
 }
 
 static ssize_t


### PR DESCRIPTION
Because ZFS bypasses the page cache we don't inherit per-task I/O
accounting for free.  However, the Linux kernel does provide helper
functions allow us to perform our own accounting.  These are most
commonly used for direct IO which also bypasses the page cache, but
they can be used for the common read/write call paths as well.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #313
Issue #1275
