### PR TITLE
Some more nvlist allocations in hold processing need to use KM_PUSHPAGE.

### DIFF
--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -260,7 +260,7 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 	uint64_t now = gethrestime_sec();
 
 	if (dduha->dduha_minor != 0)
-		tmpholds = fnvlist_alloc();
+		VERIFY0(nvlist_alloc(&tmpholds, NV_UNIQUE_NAME, KM_PUSHPAGE));
 	else
 		tmpholds = NULL;
 	for (pair = nvlist_next_nvpair(dduha->dduha_chkholds, NULL);
@@ -315,7 +315,8 @@ dsl_dataset_user_hold(nvlist_t *holds, minor_t cleanup_minor, nvlist_t *errlist)
 		return (0);
 
 	dduha.dduha_holds = holds;
-	dduha.dduha_chkholds = fnvlist_alloc();
+	VERIFY0(nvlist_alloc(&dduha.dduha_chkholds, NV_UNIQUE_NAME,
+		KM_PUSHPAGE));
 	dduha.dduha_errlist = errlist;
 	dduha.dduha_minor = cleanup_minor;
 


### PR DESCRIPTION
This should hopefully catch the rest of the allocations in the
user hold/release processing that were missed by commit
65c67ea86e9f112177f1ad32de8e780f10798a64.

Contrary to the name of the branch, fixes #1898 and, hopefully the rest of #1868.
