### PR TITLE
Add explicit Conflicts for zfs-fuse packages

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -48,6 +48,10 @@ Requires:       spl = %{version}
 Requires:       %{name}-kmod = %{version}
 Provides:       %{name}-kmod-common = %{version}
 
+# zfs-fuse provides the same commands and manpages that ZoL does. Renaming those on
+# either side would conflict with all available documentation.
+Conflicts:      zfs-fuse
+
 %if 0%{?rhel}%{?fedora}%{?suse_version}
 BuildRequires:  zlib-devel
 BuildRequires:  libuuid-devel


### PR DESCRIPTION
zfs-fuse provides the same commands and man page names as ZoL.
Changing the names on either side would make each incompatible with
all existing documentation about ZFS. Providing bit identical files
is not possible due to differing codebases.

This fixes #1866.
