### PR TITLE
Fix atime handling.

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -559,7 +559,6 @@ out:
 	zfs_range_unlock(rl);
 
 	ZFS_ACCESSTIME_STAMP(zsb, zp);
-	zfs_inode_update(zp);
 	ZFS_EXIT(zsb);
 	return (error);
 }
@@ -2148,7 +2147,6 @@ update:
 		error = 0;
 
 	ZFS_ACCESSTIME_STAMP(zsb, zp);
-	zfs_inode_update(zp);
 
 out:
 	ZFS_EXIT(zsb);
@@ -3681,7 +3679,6 @@ zfs_readlink(struct inode *ip, uio_t *uio, cred_t *cr)
 	mutex_exit(&zp->z_lock);
 
 	ZFS_ACCESSTIME_STAMP(zsb, zp);
-	zfs_inode_update(zp);
 	ZFS_EXIT(zsb);
 	return (error);
 }

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -1123,6 +1123,8 @@ zfs_tstamp_update_setup(znode_t *zp, uint_t flag, uint64_t mtime[2],
 
 	if (flag & ATTR_ATIME) {
 		ZFS_TIME_ENCODE(&now, zp->z_atime);
+		ZTOI(zp)->i_atime.tv_sec = zp->z_atime[0];
+		ZTOI(zp)->i_atime.tv_nsec = zp->z_atime[1];
 	}
 
 	if (flag & ATTR_MTIME) {


### PR DESCRIPTION
Previously, the atime-modifying vnops called ZFS_ACCESSTIME_STAMP()
followed by zfs_inode_update() to update the atime.  However, since atimes
are cached in the znode for delayed writing, the zfs_inode_update()
function would effectively ignore the cached atime by reading it from
the SA.

This commit moves the updating of the atime in the inode into
zfs_tstamp_update_setup() which is called by the ZFS_ACCESSTIME_STAMP()
macro and eliminates the call to zfs_inode_update() in the atime-modifying
vnops.

It's possible the same thing could have been done directly in
zfs_inode_update() but I wasn't sure that it was safe in all cases where
it is called.

The effect is that atime handling is as if "strictatime" were selected;
even if the filesystem is mounted with "relatime".

Works around #1917
