### PR TITLE
Accept user specified spl and kernel source dir.

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -141,7 +141,7 @@ AC_DEFUN([ZFS_AC_RPM], [
 
 	RPM_DEFINE_COMMON='--define "$(DEBUG_ZFS) 1" --define "$(DEBUG_DMU_TX) 1"'
 	RPM_DEFINE_UTIL=
-	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)"'
+	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)" --define "require_spldir $(SPL)" --define "require_splobj $(SPL_OBJ)" --define "ksrc $(LINUX)" --define "kobj $(LINUX_OBJ)"'
 	RPM_DEFINE_DKMS=
 
 	SRPM_DEFINE_COMMON='--define "build_src_rpm 1"'

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -1,4 +1,33 @@
 %define module  @PACKAGE@
+
+%if !%{defined ksrc}
+%if 0%{?rhel}%{?fedora}
+%define ksrc    ${kernel_version##*___}
+%else
+%define ksrc    "$( \
+        if [ -e "/usr/src/linux-${kernel_version%%___*}" ]; then \
+            echo "/usr/src/linux-${kernel_version%%___*}"; \
+        elif [ -e "/lib/modules/${kernel_version%%___*}/source" ]; then \
+            echo "/lib/modules/${kernel_version%%___*}/source"; \
+        else \
+            echo "/lib/modules/${kernel_version%%___*}/build"; \
+        fi)"
+%endif
+%endif
+
+%if !%{defined kobj}
+%if 0%{?rhel}%{?fedora}
+%define kobj    ${kernel_version##*___}
+%else
+%define kobj    "$( \
+        if [ -e "/usr/src/linux-${kernel_version%%___*}" ]; then \
+            echo "/usr/src/linux-${kernel_version%%___*}"; \
+        else \
+            echo "/lib/modules/${kernel_version%%___*}/build"; \
+        fi)"
+%endif
+%endif
+
 #define repo    rpmfusion
 #define repo    chaos
 
@@ -125,18 +154,8 @@ for kernel_version in %{?kernel_versions}; do
     cd _kmod_build_${kernel_version%%___*}
     %configure \
         --with-config=kernel \
-%if 0%{?rhel}%{?fedora}
-        --with-linux="${kernel_version##*___}" \
-        --with-linux-obj="${kernel_version##*___}" \
-%else
-        --with-linux="$( \
-        if [ -e "/lib/modules/${kernel_version%%___*}/source" ]; then \
-            echo "/lib/modules/${kernel_version%%___*}/source"; \
-        else \
-            echo "/lib/modules/${kernel_version%%___*}/build"; \
-        fi)" \
-        --with-linux-obj="/lib/modules/${kernel_version%%___*}/build" \
-%endif
+        --with-linux=%{ksrc} \
+        --with-linux-obj=%{kobj} \
         --with-spl="%{spldir}" \
         --with-spl-obj="%{splobj}" \
         %{debug} \


### PR DESCRIPTION
I've issued this patch several times, but this time I'd make it a simple one, not a combination of many fixes.

Having '/usr/src/spl-VERSION' hardcoded (and almost the only choice) is a BAD THING (tm). This patch will accept the values issues with a previous './configure --with-spl=... --with-spl-obj=...' and generate propper zfs-kmod.spec file that is usable without any softlinks or installs of spl before hand.
