### PR TITLE
Fix zed io-spare.sh dash incompatibility

### DIFF
--- a/cmd/zed/zed.d/io-spare.sh
+++ b/cmd/zed/zed.d/io-spare.sh
@@ -54,10 +54,11 @@ flock -x 8
 # Given a <pool> and <device> return the status, (ONLINE, FAULTED, etc...).
 vdev_status() {
 	local POOL=$1
-	local VDEV=`basename $2`
+	local VDEV=$2
+	local T='	'	# tab character since '\t' isn't portable
 
-	${ZPOOL} status ${POOL} | \
-	    awk -v pat="${VDEV}|${VDEV/-part?}" '$0 ~ pat { print $1" "$2 }'
+	${ZPOOL} status ${POOL} | sed -n -e \
+	    "s,^[ $T]*\(.*$VDEV\(-part[0-9]\+\)\?\)[ $T]*\([A-Z]\+\).*,\1 \3,p"
 	return 0
 }
 


### PR DESCRIPTION
The zed's io-spare.sh script defines a vdev_status() function to query
the 'zpool status' output for obtaining the status of a specified vdev.
This function contains a small awk script that uses a parameter
expansion (${parameter/pattern/string}) supported in bash but not
in dash.  Under dash, this fails with a "Bad substitution" error.

This commit replaces the awk script with a (hopefully more portable)
sed script that has been tested under both bash and dash.

Fixes #2536
