### PR TITLE
Add UNSHARING of filesystems and EXPORTING pools at 'stop' action.

### DIFF
--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -106,8 +106,19 @@ stop()
 {
 	[ ! -f "$LOCKFILE" ] && return 3
 
+	log_begin_msg "Unsharing ZFS filesystems"
+	"$ZFS" unshare -a
+	log_end_msg $?
+
 	log_begin_msg "Unmounting ZFS filesystems"
 	"$ZFS" umount -a
+	log_end_msg $?
+
+	log_begin_msg "Exporting ZFS pools"
+	"$ZPOOL" list -H -o name | \
+	    while read pool; do
+		"$ZPOOL" export $pool
+	done
 	log_end_msg $?
 
 	rm -f "$LOCKFILE"


### PR DESCRIPTION
Make sure we unshare all filesystems before we unmount them. Just to be sure...

Export the pools after unmounting filesystems (in case user imports it on another host).
