### PR TITLE
Properly ignore bdi_setup_and_register return value in autotools check

### DIFF
--- a/config/kernel-bdi-setup-and-register.m4
+++ b/config/kernel-bdi-setup-and-register.m4
@@ -7,6 +7,8 @@ dnl # up and tearing down the bdi structure.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER],
 	[AC_MSG_CHECKING([whether bdi_setup_and_register() is available])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Wno-unused-result"
 	ZFS_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/backing-dev.h>
 	], [
@@ -18,4 +20,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER],
 	], [
 		AC_MSG_RESULT(no)
 	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])


### PR DESCRIPTION
This broke compilation against Linux 3.13 and GCC 4.7.3. zfsonlinux/spl#312 is required to test this, but the reverse is not necessarily true. This issue is more likely attributable to GCC 4.7.3 than Linux 3.13, although I did not check that possibility.

Signed-off-by: Richard Yao ryao@gentoo.org
