### PR TITLE
Replace zed's use of malloc with calloc

### DIFF
--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -51,11 +51,9 @@ zed_conf_create(void)
 {
 	struct zed_conf *zcp;
 
-	zcp = malloc(sizeof (*zcp));
+	zcp = calloc(1, sizeof (*zcp));
 	if (!zcp)
 		goto nomem;
-
-	memset(zcp, 0, sizeof (*zcp));
 
 	zcp->syslog_facility = LOG_DAEMON;
 	zcp->min_events = ZED_MIN_EVENTS;

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -61,7 +61,7 @@ _zed_exec_create_env(zed_strings_t *zsp)
 	for (q = zed_strings_first(zsp); q; q = zed_strings_next(zsp))
 		buflen += strlen(q) + 1;
 
-	buf = malloc(buflen);
+	buf = calloc(1, buflen);
 	if (!buf)
 		return (NULL);
 

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -82,11 +82,10 @@ zed_strings_create(void)
 {
 	zed_strings_t *zsp;
 
-	zsp = malloc(sizeof (*zsp));
+	zsp = calloc(1, sizeof (*zsp));
 	if (!zsp)
 		return (NULL);
 
-	memset(zsp, 0, sizeof (*zsp));
 	avl_create(&zsp->tree, _zed_strings_node_compare,
 	    sizeof (zed_strings_node_t), offsetof(zed_strings_node_t, node));
 
@@ -131,11 +130,10 @@ zed_strings_add(zed_strings_t *zsp, const char *s)
 		return (-1);
 	}
 	len = sizeof (zed_strings_node_t) + strlen(s) + 1;
-	np = malloc(len);
+	np = calloc(1, len);
 	if (!np)
 		return (-1);
 
-	memset(np, 0, len);
 	assert((char *) np->string + strlen(s) < (char *) np + len);
 	(void) strcpy(np->string, s);
 	avl_add(&zsp->tree, np);


### PR DESCRIPTION
When zed allocates memory via malloc(), it typically follows that with a memset().  However, calloc() implementations can often perform optimizations when zeroing memory:

https://stackoverflow.com/questions/2688466/why-mallocmemset-is-slower-than-calloc

This commit replaces zed's use of malloc() with calloc().

Since these memory allocations are typically quite small, switching to calloc() isn't currently expected to offer any noticeable performance improvement. But it's not inconceivable that MMAP_THRESHOLD could be reached as additional nvpairs are added to events over time.
