### PR TITLE
Do not export pool to prevent cache from been removed

### DIFF
--- a/etc/init.d/zfs.lsb.in
+++ b/etc/init.d/zfs.lsb.in
@@ -112,13 +112,6 @@ stop()
 	"$ZFS" umount -a
 	log_end_msg $?
 
-	log_begin_msg "Exporting ZFS pools"
-	"$ZPOOL" list -H -o name | \
-	    while read pool; do
-		"$ZPOOL" export $pool
-	done
-	log_end_msg $?
-
 	rm -f "$LOCKFILE"
 }
 


### PR DESCRIPTION
zfs.lsb.in will do nothing if no caches exist. But this script also exports pools which causes cache been removed. On next boot, pool won't be imported, so file systems won't be mounted too.
