### PR TITLE
Remove MAX when initializing arc_c_max

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4019,7 +4019,7 @@ arc_init(void)
 	/* set min cache to 1/32 of all memory, or 64MB, whichever is more */
 	arc_c_min = MAX(arc_c / 4, 64<<20);
 	/* set max to 1/2 of all memory */
-	arc_c_max = MAX(arc_c * 4, arc_c_max);
+	arc_c_max = arc_c * 4;
 
 	/*
 	 * Allow the tunables to override our calculations if they are


### PR DESCRIPTION
The MAX when initializing arc_c_max doesn't make any sense because it hasn't
been set anywhere before. Though, arc_c_max should be implicit set to zero
when initializing arc_stats, so the MAX doesn't make any difference.

Signed-off-by: david.chen tuxoko@gmail.com
