### PR TITLE
zdb: Introduce -V for verbatim import

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3186,6 +3186,7 @@ main(int argc, char **argv)
 	char *target;
 	nvlist_t *policy = NULL;
 	uint64_t max_txg = UINT64_MAX;
+	int flags = ZFS_IMPORT_MISSING_LOG;
 	int rewind = ZPOOL_NEVER_REWIND;
 	char *spa_config_path_env;
 
@@ -3203,7 +3204,7 @@ main(int argc, char **argv)
 	if (spa_config_path_env != NULL)
 		spa_config_path = spa_config_path_env;
 
-	while ((c = getopt(argc, argv, "bcdhilmM:suCDRSAFLXevp:t:U:P")) != -1) {
+	while ((c = getopt(argc, argv, "bcdhilmM:suCDRSAFLVXevp:t:U:P")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -3228,6 +3229,9 @@ main(int argc, char **argv)
 		case 'e':
 		case 'P':
 			dump_opt[c]++;
+			break;
+		case 'V':
+			flags = ZFS_IMPORT_VERBATIM;
 			break;
 		case 'v':
 			verbose++;
@@ -3340,11 +3344,7 @@ main(int argc, char **argv)
 				fatal("can't open '%s': %s",
 				    target, strerror(ENOMEM));
 			}
-			if ((error = spa_import(name, cfg, NULL,
-			    ZFS_IMPORT_MISSING_LOG)) != 0) {
-				error = spa_import(name, cfg, NULL,
-				    ZFS_IMPORT_VERBATIM);
-			}
+			error = spa_import(name, cfg, NULL, flags);
 		}
 	}
 

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -19,7 +19,7 @@
 \fBzdb\fR - Display zpool debugging and consistency information
 
 .SH "SYNOPSIS"
-\fBzdb\fR [-CumdibcsDvhLXFPA] [-e [-p \fIpath\fR...]] [-t \fItxg\fR]
+\fBzdb\fR [-CumdibcsDvhLVXFPA] [-e [-p \fIpath\fR...]] [-t \fItxg\fR]
     [-U \fIcache\fR] [-M \fIinflight I/Os\fR] [\fIpoolname\fR
     [\fIobject\fR ...]]
 
@@ -427,6 +427,17 @@ Enable verbosity. Specify multiple times for increased verbosity.
 .RS 4n
 Attempt \'extreme\' transaction rewind, that is attempt the same recovery as
 \fB-F\fR but read transactions otherwise deemed too old.
+.RE
+
+.sp
+.ne 2
+.na
+\fB-V\fR
+.ad
+.sp .6
+.RS 4n
+Attempt a verbatim import. This mimics the behavior of the kernel when loading
+a pool from a cachefile.
 .RE
 
 .P


### PR DESCRIPTION
When given a pool name via -e, zdb would attempt an import. If it
failed, then it would attempt a verbatim import. This made debugging
corrupt pools difficult because verbatim import will often segfault when
a normal import is unable to function. This is also confusing to users
attempting to follow instructions from ZFS developers in situations
where they cannot provide direct access to pools. This is easily
resolved by introducing a -V switch to zdb. When specified, a verbatim
import is done. Otherwise, the behavior is as it was previously, except
no verbatim import is done on failure. This resolves the segmentation
fault in zfsonlinux/zfs#2371.

Since `zpool import -V` is undocumented (because it is unsafe), no
changes are made to the man page to mention this new -V option to zdb.

Signed-off-by: Richard Yao ryao@gentoo.org
