### PR TITLE
Correct autodetection of bootfs property

### DIFF
--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -18,13 +18,13 @@ case "$root" in
 
 			# Might be imported by the kernel module, so try searching before
 			# we import anything.
-			zfsbootfs=`zpool list -H -o bootfs | sed -n '/-/ !p' | sed 'q'`
+			zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
 			if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
 				[ "$zfsbootfs" = "no pools available" ] ; then
 				# Not there, so we need to import everything.
 				info "ZFS: Attempting to import additional pools."
 				zpool import -N -a ${ZPOOL_FORCE}
-				zfsbootfs=`zpool list -H -o bootfs | sed -n '/-/ !p' | sed 'q'`
+				zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
 				if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
 					[ "$zfsbootfs" = "no pools available" ] ; then
 					rootok=0


### PR DESCRIPTION
Remove lines that contain only a hyphen (match '^-$' instead of '-').

I had a root fs with a hyphen in the name (fedora/ROOT/Fedora20-Dev), it was not detected because sed eliminated that line of output from 'zpool list -Ho bootfs'.
