### PR TITLE
Change disable/enable flags to booleans.

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -621,7 +621,7 @@ void dmu_xuio_clear(struct xuio *uio, int i);
 void xuio_stat_wbuf_copied(void);
 void xuio_stat_wbuf_nocopy(void);
 
-extern int zfs_prefetch_disable;
+extern bool zfs_prefetch_disable;
 
 /*
  * Asynchronously try to read in the data.
@@ -810,7 +810,7 @@ int dmu_diff(const char *tosnap_name, const char *fromsnap_name,
 #define	ZFS_CRC64_POLY	0xC96C5795D7870F42ULL	/* ECMA-182, reflected form */
 extern uint64_t zfs_crc64_table[256];
 
-extern int zfs_mdcomp_disable;
+extern bool zfs_mdcomp_disable;
 
 #ifdef	__cplusplus
 }

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -45,7 +45,7 @@ typedef enum vdev_dtl_type {
 	DTL_TYPES
 } vdev_dtl_type_t;
 
-extern int zfs_nocacheflush;
+extern bool zfs_nocacheflush;
 
 extern int vdev_open(vdev_t *);
 extern void vdev_open_children(vdev_t *);

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -483,7 +483,7 @@ extern void	zil_set_sync(zilog_t *zilog, uint64_t syncval);
 
 extern void	zil_set_logbias(zilog_t *zilog, uint64_t slogval);
 
-extern int zil_replay_disable;
+extern bool zil_replay_disable;
 
 #ifdef	__cplusplus
 }

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -553,7 +553,7 @@ extern void zio_fini(void);
  * Fault injection
  */
 struct zinject_record;
