### PR TITLE
vdev_id: support per-channel slot mappings

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -39,18 +39,20 @@
 # channel 86:00.0 1         C
 # channel 86:00.0 0         D
 #
-# #    Linux	Mapped
-# #    Slot	Slot
-# slot 1        7
-# slot 2        10
-# slot 3        3
-# slot 4        6
-# slot 5        2
-# slot 6        8
-# slot 7        1
-# slot 8        4
-# slot 9        9
-# slot 10       5
+# # Custom mapping for Channel A
+#
+# #    Linux      Mapped
+# #    Slot       Slot      Channel
+# slot 1          7         A
+# slot 2          10        A
+# slot 3          3         A
+# slot 4          6         A
+#
+# # Default mapping for B, C, and D
+# slot 1          4
+# slot 2          2
+# slot 3          1
+# slot 4          3
 
 # #
 # # Example vdev_id.conf - sas_switch
@@ -110,10 +112,11 @@ EOF
 
 map_slot() {
 	local LINUX_SLOT=$1
+	local CHANNEL=$2
 	local MAPPED_SLOT=
 
-	MAPPED_SLOT=`awk "\\$1 == \"slot\" && \\$2 == ${LINUX_SLOT} \
-			{ print \\$3; exit }" $CONFIG`
+	MAPPED_SLOT=`awk "\\$1 == \"slot\" && \\$2 == ${LINUX_SLOT} && \
+			\\$4 ~ /^(${CHANNEL}|)$/ { print \\$3; exit }" $CONFIG`
 	if [ -z "$MAPPED_SLOT" ] ; then
 		MAPPED_SLOT=$LINUX_SLOT
 	fi
@@ -254,8 +257,8 @@ sas_handler() {
 		return
 	fi
 
-	SLOT=`map_slot $SLOT`
 	CHAN=`map_channel $PCI_ID $PORT`
+	SLOT=`map_slot $SLOT $CHAN`
 	if [ -z "$CHAN" ] ; then
 		return
 	fi

--- a/etc/zfs/vdev_id.conf.sas_direct.example
+++ b/etc/zfs/vdev_id.conf.sas_direct.example
@@ -8,15 +8,18 @@ channel 85:00.0 0         B
 channel 86:00.0 1         C
 channel 86:00.0 0         D
 
+
+# Custom mapping for Channel A
+
 #    Linux      Mapped
-#    Slot       Slot
-slot 1          7
-slot 2          10
-slot 3          3
-slot 4          6
-slot 5          2
-slot 6          8
-slot 7          1
-slot 8          4
-slot 9          9
-slot 10         5
+#    Slot       Slot      Channel
+slot 1          7         A
+slot 2          10        A
+slot 3          3         A
+slot 4          6         A
+
+# Default mapping for B, C, and D
+slot 1          4
+slot 2          2
+slot 3          1
+slot 4          3

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -49,9 +49,17 @@ connected to the disk enclosure being mapped.
 \fIname\fR - specifies the name of the channel.
 
 .TP
-\fIslot\fR <old> <new>
-Maps a disk slot number as reported by the operating system
-to an alternative slot number.
+\fIslot\fR <old> <new> [channel]
+Maps a disk slot number as reported by the operating system to an
+alternative slot number.  If the \fIchannel\fR parameter is specified
+then the mapping is only applied to slots in the named channel,
+otherwise the mapping is applied to all channels. The first-specified
+\fIslot\fR rule that can match a slot takes precedence.  Therefore a
+channel-specific mapping for a given slot should generally appear before
+a generic mapping for the same slot.  In this way a custom mapping may
+be applied to a particular channel and a default mapping applied to the
+others.
+
 .TP
 \fImultipath\fR <yes|no>
 Specifies whether
@@ -84,99 +92,69 @@ device is connected to.  The default is 4.
 A non-multipath configuration with direct-attached SAS enclosures and an
 arbitrary slot re-mapping.
 .P
+.nf
 	multipath     no
-.br
 	topology      sas_direct
-.br
 	phys_per_port 4
-.br
 
-.br
 	#       PCI_SLOT HBA PORT  CHANNEL NAME
-.br
 	channel 85:00.0  1         A
-.br
 	channel 85:00.0  0         B
-.br
 	channel 86:00.0  1         C
-.br
 	channel 86:00.0  0         D
-.br
 
-.br
+	# Custom mapping for Channel A
+
 	#    Linux      Mapped
-.br
-	#    Slot       Slot
-.br
-	slot 1          7
-.br
-	slot 2          10
-.br
-	slot 3          3
-.br
-	slot 4          6
-.br
-	slot 5          2
-.br
-	slot 6          8
-.br
-	slot 7          1
-.br
-	slot 8          4
-.br
-	slot 9          9
-.br
-	slot 10         5
-.br
+	#    Slot       Slot      Channel
+	slot 1          7         A
+	slot 2          10        A
+	slot 3          3         A
+	slot 4          6         A
+
+	# Default mapping for B, C, and D
+
+	slot 1          4
+	slot 2          2
+	slot 3          1
+	slot 4          3
+.fi
 .P
 A SAS-switch topology.  Note that the
 .I channel
 keyword takes only two arguments in this example.
 .P
+.nf
 	topology      sas_switch
-.br
 
-.br
 	#       SWITCH PORT  CHANNEL NAME
-.br
 	channel 1            A
-.br
 	channel 2            B
-.br
 	channel 3            C
-.br
 	channel 4            D
-.br
+.fi
 .P
 A multipath configuration.  Note that channel names have multiple
 definitions - one per physical path.
 .P
+.nf
 	multipath yes
-.br
 
-.br
 	#       PCI_SLOT HBA PORT  CHANNEL NAME
-.br
 	channel 85:00.0  1         A
-.br
 	channel 85:00.0  0         B
-.br
 	channel 86:00.0  1         A
-.br
 	channel 86:00.0  0         B
-.br
+.fi
 .P
 A configuration using device link aliases.
 .P
-.br
+.nf
 	#     by-vdev
-.br
 	#     name     fully qualified or base name of device link
-.br
 	alias d1       /dev/disk/by-id/wwn-0x5000c5002de3b9ca
-.br
 	alias d2       wwn-0x5000c5002def789e
-.br
+.fi
 .P
 
 .SH FILES


### PR DESCRIPTION
The vdev_id udev helper currently applies slot renumbering rules to
every channel (JBOD) in the system.  This is too inflexible for systems
with non-homogeneous storage topologies.  The "slot" keyword now takes
an optional third parameter which names a channel to which the mapping
will apply.  If the third parameter is omitted then the rule applies to
all channels.  The first-specified rule that can match a slot takes
precedence.  Therefore a channel-specific rule for a given slot should
generally appear before a generic rule for the same slot number.  In
this way a custom slot mapping can be applied to a particular channel
and a default mapping applied to the rest.

Signed-off-by: Ned Bass bass6@llnl.gov
