### PR TITLE
Undirty removed spill blocks.

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -869,13 +869,16 @@ dbuf_free_range(dnode_t *dn, uint64_t start, uint64_t end, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db, *db_next;
 	uint64_t txg = tx->tx_txg;
+	boolean_t freespill =
+	    (start == DMU_SPILL_BLKID || end == DMU_SPILL_BLKID);
 
-	if (end > dn->dn_maxblkid && (end != DMU_SPILL_BLKID))
+	if (end > dn->dn_maxblkid && !freespill)
 		end = dn->dn_maxblkid;
 	dprintf_dnode(dn, "start=%llu end=%llu\n", start, end);
 
 	mutex_enter(&dn->dn_dbufs_mtx);
-	if (start >= dn->dn_unlisted_l0_blkid * dn->dn_datablksz) {
+	if (start >= dn->dn_unlisted_l0_blkid * dn->dn_datablksz &&
+	    !freespill) {
 		/* There can't be any dbufs in this range; no need to search. */
 		mutex_exit(&dn->dn_dbufs_mtx);
 		return;
@@ -896,7 +899,7 @@ dbuf_free_range(dnode_t *dn, uint64_t start, uint64_t end, dmu_tx_t *tx)
 
 		if (db->db_level != 0)
 			continue;
-		if (db->db_blkid < start || db->db_blkid > end)
+		if ((db->db_blkid < start || db->db_blkid > end) && !freespill)
 			continue;
 
 		/* found a level 0 buffer in the range */


### PR DESCRIPTION
If a spill block's dbuf hasn't yet been written when a the spill block
is removed, the unwritten version will still be written.  This patch
undirties the dbuf in this case to prevent it to be written.

The most common case in which this could happen is when xattr=sa is being
used and a long xattr is immediately replaced by a short xattr as in:

```
setfattr -n user.test -v very_very_very..._long_value  <file>
setfattr -n user.test -v short_value  <file>
```

The first value must be sufficiently long that a spill block is generated
and the second value must be short enough to not require a spill block.
In practice, this would typically happen due to internal xattr operations
as a result of setting acltype=posixacl.
