### PR TITLE
Rertzinger/feature systemd

### DIFF
--- a/etc/systemd/system/zfs-import.service
+++ b/etc/systemd/system/zfs-import.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Import ZFS pools
+DefaultDependencies=no
+Requires=zfs-module.service
+Requires=systemd-udev-settle.service
+After=zfs-module.service
+After=systemd-udev-settle.service
+ConditionPathExists=/etc/zfs/zpool.cache
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/zpool import -c /etc/zfs/zpool.cache -aN

--- a/etc/systemd/system/zfs-module.service
+++ b/etc/systemd/system/zfs-module.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=ZFS file system kernel modules
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/modprobe zfs

--- a/etc/systemd/system/zfs-mount.service
+++ b/etc/systemd/system/zfs-mount.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mount ZFS filesystems
+DefaultDependencies=no
+Wants=zfs-import.service
+Requires=systemd-udev-settle.service
+After=systemd-udev-settle.service
+After=zfs-import.service
+After=zfs-module.service
+Before=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/zfs mount -a

--- a/etc/systemd/system/zfs-share.service
+++ b/etc/systemd/system/zfs-share.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ZFS file system shares
+After=nfs-server.service
+After=smb.service
+PartOf=nfs-server.service
+PartOf=smb.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/zfs share -a

--- a/etc/systemd/system/zfs.target
+++ b/etc/systemd/system/zfs.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=ZFS startup target
+Requires=zfs-mount.service
+Requires=zfs-share.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
```
Add systemd unit files for ZFS startup

This adds systemd unit files replacing the functionality offered by
the SysV init script found in etc/init.d.

It has been developed and tested on Fedora 19.
```
