### PR TITLE
Improve systemd script to not leave stale sharetab

### DIFF
--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -10,4 +10,5 @@ PartOf=smb.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=-@bindir@/rm /etc/dfs/sharetab
 ExecStart=@sbindir@/zfs share -a


### PR DESCRIPTION
The systemd script zfs-share.service does 'zfs share -a' to share
any required datasets.  Unfortunately, /etc/dfs/sharetab is stale
from the previous boot.  Delete it before we share.

Signed-off-by: Dan Swartzendruber dswartz@druber.com
