### PR TITLE
Fix typo in commit b83e3e48c9b183a80dd00eb6c7431a1cbc7d89c9

### DIFF
--- a/config/kernel-bdi.m4
+++ b/config/kernel-bdi.m4
@@ -8,7 +8,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI], [
 		#include <linux/fs.h>
 
 		static const struct super_block
-		    sb __attribute__ ((unused)) {
+		    sb __attribute__ ((unused)) = {
 			.s_bdi = NULL,
 		};
 	],[


### PR DESCRIPTION
There's a missing semicolon in the first hunk of this commit
in config/kernel-bdi.m4. This results in the test always failing.
The effects were noticed when rrdtool, a tool which modifies files
by mmap() and msync(), would have data never get saved to disk
in spite of the files working while the mounted filesystem remains
mounted.
