### PR TITLE
Force direct reclaim threads to wait for concurrent reclaimer

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2545,6 +2545,7 @@ static int
 __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 {
 	uint64_t pages;
+	int is_kswapd = current_is_kswapd();
 
 	/* The arc is considered warm once reclaim has occurred */
 	if (unlikely(arc_warm == B_FALSE))
@@ -2559,9 +2560,14 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	if (!(sc->gfp_mask & __GFP_FS))
 		return (-1);
 
-	/* Reclaim in progress */
-	if (mutex_tryenter(&arc_reclaim_thr_lock) == 0)
+	/* Concurrent reclaim in progress, wait for it to finish. */
+	if (mutex_tryenter(&arc_reclaim_thr_lock) == 0) {
+		if (!is_kswapd) {
+			mutex_enter(&arc_reclaim_thr_lock);
+			goto no_grow;
+		}
 		return (-1);
+	}
 
 	/*
 	 * Evict the requested number of pages by shrinking arc_c the
@@ -2574,6 +2580,7 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		arc_kmem_reap_now(ARC_RECLAIM_CONS, ptob(sc->nr_to_scan));
 	}
 
+no_grow:
 	/*
 	 * When direct reclaim is observed it usually indicates a rapid
 	 * increase in memory pressure.  This occurs because the kswapd
@@ -2581,7 +2588,7 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	 * available.  In this case set arc_no_grow to briefly pause arc
 	 * growth to avoid compounding the memory pressure.
 	 */
-	if (current_is_kswapd()) {
+	if (is_kswapd) {
 		ARCSTAT_BUMP(arcstat_memory_indirect_count);
 	} else {
 		arc_no_grow = B_TRUE;


### PR DESCRIPTION
Currently, direct reclaim threads will return immediately upon seeing a
concurrent reclaimer in progress. These threads might go on to invoke OOM if
ARC does not evict enough memory in time.

This patch tries to alleviate this issue by forcing the direct reclaim threads
to wait on arc_reclaim_thr_lock. Also, switch on arc_no_grow before returning.
