### PR TITLE
Use KM_PUSHPAGE in spa_add() for spa_label_features.

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -542,7 +542,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 
 	if (spa->spa_label_features == NULL) {
 		VERIFY(nvlist_alloc(&spa->spa_label_features, NV_UNIQUE_NAME,
-		    KM_SLEEP) == 0);
+		    KM_PUSHPAGE) == 0);
 	}
 
 	spa->spa_debug = ((zfs_flags & ZFS_DEBUG_SPA) != 0);


### PR DESCRIPTION
The spa_label_features nvlist is used in the sync context during pool
version upgrade.
