### PR TITLE
Update spec file to enable systemd for RHEL7

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -17,6 +17,11 @@
 %define _systemd 1
 %endif
 
+# RHEL >= 7 comes with systemd
+%if 0%{?rhel} >= 7
+%define _systemd 1
+%endif
+
 # Fedora >= 15 comes with systemd, but only >= 18 has
 # the proper macros
 %if 0%{?fedora} >= 18


### PR DESCRIPTION
The zfs spec file needs to be updated, so it will include systemd specific config files.
