### PR TITLE
Annotate tasks which require KM_PUSHPAGE

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -445,11 +445,12 @@ typedef struct taskq_ent {
 #define	TASKQ_THREADS_CPU_PCT	0x0008	/* Scale # threads by # cpus */
 #define	TASKQ_DC_BATCH		0x0010	/* Mark threads as batch */
 
-#define	TQ_SLEEP	KM_SLEEP	/* Can block for memory */
-#define	TQ_NOSLEEP	KM_NOSLEEP	/* cannot block for memory; may fail */
-#define	TQ_PUSHPAGE	KM_PUSHPAGE	/* Cannot perform I/O */
-#define	TQ_NOQUEUE	0x02		/* Do not enqueue if can't dispatch */
-#define	TQ_FRONT	0x08		/* Queue in front */
+#define	TQ_SLEEP		KM_SLEEP	/* Can block for memory */
+#define	TQ_NOSLEEP		KM_NOSLEEP	/* Cannot block for memory */
+#define	TQ_PUSHPAGE		KM_PUSHPAGE	/* Cannot perform I/O */
+#define	TQ_NOQUEUE		0x02	/* Do not enqueue if can't dispatch */
+#define	TQ_FRONT		0x08	/* Queue in front */
+#define	TQ_PUSHPAGE_THREAD	0x10	/* Only allow KM_PUSHPAGE in thread */
 
 extern taskq_t *system_taskq;
 

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -199,7 +199,7 @@ enum zio_flag {
 	ZIO_FLAG_FASTWRITE	= 1 << 28
 };
 
-#define	ZIO_FLAG_MUSTSUCCEED		0
+#define	ZIO_FLAG_MUSTSUCCEED		ZIO_FLAG_TRYHARD
 
 #define	ZIO_DDT_CHILD_FLAGS(zio)				\
 	(((zio)->io_flags & ZIO_FLAG_DDT_INHERIT) |		\

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -185,7 +185,7 @@ vdev_file_io_start(zio_t *zio)
 	}
 
 	VERIFY3U(taskq_dispatch(system_taskq, vdev_file_io_strategy, zio,
-	    TQ_SLEEP), !=, 0);
+	    TQ_PUSHPAGE | TQ_PUSHPAGE_THREAD), !=, 0);
 
 	return (ZIO_PIPELINE_STOP);
 }


### PR DESCRIPTION
When the txg_sync thread issues an I/O and blocks in zio_wait().
Then it is critical that all processes involved in handling that
I/O use KM_PUSHPAGE when performing allocations.

If they use KM_SLEEP then it is possible that during a low memory
condition direct reclaim will be invoked and it may attempt to
flush dirty data to the file system.  This will result in the
thread attempting to assign a TX will block until the txg_sync
thread completes.

The end result is a deadlock with the txg_sync thread blocked on
the original I/O, and the taskq thread blocked on the txg_sync
thread.

To prevent developers from accidentally introducing this type
of deadlock.  This patch passes the TQ_PUSHPAGE_THREAD flag when
dispatching a I/O to a taskq which the txg_sync thread is waiting
on.  This causes the taskq thread to set the PF_NOFS flag in its
task struct while the zio_execute() function is being executed.
Thereby ensuring that any accidental misuse of the KM_SLEEP is
quickly causes and fixed.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1928
