### PR TITLE
Illumos 4936 fix potential overflow in lz4

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -907,6 +907,9 @@ LZ4_uncompress_unknownOutputSize(const char *source, char *dest, int isize,
 		}
 		/* copy literals */
 		cpy = op + length;
+		/* CORNER-CASE: cpy might overflow. */
+		if (cpy < op)
+			goto _output_error;	/* cpy was overflowed, bail! */
 		if ((cpy > oend - COPYLENGTH) ||
 		    (ip + length > iend - COPYLENGTH)) {
 			if (cpy > oend)


### PR DESCRIPTION
4936 lz4 could theoretically overflow a pointer with a certain input
Reviewed by: Saso Kiselkov skiselkov.ml@gmail.com
Reviewed by: Keith Wesolowski keith.wesolowski@joyent.com
Approved by: Gordon Ross gordon.ross@nexenta.com
Ported by: Tim Chase tim@chase2k.com

Porting notes:

This fixes the widely-reported "20-year-old vulnerability" in
LZO/LZ4 implementations which inherited said bug from the reference
implementation.

Added several comments regarding the removal of real_LZ4_uncompress()
which exists in the reference implementation but has been removed here
since it's not used.
