### PR TITLE
Revert "Fix __zio_execute() asynchronous dispatch"

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1342,7 +1342,6 @@ __zio_execute(zio_t *zio)
 			return;
 		}
 
-#ifdef _KERNEL
 		/*
 		 * If we executing in the context of the tx_sync_thread,
 		 * or we are performing pool initialization outside of a
@@ -1357,7 +1356,6 @@ __zio_execute(zio_t *zio)
 			zio_taskq_dispatch(zio, ZIO_TASKQ_ISSUE, cut);
 			return;
 		}
-#endif
 
 		zio->io_stage = stage;
 		rv = zio_pipeline[highbit(stage) - 1](zio);


### PR DESCRIPTION
This reverts commit 91579709fccd3e55a21970742b66c388fb1403db which
limited the asynchronous dispatch to kernel space.  We want to do
this for two reasons:

1) While we have slightly more headroom in user space excessively
   deep stacks have been observed while running ztest, see #2293.

2) Removing this conditional makes the pipeline behave consistently
   regardless of if it's executing in kernel space or user space.
   This way we're more likely to uncover subtle issues with ztest.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2293
