### PR TITLE
Fixes #1841 : add missing libzfs_core to some Makefiles

### DIFF
--- a/cmd/mount_zfs/Makefile.am
+++ b/cmd/mount_zfs/Makefile.am
@@ -18,6 +18,7 @@ mount_zfs_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
 mount_zfs_LDADD += $(LIBSELINUX)

--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -14,6 +14,7 @@ zdb_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
 zdb_LDADD += $(ZLIB)

--- a/cmd/zhack/Makefile.am
+++ b/cmd/zhack/Makefile.am
@@ -13,6 +13,7 @@ zhack_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
 zhack_LDADD += $(ZLIB)

--- a/cmd/zinject/Makefile.am
+++ b/cmd/zinject/Makefile.am
@@ -15,4 +15,5 @@ zinject_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la

--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -17,4 +17,5 @@ zpool_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la

--- a/cmd/zstreamdump/Makefile.am
+++ b/cmd/zstreamdump/Makefile.am
@@ -13,6 +13,7 @@ zstreamdump_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
 zstreamdump_LDADD += $(ZLIB)

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -15,6 +15,7 @@ ztest_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
 ztest_LDADD += -lm -ldl


### PR DESCRIPTION
I added libzfs_core to the appropriate Makefiles. "make deb" works now.
