### PR TITLE
2493 change efi_rescan() to wait longer

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -506,7 +506,7 @@ int
 efi_rescan(int fd)
 {
 #if defined(__linux__)
-	int retry = 5;
+	int retry = 10;
 	int error;
 
 	/* Notify the kernel a devices partition table has been updated */
@@ -516,6 +516,7 @@ efi_rescan(int fd)
 			    "the partition table: %d\n", errno);
 			return (-1);
 		}
+		usleep(50000);
 	}
 #endif
 


### PR DESCRIPTION
Per the suggestion in #2493, changed efi_rescan()
to loop 10 times instead of 5 and to sleep at the
end of each loop. This helps with some instances
where the kernel does not reload the partition table
fast enough for ZFS to detect
