### PR TITLE
Remove tsd_exit() from ZFS_EXIT()

### DIFF
--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -263,7 +263,6 @@ typedef struct znode {
 #define	ZFS_EXIT(zsb) \
 	{ \
 		rrw_exit(&(zsb)->z_teardown_lock, FTAG); \
-		tsd_exit(); \
 	}
 
 /* Verifies the znode is valid */


### PR DESCRIPTION
This is causing NULL pointers to be passed to strfree(), which is bad.
Illumos does not do this and I can see no reason to do tsd_exit() in
ZFS_EXIT(), so lets remove it.

Signed-off-by: Richard Yao ryao@gentoo.org
