### PR TITLE
Treat spill block dbufs as meta data

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -263,7 +263,10 @@ dbuf_evict_user(dmu_buf_impl_t *db)
 boolean_t
 dbuf_is_metadata(dmu_buf_impl_t *db)
 {
-	if (db->db_level > 0) {
+	/*
+	 * Consider indirect blocks and spill blocks to be meta data.
+	 */
+	if (db->db_level > 0 || db->db_blkid == DMU_SPILL_BLKID) {
 		return (B_TRUE);
 	} else {
 		boolean_t is_metadata;


### PR DESCRIPTION
When the system attributes (SAs) for an object exceed what can
can be stored in the bonus area of a dnode a spill block is
allocated.  These spill blocks are currently considered data
blocks.  However, they should be accounted for as meta data
because they are effectively an extension of the dnode.

This change goes beyond fixing an accounting mistake.  By changing
the spill block to meta data they will now be dropped from the
cache when the meta limit is reached.  This then allows the dnode
which the spill block was pinning to be freed.  If they are treated
as data and there's no need to free data block they may pin meta
data pushing us over the meta limit.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
