### PR TITLE
Linux 3.13 compatibility for older GCC versions

### DIFF
--- a/config/kernel-bdi-setup-and-register.m4
+++ b/config/kernel-bdi-setup-and-register.m4
@@ -1,6 +1,6 @@
 dnl #
 dnl # 2.6.34 API change
-dnl # The bdi_setup_and_register() helper function is avilable and
+dnl # The bdi_setup_and_register() helper function is avaliable and
 dnl # exported by the kernel.  This is a trivial helper function but
 dnl # using it significantly simplifies the code surrounding setting
 dnl # up and tearing down the bdi structure.
@@ -10,7 +10,8 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER],
 	ZFS_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/backing-dev.h>
 	], [
-		bdi_setup_and_register(NULL, NULL, 0);
+		int r = bdi_setup_and_register(NULL, NULL, 0);
+		r = *(&r);
 	], [bdi_setup_and_register], [mm/backing-dev.c], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_BDI_SETUP_AND_REGISTER, 1,


### PR DESCRIPTION
This enables Linux 3.13 compatibility without depending on newer versions of GCC. It supersedes pull request #2135. It has been subject to tests on CentOS 6.5 with Linux 3.13.6 and GCC 4.4.7-4; Gentoo with Linux 3.13.0 and GCC 4.7.3-r1; and Gentoo with Linux 3.12.6 and GCC 4.8.2-r1. These tests detected no regressions. The CentOS test confirmed that this enables compatibility with older GCC versions. However, that should be self-evident when reading the commit messages.
