### PR TITLE
Squashed commit of the following:

### DIFF
--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -28,7 +28,7 @@
 
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/va_list.h>
 
 #if defined(_KERNEL) && !defined(_BOOT)
@@ -132,7 +132,7 @@ typedef struct nv_alloc {
 } nv_alloc_t;
 
 struct nv_alloc_ops {
-	int (*nv_ao_init)(nv_alloc_t *, __va_list);
+	int (*nv_ao_init)(nv_alloc_t *, va_list);
 	void (*nv_ao_fini)(nv_alloc_t *);
 	void *(*nv_ao_alloc)(nv_alloc_t *, size_t);
 	void (*nv_ao_free)(nv_alloc_t *, void *, size_t);

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -30,7 +30,7 @@
 
 #include <sys/isa_defs.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -148,9 +148,9 @@ extern void dprintf_setup(int *argc, char **argv);
 extern void __dprintf(const char *file, const char *func,
     int line, const char *fmt, ...);
 extern void cmn_err(int, const char *, ...);
-extern void vcmn_err(int, const char *, __va_list);
+extern void vcmn_err(int, const char *, va_list);
 extern void panic(const char *, ...);
-extern void vpanic(const char *, __va_list);
+extern void vpanic(const char *, va_list);
 
 #define	fm_panic	panic
 

--- a/lib/libspl/include/sys/param.h
+++ b/lib/libspl/include/sys/param.h
@@ -57,6 +57,7 @@
 #define	MAXUID		UINT32_MAX	/* max user id */
 #define	MAXPROJID	MAXUID		/* max project id */
 
+#undef 	PAGESIZE
 #define	PAGESIZE	(sysconf(_SC_PAGESIZE))
 
 #endif

--- a/lib/libspl/include/sys/va_list.h
+++ b/lib/libspl/include/sys/va_list.h
@@ -29,8 +29,4 @@
 
 #include <stdarg.h>
 
-#ifndef __va_list
-typedef __gnuc_va_list __va_list;
-#endif
-
 #endif

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -42,7 +42,7 @@
 #include <sys/mnttab.h>
 #include <sys/mntent.h>
 #include <sys/types.h>
-#include <wait.h>
+#include <sys/wait.h>
 
 #include <libzfs.h>
 #include <libzfs_core.h>

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zlib.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/spa.h>
 #include <sys/stat.h>
 #include <sys/processor.h>

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -49,7 +49,7 @@
 #include <strings.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/u8_textprep_data.h>
 
 

--- a/module/unicode/uconv.c
+++ b/module/unicode/uconv.c
@@ -46,7 +46,7 @@
 #include <sys/u8_textprep.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 
 /*

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -39,7 +39,7 @@
 #include <sys/sunddi.h>
 #include <sys/sa_impl.h>
 #include <sys/dnode.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/zfs_context.h>
 
 /*


### PR DESCRIPTION
minor code cleanups:

commit ef41ff8f99ec8de50032ded6873de226d3f47dc4
Author: Alec Salazar alec.j.salazar@gmail.com
Date:   Tue Aug 5 09:10:54 2014 -0400

```
replace __va_list with va_list

most of the codebase already uses va_list, which is specified by
iso-c. gcc/glibc provides 'typedef __gnuc_va_list va_list'. and
when not using gcc/glibc we can't expect to find __gnuc_va_list.
```

commit 5d00656706d160dbf096849c2d0d7d268339858e
Author: Alec Salazar alec.j.salazar@gmail.com
Date:   Sun Aug 10 21:23:13 2014 -0400

```
fix incorrect include redirects

changes include headers sys/errno to errno
sys/signal to signal and wait to sys/wait
```

commit 44f60a038eac0e933eb6e6b37d9b121a4e085874
Author: Alec Salazar alec.j.salazar@gmail.com
Date:   Tue Aug 5 10:53:16 2014 -0400

```
undefine pagesize

add undef PAGESIZE to clear redefinition warning on platforms
where this value is already set, maintaining current behavior of
retrieving this value from POSIX defined sysconf(_SC_PAGESIZE).
```
