### PR TITLE
Inform OpenRC that ZFS uses mtab

### DIFF
--- a/etc/init.d/zfs.gentoo.in
+++ b/etc/init.d/zfs.gentoo.in
@@ -20,6 +20,7 @@ depend()
 
 	# bootmisc will log to /var which may be a different zfs than root.
 	before bootmisc logger
+	use mtab
 	keyword -lxc -openvz -prefix -vserver
 }
 


### PR DESCRIPTION
p_l in #zfsonlinux reported that he had issues mounting filesystems that
were resolved by adding rc_need="mtab" to /etc/init.d/zfs. Closer
inspection revealed that we do have a race, but it is not clear how this
race caused mounting to fail. What is clear is that this race should be
fixed, so lets add the proper `use mtab` line to handle it.

Signed-off-by: Richard Yao ryao@gentoo.org
