### PR TITLE
Improve dirty page writeout performance and fsync correctness

### DIFF
--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -74,8 +74,10 @@ extern int zfs_getsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
 extern int zfs_setsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
     cred_t *cr);
 extern int zfs_getpage(struct inode *ip, struct page *pl[], int nr_pages);
-extern int zfs_putpage(struct inode *ip, struct page *pp,
-    struct writeback_control *wbc);
+extern int zfs_putpage_single(struct page *pp, struct writeback_control *wbc,
+	cred_t *cr);
+extern int zfs_putpage(struct inode *ip, struct writeback_control *wbc,
+	cred_t *cr);
 extern int zfs_dirty_inode(struct inode *ip, int flags);
 extern int zfs_map(struct inode *ip, offset_t off, caddr_t *addrp,
     size_t len, unsigned long vm_flags);

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -399,66 +399,16 @@ zpl_readpages(struct file *filp, struct address_space *mapping,
 }
 
 int
-zpl_putpage(struct page *pp, struct writeback_control *wbc, void *data)
-{
-	struct address_space *mapping = data;
-
-	ASSERT(PageLocked(pp));
-	ASSERT(!PageWriteback(pp));
-	ASSERT(!(current->flags & PF_NOFS));
-
-	/*
-	 * Annotate this call path with a flag that indicates that it is
-	 * unsafe to use KM_SLEEP during memory allocations due to the
-	 * potential for a deadlock.  KM_PUSHPAGE should be used instead.
-	 */
-	current->flags |= PF_NOFS;
-	(void) zfs_putpage(mapping->host, pp, wbc);
-	current->flags &= ~PF_NOFS;
-
-	return (0);
-}
-
-static int
 zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 {
-	znode_t		*zp = ITOZ(mapping->host);
-	zfs_sb_t	*zsb = ITOZSB(mapping->host);
-	enum writeback_sync_modes sync_mode;
-	int result;
+	cred_t *cr = CRED();
+	int err;
 
-	ZFS_ENTER(zsb);
-	if (zsb->z_os->os_sync == ZFS_SYNC_ALWAYS)
-		wbc->sync_mode = WB_SYNC_ALL;
-	ZFS_EXIT(zsb);
-	sync_mode = wbc->sync_mode;
+	crhold(cr);
+	err = -zfs_putpage(mapping->host, wbc, cr);
+	crfree(cr);
 
-	/*
-	 * We don't want to run write_cache_pages() in SYNC mode here, because
-	 * that would make putpage() wait for a single page to be committed to
-	 * disk every single time, resulting in atrocious performance. Instead
-	 * we run it once in non-SYNC mode so that the ZIL gets all the data,
-	 * and then we commit it all in one go.
-	 */
-	wbc->sync_mode = WB_SYNC_NONE;
-	result = write_cache_pages(mapping, wbc, zpl_putpage, mapping);
-	if (sync_mode != wbc->sync_mode) {
-		ZFS_ENTER(zsb);
-		ZFS_VERIFY_ZP(zp);
-		zil_commit(zsb->z_log, zp->z_id);
-		ZFS_EXIT(zsb);
-
-		/*
-		 * We need to call write_cache_pages() again (we can't just
-		 * return after the commit) because the previous call in
-		 * non-SYNC mode does not guarantee that we got all the dirty
-		 * pages (see the implementation of write_cache_pages() for
-		 * details). That being said, this is a no-op in most cases.
-		 */
-		wbc->sync_mode = sync_mode;
-		result = write_cache_pages(mapping, wbc, zpl_putpage, mapping);
-	}
-	return (result);
+	return (err);
 }
 
 /*
@@ -467,13 +417,24 @@ zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
  * which never call .write().  These dirty pages are kept in sync with
  * the ARC buffers via this hook.
  */
-static int
+int
 zpl_writepage(struct page *pp, struct writeback_control *wbc)
 {
-	if (ITOZSB(pp->mapping->host)->z_os->os_sync == ZFS_SYNC_ALWAYS)
-		wbc->sync_mode = WB_SYNC_ALL;
+	cred_t *cr = CRED();
+	int err;
 
-	return (zpl_putpage(pp, wbc, pp->mapping));
+	ASSERT(PageLocked(pp));
+
+	if (pp->mapping == NULL) {
+		unlock_page(pp);
+		return (0);
+	}
+
+	crhold(cr);
+	err = -zfs_putpage_single(pp, wbc, cr);
+	crfree(cr);
+
+	return (err);
 }
 
 /*


### PR DESCRIPTION
This refactors the internal layering in the ZPL to promote greater
performance and improved correctness. In specific, ->fsync, ->writepages
and ->writepage have been changed. The changes reduce divergence with
other Open ZFS platforms while improving performance and correctness.

->fsync() will now call write_inode_now() to ensure that all dirty pages
have been moved to ARC prior to zil_commit(). This is equivalent to
calling VOP_PUTPAGE() on Illumos because we do not implement
->write_inode at this time.

->writepages has been refactored to call zfs_range_lock() once per call.
Each zfs_range_lock() does its own memory allocation and various tree
operations, so making it occur only once reduces the computational
complexity of writepages, by at least a factor of log(N) where N is the
number of pages. This brings us to parity with other Open ZFS
implementations and also avoids significant virtual memory contention
that is prevalent in Linux's vmalloc(). In addition, we now pass
WB_SYNC_NONE to write_cache_pages, which eliminates an opportunity for
unnecessary blocking. This moves responsibility for ensuring synchronous
semantics entirely to zil_commit(), where it should have been in the
first place. It also eliminates an opportunity for concurrent threads
block each other on writeback.

->writepage has been refactored to permit the changes to ->writepages.
Situations where it is told to write out an invalidated page is now
properly handled by ignoring them. This avoids a theoretical NULL
pointer dereference.

These changes substantially improve 32-thread 4K randomwrite IO on a RAM
disk in filebench's randomwrite benchmark. This has been tested with the
following commands on a boot that passed ramdisk_size=8388604 to the
kernel commandline:

modprobe loop
losetup loop0 /dev/ram0
zpool create -o ashift=12 -O recordsize=4K test /dev/loop0
zpool export test
losetup -D
zpool import -d /dev test

filebench << END
load randomwrite
set \$dir=/test
set \$nthreads=32
set \$iosize=4096
run 60
END

zpool destroy test
modprobe -r loop

Previous tests on Gentoo Linux using a kernel compiled from CentOS
2.6.32-431.11.2.el6.x86_64 kernel with the default .config showed single
threaded performance at roughly 10k to 11k IOPS with 32-thread
performance at 5k-6k in this benchmark. Tests with this patch show a
performance improvement to 15k to 17k in the 32-thread case. These tests
were conducted on a single processor Xeon E5-2620 with 64GB of RAM.

Signed-off-by: Richard Yao ryao@gentoo.org
