### PR TITLE
Use a dedicated taskq for vdev_file

### DIFF
--- a/include/sys/vdev_file.h
+++ b/include/sys/vdev_file.h
@@ -39,6 +39,9 @@ typedef struct vdev_file {
 	vnode_t		*vf_vnode;
 } vdev_file_t;
 
+extern void vdev_file_init(void);
+extern void vdev_file_fini(void);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -34,6 +34,7 @@
 #include <sys/zap.h>
 #include <sys/zil.h>
 #include <sys/vdev_impl.h>
+#include <sys/vdev_file.h>
 #include <sys/metaslab.h>
 #include <sys/uberblock_impl.h>
 #include <sys/txg.h>
@@ -1660,6 +1661,7 @@ spa_init(int mode)
 	dmu_init();
 	zil_init();
 	vdev_cache_stat_init();
+	vdev_file_init();
 	zfs_prop_init();
 	zpool_prop_init();
 	zpool_feature_init();
@@ -1674,6 +1676,7 @@ spa_fini(void)
 
 	spa_evict_all();
 
+	vdev_file_fini();
 	vdev_cache_stat_fini();
 	zil_fini();
 	dmu_fini();


### PR DESCRIPTION
Originally, vdev_file uses system_taskq. This would cause deadlock, especially
on system with few CPUs. The reason is that prefetcher threads, which are on
system_taskq, will sometimes be blocked waiting for I/O to finished. If the
prefetcher threads consume all the tasks in system_taskq, the I/O cannot be
served and thus results in deadlock.

We fix this by creating a dedicated vdev_file_taskq for vdev_file I/O.

Signed-off-by: Chunwei Chen tuxoko@gmail.com
