### PR TITLE
Import zfs pools after cryptsetup

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -3,6 +3,7 @@ Description=Import ZFS pools by cache file
 DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
+After=cryptsetup.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 
 [Service]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -3,6 +3,7 @@ Description=Import ZFS pools by device scanning
 DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
+After=cryptsetup.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 
 [Service]


### PR DESCRIPTION
The zfs-import-cache.service and zfs-import-scan.service should
should be started after cryptsetup to ensure all LUKS devices have
been opened.

Signed-off-by: alteriks alteriks@gmail.com
Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Closes #1474
