### PR TITLE
Zpool upgrade returns error messages to stdout instead of stderr

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -4685,7 +4685,7 @@ upgrade_version(zpool_handle_t *zhp, uint64_t version)
 		return (ret);
 
 	if (unsupp_fs) {
-		(void) printf(gettext("Upgrade not performed due to %d "
+		(void) fprintf(stderr, gettext("Upgrade not performed due to %d "
 		    "unsupported filesystems (max v%d).\n"),
 		    unsupp_fs, (int) ZPL_VERSION);
 		return (1);
@@ -4900,7 +4900,7 @@ upgrade_one(zpool_handle_t *zhp, void *data)
 	int ret;
 
 	if (strcmp("log", zpool_get_name(zhp)) == 0) {
-		(void) printf(gettext("'log' is now a reserved word\n"
+		(void) fprintf(stderr, gettext("'log' is now a reserved word\n"
 		    "Pool 'log' must be renamed using export and import"
 		    " to upgrade.\n"));
 		return (1);


### PR DESCRIPTION
Zpool upgrade returns error messages to stdout instead of stderr:
1. In function:

``` C
static int
upgrade_version(zpool_handle_t *zhp, uint64_t version)
```

Following code currently returns error message to stdout:

``` C
    if (unsupp_fs) {
        (void) printf(gettext("Upgrade not performed due to %d "
            "unsupported filesystems (max v%d).\n"),
            unsupp_fs, (int) ZPL_VERSION);
        return (1);
    }
```

Also in function:

``` C
static int
upgrade_one(zpool_handle_t *zhp, void *data)
```

Following code currently returns error message to stdout:

``` C
    if (strcmp("log", zpool_get_name(zhp)) == 0) {
        (void) printf(gettext("'log' is now a reserved word\n"
            "Pool 'log' must be renamed using export and import"
            " to upgrade.\n"));
        return (1);
    }
```

We can take a simple test (note: log is my pool name):
1. Redirect stdout to /dev/null

``` shell
zpool upgrade log 1> /dev/null
```
1. Redirect stderr to /dev/null

``` shell
zpool upgrade log 2> /dev/null
This system supports ZFS pool feature flags.

'log' is now a reserved word
Pool 'log' must be renamed using export and import to upgrade.
```
