### PR TITLE
Use ddi_time_after and friends to compare time

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -86,7 +86,7 @@ typedef const struct vdev_ops {
 struct vdev_cache_entry {
 	char		*ve_data;
 	uint64_t	ve_offset;
-	uint64_t	ve_lastused;
+	clock_t		ve_lastused;
 	avl_node_t	ve_offset_node;
 	avl_node_t	ve_lastused_node;
 	uint32_t	ve_hits;

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -584,6 +584,16 @@ extern vnode_t *rootdir;
 #define	ddi_get_lbolt64()	(gethrtime() >> 23)
 #define	hz	119	/* frequency when using gethrtime() >> 23 for lbolt */
 
+#define ddi_time_before(a, b)		(a < b)
+#define ddi_time_after(a, b)		ddi_time_before(b, a)
+#define ddi_time_before_eq(a, b)	(!ddi_time_after(a, b))
+#define ddi_time_after_eq(a, b)		ddi_time_before_eq(b, a)
+
+#define ddi_time_before64(a, b)		(a < b)
+#define ddi_time_after64(a, b)		ddi_time_before64(b, a)
+#define ddi_time_before_eq64(a, b)	(!ddi_time_after64(a, b))
+#define ddi_time_after_eq64(a, b)	ddi_time_before_eq64(b, a)
+
 extern void delay(clock_t ticks);
 
 #define	SEC_TO_TICK(sec)	((sec) * hz)

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2480,7 +2480,7 @@ arc_adapt_thread(void)
 #endif /* !_KERNEL */
 
 		/* No recent memory pressure allow the ARC to grow. */
-		if (arc_no_grow && ddi_get_lbolt() >= arc_grow_time)
+		if (arc_no_grow && ddi_time_after_eq(ddi_get_lbolt(), arc_grow_time))
 			arc_no_grow = FALSE;
 
 		arc_adjust_meta();
@@ -2918,7 +2918,7 @@ arc_access(arc_buf_hdr_t *buf, kmutex_t *hash_lock)
 		 * but it is still in the cache. Move it to the MFU
 		 * state.
 		 */
-		if (now > buf->b_arc_access + ARC_MINTIME) {
+		if (ddi_time_after(now, buf->b_arc_access + ARC_MINTIME)) {
 			/*
 			 * More than 125ms have passed since we
 			 * instantiated this buffer.  Move it to the

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -480,7 +480,7 @@ txg_sync_thread(dsl_pool_t *dp)
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 	vdev_stat_t *vs1, *vs2;
-	uint64_t start, delta;
+	clock_t start, delta;
 
 #ifdef _KERNEL
 	/*
@@ -498,7 +498,7 @@ txg_sync_thread(dsl_pool_t *dp)
 
 	start = delta = 0;
 	for (;;) {
-		uint64_t timer, timeout;
+		clock_t timer, timeout;
 		uint64_t txg;
 
 		timeout = zfs_txg_timeout * hz;

--- a/module/zfs/vdev_cache.c
+++ b/module/zfs/vdev_cache.c
@@ -123,9 +123,9 @@ vdev_cache_lastused_compare(const void *a1, const void *a2)
 	const vdev_cache_entry_t *ve1 = a1;
 	const vdev_cache_entry_t *ve2 = a2;
 
-	if (ve1->ve_lastused < ve2->ve_lastused)
+	if (ddi_time_before(ve1->ve_lastused, ve2->ve_lastused))
 		return (-1);
-	if (ve1->ve_lastused > ve2->ve_lastused)
+	if (ddi_time_after(ve1->ve_lastused, ve2->ve_lastused))
 		return (1);
 
 	/*

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -345,9 +345,9 @@ spa_handle_ignored_writes(spa_t *spa)
 
 		if (handler->zi_record.zi_duration > 0) {
 			VERIFY(handler->zi_record.zi_timer == 0 ||
-			    handler->zi_record.zi_timer +
-			    handler->zi_record.zi_duration * hz >
-			    ddi_get_lbolt64());
+			    ddi_time_after64((int64_t)handler->zi_record.zi_timer +
+			    handler->zi_record.zi_duration * hz,
+			    ddi_get_lbolt64()));
 		} else {
 			/* duration is negative so the subtraction here adds */
 			VERIFY(handler->zi_record.zi_timer == 0 ||


### PR DESCRIPTION
Also, make sure we use clock_t for ddi_get_lbolt to prevent type conversion
from screwing things.

Signed-off-by: Chunwei Chen tuxoko@gmail.com

depends on https://github.com/zfsonlinux/spl/pull/335
