### PR TITLE
Fix deadlock in zfs_zget()

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -918,8 +918,8 @@ again:
 			*zpp = zp;
 			err = 0;
 		}
-		sa_buf_rele(db, NULL);
 		mutex_exit(&zp->z_lock);
+		sa_buf_rele(db, NULL);
 		ZFS_OBJ_HOLD_EXIT(zsb, obj_num);
 		return (err);
 	}


### PR DESCRIPTION
There are three correctness fixes in this pull request:
1. inode writeback should never deadlock on itself, but the fix for zfsonlinux/zfs#180 enabled this.
2. zfs_zget() should exit with a hold on the inode, but that was never present in the Linux port when the inode was already constructed. This can lead to undefined behavior, such as inodes that are evicted when they have users.
3. There is a potential lock ordering issue that we inherited from Solaris. The fix has been split into a separate patch and will be sent to Illumos.
