### PR TITLE
Update kernel-bdi-setup-and-register test for warn_unused_result attribute.

### DIFF
--- a/config/kernel-bdi-setup-and-register.m4
+++ b/config/kernel-bdi-setup-and-register.m4
@@ -12,7 +12,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER],
 	ZFS_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/backing-dev.h>
 	], [
-		bdi_setup_and_register(NULL, NULL, 0);
+		(void) bdi_setup_and_register(NULL, NULL, 0);
 	], [bdi_setup_and_register], [mm/backing-dev.c], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_BDI_SETUP_AND_REGISTER, 1,


### PR DESCRIPTION
Linux 3.13 updated the backing-dev.h header to require that the return value of bdi_setup_and_register be checked, which causes the kernel-bdi-setup-and-register test to fail.

The testing I did for this fix is minimal: I verified that zfs now builds under Fedora 20 with the 3.13.3 kernel (specifically, Fedora's kernel-3.13.3-201.fc20.x86_64), and that I could mount a ZFS filesystem and access a few files.

This fixes the issue referenced in #2102.
