### PR TITLE
Fix LZ4 endianness autodetection

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -207,11 +207,12 @@ lz4_decompress_zfs(void *s_start, void *d_start, size_t s_len,
  * Little Endian or Big Endian?
  * Note: overwrite the below #define if you know your architecture endianess.
  */
-#if (defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN) || \
-	defined(_BIG_ENDIAN) || defined(_ARCH_PPC) || defined(__PPC__) || \
+#if (defined(_KERNEL) && (defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN) || \
+	defined(_BIG_ENDIAN))) || defined(_ARCH_PPC) || defined(__PPC__) || \
 	defined(__PPC) || defined(PPC) || defined(__powerpc__) || \
 	defined(__powerpc) || defined(powerpc) || \
-	((defined(__BYTE_ORDER__)&&(__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))))
+	(!defined(_KERNEL) && defined(__BYTE_ORDER__) && \
+	(__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
 #define	LZ4_BIG_ENDIAN 1
 #else
 /*


### PR DESCRIPTION
`__BIG_ENDIAN__` is a kernel macro that is only defined when the CPU
is big-endian, but when built in userspace it is always defined.
Let's use different checks depending on whether we're building for
user-space or kernel space.

The "PowerPC" architecture checks were kept just because it's what
Illumos does.

Fixes #1964
Fixed #1965
Signed-off-by: DHE git@dehacked.net
