### PR TITLE
Remove SELinux enforcing check from init scripts

### DIFF
--- a/etc/init.d/zfs.fedora.in
+++ b/etc/init.d/zfs.fedora.in
@@ -126,12 +126,6 @@ start()
 		return 5
 	}
 
-        # Requires selinux policy which has not been written.
-        if [ -r "/selinux/enforce" ] &&
-           [ "$(cat /selinux/enforce)" = "1" ]; then
-                action $"SELinux ZFS policy required: " /bin/false || return 6
-        fi
-
 	# Delay until all required block devices are present.
 	udevadm settle
 

--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -49,14 +49,6 @@ start()
 {
 	[ -f "$LOCKFILE" ] && return 3
 
-	# Requires selinux policy which has not been written.
-	if [ -r "/selinux/enforce" ] &&
-	   [ "$(cat /selinux/enforce)" = "1" ]; then
-
-		log_failure_msg "SELinux ZFS policy required"
-		return 4
-	fi
-
 	# Delay until all required block devices are present.
 	udevadm settle
 

--- a/etc/init.d/zfs.redhat.in
+++ b/etc/init.d/zfs.redhat.in
@@ -76,12 +76,6 @@ start()
 		return 5
 	}
 
-        # Requires selinux policy which has not been written.
-        if [ -r "/selinux/enforce" ] &&
-           [ "$(cat /selinux/enforce)" = "1" ]; then
-                action $"SELinux ZFS policy required: " /bin/false || return 6
-        fi
-
 	# Delay until all required block devices are present.
 	if [ -x /sbin/udevadm ]; then
 		/sbin/udevadm settle


### PR DESCRIPTION
The default SELinux policy for RHEL and Fedora has been updated
to include ZFS in the list of filesystems which support xattrs.
Therefore, there's no longer a need to detect this in the init
scripts.

References:
  https://bugzilla.redhat.com/show_bug.cgi?id=811532
  https://bugzilla.redhat.com/show_bug.cgi?id=816543

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2166
