### PR TITLE
sighandler() should take 2 arguments

### DIFF
--- a/cmd/arcstat/arcstat.py
+++ b/cmd/arcstat/arcstat.py
@@ -229,11 +229,20 @@ def print_header():
         sys.stdout.write("%*s%s" % (cols[col][0], col, sep))
     sys.stdout.write("\n")
 
+def get_terminal_lines():
+    try:
+        import fcntl, termios, struct
+        data = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
+        sz = struct.unpack('hh', data)
+        return sz[0]
+    except:
+        pass
 
 def init():
     global sint
     global count
     global hdr
+    global hdr_intr
     global xhdr
     global opfile
     global sep
@@ -302,6 +311,10 @@ def init():
 
     if xflag:
         hdr = xhdr
+
+    lines = get_terminal_lines()
+    if lines:
+        hdr_intr = lines - 3
 
     # check if L2ARC exists
     snap_stats()


### PR DESCRIPTION
Stopping arcstat.py with ^C always ends up with error:
TypeError: sighandler() takes no arguments (2 given)

Signed-off-by: Isaac Huang he.huang@intel.com
Issue #2179
