### PR TITLE
Fixed memory leaks in zevent handling

### DIFF
--- a/include/sys/fm/util.h
+++ b/include/sys/fm/util.h
@@ -93,7 +93,7 @@ typedef struct zfs_zevent {
 extern void fm_init(void);
 extern void fm_fini(void);
 extern void fm_nvprint(nvlist_t *);
-extern void zfs_zevent_post(nvlist_t *, nvlist_t *, zevent_cb_t *);
+extern int zfs_zevent_post(nvlist_t *, nvlist_t *, zevent_cb_t *);
 extern void zfs_zevent_drain_all(int *);
 extern int zfs_zevent_fd_hold(int, minor_t *, zfs_zevent_t **);
 extern void zfs_zevent_fd_rele(int);


### PR DESCRIPTION
Some nvlist_t could be leaked in error handling paths.
Also make sure cb argument to zfs_zevent_post() cannnot
be NULL.

Signed-off-by: Isaac Huang he.huang@intel.com
Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2158
