### PR TITLE
Change the default 'zfs_dedup_prefetch' value to '0'

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -503,7 +503,7 @@ Default value: \fB1,000,000\fR.
 .RS 12n
 Enable prefetching dedup-ed blks
 .sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
+Use \fB1\fR for yes and \fB0\fR to disable (default).
 .RE
 
 .sp

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -43,7 +43,7 @@ static kmem_cache_t *ddt_entry_cache;
 /*
  * Enable/disable prefetching of dedup-ed blocks which are going to be freed.
  */
-int zfs_dedup_prefetch = 1;
+int zfs_dedup_prefetch = 0;
 
 static const ddt_ops_t *ddt_ops[DDT_TYPES] = {
 	&ddt_zap_ops,


### PR DESCRIPTION
This gives a huge performance improvement in operations with deduped
datasets especially when the bottleneck is the amount of ram
available for zfs.

Closes #2639
