### PR TITLE
Fix dmu_zfetch stream's element type

### DIFF
--- a/include/sys/dmu_zfetch.h
+++ b/include/sys/dmu_zfetch.h
@@ -50,7 +50,7 @@ typedef struct zstream {
 	uint64_t	zst_cap;	/* prefetch limit (cap), in blocks */
 	kmutex_t	zst_lock;	/* protects stream */
 	clock_t		zst_last;	/* lbolt of last prefetch */
-	avl_node_t	zst_node;	/* embed avl node here */
+	list_node_t	zst_node;	/* next zstream here */
 } zstream_t;
 
 typedef struct zfetch {


### PR DESCRIPTION
dmu_zfetch organize streams with list, not avl_node_t.  The reason it works well is zfs's list convert avl_node\* to list*,so no warning happened.
