### PR TITLE
Set zfs-dkms RPM required dkms to EPEL/Fedora

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -14,11 +14,7 @@ Source0:        %{module}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
-%if 0%{?dkms_version:1}
-Requires:       dkms = %{dkms_version}
-%else
-Requires:       dkms >= 2.2.0.2
-%endif
+Requires:       dkms >= 2.2.0.3-20
 Requires:       spl-dkms = %{version}
 Requires:       gcc, make, perl
 Requires:       kernel-devel


### PR DESCRIPTION
Version 2.2.0.3-20 of dkms added the necessary patches to support ZoL, https://bugzilla.redhat.com/show_bug.cgi?id=1023598.  This PR sets the zfs-dkms RPM requirement to that version or higher.
