### PR TITLE
Set LANG=C before calling rpmbuild

### DIFF
--- a/config/rpm.am
+++ b/config/rpm.am
@@ -63,7 +63,7 @@ srpm-common: dist
 		rpmbuild="$$rpmbuild" \
 		rpmspec="$$rpmspec" \
 		rpm-local || exit 1; \
-	$(RPMBUILD) \
+	LANG=C $(RPMBUILD) \
 		--define "_tmppath $$rpmbuild/TMP" \
 		--define "_topdir $$rpmbuild" \
 		$(def) -bs $$rpmbuild/SPECS/$$rpmspec || exit 1; \
@@ -79,7 +79,7 @@ rpm-common:
 		rpmbuild="$$rpmbuild" \
 		rpmspec="$$rpmspec" \
 		rpm-local || exit 1; \
-	${RPMBUILD} \
+	LANG=C ${RPMBUILD} \
 		--define "_tmppath $$rpmbuild/TMP" \
 		--define "_topdir $$rpmbuild" \
 		$(def) --rebuild $$rpmpkg || exit 1; \

--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -64,7 +64,7 @@ print_akmodtemplate ()
 	cat <<EOF
 
 %global akmod_install mkdir -p \$RPM_BUILD_ROOT/%{_usrsrc}/akmods/; \\\
-rpmbuild --define "_sourcedir %{_sourcedir}" \\\
+LANG=C rpmbuild --define "_sourcedir %{_sourcedir}" \\\
 --define "_srcrpmdir \$RPM_BUILD_ROOT/%{_usrsrc}/akmods/" \\\
 -bs --nodeps %{_specdir}/%{name}.spec ; \\\
 ln -s \$(ls \$RPM_BUILD_ROOT/%{_usrsrc}/akmods/) \$RPM_BUILD_ROOT/%{_usrsrc}/akmods/${kmodname}-kmod.latest


### PR DESCRIPTION
Set LANG to a reasonable default (C) before calling 'rpmbuild' to
avoid rpmbuild failing on the translated date string in the changelog.

See https://github.com/zfsonlinux/spl/pull/361 for SPL part of the fix.

Closes: #306
