### PR TITLE
Remove obsolete comment about guard pages

### DIFF
--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -168,12 +168,6 @@ zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
 	 * PTHREAD_STACK_MIN is the minimum stack required for a NULL
 	 * procedure in user space and is added in to the stack
 	 * requirements.
-	 *
-	 * Some buggy NPTL threading implementations include the
-	 * guard area within the stack size allocations.  In
-	 * this case we allocate an extra page to account for the
-	 * guard area since we only have two pages of usable stack
-	 * on Linux.
 	 */
 
 	stack = PTHREAD_STACK_MIN + MAX(stksize, STACK_SIZE) * 4;


### PR DESCRIPTION
Remove an obsolete comment that refers to code removed by commit
79c6e4c4. The code and comment related to space consumed by guard
pages in user-space stacks, which we no longer take into account.

Signed-off-by: Ned Bass bass6@llnl.gov
