### PR TITLE
Move the libraries into separate packages.

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -45,6 +45,10 @@ ExclusiveArch:  i386 i686 x86_64
 ExcludeArch:    ppc ppc64
 
 Requires:       spl = %{version}
+Requires:       libzpool2 = %{version}
+Requires:       libnvpair1 = %{version}
+Requires:       libuutil1 = %{version}
+Requires:       libzfs2 = %{version}
 Requires:       %{name}-kmod = %{version}
 Provides:       %{name}-kmod-common = %{version}
 
@@ -67,12 +71,54 @@ BuildRequires: systemd
 %endif
 
 %description
-This package contains the ZFS command line utilities and libraries.
+This package contains the ZFS command line utilities.
 
-%package devel
+%package -n libzpool2
+Summary:        Native ZFS pool library for Linux
+Group:          System Environment/Kernel
+
+%description -n libzpool2
+This package contains the zpool library, which provides support
+for managing zpools
+
+%package -n libnvpair1
+Summary:        Solaris name-value library for Linux
+Group:          System Environment/Kernel
+
+%description -n libnvpair1
+This package contains routines for packing and unpacking nv pairs for
+transporting data across process boundaries, transporting between
+kernel and userland, and possibly saving onto disk files.
+
+%package -n libuutil1
+Summary:        Solaris userland utility library for Linux
+Group:          System Environment/Kernel
+
+%description -n libuutil1
+This library provides a variety of glue functions for ZFS on Linux:
+ * libspl: The Solaris Porting Layer userland library, which provides APIs
+   that make it possible to run Solaris user code in a Linux environment
+   with relatively minimal modification.
+ * libavl: The Adelson-Velskii Landis balanced binary tree manipulation
+   library.
+ * libefi: The Extensible Firmware Interface library for GUID disk
+   partitioning.
+ * libshare: NFS, SMB, and iSCSI service integration for ZFS.
+
+%package -n libzfs2
+Summary:        Native ZFS filesystem library for Linux
+Group:          System Environment/Kernel
+
+%description -n libzfs2
+This package provides support for managing ZFS filesystems
+
+%package -n libzfs2-devel
 Summary:        Development headers
 Group:          System Environment/Kernel
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       libzfs2 = %{version}
+Provides:       libzpool2-devel
+Provides:       libnvpair1-devel
+Provides:       libuutil1-devel
 
 %description devel
 This package contains the header files needed for building additional
@@ -166,7 +212,6 @@ exit 0
 %doc OPENSOLARIS.LICENSE README.markdown
 %{_sbindir}/*
 %{_bindir}/*
-%{_libdir}/*.so.*
 %{_libexecdir}/%{name}
 %{_mandir}/man1/*
 %{_mandir}/man5/*
@@ -182,6 +227,18 @@ exit 0
 %else
 %{_sysconfdir}/init.d/*
 %endif
+
+%files -n libzpool2
+%{_libdir}/libzpool.so.*
+
+%files -n libnvpair1
+%{_libdir}/libnvpair.so.*
+
+%files -n libuutil1
+%{_libdir}/libuutil.so.*
+
+%files -n libzfs2
+%{_libdir}/libzfs*.so.*
 
 %files devel
 %{_libdir}/*.so


### PR DESCRIPTION
Creates the following additional packages: libzpool2, libnvpair1, libuutil1 and libzfs2.

Talk in Debian GNU/Linux concluded that there is no point in separating libzfs and libzfs_core. They are so dependent on each other that there is no/little point/requirement to have them separated. So <code>libzfs_core.so.1</code> is in the <code>libzfs2</code> package.

Visual inspection have shown everything is a-ok. Building and installing on Fedora20 works as well...

<code>
Fedora20ZFS-x64:/usr/src/zfs# rpm -iv `find *.{x86_64,noarch}.rpm | egrep -v 'devel|dracut|test|debug|dkms'`
Preparing packages...
libnvpair1-0.6.2-276_gbb2a918.fc20.x86_64
libuutil1-0.6.2-276_gbb2a918.fc20.x86_64
libzfs2-0.6.2-276_gbb2a918.fc20.x86_64
libzpool2-0.6.2-276_gbb2a918.fc20.x86_64
zfs-0.6.2-276_gbb2a918.fc20.x86_64
kmod-zfs-3.12.10-300.fc20.x86_64-0.6.2-276_gbb2a918.fc20.x86_64
</code>

Closes: #2329
