### PR TITLE
Amend Dracut module to export ZFS root on shutdown

### DIFF
--- a/dracut/90zfs/.gitignore
+++ b/dracut/90zfs/.gitignore
@@ -1,3 +1,4 @@
+export-zfs.sh
 module-setup.sh
 mount-zfs.sh
 parse-zfs.sh

--- a/dracut/90zfs/Makefile.am
+++ b/dracut/90zfs/Makefile.am
@@ -1,10 +1,12 @@
 pkgdracutdir = $(dracutdir)/modules.d/90zfs
 pkgdracut_SCRIPTS = \
+	$(top_srcdir)/dracut/90zfs/export-zfs.sh \
 	$(top_srcdir)/dracut/90zfs/module-setup.sh \
 	$(top_srcdir)/dracut/90zfs/mount-zfs.sh \
 	$(top_srcdir)/dracut/90zfs/parse-zfs.sh
 
 EXTRA_DIST = \
+	$(top_srcdir)/dracut/90zfs/export-zfs.sh.in \
 	$(top_srcdir)/dracut/90zfs/module-setup.sh.in \
 	$(top_srcdir)/dracut/90zfs/mount-zfs.sh.in \
 	$(top_srcdir)/dracut/90zfs/parse-zfs.sh.in

--- a/dracut/90zfs/export-zfs.sh.in
+++ b/dracut/90zfs/export-zfs.sh.in
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+_do_zpool_export() {
+	local ret=0
+	local final=$1
+	local force
+
+	if [ "x$final" != "x" ]; then
+		force="-f"
+	fi
+
+	info "Exporting ZFS storage pools"
+	zpool list -H | while read fs rest ; do
+		zpool export $force "$fs" || ret=$?
+	done
+
+	if [ "x$final" != "x" ]; then
+		info "zpool list"
+		zpool list 2>&1 | vinfo
+	fi
+
+	return $ret
+}
+
+if command -v zpool >/dev/null; then
+	_do_zpool_export $1
+else
+	:
+fi

--- a/dracut/90zfs/module-setup.sh.in
+++ b/dracut/90zfs/module-setup.sh.in
@@ -39,6 +39,7 @@ install() {
 	dracut_install hostid
 	inst_hook cmdline 95 "$moddir/parse-zfs.sh"
 	inst_hook mount 98 "$moddir/mount-zfs.sh"
+	inst_hook shutdown 30 "$moddir/export-zfs.sh"
 
 	if [ -e @sysconfdir@/zfs/zpool.cache ]; then
 		inst @sysconfdir@/zfs/zpool.cache

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -67,5 +67,7 @@ case "$root" in
 		else
 			mount -o zfsutil -t zfs "$zfsbootfs" "$NEWROOT" && ROOTFS_MOUNTED=yes
 		fi
+
+		need_shutdown
 		;;
 esac


### PR DESCRIPTION
Make use of Dracut's ability to restore the initramfs on shutdown and pivot to it, allowing for a clean unmount and export of the ZFS root. No need to force-import on every reboot anymore.
