### PR TITLE
Change startup mode of ZED

### DIFF
--- a/etc/systemd/system/zed.service.in
+++ b/etc/systemd/system/zed.service.in
@@ -5,9 +5,5 @@ After=zfs-import-cache.service
 After=zfs-import-scan.service
 
 [Service]
-Type=forking
-ExecStart=@sbindir@/zed
-PIDFile=@runstatedir@/zed.pid
-User=root
-Group=root
+ExecStart=@sbindir@/zed -F
 Restart=on-abort


### PR DESCRIPTION
Change the startup mode of ZED to non-forking. While systemd can
track processes that detach from the terminal just fine running
processes in non-forking mode is the preferred mode of operation.

Also remove user/group definitions as root/root is the default.
