### PR TITLE
3525 persistent l2arc.

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -171,13 +171,14 @@ void arc_fini(void);
  * Level 2 ARC
  */
 
-void l2arc_add_vdev(spa_t *spa, vdev_t *vd);
+void l2arc_add_vdev(spa_t *spa, vdev_t *vd, boolean_t rebuild);
 void l2arc_remove_vdev(vdev_t *vd);
 boolean_t l2arc_vdev_present(vdev_t *vd);
 void l2arc_init(void);
 void l2arc_fini(void);
 void l2arc_start(void);
 void l2arc_stop(void);
+void l2arc_spa_rebuild_start(spa_t *spa);
 
 #ifndef _KERNEL
 extern boolean_t arc_watch;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -24,6 +24,7 @@
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -534,6 +535,7 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_PHYS_PATH		"phys_path"
 #define	ZPOOL_CONFIG_IS_LOG		"is_log"
 #define	ZPOOL_CONFIG_L2CACHE		"l2cache"
+#define	ZPOOL_CONFIG_L2CACHE_PERSISTENT	"l2cache_persistent"
 #define	ZPOOL_CONFIG_HOLE_ARRAY		"hole_array"
 #define	ZPOOL_CONFIG_VDEV_CHILDREN	"vdev_children"
 #define	ZPOOL_CONFIG_IS_HOLE		"is_hole"

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2013 Saso Kiselkov. All rights reserved.
  */
 
 #ifndef _SYS_SPA_H
@@ -435,6 +436,17 @@ _NOTE(CONSTCOND) } while (0)
 	((zc1).zc_word[2] - (zc2).zc_word[2]) | \
 	((zc1).zc_word[3] - (zc2).zc_word[3])))
 
+#define	ZIO_CHECKSUM_BSWAP(_zc) \
+	do { \
+		zio_cksum_t *zc = (_zc); \
+		zc->zc_word[0] = BSWAP_64(zc->zc_word[0]); \
+		zc->zc_word[1] = BSWAP_64(zc->zc_word[1]); \
+		zc->zc_word[2] = BSWAP_64(zc->zc_word[2]); \
+		zc->zc_word[3] = BSWAP_64(zc->zc_word[3]); \
+		_NOTE(NOTREACHED) \
+		_NOTE(CONSTCOND) \
+	} while (0)
+
 #define	DVA_IS_VALID(dva)	(DVA_GET_ASIZE(dva) != 0)
 
 #define	ZIO_SET_CHECKSUM(zcp, w0, w1, w2, w3)	\
@@ -596,14 +608,15 @@ extern void spa_inject_delref(spa_t *spa);
 extern void spa_scan_stat_init(spa_t *spa);
 extern int spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps);
 
-#define	SPA_ASYNC_CONFIG_UPDATE	0x01
-#define	SPA_ASYNC_REMOVE	0x02
-#define	SPA_ASYNC_PROBE		0x04
-#define	SPA_ASYNC_RESILVER_DONE	0x08
-#define	SPA_ASYNC_RESILVER	0x10
-#define	SPA_ASYNC_AUTOEXPAND	0x20
-#define	SPA_ASYNC_REMOVE_DONE	0x40
-#define	SPA_ASYNC_REMOVE_STOP	0x80
+#define	SPA_ASYNC_CONFIG_UPDATE		0x01
+#define	SPA_ASYNC_REMOVE		0x02
+#define	SPA_ASYNC_PROBE			0x04
+#define	SPA_ASYNC_RESILVER_DONE		0x08
+#define	SPA_ASYNC_RESILVER		0x10
+#define	SPA_ASYNC_AUTOEXPAND		0x20
+#define	SPA_ASYNC_REMOVE_DONE		0x40
+#define	SPA_ASYNC_REMOVE_STOP		0x80
+#define	SPA_ASYNC_L2CACHE_REBUILD	0x100
 
 /*
  * Controls the behavior of spa_vdev_remove().

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Use is subject to license terms.
  */
 
@@ -95,5 +96,15 @@ extern void __assert(const char *, const char *, int);
 #define	ASSERT0(x)		VERIFY0(x)
 #define	ASSERTV(x)		x
 #endif  /* NDEBUG */
+
+/*
+ * Compile-time assertion. The condition 'x' must be constant.
+ */
+#define	CTASSERT_GLOBAL(x)	_CTASSERT(x, __LINE__)
+#define	CTASSERT(x)		{_CTASSERT(x, __LINE__); }
+#define	_CTASSERT(x, y)		__CTASSERT(x, y)
+#define	__CTASSERT(x, y)	\
+	typedef char __attribute__((unused))	\
+	__compile_time_assertion__ ## y[(x) ? 1 : -1]
 
 #endif  /* _LIBSPL_ASSERT_H */

--- a/lib/libspl/include/sys/list.h
+++ b/lib/libspl/include/sys/list.h
@@ -22,6 +22,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2013 Saso Kiselkov, All rights reserved.
+ */
 
 #ifndef	_SYS_LIST_H
 #define	_SYS_LIST_H
@@ -32,6 +35,19 @@
 extern "C" {
 #endif
 
+/*
+ * Please note that a list_node_t contains pointers back to its parent list_t
+ * so you cannot copy the list_t around once it has been initialized. In
+ * particular, this kind of construct won't work:
+ *
+ * struct { list_t l; } a, b;
+ * list_create(&a.l, ...);
+ * b = a;    <= This will break the list in `b', as the `l' element in `a'
+ *              got copied to a different memory address.
+ *
+ * When copying structures with lists use list_move_tail() to move the list
+ * from the src to dst (the source reference will then become invalid).
+ */
 typedef struct list_node list_node_t;
 typedef struct list list_t;
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1536,8 +1536,14 @@ vdev_reopen(vdev_t *vd)
 		(void) vdev_validate_aux(vd);
 		if (vdev_readable(vd) && vdev_writeable(vd) &&
 		    vd->vdev_aux == &spa->spa_l2cache &&
-		    !l2arc_vdev_present(vd))
-			l2arc_add_vdev(spa, vd);
+		    !l2arc_vdev_present(vd)) {
+			/*
+			 * When reopening we can assume persistent L2ARC is
+			 * supported, since we've already opened the device
+			 * in the past and prepended an L2ARC uberblock.
+			 */
+			l2arc_add_vdev(spa, vd, B_TRUE);
+		}
 	} else {
 		(void) vdev_validate(vd, B_TRUE);
 	}

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -283,6 +283,11 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 			    vd->vdev_removing);
 	}
 
+	if (flags & VDEV_CONFIG_L2CACHE)
+		/* indicate that we support L2ARC persistency */
+		VERIFY(nvlist_add_boolean_value(nv,
+		    ZPOOL_CONFIG_L2CACHE_PERSISTENT, B_TRUE) == 0);
+
 	if (vd->vdev_dtl_sm != NULL) {
 		fnvlist_add_uint64(nv, ZPOOL_CONFIG_DTL,
 		    space_map_object(vd->vdev_dtl_sm));


### PR DESCRIPTION
For details, see: https://www.illumos.org/issues/3525

v2: Change two KM_SLEEP to KM_PUSHPAGE.
v3: Change one more KM_SLEEP.
v4: Fix log buffer alignment in l2arc_dev_log_commit.
v5: Fix style.
v6: l2arc vdev can go away, remove ASSERT in l2arc_spa_rebuild_start.

Close #925

Ported-by: Yuxuan Shui yshuiv7@gmail.com
