### PR TITLE
Explicitly include SPL compat headers

### DIFF
--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -26,14 +26,15 @@
 #define	_SYS_ZPL_H
 
 #include <sys/vfs.h>
-#include <linux/vfs_compat.h>
-#include <linux/xattr_compat.h>
+#include <linux/aio.h>
 #include <linux/dcache_compat.h>
 #include <linux/exportfs.h>
-#include <linux/writeback.h>
 #include <linux/falloc.h>
+#include <linux/file_compat.h>
 #include <linux/task_io_accounting_ops.h>
-#include <linux/aio.h>
+#include <linux/vfs_compat.h>
+#include <linux/writeback.h>
+#include <linux/xattr_compat.h>
 
 /* zpl_inode.c */
 extern void zpl_vap_init(vattr_t *vap, struct inode *dir,

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -1030,6 +1030,7 @@ done:
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+#include <linux/module_compat.h>
 
 static int avl_init(void) { return 0; }
 static int avl_fini(void) { return 0; }

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -3293,6 +3293,7 @@ nvs_xdr(nvstream_t *nvs, nvlist_t *nvl, char *buf, size_t *buflen)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+#include <linux/module_compat.h>
 
 static int nvpair_init(void) { return 0; }
 static int nvpair_fini(void) { return 0; }

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -2133,6 +2133,7 @@ u8_textprep_str(char *inarray, size_t *inlen, char *outarray, size_t *outlen,
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+#include <linux/module_compat.h>
 
 static int unicode_init(void) { return 0; }
 static int unicode_fini(void) { return 0; }

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -678,6 +678,7 @@ zfs_prop_align_right(zfs_prop_t prop)
 #endif
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+#include <linux/module_compat.h>
 
 static int zcommon_init(void) { return 0; }
 static int zcommon_fini(void) { return 0; }

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -140,6 +140,7 @@
 #include <vm/anon.h>
 #include <sys/fs/swapnode.h>
 #include <sys/zpl.h>
+#include <linux/mm_compat.h>
 #endif
 #include <sys/callb.h>
 #include <sys/kstat.h>

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -186,6 +186,7 @@
 #include <sys/zfeature.h>
 
 #include <linux/miscdevice.h>
+#include <linux/module_compat.h>
 
 #include "zfs_namecheck.h"
 #include "zfs_prop.h"

--- a/module/zpios/pios.c
+++ b/module/zpios/pios.c
@@ -36,6 +36,7 @@
 #include <sys/txg.h>
 #include <sys/dsl_destroy.h>
 #include <linux/miscdevice.h>
+#include <linux/module_compat.h>
 #include "zpios-internal.h"
 
 


### PR DESCRIPTION
Inclusion of SPL compatibility headers was moved out of the public
header sys/types.h to avoid conflicts with external packages.  Include a
few compatiblity headers explicitly to cope with that change.  Also,
sort some linux-specific inclusions alphabetically.

Signed-off-by: Ned Bass bass6@llnl.gov
