### PR TITLE
Return default value on numeric properties failing the "head check.

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1765,8 +1765,10 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 	 * the property is valid for the snapshot's head dataset type.
 	 */
 	if (zhp->zfs_type == ZFS_TYPE_SNAPSHOT &&
-		!zfs_prop_valid_for_type(prop, zhp->zfs_head_type, B_TRUE))
+		!zfs_prop_valid_for_type(prop, zhp->zfs_head_type, B_TRUE)) {
+			*val = zfs_prop_default_numeric(prop);
 			return (-1);
+	}
 
 	switch (prop) {
 	case ZFS_PROP_ATIME:


### PR DESCRIPTION
Updates 962d52421236fc9cd61d59b4f18cff3276077da9.

The referenced fix to get_numeric_property() caused numeric property
lookups to consider the type of the parent (head) dataset when checking
validity but there are some cases in the caller expects to see the
property's default value even when the lookup is invalid.

One case in which this is true is change_one() which is part of the
renaming infrastructure.  It may look up "zoned" on a snapshot of a volume
which is not valid but it expects to see the default value of false.

There may be other, yet unidentified cases in which zfs_prop_get_int()
is used on technically invalid properties but which expect the property's
default value to be returned.
