### PR TITLE
vdev_id: use mawk-compatible regular expression

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -116,7 +116,7 @@ map_slot() {
 	local MAPPED_SLOT=
 
 	MAPPED_SLOT=`awk "\\$1 == \"slot\" && \\$2 == ${LINUX_SLOT} && \
-			\\$4 ~ /^(${CHANNEL}|)$/ { print \\$3; exit }" $CONFIG`
+			\\$4 ~ /^${CHANNEL}$|^$/ { print \\$3; exit }" $CONFIG`
 	if [ -z "$MAPPED_SLOT" ] ; then
 		MAPPED_SLOT=$LINUX_SLOT
 	fi


### PR DESCRIPTION
Slot mapping in vdev_id doesn't work on systems using mawk as the 'awk'
alternative. A regular expression in map_slot() contains an unquoted
empty string following the alternation (|) operator, which results in an
"missing operand" error with mawk. The solution is to rearrange the
expression so the alternation has two operands.

Issue zfsonlinux/pkg-zfs#136
Issue zfsonlinux/zfs#2965

Signed-off-by: Ned Bass bass6@llnl.gov
