### PR TITLE
Fix multipath bug in vdev_id script which causes wrong field to be used ...

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -180,8 +180,8 @@ sas_handler() {
 		fi
 
 		# Get the raw scsi device name from multipath -l.
-                # (Strip off leading pipe symbols which make for inconsistent field numbering.)
-		DEV=`multipath -l $DM_NAME | sed -e 's/^|/ /' | awk '/running/{print $3 ; exit}'`
+		# Strip off leading pipe symbols which make for inconsistent field numbering.
+		DEV=`multipath -l $DM_NAME | awk '/running/{gsub("^[|]"," "); print $3 ; exit}'`
 		if [ -z "$DEV" ] ; then
 			return
 		fi


### PR DESCRIPTION
...as device name.

This probably fixes 1692 (at least it does for me).

cheers,
Simon
