### PR TITLE
omit compiler warning by sticking to RAII

### DIFF
--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -82,7 +82,7 @@ typedef struct umem_cache {
 static inline void *
 umem_alloc(size_t size, int flags)
 {
-	void *ptr;
+	void *ptr = NULL;
 
 	do {
 		ptr = malloc(size);
@@ -94,8 +94,8 @@ umem_alloc(size_t size, int flags)
 static inline void *
 umem_alloc_aligned(size_t size, size_t align, int flags)
 {
-	void *ptr;
-	int rc;
+	void *ptr = NULL;
+	int rc = EINVAL;
 
 	do {
 		rc = posix_memalign(&ptr, align, size);
@@ -117,7 +117,7 @@ umem_alloc_aligned(size_t size, size_t align, int flags)
 static inline void *
 umem_zalloc(size_t size, int flags)
 {
-	void *ptr;
+	void *ptr = NULL;
 
 	ptr = umem_alloc(size, flags);
 	if (ptr)
@@ -170,7 +170,7 @@ umem_cache_destroy(umem_cache_t *cp)
 static inline void *
 umem_cache_alloc(umem_cache_t *cp, int flags)
 {
-	void *ptr;
+	void *ptr = NULL;
 
 	if (cp->cache_align != 0)
 		ptr = umem_alloc_aligned(


### PR DESCRIPTION
gcc warns about uninitialized 'ptr' when using -Wmaybe-uninitialized. It is always good practice to initialize locals.
