### PR TITLE
Fix snapshots with dirty inodes

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -3993,6 +3993,9 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	int		error;
 	int		cnt = 0;
 
+	if (zfs_is_readonly(zsb) || dmu_objset_is_snapshot(zsb->z_os))
+		return (0);
+
 	ZFS_ENTER(zsb);
 	ZFS_VERIFY_ZP(zp);
 


### PR DESCRIPTION
Filesystems which are mounted read-only or are immutable because
they are snapshots must not be allowed to dirty and inode.  This
will result in a write which will correctly cause a kernel panic
because these filesystem are (and must be) immutable.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #2812
