### PR TITLE
Add large_block feature flag (WIP)

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -83,13 +83,16 @@ struct dsl_dataset;
 	BF64_SET(x, low, len, ((val) >> (shift)) - (bias))
 
 /*
- * We currently support nine block sizes, from 512 bytes to 128K.
- * We could go higher, but the benefits are near-zero and the cost
- * of COWing a giant block to modify one byte would become excessive.
+ * We currently support fifteen block sizes, from 512 bytes to 8M.
+ * The benefits of larger blocks, and thus larger IO, need to be weighed
+ * against the cost of COWing a giant block to modify one byte.
  */
 #define	SPA_MINBLOCKSHIFT	9
-#define	SPA_MAXBLOCKSHIFT	17
+#define	SPA_OLD_MAXBLOCKSHIFT	17
+#define	SPA_MAXBLOCKSHIFT	20
+//#define	SPA_MAXBLOCKSHIFT	23
 #define	SPA_MINBLOCKSIZE	(1ULL << SPA_MINBLOCKSHIFT)
+#define	SPA_OLD_MAXBLOCKSIZE	(1ULL << SPA_OLD_MAXBLOCKSHIFT)
 #define	SPA_MAXBLOCKSIZE	(1ULL << SPA_MAXBLOCKSHIFT)
 
 #define	SPA_BLOCKSIZES		(SPA_MAXBLOCKSHIFT - SPA_MINBLOCKSHIFT + 1)
@@ -625,6 +628,8 @@ extern spa_load_state_t spa_load_state(spa_t *spa);
 extern uint64_t spa_freeze_txg(spa_t *spa);
 extern uint64_t spa_get_asize(spa_t *spa, uint64_t lsize);
 extern uint64_t spa_get_dspace(spa_t *spa);
+extern uint64_t spa_get_maxblksz(spa_t *spa);
+extern void spa_set_maxblksz(spa_t *spa, uint64_t maxblksz);
 extern void spa_update_dspace(spa_t *spa);
 extern uint64_t spa_version(spa_t *spa);
 extern boolean_t spa_deflate(spa_t *spa);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -198,6 +198,8 @@ struct spa {
 	vdev_t		*spa_pending_vdev;	/* pending vdev additions */
 	kmutex_t	spa_props_lock;		/* property lock */
 	uint64_t	spa_pool_props_object;	/* object for properties */
+	kmutex_t	spa_maxblksz_lock;	/* max block size lock */
+	uint64_t	spa_maxblksz;		/* max block size */
 	uint64_t	spa_bootfs;		/* default boot filesystem */
 	uint64_t	spa_failmode;		/* failure mode for the pool */
 	uint64_t	spa_delegation;		/* delegation on/off */

--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -54,6 +54,13 @@ typedef enum spa_feature {
 	SPA_FEATURE_ASYNC_DESTROY,
 	SPA_FEATURE_EMPTY_BPOBJ,
 	SPA_FEATURE_LZ4_COMPRESS,
+	/*
+	 * XXX: This may make more sense as a dataset level feature flag.
+	 * We shouldn't have to taint the entire pool when this is in use.
+	 * The max value could be added to the objset, for now we do it as
+	 * a pool level flag because we don't have dataset level flags.
+	 */
+	SPA_FEATURE_LARGE_BLOCKS,
 	SPA_FEATURES
 } spa_feature_t;
 

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -231,5 +231,22 @@ moment, this operation cannot be reversed. Booting off of
 
 .RE
 
+.sp
+.ne 2
+.na
+\fB\fBlarge_blocks\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	org.openzfs:large_block
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
+.TE
+
+The \fBlarge_block\fR feature allows the record size on a dataset to be
+set larger than 128k.  *** FINISH THIS SUMMARY ***
+.RE
+
 .SH "SEE ALSO"
 \fBzpool\fR(8)

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -360,7 +360,7 @@ zfs_prop_init(void)
 	    "<1.00x or higher if compressed>", "REFRATIO");
 	zprop_register_number(ZFS_PROP_VOLBLOCKSIZE, "volblocksize",
 	    ZVOL_DEFAULT_BLOCKSIZE, PROP_ONETIME,
-	    ZFS_TYPE_VOLUME, "512 to 128k, power of 2",	"VOLBLOCK");
+	    ZFS_TYPE_VOLUME, "512 to 8M, power of 2",	"VOLBLOCK");
 	zprop_register_number(ZFS_PROP_USEDSNAP, "usedbysnapshots", 0,
 	    PROP_READONLY, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME, "<size>",
 	    "USEDSNAP");
