### PR TITLE
bio_alloc() with __GFP_WAIT never returns NULL

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -26,7 +26,7 @@
  *
  * ZFS volume emulation driver.
  *
- * Makes a DMU object look like a volume of arbitrary size, up to 2^64 bytes.
+ * Makes a DMU objectset look like a volume of arbitrary size, up to 2^64 bytes.
  * Volumes are accessed through the symbolic links named:
  *
  * /dev/<pool_name>/<dataset_name>


### PR DESCRIPTION
So there's no need to check for NULL returns. Just ASSERT.

Signed-off-by: Isaac Huang he.huang@intel.com
Issue #2703
