### PR TITLE
Record tx_assign_histogram correctly

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -550,6 +550,7 @@ void dmu_tx_abort(dmu_tx_t *tx);
 int dmu_tx_assign(dmu_tx_t *tx, enum txg_how txg_how);
 void dmu_tx_wait(dmu_tx_t *tx);
 void dmu_tx_commit(dmu_tx_t *tx);
+void dmu_tx_assign_add_nsecs(dmu_tx_t *tx, uint64_t nsecs);
 
 /*
  * To register a commit callback, dmu_tx_callback_register() must be called.

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1119,7 +1119,7 @@ dmu_tx_assign(dmu_tx_t *tx, txg_how_t txg_how)
 
 	txg_rele_to_quiesce(&tx->tx_txgh);
 
-	spa_tx_assign_add_nsecs(tx->tx_pool->dp_spa, gethrtime() - before);
+	dmu_tx_assign_add_nsecs(tx, gethrtime() - before);
 
 	return (0);
 }
@@ -1445,6 +1445,12 @@ dmu_tx_hold_sa(dmu_tx_t *tx, sa_handle_t *hdl, boolean_t may_grow)
 		}
 		DB_DNODE_EXIT(db);
 	}
+}
+
+void
+dmu_tx_assign_add_nsecs(dmu_tx_t *tx, uint64_t nsecs)
+{
+	spa_tx_assign_add_nsecs(tx->tx_pool->dp_spa, nsecs);
 }
 
 void

--- a/module/zfs/zfs_acl.c
+++ b/module/zfs/zfs_acl.c
@@ -2043,6 +2043,7 @@ zfs_setacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 	zfs_fuid_info_t	*fuidp = NULL;
 	boolean_t	fuid_dirtied;
 	uint64_t	acl_obj;
+	hrtime_t before;
 
 	if (mask == 0)
 		return (SET_ERROR(ENOSYS));
@@ -2066,6 +2067,7 @@ zfs_setacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 		aclp->z_hints |=
 		    (zp->z_pflags & V4_ACL_WIDE_FLAGS);
 	}
+	before = gethrtime();
 top:
 	mutex_enter(&zp->z_acl_lock);
 	mutex_enter(&zp->z_lock);
@@ -2112,6 +2114,7 @@ top:
 		zfs_acl_free(aclp);
 		return (error);
 	}
+	dmu_tx_assign_add_nsecs(tx, gethrtime() - before);
 
 	error = zfs_aclset_common(zp, aclp, cr, tx);
 	ASSERT(error == 0);

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -956,6 +956,7 @@ zfs_make_xattrdir(znode_t *zp, vattr_t *vap, struct inode **xipp, cred_t *cr)
 	int error;
 	zfs_acl_ids_t acl_ids;
 	boolean_t fuid_dirtied;
+	hrtime_t before;
 #ifdef DEBUG
 	uint64_t parent;
 #endif
@@ -973,6 +974,7 @@ zfs_make_xattrdir(znode_t *zp, vattr_t *vap, struct inode **xipp, cred_t *cr)
 		return (SET_ERROR(EDQUOT));
 	}
 
+	before = gethrtime();
 top:
 	tx = dmu_tx_create(zsb->z_os);
 	dmu_tx_hold_sa_create(tx, acl_ids.z_aclp->z_acl_bytes +
@@ -993,6 +995,7 @@ top:
 		dmu_tx_abort(tx);
 		return (error);
 	}
+	dmu_tx_assign_add_nsecs(tx, gethrtime() - before);
 	zfs_mknode(zp, vap, tx, cr, IS_XATTR, &xzp, &acl_ids);
 
 	if (fuid_dirtied)


### PR DESCRIPTION
`spa_tx_assign_add_nsecs` was added in 2d37239a28b8b2ddc0e8312093f8d8810c6351fa to record the amount of time taken to assign a transaction to TXG.

Unfortunately, this only kicks in for `dmu_tx_try_assign` with `TXG_WAIT`, and it misses all the interesting and important cases (such as `zfs_write` and all ther other ZPL functions) where `dmu_tx_assign` is called with `TXG_NOWAIT`, and `ERESTART` results in a new transaction created.

This change introduces a new function `dmu_tx_assign_add_nsecs`, and make these `TXG_NOWAIT` callers call this function appropriately. This allows more accurate insights into the time spent on assigning TXG.
