### PR TITLE
Updates to SPA TXG history kstat

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -557,8 +557,9 @@ typedef enum txg_state {
 	TXG_STATE_BIRTH		= 0,
 	TXG_STATE_OPEN		= 1,
 	TXG_STATE_QUIESCED	= 2,
-	TXG_STATE_SYNCED	= 3,
-	TXG_STATE_COMMITTED	= 4,
+	TXG_STATE_WAIT_FOR_SYNC	= 3,
+	TXG_STATE_SYNCED	= 4,
+	TXG_STATE_COMMITTED	= 5,
 } txg_state_t;
 
 extern void spa_stats_init(spa_t *spa);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -555,6 +555,8 @@ txg_sync_thread(dsl_pool_t *dp)
 		    txg, tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
 		mutex_exit(&tx->tx_sync_lock);
 
+		spa_txg_history_set(spa, txg, TXG_STATE_WAIT_FOR_SYNC, gethrtime());
+
 		start = ddi_get_lbolt();
 		spa_sync(spa, txg);
 		delta = ddi_get_lbolt() - start;


### PR DESCRIPTION
I would like to solicit feedback on the next two commits.
One is minor change to the timestamps usage, - clean up mostly.
Second is more serious one - we have added another state for the TXG lifecycle - WAIT_FOR_SYNC.
While working on adding support for the SPA TXG history for our add-on tool (available at https://github.com/imp/izarc) we noticed that quite frequently there are two TXG simultaneously in S (syncing) state. This is obviously not possible. What happens in reality is that a TXG left QUIESCING state and now waits for the previous TXG that is SYNCING now to finish and free the SYNC slot. However, in this situation the time spent waiting erroneously accounted as SYNCING as well. Since the syncing is usually non-trivial time wise, the time measurements could be quite incorrect.
