### PR TITLE
Exposing kstats from dsl_pool

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -71,6 +71,13 @@ typedef struct zfs_all_blkstats {
 	zfs_blkstat_t	zab_type[DN_MAX_LEVELS + 1][DMU_OT_TOTAL + 1];
 } zfs_all_blkstats_t;
 
+/*
+ * Used for kstat.
+ */
+typedef struct dsl_pool_stats {
+	kstat_named_t dp_write_limit;
+	kstat_named_t dp_throughput;
+} dsl_pool_stats_t;
 
 typedef struct dsl_pool {
 	/* Immutable */
@@ -120,6 +127,9 @@ typedef struct dsl_pool {
 	rrwlock_t dp_config_rwlock;
 
 	zfs_all_blkstats_t *dp_blkstats;
+
+	dsl_pool_stats_t	dp_stats;		/* assorted dsl_pool statistics */
+	kstat_t	*dp_ksp;
 } dsl_pool_t;
 
 int dsl_pool_init(spa_t *spa, uint64_t txg, dsl_pool_t **dpp);


### PR DESCRIPTION
dp_throughput and dp_write_limit are critical inputs to the write limit
computation of txg, so it is useful to be able to track them.

This change exposes them as kstats.

Both of these values are already defined in dsl_pool_t, so the change
ends up maintaining two copies of the same value, which is bit error
prone. OTOH, this change is less intrusive, and these values aren't
updated all that frequently, so hopefully this is OK.