-extern uint32_t zio_injection_enabled;
+extern bool zio_injection_enabled;
 extern int zio_inject_fault(char *name, int flags, int *id,
     struct zinject_record *record);
 extern int zio_inject_list_next(int *id, char *name, size_t buflen,

--- a/lib/libspl/include/sys/types.h
+++ b/lib/libspl/include/sys/types.h
@@ -38,6 +38,7 @@
 #include <inttypes.h>
 
 typedef enum boolean { B_FALSE, B_TRUE } boolean_t;
+typedef boolean_t bool;
 
 typedef unsigned char	uchar_t;
 typedef unsigned short	ushort_t;

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -27,12 +27,12 @@ Description of the different parameters to the ZFS module.
 .sp
 .ne 2
 .na
-\fBl2arc_feed_again\fR (int)
+\fBl2arc_feed_again\fR (bool)
 .ad
 .RS 12n
 Turbo L2ARC warmup
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to enable turbo warmup (default) and \fB0\fR \fBN\fR to disable.
 .RE
 
 .sp
@@ -82,34 +82,34 @@ Default value: \fB200\fR.
 .sp
 .ne 2
 .na
-\fBl2arc_nocompress\fR (int)
+\fBl2arc_nocompress\fR (bool)
 .ad
 .RS 12n
 Skip compressing L2ARC buffers
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to skip compressing L2ARC buffers and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
 .ne 2
 .na
-\fBl2arc_noprefetch\fR (int)
+\fBl2arc_noprefetch\fR (bool)
 .ad
 .RS 12n
 Skip caching prefetched buffers
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to skip caching prefetched buffers (default) and \fB0\fR or \fBN\fR for no.
 .RE
 
 .sp
 .ne 2
 .na
-\fBl2arc_norw\fR (int)
+\fBl2arc_norw\fR (bool)
 .ad
 .RS 12n
 No reads during writes
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable reads during writes and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -137,12 +137,12 @@ Default value: \fB8,388,608\fR.
 .sp
 .ne 2
 .na
-\fBmetaslab_debug\fR (int)
+\fBmetaslab_debug\fR (bool)
 .ad
 .RS 12n
 Keep space maps in core to verify frees
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to enable debugging and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -241,12 +241,12 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_arc_memory_throttle_disable\fR (int)
+\fBzfs_arc_memory_throttle_disable\fR (bool)
 .ad
 .RS 12n
 Disable memory throttle
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to disable memory throttle (default) and \fB0\fR or \fBN\fR for no.
 .RE
 
 .sp
@@ -318,12 +318,12 @@ Default value: \fB5\fR.
 .sp
 .ne 2
 .na
-\fBzfs_autoimport_disable\fR (int)
+\fBzfs_autoimport_disable\fR (bool)
 .ad
 .RS 12n
 Disable pool import at module load
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable automatic pool import and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -340,12 +340,12 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_deadman_enabled\fR (int)
+\fBzfs_deadman_enabled\fR (bool)
 .ad
 .RS 12n
 Enable deadman timer
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to enable deadman timer (default) and \fB0\fR or \fBN\fR to disable.
 .RE
 
 .sp
@@ -367,12 +367,12 @@ Default value: \fB1,000,000\fR.
 .sp
 .ne 2
 .na
-\fBzfs_dedup_prefetch\fR (int)
+\fBzfs_dedup_prefetch\fR (bool)
 .ad
 .RS 12n
-Enable prefetching dedup-ed blks
+Enable prefetching dedup-ed blocks
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to enable prefetching dedup-ed blocks (default) and \fB0\fR or \fBN\fR to disable.
 .RE
 
 .sp
@@ -644,12 +644,12 @@ Default value: \fB10\fR.
 .sp
 .ne 2
 .na
-\fBzfs_disable_dup_eviction\fR (int)
+\fBzfs_disable_dup_eviction\fR (bool)
 .ad
 .RS 12n
 Disable duplicate buffer eviction
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable duplicate buffer eviction and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -699,56 +699,56 @@ Default value: \fB32,768\fR.
 .sp
 .ne 2
 .na
-\fBzfs_mdcomp_disable\fR (int)
+\fBzfs_mdcomp_disable\fR (bool)
 .ad
 .RS 12n
 Disable meta data compression
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable meta data compression and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
 .ne 2
 .na
-\fBzfs_no_scrub_io\fR (int)
+\fBzfs_no_scrub_io\fR (bool)
 .ad
 .RS 12n
 Set for no scrub I/O
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable scrub i/o and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
 .ne 2
 .na
-\fBzfs_no_scrub_prefetch\fR (int)
+\fBzfs_no_scrub_prefetch\fR (bool)
 .ad
 .RS 12n
 Set for no scrub prefetching
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR disable scrub prefetching and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
 .ne 2
 .na
-\fBzfs_nocacheflush\fR (int)
+\fBzfs_nocacheflush\fR (bool)
 .ad
 .RS 12n
 Disable cache flushes
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
 .ne 2
 .na
-\fBzfs_nopwrite_enabled\fR (int)
+\fBzfs_nopwrite_enabled\fR (bool)
 .ad
 .RS 12n
 Enable NOP writes
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR or \fBY\fR to enable NOP writes (default) and \fB0\fR or \fBN\fR to disable.
 .RE
 
 .sp
@@ -765,12 +765,12 @@ Default value: \fB100\fR.
 .sp
 .ne 2
 .na
-\fBzfs_prefetch_disable\fR (int)
+\fBzfs_prefetch_disable\fR (bool)
 .ad
 .RS 12n
 Disable all ZFS prefetching
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable prefetch and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -798,12 +798,12 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_read_history_hits\fR (int)
+\fBzfs_read_history_hits\fR (bool)
 .ad
 .RS 12n
 Include cache hits in read history
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to include cache hits in read history and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -876,12 +876,12 @@ Default value: \fB4\fR.
 .sp
 .ne 2
 .na
-\fBzfs_send_corrupt_data\fR (int)
+\fBzfs_send_corrupt_data\fR (bool)
 .ad
 .RS 12n
 Allow to send corrupt data (ignore read/checksum errors when sending data)
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to ignore r/w errors  and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -1050,12 +1050,12 @@ Default value: \fB80\fR.
 .sp
 .ne 2
 .na
-\fBzfs_zevent_console\fR (int)
+\fBzfs_zevent_console\fR (bool)
 .ad
 .RS 12n
 Log events to the console
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to log events to the console and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -1072,12 +1072,12 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzil_replay_disable\fR (int)
+\fBzil_replay_disable\fR (bool)
 .ad
 .RS 12n
 Disable intent logging replay
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to disable intent logging replay and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -1116,12 +1116,12 @@ Default value: \fB30,000\fR.
 .sp
 .ne 2
 .na
-\fBzio_injection_enabled\fR (int)
+\fBzio_injection_enabled\fR (bool)
 .ad
 .RS 12n
 Enable fault injection
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to enable fault injection and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp
@@ -1138,12 +1138,12 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzvol_inhibit_dev\fR (uint)
+\fBzvol_inhibit_dev\fR (bool)
 .ad
 .RS 12n
 Do not create zvol device nodes
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR or \fBY\fR to inhibit zvol device nodes and \fB0\fR or \fBN\fR for no (default).
 .RE
 
 .sp

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -185,10 +185,10 @@ int zfs_arc_shrink_shift = 5;
 int zfs_arc_min_prefetch_lifespan = HZ;
 
 /* disable arc proactive arc throttle due to low memory */
-int zfs_arc_memory_throttle_disable = 1;
+bool zfs_arc_memory_throttle_disable = B_TRUE;
 
 /* disable duplicate buffer eviction */
-int zfs_disable_dup_eviction = 0;
+bool zfs_disable_dup_eviction = B_FALSE;
 
 /*
  * If this percent of memory is free, don't throttle.
@@ -691,10 +691,10 @@ unsigned long l2arc_headroom = L2ARC_HEADROOM;		/* # of dev writes */
 unsigned long l2arc_headroom_boost = L2ARC_HEADROOM_BOOST;
 unsigned long l2arc_feed_secs = L2ARC_FEED_SECS;	/* interval seconds */
 unsigned long l2arc_feed_min_ms = L2ARC_FEED_MIN_MS;	/* min interval msecs */
-int l2arc_noprefetch = B_TRUE;			/* don't cache prefetch bufs */
-int l2arc_nocompress = B_FALSE;			/* don't compress bufs */
-int l2arc_feed_again = B_TRUE;			/* turbo warmup */
-int l2arc_norw = B_FALSE;			/* no reads during writes */
+bool l2arc_noprefetch = B_TRUE;			/* don't cache prefetch bufs */
+bool l2arc_nocompress = B_FALSE;		/* don't compress bufs */
+bool l2arc_feed_again = B_TRUE;			/* turbo warmup */
+bool l2arc_norw = B_FALSE;			/* no reads during writes */
 
 /*
  * L2ARC Internals
@@ -5550,10 +5550,10 @@ MODULE_PARM_DESC(zfs_arc_shrink_shift, "log2(fraction of arc to reclaim)");
 module_param(zfs_arc_p_min_shift, int, 0644);
 MODULE_PARM_DESC(zfs_arc_p_min_shift, "arc_c shift to calc min/max arc_p");
 
-module_param(zfs_disable_dup_eviction, int, 0644);
+module_param(zfs_disable_dup_eviction, bool, 0644);
 MODULE_PARM_DESC(zfs_disable_dup_eviction, "disable duplicate buffer eviction");
 
-module_param(zfs_arc_memory_throttle_disable, int, 0644);
+module_param(zfs_arc_memory_throttle_disable, bool, 0644);
 MODULE_PARM_DESC(zfs_arc_memory_throttle_disable, "disable memory throttle");
 
 module_param(zfs_arc_min_prefetch_lifespan, int, 0644);
@@ -5577,16 +5577,16 @@ MODULE_PARM_DESC(l2arc_feed_secs, "Seconds between L2ARC writing");
 module_param(l2arc_feed_min_ms, ulong, 0644);
 MODULE_PARM_DESC(l2arc_feed_min_ms, "Min feed interval in milliseconds");
 
-module_param(l2arc_noprefetch, int, 0644);
+module_param(l2arc_noprefetch, bool, 0644);
 MODULE_PARM_DESC(l2arc_noprefetch, "Skip caching prefetched buffers");
 
-module_param(l2arc_nocompress, int, 0644);
+module_param(l2arc_nocompress, bool, 0644);
 MODULE_PARM_DESC(l2arc_nocompress, "Skip compressing L2ARC buffers");
 
-module_param(l2arc_feed_again, int, 0644);
+module_param(l2arc_feed_again, bool, 0644);
 MODULE_PARM_DESC(l2arc_feed_again, "Turbo L2ARC warmup");
 
-module_param(l2arc_norw, int, 0644);
+module_param(l2arc_norw, bool, 0644);
 MODULE_PARM_DESC(l2arc_norw, "No reads during writes");
 
 #endif

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -40,7 +40,7 @@
 /*
  * Enable/disable prefetching of dedup-ed blocks which are going to be freed.
  */
-int zfs_dedup_prefetch = 1;
+bool zfs_dedup_prefetch = B_TRUE;
 
 static const ddt_ops_t *ddt_ops[DDT_TYPES] = {
 	&ddt_zap_ops,
@@ -1208,6 +1208,6 @@ ddt_walk(spa_t *spa, ddt_bookmark_t *ddb, ddt_entry_t *dde)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(zfs_dedup_prefetch, int, 0644);
+module_param(zfs_dedup_prefetch, bool, 0644);
 MODULE_PARM_DESC(zfs_dedup_prefetch, "Enable prefetching dedup-ed blks");
 #endif

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -51,7 +51,7 @@
 /*
  * Enable/disable nopwrite feature.
  */
-int zfs_nopwrite_enabled = 1;
+bool zfs_nopwrite_enabled = B_TRUE;
 
 const dmu_object_type_info_t dmu_ot[DMU_OT_NUMTYPES] = {
 	{	DMU_BSWAP_UINT8,	TRUE,	"unallocated"		},
@@ -1754,7 +1754,7 @@ dmu_object_set_compress(objset_t *os, uint64_t object, uint8_t compress,
 	dnode_rele(dn, FTAG);
 }
 
-int zfs_mdcomp_disable = 0;
+bool zfs_mdcomp_disable = B_FALSE;
 
 void
 dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
@@ -2068,10 +2068,10 @@ EXPORT_SYMBOL(dmu_assign_arcbuf);
 EXPORT_SYMBOL(dmu_buf_hold);
 EXPORT_SYMBOL(dmu_ot);
 
-module_param(zfs_mdcomp_disable, int, 0644);
+module_param(zfs_mdcomp_disable, bool, 0644);
 MODULE_PARM_DESC(zfs_mdcomp_disable, "Disable meta data compression");
 
-module_param(zfs_nopwrite_enabled, int, 0644);
+module_param(zfs_nopwrite_enabled, bool, 0644);
 MODULE_PARM_DESC(zfs_nopwrite_enabled, "Enable NOP writes");
 
 #endif

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -52,7 +52,7 @@
 #include <sys/dsl_destroy.h>
 
 /* Set this tunable to TRUE to replace corrupt data with 0x2f5baddb10c */
-int zfs_send_corrupt_data = B_FALSE;
+bool zfs_send_corrupt_data = B_FALSE;
 
 static char *dmu_recv_tag = "dmu_recv_tag";
 static const char *recv_clone_name = "%recv";
@@ -1851,6 +1851,6 @@ dmu_objset_is_receiving(objset_t *os)
 }
 
 #if defined(_KERNEL)
-module_param(zfs_send_corrupt_data, int, 0644);
+module_param(zfs_send_corrupt_data, bool, 0644);
 MODULE_PARM_DESC(zfs_send_corrupt_data, "Allow sending corrupt data");
 #endif

--- a/module/zfs/dmu_zfetch.c
+++ b/module/zfs/dmu_zfetch.c
@@ -40,7 +40,7 @@
  * until we can get this working the way we want it to.
  */
 
-int zfs_prefetch_disable = 0;
+bool zfs_prefetch_disable = B_FALSE;
 
 /* max # of streams per zfetch */
 unsigned int	zfetch_max_streams = 8;
@@ -729,7 +729,7 @@ dmu_zfetch(zfetch_t *zf, uint64_t offset, uint64_t size, int prefetched)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(zfs_prefetch_disable, int, 0644);
+module_param(zfs_prefetch_disable, bool, 0644);
 MODULE_PARM_DESC(zfs_prefetch_disable, "Disable all ZFS prefetching");
 
 module_param(zfetch_max_streams, uint, 0644);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -64,8 +64,8 @@ int zfs_scan_idle = 50;			/* idle window in clock ticks */
 int zfs_scan_min_time_ms = 1000; /* min millisecs to scrub per txg */
 int zfs_free_min_time_ms = 1000; /* min millisecs to free per txg */
 int zfs_resilver_min_time_ms = 3000; /* min millisecs to resilver per txg */
-int zfs_no_scrub_io = B_FALSE; /* set to disable scrub i/o */
-int zfs_no_scrub_prefetch = B_FALSE; /* set to disable srub prefetching */
+bool zfs_no_scrub_io = B_FALSE; /* set to disable scrub i/o */
+bool zfs_no_scrub_prefetch = B_FALSE; /* set to disable scrub prefetching */
 enum ddt_class zfs_scrub_ddt_class_max = DDT_CLASS_DUPLICATE;
 int dsl_scan_delay_completion = B_FALSE; /* set to delay scan completion */
 
@@ -1778,9 +1778,9 @@ MODULE_PARM_DESC(zfs_free_min_time_ms, "Min millisecs to free per txg");
 module_param(zfs_resilver_min_time_ms, int, 0644);
 MODULE_PARM_DESC(zfs_resilver_min_time_ms, "Min millisecs to resilver per txg");
 
-module_param(zfs_no_scrub_io, int, 0644);
+module_param(zfs_no_scrub_io, bool, 0644);
 MODULE_PARM_DESC(zfs_no_scrub_io, "Set to disable scrub I/O");
 
-module_param(zfs_no_scrub_prefetch, int, 0644);
+module_param(zfs_no_scrub_prefetch, bool, 0644);
 MODULE_PARM_DESC(zfs_no_scrub_prefetch, "Set to disable scrub prefetching");
 #endif

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -78,7 +78,7 @@
 
 int zfs_zevent_len_max = 0;
 int zfs_zevent_cols = 80;
-int zfs_zevent_console = 0;
+bool zfs_zevent_console = B_FALSE;
 
 static int zevent_len_cur = 0;
 static int zevent_waiters = 0;
@@ -1553,7 +1553,7 @@ MODULE_PARM_DESC(zfs_zevent_len_max, "Max event queue length");
 module_param(zfs_zevent_cols, int, 0644);
 MODULE_PARM_DESC(zfs_zevent_cols, "Max event column width");
 
-module_param(zfs_zevent_console, int, 0644);
+module_param(zfs_zevent_console, bool, 0644);
 MODULE_PARM_DESC(zfs_zevent_console, "Log events to the console");
 
 #endif /* _KERNEL */

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -83,7 +83,7 @@ int zfs_mg_noalloc_threshold = 0;
 /*
  * Metaslab debugging: when set, keeps all space maps in core to verify frees.
  */
-int metaslab_debug = 0;
+bool metaslab_debug = B_FALSE;
 
 /*
  * Minimum size which forces the dynamic allocator to change
@@ -2109,6 +2109,6 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(metaslab_debug, int, 0644);
+module_param(metaslab_debug, bool, 0644);
 MODULE_PARM_DESC(metaslab_debug, "keep space maps in core to verify frees");
 #endif /* _KERNEL && HAVE_SPL */

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -65,7 +65,7 @@ static uint64_t spa_config_generation = 1;
  * userland pools when doing testing.
  */
 char *spa_config_path = ZPOOL_CACHE;
-int zfs_autoimport_disable = 0;
+bool zfs_autoimport_disable = B_FALSE;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -527,7 +527,7 @@ EXPORT_SYMBOL(spa_config_update);
 module_param(spa_config_path, charp, 0444);
 MODULE_PARM_DESC(spa_config_path, "SPA config file (/etc/zfs/zpool.cache)");
 
-module_param(zfs_autoimport_disable, int, 0644);
+module_param(zfs_autoimport_disable, bool, 0644);
 MODULE_PARM_DESC(zfs_autoimport_disable, "Disable pool import at module load");
 
 #endif

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -250,7 +250,7 @@ unsigned long zfs_deadman_synctime_ms = 1000000ULL;
 /*
  * By default the deadman is enabled.
  */
-int zfs_deadman_enabled = 1;
+bool zfs_deadman_enabled = B_TRUE;
 
 /*
  * The worst case is single-sector max-parity RAID-Z blocks, in which
@@ -1885,7 +1885,7 @@ EXPORT_SYMBOL(spa_namespace_lock);
 module_param(zfs_deadman_synctime_ms, ulong, 0644);
 MODULE_PARM_DESC(zfs_deadman_synctime_ms, "Expiration time in milliseconds");
 
-module_param(zfs_deadman_enabled, int, 0644);
+module_param(zfs_deadman_enabled, bool, 0644);
 MODULE_PARM_DESC(zfs_deadman_enabled, "Enable deadman timer");
 
 module_param(spa_asize_inflation, int, 0644);

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -30,7 +30,7 @@ int zfs_read_history = 0;
 /*
  * Include cache hits in history, disabled by default.
  */
-int zfs_read_history_hits = 0;
+bool zfs_read_history_hits = B_FALSE;
 
 /*
  * Keeps stats on the last N txgs, disabled by default.
@@ -203,7 +203,7 @@ spa_read_history_add(spa_t *spa, const zbookmark_t *zb, uint32_t aflags)
 	if (zfs_read_history == 0 && ssh->size == 0)
 		return;
 
-	if (zfs_read_history_hits == 0 && (aflags & ARC_CACHED))
+	if (!zfs_read_history_hits && (aflags & ARC_CACHED))
 		return;
 
 	srh = kmem_zalloc(sizeof (spa_read_history_t), KM_PUSHPAGE);
@@ -678,7 +678,7 @@ spa_stats_destroy(spa_t *spa)
 module_param(zfs_read_history, int, 0644);
 MODULE_PARM_DESC(zfs_read_history, "Historic statistics for the last N reads");
 
-module_param(zfs_read_history_hits, int, 0644);
+module_param(zfs_read_history_hits, bool, 0644);
 MODULE_PARM_DESC(zfs_read_history_hits, "Include cache hits in read history");
 
 module_param(zfs_txg_history, int, 0644);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -90,14 +90,14 @@ static kstat_t *zil_ksp;
 /*
  * Disable intent logging replay.  This global ZIL switch affects all pools.
  */
-int zil_replay_disable = 0;
+bool zil_replay_disable = B_FALSE;
 
 /*
  * Tunable parameter for debugging or performance analysis.  Setting
  * zfs_nocacheflush will cause corruption on power loss if a volatile
  * out-of-order write cache is enabled.
  */
-int zfs_nocacheflush = 0;
+bool zfs_nocacheflush = B_FALSE;
 
 static kmem_cache_t *zil_lwb_cache;
 
@@ -2237,10 +2237,10 @@ zil_vdev_offline(const char *osname, void *arg)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(zil_replay_disable, int, 0644);
+module_param(zil_replay_disable, bool, 0644);
 MODULE_PARM_DESC(zil_replay_disable, "Disable intent logging replay");
 
-module_param(zfs_nocacheflush, int, 0644);
+module_param(zfs_nocacheflush, bool, 0644);
 MODULE_PARM_DESC(zfs_nocacheflush, "Disable cache flushes");
 
 module_param(zil_slog_limit, ulong, 0644);

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -47,7 +47,7 @@
 #include <sys/dmu_objset.h>
 #include <sys/fs/zfs.h>
 
-uint32_t zio_injection_enabled = 0;
+bool zio_injection_enabled = B_FALSE;
 
 typedef struct inject_handler {
 	int			zi_id;
@@ -331,7 +331,7 @@ spa_handle_ignored_writes(spa_t *spa)
 {
 	inject_handler_t *handler;
 
-	if (zio_injection_enabled == 0)
+	if (!zio_injection_enabled)
 		return;
 
 	rw_enter(&inject_lock, RW_READER);
@@ -367,7 +367,7 @@ zio_handle_io_delay(zio_t *zio)
 	inject_handler_t *handler;
 	uint64_t seconds = 0;
 
-	if (zio_injection_enabled == 0)
+	if (!zio_injection_enabled)
 		return (0);
 
 	rw_enter(&inject_lock, RW_READER);
@@ -524,6 +524,6 @@ zio_inject_fini(void)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(zio_injection_enabled, int, 0644);
+module_param(zio_injection_enabled, bool, 0644);
 MODULE_PARM_DESC(zio_injection_enabled, "Enable fault injection");
 #endif

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -47,7 +47,7 @@
 #include <sys/zvol.h>
 #include <linux/blkdev_compat.h>
 
-unsigned int zvol_inhibit_dev = 0;
+bool zvol_inhibit_dev = B_FALSE;
 unsigned int zvol_major = ZVOL_MAJOR;
 unsigned int zvol_threads = 32;
 unsigned long zvol_max_discard_blocks = 16384;
@@ -1668,7 +1668,7 @@ zvol_fini(void)
 	list_destroy(&zvol_state_list);
 }
 
-module_param(zvol_inhibit_dev, uint, 0644);
+module_param(zvol_inhibit_dev, bool, 0644);
 MODULE_PARM_DESC(zvol_inhibit_dev, "Do not create zvol device nodes");
 
 module_param(zvol_major, uint, 0444);


### PR DESCRIPTION
Minor ... 'improvement' to indicate that a bool really IS a bool and not an int (and make sure you can't set it to an unvalid value, such as <code>2</code> etc...

Backwards comparability is still maintained, because it accepts <code>Y</code> or <code>1</code> (as well as <code>N</code> or <code>0</code> respectivly).

Includes man update and a spelling error (srub should be scrub).
