### PR TITLE
config: compile test rather than run test

### DIFF
--- a/config/always-no-aggressive-loop-optimizations.m4
+++ b/config/always-no-aggressive-loop-optimizations.m4
@@ -7,7 +7,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_NO_AGGRESSIVE_LOOP_OPTIMIZATIONS], [
 	saved_flags="$CFLAGS"
 	CFLAGS="$CFLAGS -fno-aggressive-loop-optimizations"
 
-	AC_RUN_IFELSE([AC_LANG_PROGRAM([], [])], [
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		NO_AGGRESSIVE_LOOP_OPTIMIZATIONS=-fno-aggressive-loop-optimizations
 		AC_MSG_RESULT([yes])
 	], [

--- a/config/always-no-unused-but-set-variable.m4
+++ b/config/always-no-unused-but-set-variable.m4
@@ -12,7 +12,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_NO_UNUSED_BUT_SET_VARIABLE], [
 	saved_flags="$CFLAGS"
 	CFLAGS="$CFLAGS -Wunused-but-set-variable"
 
-	AC_RUN_IFELSE([AC_LANG_PROGRAM([], [])],
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
 	[
 		NO_UNUSED_BUT_SET_VARIABLE=-Wno-unused-but-set-variable
 		AC_MSG_RESULT([yes])

--- a/config/user-frame-larger-than.m4
+++ b/config/user-frame-larger-than.m4
@@ -7,7 +7,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_FRAME_LARGER_THAN], [
 	saved_flags="$CFLAGS"
 	CFLAGS="$CFLAGS -Wframe-larger-than=1024"
 
-	AC_RUN_IFELSE([AC_LANG_PROGRAM([], [])],
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
 	[
 		FRAME_LARGER_THAN=-Wframe-larger-than=1024
 		AC_MSG_RESULT([yes])


### PR DESCRIPTION
When testing compiler flags, we only need to do compile test. Otherwise,
configure will fail with "configure: error: cannot run test program while
cross compiling" when cross compiling.

Signed-off-by: Chunwei Chen tuxoko@gmail.com
