### PR TITLE
Fix z_teardown_inactive_lock deadlock

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -1009,7 +1009,7 @@ zfs_rezget(znode_t *zp)
 	}
 
 	if (zp->z_xattr_parent) {
-		iput(ZTOI(zp->z_xattr_parent));
+		zfs_iput_async(ZTOI(zp->z_xattr_parent));
 		zp->z_xattr_parent = NULL;
 	}
 	rw_exit(&zp->z_xattr_lock);


### PR DESCRIPTION
When rolling back a mounted filesystem zfs_suspend() is called
which acquires the z_teardown_inactive_lock.  This lock can not
be dropped until the filesystem has been rolled back and resumed
in zfs_resume_fs().

Therefore, we must not call iput() under this lock because it
may result in the inode->evict() handler being called which also
takes this lock.  Instead use zfs_iput_async() to ensure dropping
the last reference is deferred and runs in a safe context.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2670
