### PR TITLE
Fix libblkid ZFS detection when making new pools

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -377,7 +377,7 @@ check_slice(const char *path, blkid_cache cache, int force, boolean_t isspare)
 	 * using check_file() to see if it's safe.  The one safe
 	 * case is a spare device shared between multiple pools.
 	 */
-	if (strcmp(value, "zfs") == 0) {
+	if (strcmp(value, "zfs_member") == 0) {
 		err = check_file(path, force, isspare);
 	} else {
 		if (force) {


### PR DESCRIPTION
zfsonlinux/zfs@1db7b9be75a225cedb3b7a60028ca5695e5b8346 should have
fixed this, but this particular string was overlooked.

Signed-off-by: Richard Yao ryao@gentoo.org
