### PR TITLE
Workaround for 'zfs diff' shares error

### DIFF
--- a/module/zfs/zpl_ctldir.c
+++ b/module/zfs/zpl_ctldir.c
@@ -497,10 +497,11 @@ zpl_shares_getattr(struct vfsmount *mnt, struct dentry *dentry,
 	}
 
 	error = -zfs_zget(zsb, zsb->z_shares_dir, &dzp);
-	if (error == 0)
-		error = -zfs_getattr_fast(dentry->d_inode, stat);
+	if (error == 0) {
+		error = -zfs_getattr_fast(ZTOI(dzp), stat);
+		iput(ZTOI(dzp));
+	}
 
-	iput(ZTOI(dzp));
 	ZFS_EXIT(zsb);
 	ASSERT3S(error, <=, 0);
 


### PR DESCRIPTION
For some reason which is not yet fully explained it's possible for
stat64() to fail with EIO on the .zfs/shares directory.  This then
causes the entire 'zfs diff' command to fail even though the shares
directory is not needed.

Until the root cause of the stat64() failure can be determined a
viable work around is to explicitly set the di->shares inode
number.  The Linux .zfs directory implementation will always use
the same well known inode numbers for the top level directories.
Obtaining the number through stat64() is cleaner, but in case that
fails it can be safely assigned based on the known constant.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1426
Issue #481
