### PR TITLE
dmu_tx_assign() should not return ENOMEM

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3986,9 +3986,14 @@ arc_tempreserve_space(uint64_t reserve, uint64_t txg)
 
 	if (reserve > arc_c/4 && !arc_no_grow)
 		arc_c = MIN(arc_c_max, reserve * 4);
+
+	/*
+	 * Throttle when the calculated memory footprint for the TXG
+	 * exceeds the target ARC size.
+	 */
 	if (reserve > arc_c) {
 		DMU_TX_STAT_BUMP(dmu_tx_memory_reserve);
-		return (SET_ERROR(ENOMEM));
+		return (SET_ERROR(ERESTART));
 	}
 
 	/*


### PR DESCRIPTION
As described in the comment above dmu_tx_assign() this function must
only fail if the pool is out of space.  If for some other reason the
TX cannot be assigned (such as memory pressure) ERESTART must be
returned.  Alternately, EAGAIN could be returned to inject a delay
but that isn't required because the caller will block on the condition
variable waiting for the next TXG.

/*
- Assign tx to a transaction group.  txg_how can be one of:
  *
- (1)  TXG_WAIT.  If the current open txg is full, waits until there's
-      a new one.  This should be used when you're not holding locks.
-      It will only fail if we're truly out of space (or over quota).
- ...
  */

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
