### PR TITLE
Fix corrupted l2_asize in arcstats

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -743,8 +743,8 @@ struct l2arc_buf_hdr {
 	/* compression applied to buffer data */
 	enum zio_compress	b_compress;
 	/* real alloc'd buffer size depending on b_compress applied */
-	uint32_t		b_asize;
 	uint32_t		b_hits;
+	uint64_t		b_asize;
 	/* temporary buffer holder for in-flight compressed data */
 	void			*b_tmp_cdata;
 };


### PR DESCRIPTION
Commit e0b0ca9 accidentally corrupted the l2_asize displayed in
arcstats.  This was caused by changing the l2arc_buf_hdr.b_asize
member from an int to uint32_t type.  There are places in the
code where this field is cast to a uint64_t resulting in the
b_hits member being treated as part of b_asize.

To resolve the issue the type has been changed to a uint64_t,
and the b_hits member is placed after the enum to prevent the
size of the structure from increasing.

This is a good example of exactly why it's a bad idea to use
ambiguous types (int) in these structures.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1990
