### PR TITLE
Arc isn't warmup when call arc_shrinker_func

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2358,10 +2358,6 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 {
 	uint64_t pages;
 
-	/* The arc is considered warm once reclaim has occurred */
-	if (unlikely(arc_warm == B_FALSE))
-		arc_warm = B_TRUE;
-
 	/* Return the potential number of reclaimable pages */
 	pages = btop(arc_evictable_memory());
 	if (sc->nr_to_scan == 0)


### PR DESCRIPTION
Arc may not be warmed up when call arc_shrinker_func. If user drops cache, other threads will call arc_shrinker_func directly. (ie. echo 2>/proc/sys/vm/drop_caches) Arc cache may not be warmed up at this moment. So arc_warm shouldn't be set here.
