### PR TITLE
Illumos 5174 - add sdt probe for blocked read in dbuf_read()

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -726,6 +726,8 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 			    db->db_state == DB_FILL) {
 				ASSERT(db->db_state == DB_READ ||
 				    (flags & DB_RF_HAVESTRUCT) == 0);
+				DTRACE_PROBE2(blocked__read, dmu_buf_impl_t *,
+				    db, zio_t *, zio);
 				cv_wait(&db->db_changed, &db->db_mtx);
 			}
 			if (db->db_state == DB_UNCACHED)


### PR DESCRIPTION
5174 add sdt probe for blocked read in dbuf_read()
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Basil Crow basil.crow@delphix.com

References:
  https://www.illumos.org/issues/5174
  https://reviews.csiden.org/r/101/

Ported by: Turbo Fredriksson turbo@bayour.com
