### PR TITLE
Work around GCC 4.8 aggressive loop optimization.

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1070,7 +1070,7 @@ dump_indirect(dnode_t *dn)
 	for (j = 0; j < dnp->dn_nblkptr; j++) {
 		czb.zb_blkid = j;
 		(void) visit_indirect(dmu_objset_spa(dn->dn_objset), dnp,
-		    &dnp->dn_blkptr[j], &czb);
+		    &((blkptr_t *)dnp->dn_blkptr)[j], &czb);
 	}
 
 	(void) printf("\n");

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1898,7 +1898,7 @@ __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 	doi->doi_max_offset = (dn->dn_maxblkid + 1) * dn->dn_datablksz;
 	doi->doi_fill_count = 0;
 	for (i = 0; i < dnp->dn_nblkptr; i++)
-		doi->doi_fill_count += dnp->dn_blkptr[i].blk_fill;
+		doi->doi_fill_count += ((blkptr_t *)dnp->dn_blkptr)[i].blk_fill;
 }
 
 void

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -970,7 +970,7 @@ dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 	 */
 	bp->blk_fill = 0;
 	for (i = 0; i < dnp->dn_nblkptr; i++)
-		bp->blk_fill += dnp->dn_blkptr[i].blk_fill;
+		bp->blk_fill += ((blkptr_t *)dnp->dn_blkptr)[i].blk_fill;
 }
 
 /* ARGSUSED */

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -391,7 +391,7 @@ prefetch_dnode_metadata(traverse_data_t *td, const dnode_phys_t *dnp,
 
 	for (j = 0; j < dnp->dn_nblkptr; j++) {
 		SET_BOOKMARK(&czb, objset, object, dnp->dn_nlevels - 1, j);
-		traverse_prefetch_metadata(td, &dnp->dn_blkptr[j], &czb);
+		traverse_prefetch_metadata(td, &((blkptr_t *)dnp->dn_blkptr)[j], &czb);
 	}
 
 	if (dnp->dn_flags & DNODE_FLAG_SPILL_BLKPTR) {
@@ -409,7 +409,7 @@ traverse_dnode(traverse_data_t *td, const dnode_phys_t *dnp,
 
 	for (j = 0; j < dnp->dn_nblkptr; j++) {
 		SET_BOOKMARK(&czb, objset, object, dnp->dn_nlevels - 1, j);
-		err = traverse_visitbp(td, dnp, &dnp->dn_blkptr[j], &czb);
+		err = traverse_visitbp(td, dnp, &((blkptr_t *)dnp->dn_blkptr)[j], &czb);
 		if (err != 0) {
 			if (!TD_HARD(td))
 				break;

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -59,7 +59,7 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 
 	/* check for existing blkptrs in the dnode */
 	for (i = 0; i < nblkptr; i++)
-		if (!BP_IS_HOLE(&dn->dn_phys->dn_blkptr[i]))
+		if (!BP_IS_HOLE(&((blkptr_t *)dn->dn_phys->dn_blkptr)[i]))
 			break;
 	if (i != nblkptr) {
 		/* transfer dnode's block pointers to new indirect block */
@@ -86,7 +86,7 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 		if (child->db_parent && child->db_parent != dn->dn_dbuf) {
 			ASSERT(child->db_parent->db_level == db->db_level);
 			ASSERT(child->db_blkptr !=
-			    &dn->dn_phys->dn_blkptr[child->db_blkid]);
+			    &((blkptr_t *)dn->dn_phys->dn_blkptr)[child->db_blkid]);
 			mutex_exit(&child->db_mtx);
 			continue;
 		}

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -641,7 +641,7 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 		}
 		for (i = 0, cdnp = (*bufp)->b_data; i < epb; i++, cdnp++) {
 			for (j = 0; j < cdnp->dn_nblkptr; j++) {
-				blkptr_t *cbp = &cdnp->dn_blkptr[j];
+				blkptr_t *cbp = &((blkptr_t *)cdnp->dn_blkptr)[j];
 				dsl_scan_prefetch(scn, *bufp, cbp,
 				    zb->zb_objset, zb->zb_blkid * epb + i, j);
 			}
@@ -698,7 +698,7 @@ dsl_scan_visitdnode(dsl_scan_t *scn, dsl_dataset_t *ds,
 
 		SET_BOOKMARK(&czb, ds ? ds->ds_object : 0, object,
 		    dnp->dn_nlevels - 1, j);
-		dsl_scan_visitbp(&dnp->dn_blkptr[j],
+		dsl_scan_visitbp(&((blkptr_t *)dnp->dn_blkptr)[j],
 		    &czb, dnp, buf, ds, scn, ostype, tx);
 	}
 


### PR DESCRIPTION
GCC >+ 4.8's aggressive loop optimization breaks some of the iterators
over the dn_blkptr[] pseudo-array in dnode_phys.  Since dn_blkptr[] is
defined as a single-element array, GCC believes an iterator can only
access index 0 and will unroll the loop into a single iteration.

This commit works around the optimization by casting the array to a
pointer and is definitely a hack.  It fixes all obvious iterators that
might break, however, the only loop where it was known to cause problems
was this loop in dmu_objset_write_ready():

```
    for (i = 0; i < dnp->dn_nblkptr; i++)
            bp->blk_fill += dnp->dn_blkptr[i].blk_fill;
```

In the common case where dn_nblkptr is 3, the loop is only executed a
single time and "i" is equal to 1 following the loop.

The specific breakage cause by this problem is that the blk_fill of
root block pointers wouldn't be set properly when more than one blkptr
is in use (when no indrect blocks are needed).

The simple reproducing sequence is:

```
zpool create tank /tank.img
zdb -ddddd tank 0
```

and notice that "fill=31", however, there are two L0 indirect blocks with
"F=31" and "F=5".  The fill count should be 36 rather than 35.  This problem
causes an assert to be hit in a simple "zdb tank" when built with --enable-debug.
