### PR TITLE
Assert alignment in umem_alloc_aligned

### DIFF
--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -109,6 +109,8 @@ umem_alloc_aligned(size_t size, size_t align, int flags)
 		return (NULL);
 	}
 
+	ASSERT0(P2PHASE_TYPED(ptr, align, uint64_t));
+
 	return (ptr);
 }
 


### PR DESCRIPTION
Valgrind suggests that the address we are returning is not properly
aligned, so lets add an assertion.

==87740==  Address 0x1012a22a is 554 bytes inside a block of size 4,096
alloc'd
==87740==    at 0x4C2BBA0: memalign (in
/usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==87740==    by 0x4C2BCC7: posix_memalign (in
/usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==87740==    by 0x52FA845: zio_buf_alloc (umem.h:101)
==87740==    by 0x52F6226: zil_alloc_lwb (zil.c:463)
==87740==    by 0x52F8559: zil_commit (zil.c:566)
==87740==    by 0x40611D: ztest_freeze (ztest.c:5909)
==87740==    by 0x4066A7: ztest_init (ztest.c:6048)
==87740==    by 0x407AF4: main (ztest.c:6226)

Signed-off-by: Richard Yao ryao@gentoo.org
