### PR TITLE
replace _DATE_FMT with format specifiers

### DIFF
--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -40,7 +40,7 @@ print_timestamp(uint_t timestamp_fmt)
 
 	/* We only need to retrieve this once per invocation */
 	if (fmt == NULL)
-		fmt = nl_langinfo(_DATE_FMT);
+		fmt = "%c %Z";
 
 	if (timestamp_fmt == UDATE) {
 		(void) printf("%ld\n", t);


### PR DESCRIPTION
Bring into conformance with [Open Group Base Specifications](http://pubs.opengroup.org/onlinepubs/007904975/basedefs/langinfo.h.html). Or bypass nl_langinfo to pass the format specifiers directly and conform to ISO.
