### PR TITLE
Illumos 5140 - message about "%recv could not be opened" is printed when booting after crash

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -667,7 +667,15 @@ zil_claim(const char *osname, void *txarg)
 
 	error = dmu_objset_own(osname, DMU_OST_ANY, B_FALSE, FTAG, &os);
 	if (error != 0) {
-		cmn_err(CE_WARN, "can't open objset for %s", osname);
+		/*
+		 * EBUSY indicates that the objset is inconsistent, in which
+		 * case it can not have a ZIL.
+		 */
+		if (error != EBUSY) {
+			cmn_err(CE_WARN, "can't open objset for %s, error %u",
+				osname, error);
+		}
+
 		return (0);
 	}
 


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com
Reviewed by: Christopher Siden christopher.siden@delphix.com
Reviewed by: Max Grossman max.grossman@delphix.com

Original author: Matthew Ahrens

References:
  https://www.illumos.org/projects/illumos-gate//issues/5140
  https://github.com/illumos/illumos-gate/commit/2243853

Ported by: Turbo Fredriksson turbo@bayour.com
