### PR TITLE
Avoid dynamic allocation of 'search zio'

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -118,6 +118,7 @@ struct vdev_queue {
 	hrtime_t	vq_io_complete_ts; /* time last i/o completed */
 	hrtime_t	vq_io_delta_ts;
 	list_t		vq_io_list;
+	zio_t		vq_io_search; /* used as local for stack reduction */
 	kmutex_t	vq_lock;
 };
 

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -659,7 +659,6 @@ vdev_queue_io_to_issue(vdev_queue_t *vq)
 	zio_priority_t p;
 	avl_index_t idx;
 	vdev_queue_class_t *vqc;
-	zio_t *search;
 
 again:
 	ASSERT(MUTEX_HELD(&vq->vq_lock));
@@ -678,11 +677,10 @@ again:
 	 * For FIFO queues (sync), issue the i/o with the lowest timestamp.
 	 */
 	vqc = &vq->vq_class[p];
-	search = zio_buf_alloc(sizeof (*search));
-	search->io_timestamp = 0;
-	search->io_offset = vq->vq_last_offset + 1;
-	VERIFY3P(avl_find(&vqc->vqc_queued_tree, search, &idx), ==, NULL);
-	zio_buf_free(search, sizeof (*search));
+	vq->vq_io_search.io_timestamp = 0;
+	vq->vq_io_search.io_offset = vq->vq_last_offset + 1;
+	VERIFY3P(avl_find(&vqc->vqc_queued_tree, &vq->vq_io_search,
+	    &idx), ==, NULL);
 	zio = avl_nearest(&vqc->vqc_queued_tree, idx, AVL_AFTER);
 	if (zio == NULL)
 		zio = avl_first(&vqc->vqc_queued_tree);


### PR DESCRIPTION
As part of commit e8b96c6 the search zio used by the
vdev_queue_io_to_issue() function was moved to the heap
to minimize stack usage.  Functionally this is fine, but
to maximize performance it's best to minimize the number
of dynamic allocations.

To avoid this allocation temporary space for the search
zio has been reserved in the vdev_queue structure.  All
access must be serialized through the vq_lock.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
