### PR TITLE
Update zfs-mount.service.in

### DIFF
--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -7,6 +7,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=zfs-import-cache.service
 After=zfs-import-scan.service
+After=cryptsetup.target
 Before=local-fs.target
 
 [Service]


### PR DESCRIPTION
ZFS mount service should be started after cryptsetup opens all LUKS devices.
Fixes mounting issues with systemd #1474
