### PR TITLE
zfs_zget() deadlock

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -922,8 +922,8 @@ again:
 			*zpp = zp;
 			err = 0;
 		}
-		sa_buf_rele(db, NULL);
 		mutex_exit(&zp->z_lock);
+		sa_buf_rele(db, NULL);
 		ZFS_OBJ_HOLD_EXIT(zsb, obj_num);
 		return (err);
 	}


### PR DESCRIPTION
There are two correctness fixes in this pull request:
- inode writeback should never deadlock on itself, but the fix for zfsonlinux/zfs#180 enabled this.
- There is a potential lock ordering issue that we inherited from Solaris. The fix has been split into a separate patch and will be sent to Illumos.
