### PR TITLE
Add zfeature_checks_disable module option

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -186,6 +186,18 @@ Default value: 24
 .sp
 .ne 2
 .na
+\fBzfeature_checks_disable\fR (int)
+.ad
+.RS 12n
+Set to disable all feature checks while opening pools, allowing pools with
+unsupported features to be opened. Set for testing only.
+.sp
+Use \fB1\fR for yes and \fB0\fR to disable (default).
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfetch_array_rd_sz\fR (ulong)
 .ad
 .RS 12n

--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -200,3 +200,8 @@ zpool_feature_init(void)
 	    "Enhanced dataset functionality, used by other features.",
 	    B_FALSE, B_FALSE, B_FALSE, NULL);
 }
+
+#if defined(_KERNEL)
+module_param(zfeature_checks_disable, int, 0644);
+MODULE_PARM_DESC(zfeature_checks_disable, "Disable all feature checks while opening pools");
+#endif


### PR DESCRIPTION
Tuning setting to disable all feature checks while opening pools, allowing pools with unsupported features to be opened.

There's been a few discussion on how to import pools created on other operating system, and most have stumbled on a feature that isn't available on Linux.

Since the code and variable is already there, having it being turned on or of without recompiling the code might be a good thing...

Signed-off-by: Turbo Fredriksson turbo@bayour.com