@@ -398,8 +398,8 @@ zfs_prop_init(void)
 
 	/* inherit number properties */
 	zprop_register_number(ZFS_PROP_RECORDSIZE, "recordsize",
-	    SPA_MAXBLOCKSIZE, PROP_INHERIT,
-	    ZFS_TYPE_FILESYSTEM, "512 to 128k, power of 2", "RECSIZE");
+	    SPA_OLD_MAXBLOCKSIZE, PROP_INHERIT,
+	    ZFS_TYPE_FILESYSTEM, "512 to 8M, power of 2", "RECSIZE");
 
 	/* hidden properties */
 	zprop_register_hidden(ZFS_PROP_CREATETXG, "createtxg", PROP_TYPE_NUMBER,

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2102,8 +2102,8 @@ dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, dmu_tx_t *tx)
 		return (SET_ERROR(ENOTSUP));
 	if (blksz == 0)
 		blksz = SPA_MINBLOCKSIZE;
-	if (blksz > SPA_MAXBLOCKSIZE)
-		blksz = SPA_MAXBLOCKSIZE;
+	if (blksz > spa_get_maxblksz(tx->tx_objset->os_spa))
+		blksz = spa_get_maxblksz(tx->tx_objset->os_spa);
 	else
 		blksz = P2ROUNDUP(blksz, SPA_MINBLOCKSIZE);
 

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -489,8 +489,8 @@ dnode_allocate(dnode_t *dn, dmu_object_type_t ot, int blocksize, int ibs,
 
 	if (blocksize == 0)
 		blocksize = 1 << zfs_default_bs;
-	else if (blocksize > SPA_MAXBLOCKSIZE)
-		blocksize = SPA_MAXBLOCKSIZE;
+	else if (blocksize > spa_get_maxblksz(dn->dn_objset->os_spa))
+		blocksize = spa_get_maxblksz(dn->dn_objset->os_spa);
 	else
 		blocksize = P2ROUNDUP(blocksize, SPA_MINBLOCKSIZE);
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2896,6 +2896,13 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 		return (SET_ERROR(ENOENT));
 	}
 
