### PR TITLE
Fix NAME section of manpages zhack and fsck.zfs.

### DIFF
--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -23,8 +23,9 @@
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
 .\"
 .TH zhack 1 "2013 MAR 16" "ZFS on Linux" "User Commands"
+
 .SH NAME
-.BR zhack " \- libzpool debugging tool"
+zhack \- libzpool debugging tool
 .SH DESCRIPTION
 This utility pokes configuration changes directly into a ZFS pool,
 which is dangerous and can cause data corruption.

--- a/man/man8/fsck.zfs.8
+++ b/man/man8/fsck.zfs.8
@@ -25,7 +25,7 @@
 .TH fsck.zfs 8 "2013 MAR 16" "ZFS on Linux" "System Administration Commands"
 
 .SH NAME
-.BR fsck.zfs " \- Dummy ZFS filesystem checker."
+fsck.zfs \- Dummy ZFS filesystem checker.
 
 .SH SYNOPSIS
 .LP


### PR DESCRIPTION
In Debian GNU/Linux a program called 'linitian' is used to make sure that
packages conforms to the Debian GNU/Linux packaging guide lines.
This fixes the problem reported as:

```
 W: zfsutils: manpage-has-bad-whatis-entry usr/share/man/man1/zhack.1.gz
 W: zfsutils: manpage-has-bad-whatis-entry usr/share/man/man8/fsck.zfs.8.gz
```

Not something that ZoL needs to addhere to, but every other man page have their
NAME section in a special way - why not these two as well?
