### PR TITLE
Illumos 4504

### DIFF
--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -335,9 +335,9 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		prefetch_dnode_metadata(td, dnp, zb->zb_objset,
 		    DMU_META_DNODE_OBJECT);
 		if (arc_buf_size(buf) >= sizeof (objset_phys_t)) {
-			prefetch_dnode_metadata(td, &osp->os_userused_dnode,
-			    zb->zb_objset, DMU_USERUSED_OBJECT);
 			prefetch_dnode_metadata(td, &osp->os_groupused_dnode,
+			    zb->zb_objset, DMU_GROUPUSED_OBJECT);
+			prefetch_dnode_metadata(td, &osp->os_userused_dnode,
 			    zb->zb_objset, DMU_USERUSED_OBJECT);
 		}
 
@@ -348,18 +348,18 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 			err = 0;
 		}
 		if (err == 0 && arc_buf_size(buf) >= sizeof (objset_phys_t)) {
-			dnp = &osp->os_userused_dnode;
+			dnp = &osp->os_groupused_dnode;
 			err = traverse_dnode(td, dnp, zb->zb_objset,
-			    DMU_USERUSED_OBJECT);
+			    DMU_GROUPUSED_OBJECT);
 		}
 		if (err && TD_HARD(td)) {
 			lasterr = err;
 			err = 0;
 		}
 		if (err == 0 && arc_buf_size(buf) >= sizeof (objset_phys_t)) {
-			dnp = &osp->os_groupused_dnode;
+			dnp = &osp->os_userused_dnode;
 			err = traverse_dnode(td, dnp, zb->zb_objset,
-			    DMU_GROUPUSED_OBJECT);
+			    DMU_USERUSED_OBJECT);
 		}
 	}
 


### PR DESCRIPTION
4504 traverse_visitbp: visit DMU_GROUPUSED_OBJECT before DMU_USERUSED_OBJECT

References:
  https://illumos.org/issues/4504
  http://code.delphix.com/illumos-4504
  http://svnweb.freebsd.org/base?view=revision&revision=260812

Reviewed by: Christopher Siden christopher.siden@delphix.com
Reviewed by: George Wilson george.wilson@delphix.com