+	if (spa_feature_is_active(spa,
+	    &spa_feature_table[SPA_FEATURE_LARGE_BLOCKS])) {
+		spa->spa_maxblksz = SPA_MAXBLOCKSIZE;
+	} else {
+		spa->spa_maxblksz = SPA_OLD_MAXBLOCKSIZE;
+	}
+
 	if (spa->spa_state == POOL_STATE_UNINITIALIZED) {
 		zpool_rewind_policy_t policy;
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -482,6 +482,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	mutex_init(&spa->spa_scrub_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_suspend_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_vdev_top_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&spa->spa_maxblksz_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	cv_init(&spa->spa_async_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_proc_cv, NULL, CV_DEFAULT, NULL);
@@ -609,6 +610,7 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_scrub_lock);
 	mutex_destroy(&spa->spa_suspend_lock);
 	mutex_destroy(&spa->spa_vdev_top_lock);
+	mutex_destroy(&spa->spa_maxblksz_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }
@@ -1475,6 +1477,33 @@ spa_update_dspace(spa_t *spa)
 {
 	spa->spa_dspace = metaslab_class_get_dspace(spa_normal_class(spa)) +
 	    ddt_get_dedup_dspace(spa);
+}
+
+/*
+ * XXX: This locking feels too heavy weight.  Do to have rarely this
+ * value changes we should be able to do something better.
+ */
+uint64_t
+spa_get_maxblksz(spa_t *spa)
+{
+	uint64_t maxblksz;
+
+	mutex_enter(&spa->spa_maxblksz_lock);
+	maxblksz = spa->spa_maxblksz;
+	mutex_exit(&spa->spa_maxblksz_lock);
+
+	return (maxblksz);
+}
+
+void
+spa_set_maxblksz(spa_t *spa, uint64_t maxblksz)
+{
+	ASSERT(maxblksz == SPA_OLD_MAXBLOCKSIZE ||
+	    maxblksz == SPA_MAXBLOCKSIZE);
+
+	mutex_enter(&spa->spa_maxblksz_lock);
+	spa->spa_maxblksz = maxblksz;
+	mutex_exit(&spa->spa_maxblksz_lock);
 }
 
 /*

--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -164,4 +164,7 @@ zpool_feature_init(void)
 	zfeature_register(SPA_FEATURE_LZ4_COMPRESS,
 	    "org.illumos:lz4_compress", "lz4_compress",
 	    "LZ4 compression algorithm support.", B_FALSE, B_FALSE, NULL);
+	zfeature_register(SPA_FEATURE_LARGE_BLOCKS,
+	    "org.openzfs:large_blocks", "large_blocks",
+	    "Large block support (128k-8M).", B_FALSE, B_FALSE, NULL);
 }

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -184,8 +184,8 @@ blksz_changed_cb(void *arg, uint64_t newval)
 	zfs_sb_t *zsb = arg;
 
 	if (newval < SPA_MINBLOCKSIZE ||
-	    newval > SPA_MAXBLOCKSIZE || !ISP2(newval))
-		newval = SPA_MAXBLOCKSIZE;
+	    newval > spa_get_maxblksz(zsb->z_os->os_spa) || !ISP2(newval))
+		newval = spa_get_maxblksz(zsb->z_os->os_spa);
 
 	zsb->z_max_blksz = newval;
 }
@@ -662,7 +662,7 @@ zfs_sb_create(const char *osname, zfs_sb_t **zsbp)
 	 */
 	zsb->z_sb = NULL;
 	zsb->z_parent = zsb;
-	zsb->z_max_blksz = SPA_MAXBLOCKSIZE;
+	zsb->z_max_blksz = spa_get_maxblksz(os->os_spa);
 	zsb->z_show_ctldir = ZFS_SNAPDIR_VISIBLE;
 	zsb->z_os = os;
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -787,7 +787,8 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 
 			if (zp->z_blksz > max_blksz) {
 				ASSERT(!ISP2(zp->z_blksz));
-				new_blksz = MIN(end_size, SPA_MAXBLOCKSIZE);
+				new_blksz = MIN(end_size,
+				    spa_get_maxblksz(zsb->z_os->os_spa));
 			} else {
 				new_blksz = MIN(end_size, max_blksz);
 			}

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -61,6 +61,7 @@
 #endif /* _KERNEL */
 
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/refcount.h>
 #include <sys/stat.h>
 #include <sys/zap.h>
@@ -1220,7 +1221,8 @@ zfs_extend(znode_t *zp, uint64_t end)
 		 */
 		if (zp->z_blksz > ZTOZSB(zp)->z_max_blksz) {
 			ASSERT(!ISP2(zp->z_blksz));
-			newblksz = MIN(end, SPA_MAXBLOCKSIZE);
+			newblksz = MIN(end,
+			    spa_get_maxblksz(zsb->z_os->os_spa));
 		} else {
 			newblksz = MIN(end, ZTOZSB(zp)->z_max_blksz);
 		}


### PR DESCRIPTION
WARNING, this is a prototype patch which is only suitable for use on
dedicated test pools.  Do NOT use this patch on systems with data you
care about.  Once enabled it will cause new data to be written using
large blocks which are not understood by existing ZFS implementations.

This change is suitable for benchmarking the potential performance
impact of using large blocks.  The configurations of primarily
interest are raidz vdevs using a large number of devices.

TODO:

1) Feature flag & reference counting.  Matt has done some work that
   will allow us to quickly and easily track the number of blocks
   using a given feature.  This will be a handy for us to be able
   to be able to deactivate the feature once activated.  It would
   also be desirable to allow ZFS implementations without this
   feature to still import the pool read-only.  All datasets where
   large blocks were not enabled should still be safe to mount.

2) GRUB support.  Initially it may be best to prevent allowing
   increased block sizes on the boot filesystem (similar to how
   we handle gzip compression).  Once this functionality has been
   pushed in to grub this could be relaxed.  But it will take
   considerable time for any upstream grub improvement to make
   their way back in to the distributions.

3) For Linux these changes cannot be merged until we abandon the
   zio kmem caches.  They are unsuitable for making the required
   maximum 8M allocations.  This may have a performance impact
   on FreeBSD and Illumos as well, that needs to be investigated.

4) I've made one pass evaluating everywhere SPA_MAXBLOCKSIZE/SHIFT
   is used to determine if SPA_OLD_MAXBLKSIZE/SHIFT or
   SPA_MAXBLOCKSIZE/SHIFT should be used.  However, we'll want
   additional eyes on this and more testing to make sure it's right.
   In particular some MOS objects use blocksize=SPA_MAXBLOCKSIZE.
   We would probably want to keep those at 128k so that we have
   some hope of deactivating the feature (e.g. by destroying all
   filesystems with recordsize > 128k).

5) Investigate compatibility large block in Solaris's ZFS.  I
   strongly suspect they implemented this is a similar way.  It
   may be possible to allow read-only access those pools, or
   upgrade them to the new OpenZFS format.

6) Fully document the feature in zpool-features(5).

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
