### PR TITLE
Cause zfs.spec to place dracut files properly

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -5,7 +5,7 @@
 %global _dracutdir  %{_prefix}/lib/dracut
 %else
 %global _udevdir    /lib/udev
-%global _dracutdir  /lib/dracut
+%global _dracutdir  %{_prefix}/share/dracut
 %endif
 
 %bcond_with    debug


### PR DESCRIPTION
This is an extension of @behlendorf's commit https://github.com/zfsonlinux/zfs/commit/ffb21118add1a2e6cec2ce401c333b4a4e76d9a3

As the fedora conditional has been added, this allows centos/rhel-6 to fall back to the proper directory (/usr/share/dracut)
