### PR TITLE
Accept udev and dracut paths specified by ./configure

### DIFF
--- a/config/user-dracut.m4
+++ b/config/user-dracut.m4
@@ -1,8 +1,22 @@
 AC_DEFUN([ZFS_AC_CONFIG_USER_DRACUT], [
-	AC_ARG_WITH(dracutdir,
+	AC_MSG_CHECKING(for dracut directory)
+	AC_ARG_WITH([dracutdir],
 		AC_HELP_STRING([--with-dracutdir=DIR],
-		[install dracut helpers [[EPREFIX/lib/dracut]]]),
-		dracutdir=$withval, dracutdir='${exec_prefix}/lib/dracut')
+		[install dracut helpers @<:@default=check@:>@]),
+		[dracutdir=$withval],
+		[dracutdir=check])
+
+	AS_IF([test "x$dracutdir" = xcheck], [
+		path1=/usr/share/dracut
+		path2=/usr/lib/dracut
+		default=$path2
+
+		AS_IF([test -d "$path1"], [dracutdir="$path1"], [
+			AS_IF([test -d "$path2"], [dracutdir="$path2"],
+				[dracutdir="$default"])
+		])
+	])
 
 	AC_SUBST(dracutdir)
+	AC_MSG_RESULT([$dracutdir])
 ])

--- a/config/user-udev.m4
+++ b/config/user-udev.m4
@@ -1,14 +1,29 @@
 AC_DEFUN([ZFS_AC_CONFIG_USER_UDEV], [
+	AC_MSG_CHECKING(for udev directories)
 	AC_ARG_WITH(udevdir,
 		AC_HELP_STRING([--with-udevdir=DIR],
-		[install udev helpers [[EPREFIX/lib/udev]]]),
-		udevdir=$withval, udevdir='${exec_prefix}/lib/udev')
+		[install udev helpers @<:@default=check@:>@]),
+		[udevdir=$withval],
+		[udevdir=check])
+
+	AS_IF([test "x$udevdir" = xcheck], [
+		path1=/lib/udev
+		path2=/usr/lib/udev
+		default=$path2
+
+		AS_IF([test -d "$path1"], [udevdir="$path1"], [
+			AS_IF([test -d "$path2"], [udevdir="$path2"],
+				[udevdir="$default"])
+		])
+	])
 
 	AC_ARG_WITH(udevruledir,
 		AC_HELP_STRING([--with-udevruledir=DIR],
 		[install udev rules [[UDEVDIR/rules.d]]]),
-		udevruledir=$withval, udevruledir='${udevdir}/rules.d')
+		[udevruledir=$withval],
+		[udevruledir="${udevdir}/rules.d"])
 
 	AC_SUBST(udevdir)
 	AC_SUBST(udevruledir)
+	AC_MSG_RESULT([$udevdir;$udevruledir])
 ])

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -140,7 +140,7 @@ AC_DEFUN([ZFS_AC_RPM], [
 	])
 
 	RPM_DEFINE_COMMON='--define "$(DEBUG_ZFS) 1" --define "$(DEBUG_DMU_TX) 1"'
-	RPM_DEFINE_UTIL=
+	RPM_DEFINE_UTIL='--define "_dracutdir $(dracutdir)" --define "_udevdir $(udevdir)" --define "_udevruledir $(udevruledir)"'
 	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)" --define "require_spldir $(SPL)" --define "require_splobj $(SPL_OBJ)" --define "ksrc $(LINUX)" --define "kobj $(LINUX_OBJ)"'
 	RPM_DEFINE_DKMS=
 

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -1,11 +1,31 @@
 %global _sbindir    /sbin
 %global _libdir     /%{_lib}
-%if 0%{?fedora} >= 17
+
+# Set the default udev directory based on distribution.
+%if 0%{!?_udevdir}
+%if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
 %global _udevdir    %{_prefix}/lib/udev
-%global _dracutdir  %{_prefix}/lib/dracut
 %else
 %global _udevdir    /lib/udev
+%endif
+%endif
+
+# Set the default udevrule directory based on distribution.
+%if 0%{!?_udevruledir}
+%if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
+%global _udevruledir    %{_prefix}/lib/udevrule/rules.d
+%else
+%global _udevruledir    /lib/udevrule/rules.d
+%endif
+%endif
+
+# Set the default dracut directory based on distribution.
+%if 0%{!?_dracutdir}
+%if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
+%global _dracutdir  %{_prefix}/lib/dracut
+%else
 %global _dracutdir  %{_prefix}/share/dracut
+%endif
 %endif
 
 %bcond_with    debug
@@ -192,6 +212,7 @@ image which is ZFS aware.
 %configure \
     --with-config=user \
     --with-udevdir=%{_udevdir} \
+    --with-udevruledir=%{_udevruledir} \
     --with-dracutdir=%{_dracutdir} \
     --disable-static \
     %{debug} \


### PR DESCRIPTION
There are two common locations where udev and dracut components are
commonly installed.  When building packages using the 'make rpm|deb'
targets check those common locations and pass them to rpmbuild.  For
non-standard configurations these values can be provided by the
the following configure options:

  --with-udevdir=DIR      install udev helpers [default=check]
  --with-udevruledir=DIR  install udev rules [[UDEVDIR/rules.d]]
  --with-dracutdir=DIR    install dracut helpers [default=check]

When rebuilding using the source packages the per-distribution
default values specified in the spec file will be used.  This is
the preferred way to build packages for a distribution but the
ability to override the defaults is provided as a convenience.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1874
