### PR TITLE
Fragmentation should display as '-' if spacemap_histogram=disabled

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -274,15 +274,6 @@ zpool_get_prop_literal(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 			intval = zpool_get_prop_int(zhp, prop, &src);
 			(void) snprintf(buf, len, "%llu", (u_longlong_t)intval);
 			break;
-		case ZPOOL_PROP_FRAGMENTATION:
-			intval = zpool_get_prop_int(zhp, prop, &src);
-			if (intval == UINT64_MAX) {
-				(void) strlcpy(buf, "-", len);
-			} else {
-				(void) snprintf(buf, len, "%llu%%",
-				    (u_longlong_t)intval);
-			}
-			break;
 
 		case ZPOOL_PROP_ALTROOT:
 		case ZPOOL_PROP_CACHEFILE:
@@ -338,6 +329,15 @@ zpool_get_prop_literal(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 		case ZPOOL_PROP_CAPACITY:
 			(void) snprintf(buf, len, "%llu%%",
 			    (u_longlong_t)intval);
+			break;
+
+		case ZPOOL_PROP_FRAGMENTATION:
+			if (intval == UINT64_MAX) {
+				(void) strlcpy(buf, "-", len);
+			} else {
+				(void) snprintf(buf, len, "%llu%%",
+				    (u_longlong_t)intval);
+			}
 			break;
 
 		case ZPOOL_PROP_DEDUPRATIO:


### PR DESCRIPTION
When com.delphix:spacemap_histogram is disabled, the value of
fragmentation was printing as 18446744073709551615 (UINT64_MAX),
when it should print as '-'.

The issue was caused by a small mistake during the merge of
"4980 metaslabs should have a fragmentation metric."

upstream:
https://github.com/illumos/illumos-gate/commit/2e4c998613148111f2fc5371085331ffb39122ff
ZOL:
https://github.com/zfsonlinux/zfs/commit/f3a7f6610f2df0217ba3b99099019417a954b673

The problem is in zpool_get_prop_literal, where the handling of the
pool property ZPOOL_PROP_FRAGMENTATION was added to wrong the
section. In particular, ZPOOL_PROP_FRAGMENTATION should not be in
the section where zpool_get_state(zhp) == POOL_STATE_UNAVAIL, but
lower down after it's already been determined that the pool is in
fact available, which is where upstream illumos correctly has had
it.

Thanks to lundman for helping to track down this bug.

Issue https://github.com/zfsonlinux/zfs/issues/2664
