### PR TITLE
zp->z_sync_cnt should not use atomic operations on Linux

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -216,9 +216,15 @@ zfs_open(struct inode *ip, int mode, int flag, cred_t *cr)
 		}
 	}
 
+#ifdef __linux__
+	/* Linux only notifies us about the last close */
+	if (flag & O_SYNC)
+		zp->z_sync_cnt = 1;
+#else
 	/* Keep a count of the synchronous opens in the znode */
 	if (flag & O_SYNC)
 		atomic_inc_32(&zp->z_sync_cnt);
+#endif
 
 	ZFS_EXIT(zsb);
 	return (0);
@@ -235,9 +241,14 @@ zfs_close(struct inode *ip, int flag, cred_t *cr)
 	ZFS_ENTER(zsb);
 	ZFS_VERIFY_ZP(zp);
 
+#ifdef __linux__
+	/* Linux only notifies us about the last close */
+	zp->z_sync_cnt = 0;
+#else
 	/* Decrement the synchronous opens in the znode */
 	if (flag & O_SYNC)
 		atomic_dec_32(&zp->z_sync_cnt);
+#endif
 
 	if (!zfs_has_ctldir(zp) && zsb->z_vscan && S_ISREG(ip->i_mode) &&
 	    !(zp->z_pflags & ZFS_AV_QUARANTINED) && zp->z_size > 0)


### PR DESCRIPTION
On most UNIX systems, the VFS will notify the filesystem about all
open() and close() operations on files and ZFS will take advantage of
this to track the number of synchronous opens in zp->z_sync_cnt. This
affects the zil_commit behavior. However, Linux only notifies us about
the last close on a file, which means that concurrent synchronous opens
will leave zp->z_sync_cnt set to a non-zero value on last close. This
means that all subsequent opens receive synchronous behavior even if
they had not asked for it.

We address this by modifying zfs_open()/zfs_close() to use
zp->z_sync_cnt on Linux as a flag variable that is set on synchronous
open and cleared on synchronous close.

Signed-off-by: Richard Yao ryao@gentoo.org
