### PR TITLE
illumos 4088 - use after free in arc_release()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3665,6 +3665,7 @@ arc_release(arc_buf_t *buf, void *tag)
 	if (l2hdr) {
 		mutex_enter(&l2arc_buflist_mtx);
 		hdr->b_l2hdr = NULL;
+		list_remove(l2hdr->b_dev->l2ad_buflist, hdr);
 	}
 	buf_size = hdr->b_size;
 
@@ -3758,7 +3759,6 @@ arc_release(arc_buf_t *buf, void *tag)
 
 	if (l2hdr) {
 		ARCSTAT_INCR(arcstat_l2_asize, -l2hdr->b_asize);
-		list_remove(l2hdr->b_dev->l2ad_buflist, hdr);
 		kmem_cache_free(l2arc_hdr_cache, l2hdr);
 		arc_space_return(L2HDR_SIZE, ARC_SPACE_L2HDRS);
 		ARCSTAT_INCR(arcstat_l2_size, -buf_size);


### PR DESCRIPTION
4088 use after free in arc_release()
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Garrett D'Amore garrett@damore.org
Reviewed by: Saso Kiselkov skiselkov.ml@gmail.com
Approved by: Dan McDonald danmcd@nexenta.com
Ported by: Tim Chase tim@chase2k.com

From the illumos issue:

A race-induced use after free occurs in arc_release() where the ARC header
is used outside the critical section protected by the hash_lock.
