### PR TITLE
Implement fallocate FALLOC_FL_PUNCH_HOLE

### DIFF
--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -52,8 +52,10 @@ extern ssize_t zpl_read_common(struct inode *ip, const char *buf,
 extern ssize_t zpl_write_common(struct inode *ip, const char *buf,
     size_t len, loff_t *ppos, uio_seg_t segment, int flags,
     cred_t *cr);
+#if defined(HAVE_FILE_FALLOCATE) || defined(HAVE_INODE_FALLOCATE)
 extern long zpl_fallocate_common(struct inode *ip, int mode,
     loff_t offset, loff_t len);
+#endif /* defined(HAVE_FILE_FALLOCATE) || defined(HAVE_INODE_FALLOCATE) */
 
 extern const struct address_space_operations zpl_address_space_operations;
 extern const struct file_operations zpl_file_operations;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2565,8 +2565,6 @@ top:
 		if (err)
 			goto out3;
 
-		truncate_setsize(ip, vap->va_size);
-
 		/*
 		 * XXX - Note, we are not providing any open
 		 * mode flags here (like FNDELAY), so we may


### PR DESCRIPTION
Add support for the FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE mode of
fallocate(2).  Mimic the behavior of other native file systems such as
ext4 in cases where the file might be extended. If the offset is beyond
the end of the file, return success without changing the file. If the
extent of the punched hole would extend the file, only the existing tail
of the file is punched.

Add an autotools check for the truncate_pagecache_range() helper function
and a compatible implementation if the kernel doesn't support it.

Hole punching clears the relevent pagecache entries in zfs_space()
via truncate_pagecache_range().  For better source compatibility with
other implementations within the zfs_setattr() function, its call to
truncate_setsize() has been moved to zfs_space().
