### PR TITLE
Fix modules installation directory

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -43,7 +43,8 @@ modules_install:
 	@# Install the kernel modules
 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` $@ \
 		INSTALL_MOD_PATH=$(DESTDIR)$(INSTALL_MOD_PATH) \
-		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR)
+		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
+		KERNELRELEASE=@LINUX_VERSION@
 	@# Remove extraneous build products when packaging
 	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
 	if [ -n $$kmoddir ]; then \


### PR DESCRIPTION
While building zfs modules with kernel, compiled from deb.src, packaging process ends up installing modules in the wrong place. It installs them into
/tmp/zfs-build-builduser-zbZBpB9A/BUILDROOT/zfs-kmod-0.6.3-125_g88904bb.x86_64/lib/modules/3.16.5/
but debian (and packaging process) is looking for them in /lib/modules/3.16-3-amd64. So, packaging fails with
Processing files: kmod-zfs-3.16-3-amd64-0.6.3-125_g88904bb.x86_64
error: Directory not found: /tmp/zfs-build-builduser-zbZBpB9A/BUILDROOT/zfs-kmod-0.6.3-125_g88904bb.x86_64/lib/modules/3.16-3-amd64/extra
error: Directory not found: /tmp/zfs-build-builduser-zbZBpB9A/BUILDROOT/zfs-kmod-0.6.3-125_g88904bb.x86_64/lib/modules/3.16-3-amd64/extra/zfs
