### PR TITLE
Reduce mutex contention

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -233,7 +233,7 @@ typedef struct dmu_buf_impl {
 } dmu_buf_impl_t;
 
 /* Note: the dbuf hash table is exposed only for the mdb module */
-#define	DBUF_MUTEXES 256
+#define	DBUF_MUTEXES 8192
 #define	DBUF_HASH_MUTEX(h, idx) (&(h)->hash_mutexes[(idx) & (DBUF_MUTEXES-1)])
 typedef struct dbuf_hash_table {
 	uint64_t hash_table_mask;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -657,7 +657,7 @@ struct ht_lock {
 #endif
 };
 
-#define	BUF_LOCKS 256
+#define	BUF_LOCKS 8192
 typedef struct buf_hash_table {
 	uint64_t ht_mask;
 	arc_buf_hdr_t **ht_table;


### PR DESCRIPTION
Due to evidence of contention both the buf_hash_table and the
dbuf_hash_table sizes have been increased from 256 to 8192.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #1291
