### PR TITLE
Fix systemd config for zfs-share.service

### DIFF
--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -2,6 +2,8 @@
 Description=ZFS file system shares
 After=nfs-server.service
 After=smb.service
+After=zfs-mount.service
+Requires=zfs-mount.service
 PartOf=nfs-server.service
 PartOf=smb.service
 


### PR DESCRIPTION
The zfs-share.service rule needs to be modified to ensure that it
does not execute before zfs-mount.service.
