### PR TITLE
Add missing semi-colon to sb.s_bdi check

### DIFF
--- a/config/kernel-bdi.m4
+++ b/config/kernel-bdi.m4
@@ -10,7 +10,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI], [
 		static const struct super_block
 		    sb __attribute__ ((unused)) {
 			.s_bdi = NULL,
-		}
+		};
 	],[
 	],[
 		AC_MSG_RESULT(yes)


### PR DESCRIPTION
This fixes a regression introduced by
b83e3e48c9b183a80dd00eb6c7431a1cbc7d89c9 on Linux 3.0 and possibly other
kernels where sb.s_bdi was not being properly detected.

Reported-by: DHE
Signed-off-by: Richard Yao ryao@gentoo.org
