### PR TITLE
Some minor improvements in the init script.

### DIFF
--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -30,6 +30,7 @@ ZFS="@sbindir@/zfs"
 ZPOOL="@sbindir@/zpool"
 ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 USE_DISK_BY_ID=0
+VERBOSE_MOUNT=0
 
 # Source zfs configuration.
 [ -r '/etc/default/zfs' ] &&  . /etc/default/zfs
@@ -85,8 +86,12 @@ start()
 	fi
 
 	if [ -n "$POOL_IMPORTED" ]; then
+		if [ "$VERBOSE_MOUNT" -eq 1 ]; then
+			verbose=v
+		fi
+
 		log_begin_msg "Mounting ZFS filesystems"
-		"$ZFS" mount -a
+		"$ZFS" mount -a$verbose
 		log_end_msg $?
 
 		log_begin_msg "Exporting ZFS filesystems"


### PR DESCRIPTION
I prefer to use by-id at import time instead of using the cache file and it seems that is a much better solution than using the cache file. Maybe with that patch, we could start fazing out the cache file all together?

I like to use verbose to the mount command, so I know how far it come along (especially since I have 600+ filesystems, which takes over an hour).
