### PR TITLE
Illumos 5178 - zdb -vvvvv on old-format pool fails in dump_deadlist()

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1448,6 +1448,11 @@ dump_deadlist(dsl_deadlist_t *dl)
 	if (dump_opt['d'] < 3)
 		return;
 
+	if (dl->dl_oldfmt) {
+		dump_bpobj(&dl->dl_bpobj, "old-format deadlist", 0);
+		return;
+	}
+
 	zdb_nicenum(dl->dl_phys->dl_used, bytes);
 	zdb_nicenum(dl->dl_phys->dl_comp, comp);
 	zdb_nicenum(dl->dl_phys->dl_uncomp, uncomp);


### PR DESCRIPTION
5178 zdb -vvvvv on old-format pool fails in dump_deadlist()
Reviewed by: Christopher Siden christopher.siden@delphix.com
Reviewed by: George Wilson george.wilson@delphix.com

References:
  https://www.illumos.org/issues/5178
  https://reviews.csiden.org/r/105/

Ported by: Turbo Fredriksson turbo@bayour.com
