### PR TITLE
Make user stack limit configurable

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -208,11 +208,8 @@ extern void vpanic(const char *, va_list);
  */
 #define	TS_MAGIC		0x72f158ab4261e538ull
 #define	TS_RUN			0x00000002
-#ifdef __linux__
-#define	STACK_SIZE		8192	/* Linux x86 and amd64 */
-#else
-#define	STACK_SIZE		24576	/* Solaris */
-#endif
+#define	TS_STACK_MIN		PTHREAD_STACK_MIN
+#define	TS_STACK_MAX		(256 * 1024)
 
 /* in libzpool, p0 exists only to have its address taken */
 typedef struct proc {

--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -144,6 +144,22 @@ Maybe you'd like to run ztest for longer? To do so simply use the -T
 option and specify the runlength in seconds like so:
 .IP
 ztest -f / -V -T 120
+
+.SH "ENVIRONMENT VARIABLES"
+.TP
+.B "ZFS_STACK_SIZE=stacksize"
+Limit the default stack size to \fBstacksize\fR bytes for the purpose of
+detecting and debugging kernel stack overflows.  For x86_64 platforms this
+value should be set as follows to simulate these platforms: \fB8192\fR
+(Linux), \fB20480\fR (Illumos), \fB16384\fR (FreeBSD).
+
+In practice you may need to set these value slightly higher because
+differences in stack usage between kernel and user space can lead to spurious
+stack overflows (especially when debugging is enabled).  The specified value
+will be rounded up to a floor of PTHREAD_STACK_MIN which is the minimum stack
+required for a NULL procedure in user space.
+
+By default the stack size is limited to 256K.
 .SH "SEE ALSO"
 .BR "zpool (1)" ","
 .BR "zfs (1)" ","


### PR DESCRIPTION
To aid in detecting and debugging stack overflow issues make the
user space stack limit configurable via a new ZFS_STACK_SIZE
environment variable.  The value assigned to ZFS_STACK_SIZE will
be used as the default stack size in bytes.

Because this is mainly useful as a debugging aid in conjunction
with ztest the stack limit is disabled by default.  See the ztest(1)
man page for additional details on using the ZFS_STACK_SIZE
environment variable.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2293
