### PR TITLE
Improve VERIFY() error in dmu_write()

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -814,7 +814,7 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	if (size == 0)
 		return;
 
-	VERIFY(0 == dmu_buf_hold_array(os, object, offset, size,
+	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp));
 
 	for (i = 0; i < numbufs; i++) {


### PR DESCRIPTION
This is a debug patch designed to ensure an error code is logged
to the console when this VERIFY() is hit.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1440
