### PR TITLE
Add support for aarch64 (ARMv8)

### DIFF
--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -103,7 +103,7 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 /* arm arch specific defines */
-#elif defined(__arm) || defined(__arm__)
+#elif defined(__arm) || defined(__arm__) || defined(__aarch64__)
 
 #if !defined(__arm)
 #define	__arm
@@ -113,7 +113,7 @@ extern "C" {
 #define	__arm__
 #endif
 
-#if defined(__ARMEL__)
+#if defined(__ARMEL__) || defined(__AARCH64EL__)
 #define	_LITTLE_ENDIAN
 #else
 #define	_BIG_ENDIAN


### PR DESCRIPTION
Using the ARM reference simulation (fast model foundation v8) I cross compiled spl and zfs, to confirm it works on ARMv8 (64 bit arm architecture, called aarch64 in Linux).

As it is based on previous ARM porting, the resulting patch is disappointingly small, there was very little to do. The code fixes the compile issues and has light testing done.

```
# uname -a
Linux genericarmv8 3.14.0-1-linaro-vexpress64 #1ubuntu1~ci+140322082411 SMP Sat Mar 22 08:25:24 UTC 2014 aarch64 GNU/Linux

# file module/zfs/zfs.ko
module/zfs/zfs.ko: ELF 64-bit LSB relocatable, ARM aarch64, version 1 (SYSV),

# insmod zol.spl/module/spl/spl.ko
[ 4215.847254] SPL: Loaded module v0.6.2-27_ged650de
# insmod ./zol.zfs/module/nvpair/znvpair.ko
[ 4736.646580] znvpair: module license 'CDDL' taints kernel.
[ 4736.646626] Disabling lock debugging due to kernel taint
# insmod ./zol.zfs/module/avl/zavl.ko
# insmod ./zol.zfs/module/unicode/zunicode.ko
# insmod ./zol.zfs/module/zcommon/zcommon.ko
# insmod ./zol.zfs/module/zfs/zfs.ko
[ 4759.149949] ZFS: Loaded module v0.6.2-246_g6ac770b, ZFS pool version 5000, ZFS filesystem version 5

# ./cmd.sh zpool create BOOM /disk-image.bin 
[ 5090.043846] SPL: using hostid 0x14ac0133

# ./cmd.sh zpool status
  pool: BOOM
 state: ONLINE
  scan: none requested
config:

        NAME               STATE     READ WRITE CKSUM
        BOOM               ONLINE       0     0     0
          /disk-image.bin  ONLINE       0     0     0

# mkdir /BOOM/Hello.World
# ls -la /BOOM/
drwxr-xr-x  2 root root    2 Mar 23 17:17 Hello.World

# ./cmd.sh zfs list -t all
NAME   USED  AVAIL  REFER  MOUNTPOINT
BOOM   109K   460M    31K  /BOOM

```
