### PR TITLE
arcstat.py better print 1 header per screen

### DIFF
--- a/cmd/arcstat/arcstat.py
+++ b/cmd/arcstat/arcstat.py
@@ -230,11 +230,20 @@ def print_header():
         sys.stdout.write("%*s%s" % (cols[col][0], col, sep))
     sys.stdout.write("\n")
 
+def get_terminal_lines():
+    try:
+        import fcntl, termios, struct
+        data = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
+        sz = struct.unpack('hh', data)
+        return sz[0]
+    except:
+        pass
 
 def init():
     global sint
     global count
     global hdr
+    global hdr_intr
     global xhdr
     global opfile
     global sep
@@ -303,6 +312,10 @@ def init():
 
     if xflag:
         hdr = xhdr
+
+    lines = get_terminal_lines()
+    if lines:
+        hdr_intr = lines - 3
 
     # check if L2ARC exists
     snap_stats()


### PR DESCRIPTION
Now arcstat.py prints one header every hdr_intr
(20 by default) lines. It'd be nice if hdr_intr
is set according to terminal window size, i.e.
one header per screenful of outputs.

Signed-off-by: Isaac Huang he.huang@intel.com
Issue #2181
