### PR TITLE
check for unsupported filesystem version

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -679,11 +679,18 @@ zfs_sb_create(const char *osname, zfs_sb_t **zsbp)
 	error = zfs_get_zplprop(os, ZFS_PROP_VERSION, &zsb->z_version);
 	if (error) {
 		goto out;
+	} else if (zsb->z_version > ZPL_VERSION) {
+		(void) printk("Can't mount a version %lld file system on "
+			"this pool.\n", (u_longlong_t)zsb->z_version);
+		(void) printk("File system version is not currently "
+			"supported by this ZFS implementation.\n");
+		error = SET_ERROR(ENOTSUP);
+		goto out;
 	} else if (zsb->z_version >
 	    zfs_zpl_version_map(spa_version(dmu_objset_spa(os)))) {
 		(void) printk("Can't mount a version %lld file system "
 		    "on a version %lld pool\n. Pool must be upgraded to mount "
-		    "this file system.", (u_longlong_t)zsb->z_version,
+		    "this file system.\n", (u_longlong_t)zsb->z_version,
 		    (u_longlong_t)spa_version(dmu_objset_spa(os)));
 		error = SET_ERROR(ENOTSUP);
 		goto out;


### PR DESCRIPTION
Enhance zfs_sb_create() to detect attempt to reference a filesystem whose version we do not support, rather than telling the user the current pool does not support it and they should upgrade.
