### PR TITLE
Uninitialized variable spa_autoreplace used

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2549,7 +2549,7 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 		return (spa_vdev_err(rvd, VDEV_AUX_CORRUPT_DATA, EIO));
 
 	if (error == 0) {
-		uint64_t autoreplace;
+		uint64_t autoreplace = 0;
 
 		spa_prop_find(spa, ZPOOL_PROP_BOOTFS, &spa->spa_bootfs);
 		spa_prop_find(spa, ZPOOL_PROP_AUTOREPLACE, &autoreplace);


### PR DESCRIPTION
Caught by ztest and valgrind.

Signed-off-by: DHE git@dehacked.net
