### PR TITLE
zpool-create.sh: allow features to be disabled

### DIFF
--- a/scripts/zimport.sh
+++ b/scripts/zimport.sh
@@ -237,7 +237,7 @@ pool_create() {
 
 	# Create a file vdev RAIDZ pool.
 	FILEDIR="$POOL_DIR_PRISTINE" $ZPOOL_CREATE \
-	    -c file-raidz -p $POOL_TAG -v >/dev/null || fail 2
+	    -c file-raidz -p $POOL_TAG -v -d >/dev/null || fail 2
 
 	# Create a pool/fs filesystem with some random contents.
 	$ZFS_CMD create $POOL_TAG/fs || fail 3

--- a/scripts/zpool-config/dm0-raid0.sh
+++ b/scripts/zpool-config/dm0-raid0.sh
@@ -47,8 +47,8 @@ zpool_create() {
 	${LVCREATE} --size=${LVSIZE} --stripes=${LVSTRIPES} \
 		--name=${LVNAME} ${VGNAME} >/dev/null || exit 3
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		${DEVICES} || (zpool_dm_destroy && exit 4)
 }
 

--- a/scripts/zpool-config/file-raid0.sh
+++ b/scripts/zpool-config/file-raid0.sh
@@ -15,8 +15,8 @@ zpool_create() {
 			&>/dev/null || die "Error $? creating ${FILE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${FILES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${FILES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${FILES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${FILES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/file-raid10.sh
+++ b/scripts/zpool-config/file-raid10.sh
@@ -16,9 +16,9 @@ zpool_create() {
 			&>/dev/null || die "Error $? creating ${FILE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		mirror ${FILES_M1} mirror ${FILES_M2}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		mirror ${FILES_M1} mirror ${FILES_M2} || exit 1
 }
 

--- a/scripts/zpool-config/file-raidz.sh
+++ b/scripts/zpool-config/file-raidz.sh
@@ -15,8 +15,8 @@ zpool_create() {
 			&>/dev/null || die "Error $? creating ${FILE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${FILES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${FILES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${FILES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${FILES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/file-raidz2.sh
+++ b/scripts/zpool-config/file-raidz2.sh
@@ -15,8 +15,8 @@ zpool_create() {
 			&>/dev/null || die "Error $? creating ${FILE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${FILES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${FILES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${FILES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${FILES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/hda-raid0.sh
+++ b/scripts/zpool-config/hda-raid0.sh
@@ -6,8 +6,8 @@
 DEVICES="/dev/hda"
 
 zpool_create() {
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/lo-faulty-raid0.sh
+++ b/scripts/zpool-config/lo-faulty-raid0.sh
@@ -58,8 +58,8 @@ zpool_create() {
 		MDDEVICES="${MDDEVICES} ${MDDEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${MDDEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${MDDEVICES} ||          \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${MDDEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${MDDEVICES} ||          \
 		(destroy_md_devices "${MDDEVICES}" &&                        \
 		destroy_loop_devices "${LODEVICES}" && exit 1)
 

--- a/scripts/zpool-config/lo-faulty-raid10.sh
+++ b/scripts/zpool-config/lo-faulty-raid10.sh
@@ -63,9 +63,9 @@ zpool_create() {
 		fi 
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME}                      \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME}                      \
 		mirror ${MDDEVICES_M1} mirror ${MDDEVICES_M2}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME}                          \
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME}                          \
 		mirror ${MDDEVICES_M1} mirror ${MDDEVICES_M2} ||             \
 		(destroy_md_devices "${MDDEVICES}" &&                        \
 		destroy_loop_devices "${LODEVICES}" && exit 1)

--- a/scripts/zpool-config/lo-faulty-raidz.sh
+++ b/scripts/zpool-config/lo-faulty-raidz.sh
@@ -52,8 +52,8 @@ zpool_create() {
 		MDDEVICES="${MDDEVICES} ${MDDEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${MDDEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${MDDEVICES} ||    \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${MDDEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${MDDEVICES} ||    \
 		(destroy_md_devices "${MDDEVICES}" &&                        \
 		destroy_loop_devices "${LODEVICES}" && exit 1)
 

--- a/scripts/zpool-config/lo-faulty-raidz2.sh
+++ b/scripts/zpool-config/lo-faulty-raidz2.sh
@@ -52,8 +52,8 @@ zpool_create() {
 		MDDEVICES="${MDDEVICES} ${MDDEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${MDDEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${MDDEVICES} ||   \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${MDDEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${MDDEVICES} ||   \
 		(destroy_md_devices "${MDDEVICES}" &&                        \
 		destroy_loop_devices "${LODEVICES}" && exit 1)
 

--- a/scripts/zpool-config/lo-faulty-raidz3.sh
+++ b/scripts/zpool-config/lo-faulty-raidz3.sh
@@ -53,8 +53,8 @@ zpool_create() {
 		MDDEVICES="${MDDEVICES} ${MDDEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz3 ${MDDEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz3 ${MDDEVICES} ||   \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz3 ${MDDEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz3 ${MDDEVICES} ||   \
 		(destroy_md_devices "${MDDEVICES}" &&                        \
 		destroy_loop_devices "${LODEVICES}" && exit 1)
 

--- a/scripts/zpool-config/lo-raid0.sh
+++ b/scripts/zpool-config/lo-raid0.sh
@@ -22,8 +22,8 @@ zpool_create() {
 		DEVICES="${DEVICES} ${DEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/lo-raid10.sh
+++ b/scripts/zpool-config/lo-raid10.sh
@@ -35,9 +35,9 @@ zpool_create() {
 		DEVICES_M2="${DEVICES_M2} ${DEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		mirror ${DEVICES_M1} mirror ${DEVICES_M2}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		mirror ${DEVICES_M1} mirror ${DEVICES_M2}
 }
 

--- a/scripts/zpool-config/lo-raidz.sh
+++ b/scripts/zpool-config/lo-raidz.sh
@@ -21,8 +21,8 @@ zpool_create() {
 		DEVICES="${DEVICES} ${DEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/lo-raidz2.sh
+++ b/scripts/zpool-config/lo-raidz2.sh
@@ -22,8 +22,8 @@ zpool_create() {
 		DEVICES="${DEVICES} ${DEVICE}"
 	done
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/md0-raid10.sh
+++ b/scripts/zpool-config/md0-raid10.sh
@@ -25,8 +25,8 @@ zpool_create() {
 		--raid-devices=${MDCOUNT} ${MDDEVICES} \
 		&>/dev/null || (zpool_md_destroy && exit 1)
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		${DEVICES} || (zpool_md_destroy && exit 2)
 }
 

--- a/scripts/zpool-config/md0-raid5.sh
+++ b/scripts/zpool-config/md0-raid5.sh
@@ -25,8 +25,8 @@ zpool_create() {
 		--raid-devices=${MDCOUNT} ${MDDEVICES} \
 		&>/dev/null || (zpool_md_destroy && exit 1)
 
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} \
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} \
 		${DEVICES} || (zpool_md_destroy && exit 2)
 }
 

--- a/scripts/zpool-config/ram0-raid0.sh
+++ b/scripts/zpool-config/ram0-raid0.sh
@@ -6,8 +6,8 @@
 DEVICES="/dev/ram0"
 
 zpool_create() {
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/scsi_debug-noraid.sh
+++ b/scripts/zpool-config/scsi_debug-noraid.sh
@@ -33,8 +33,8 @@ zpool_create() {
 	${PARTED} -s ${SDDEVICE} mklabel gpt ||                              \
 		(${RMMOD} scsi_debug && die "Error $? creating gpt label")
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${SDDEVICE}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${SDDEVICE} ||           \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${SDDEVICE}"
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${SDDEVICE} ||           \
 		(${RMMOD} scsi_debug && exit 1)
 }
 

--- a/scripts/zpool-config/scsi_debug-raid0.sh
+++ b/scripts/zpool-config/scsi_debug-raid0.sh
@@ -56,8 +56,8 @@ zpool_create() {
 
 	DEVICES="${DEVICES} ${SDDEVICE}"
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES} ||            \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}"
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES} ||            \
 		(${RMMOD} scsi_debug && exit 1)
 }
 

--- a/scripts/zpool-config/scsi_debug-raid10.sh
+++ b/scripts/zpool-config/scsi_debug-raid10.sh
@@ -68,9 +68,9 @@ zpool_create() {
 		fi
 	done
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} "                   \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} "                   \
 		"mirror ${DEVICES_M1} mirror ${DEVICES_M2}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME}                          \
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME}                          \
 		mirror ${DEVICES_M1} mirror ${DEVICES_M2} ||                 \
 		(${RMMOD} scsi_debug && exit 1)
 }

--- a/scripts/zpool-config/scsi_debug-raidz.sh
+++ b/scripts/zpool-config/scsi_debug-raidz.sh
@@ -56,8 +56,8 @@ zpool_create() {
 
 	DEVICES="${DEVICES} ${SDDEVICE}"
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${DEVICES}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz ${DEVICES} ||      \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${DEVICES}"
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz ${DEVICES} ||      \
 		(${RMMOD} scsi_debug && exit 1)
 }
 

--- a/scripts/zpool-config/scsi_debug-raidz2.sh
+++ b/scripts/zpool-config/scsi_debug-raidz2.sh
@@ -56,8 +56,8 @@ zpool_create() {
 
 	DEVICES="${DEVICES} ${SDDEVICE}"
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${DEVICES}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz2 ${DEVICES} ||     \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${DEVICES}"
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz2 ${DEVICES} ||     \
 		(${RMMOD} scsi_debug && exit 1)
 }
 

--- a/scripts/zpool-config/scsi_debug-raidz3.sh
+++ b/scripts/zpool-config/scsi_debug-raidz3.sh
@@ -57,8 +57,8 @@ zpool_create() {
 
 	DEVICES="${DEVICES} ${SDDEVICE}"
 
-	msg "${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz3 ${DEVICES}"
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} raidz3 ${DEVICES} ||     \
+	msg "${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz3 ${DEVICES}"
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} raidz3 ${DEVICES} ||     \
 		(${RMMOD} scsi_debug && exit 1)
 }
 

--- a/scripts/zpool-config/sda-raid0.sh
+++ b/scripts/zpool-config/sda-raid0.sh
@@ -6,8 +6,8 @@
 DEVICES="/dev/sda"
 
 zpool_create() {
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/zpool-raid0.sh
+++ b/scripts/zpool-config/zpool-raid0.sh
@@ -70,8 +70,8 @@ zpool_create() {
         raid0_setup ${RANKS} ${CHANNELS}
 
 	ZPOOL_DEVICES="${RAID0S[*]} ${ZIL} ${L2ARC}"
-        msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
-        ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
+        msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
+        ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/zpool-raid10.sh
+++ b/scripts/zpool-config/zpool-raid10.sh
@@ -75,8 +75,8 @@ zpool_create() {
 	raid10_setup ${RANKS} ${CHANNELS}
 
 	ZPOOL_DEVICES="${RAID10S[*]} ${ZIL} ${L2ARC}"
-	msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
-	${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
+	msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
+	${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-config/zpool-raidz.sh
+++ b/scripts/zpool-config/zpool-raidz.sh
@@ -77,8 +77,8 @@ zpool_create() {
         raidz_setup ${RANKS} ${CHANNELS}
 
 	ZPOOL_DEVICES="${RAIDZS[*]} ${ZIL} ${L2ARC}"
-        msg ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
-        ${ZPOOL} create ${FORCE_FLAG} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
+        msg ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES}
+        ${ZPOOL} create ${ZPOOL_FLAGS} ${ZPOOL_NAME} ${ZPOOL_DEVICES} || exit 1
 }
 
 zpool_destroy() {

--- a/scripts/zpool-create.sh
+++ b/scripts/zpool-create.sh
@@ -14,7 +14,7 @@ PROG=zpool-create.sh
 usage() {
 cat << EOF
 USAGE:
-$0 [hvcp]
+$0 [hvfdcp]
 
 DESCRIPTION:
         Create one of several predefined zpool configurations.
@@ -23,6 +23,7 @@ OPTIONS:
         -h      Show this message
         -v      Verbose
         -f      Force everything
+        -d      Disable all features
         -c      Configuration for zpool
         -p      Name for zpool
         -d      Destroy zpool (default create)
@@ -52,10 +53,11 @@ check_config() {
 ZPOOL_CONFIG=unknown
 ZPOOL_NAME=tank
 ZPOOL_DESTROY=
+ZPOOL_FLAGS=${ZPOOL_FLAGS:-""}
 ZPOOL_OPTIONS=""
 ZFS_OPTIONS=""
 
-while getopts 'hvfc:p:dl:s:' OPTION; do
+while getopts 'hvfdc:p:dl:s:' OPTION; do
 	case $OPTION in
 	h)
 		usage
@@ -63,11 +65,15 @@ while getopts 'hvfc:p:dl:s:' OPTION; do
 		;;
 	v)
 		VERBOSE=1
-		VERBOSE_FLAG="-v"
+		ZPOOL_FLAGS="$ZPOOL_FLAGS -v"
 		;;
 	f)
 		FORCE=1
-		FORCE_FLAG="-f"
+		ZPOOL_FLAGS="$ZPOOL_FLAGS -f"
+		;;
+	d)
+		NO_FEATURES=1
+		ZPOOL_FLAGS="$ZPOOL_FLAGS -d"
 		;;
 	c)
 		ZPOOL_CONFIG=${ZPOOLDIR}/${OPTARG}.sh


### PR DESCRIPTION
The zimport.sh script makes use of the zpool-create.sh script
to construct test pools for importing with older versions of
ZoL.  It is desirable to have a way to disable all the features
so new pools can be imported with older code.

The simplest and most flexible way to achieve this was to merge
the VERBOSE_FLAG and FORCE_FLAG in to a single ZPOOL_FLAGS
variable.  The contents of this variable will be used in the
'zpool create' allowing us to easily pass arbitrary flags.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
