### PR TITLE
dmu_tx_quota kstat is not being bumped anywhere.

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -635,6 +635,7 @@ dsl_dir_tempreserve_impl(dsl_dir_t *dd, uint64_t asize, boolean_t netfree,
 		    asize, est_inflight, &used_on_disk, &ref_rsrv);
 		if (error) {
 			mutex_exit(&dd->dd_lock);
+			DMU_TX_STAT_BUMP(dmu_tx_quota);
 			return (error);
 		}
 	}
@@ -683,6 +684,7 @@ dsl_dir_tempreserve_impl(dsl_dir_t *dd, uint64_t asize, boolean_t netfree,
 		    used_on_disk>>10, est_inflight>>10,
 		    quota>>10, asize>>10, retval);
 		mutex_exit(&dd->dd_lock);
+		DMU_TX_STAT_BUMP(dmu_tx_quota);
 		return (SET_ERROR(retval));
 	}
 


### PR DESCRIPTION
It looks like 13fe019870c8779bf2f5b3ff731b512cf89133ef had removed
the code that bumped it.

I'm adding this to two places, instead of just resurrecting where it
should have been (the result of dsl_dataset_check_quota call). The
second addition is where we check the requested reservation against the
actual pool size, as I think of it as implicit quota of a sort.

I was hitting this second mode of throttling a lot when I was using
small 2GB test pool and writing 100MB file in it, because of
spa_get_asize inflation problem I discuss in pull request #1913.
