### PR TITLE
Illumos 5162 - zfs recv should use loaned arc buffer to avoid copy

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1385,7 +1385,14 @@ dmu_assign_arcbuf(dmu_buf_t *handle, uint64_t offset, arc_buf_t *buf,
 	rw_exit(&dn->dn_struct_rwlock);
 	DB_DNODE_EXIT(dbuf);
 
-	if (offset == db->db.db_offset && blksz == db->db.db_size) {
+	/*
+	 * We can only assign if the offset is aligned, the arc buf is the
+	 * same size as the dbuf, and the dbuf is not metadata.  It
+	 * can't be metadata because the loaned arc buf comes from the
+	 * user-data kmem area.
+	 */
+	if (offset == db->db.db_offset && blksz == db->db.db_size &&
+	    DBUF_GET_BUFC_TYPE(db) == ARC_BUFC_DATA) {
 		dbuf_assign_arcbuf(db, buf, tx);
 		dbuf_rele(db, FTAG);
 	} else {


### PR DESCRIPTION
5162 zfs recv should use loaned arc buffer to avoid copy
Reviewed by: George Wilson george.wilson@delphix.com\
Reviewed by: Christopher Siden christopher.siden@delphix.com\

Original author: Matthew Ahrens

References:
  https://www.illumos.org/issues/5162
  https://reviews.csiden.org/r/96/

Ported by: Turbo Fredriksson turbo@bayour.com
