### PR TITLE
[WIP] Add pool prop `partition` to disable auto partition

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -300,6 +300,7 @@ const char *zpool_prop_to_name(zpool_prop_t);
 const char *zpool_prop_default_string(zpool_prop_t);
 uint64_t zpool_prop_default_numeric(zpool_prop_t);
 boolean_t zpool_prop_readonly(zpool_prop_t);
+boolean_t zpool_prop_setonce(zpool_prop_t);
 boolean_t zpool_prop_feature(const char *);
 boolean_t zpool_prop_unsupported(const char *);
 int zpool_prop_index_to_string(zpool_prop_t, uint64_t, const char **);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -224,6 +224,7 @@ typedef enum {
 	ZPOOL_PROP_TNAME,
 	ZPOOL_PROP_MAXDNODESIZE,
 	ZPOOL_PROP_MULTIHOST,
+	ZPOOL_PROP_PARTITION,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -857,6 +858,11 @@ typedef enum zpool_errata {
 	ZPOOL_ERRATA_ZOL_2094_SCRUB,
 	ZPOOL_ERRATA_ZOL_2094_ASYNC_DESTROY,
 } zpool_errata_t;
+
+enum zpool_part {
+	ZPOOL_PARTITION_LEGACY = 0,
+	ZPOOL_PARTITION_RAW,
+};
 
 /*
  * Vdev statistics.  Note: all fields should be 64-bit because this

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -512,6 +512,14 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			goto error;
 		}
 
+		if (!flags.create && zpool_prop_setonce(prop)) {
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "property '%s' can only be set at "
+			    "creation time"), propname);
+			(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
+			goto error;
+		}
+
 		if (zprop_parse_value(hdl, elem, prop, ZFS_TYPE_POOL, retprops,
 		    &strval, &intval, errbuf) != 0)
 			goto error;
@@ -664,15 +672,6 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "property '%s' can only be set at "
 				    "import time"), propname);
-				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
-				goto error;
-			}
-			break;
-		case ZPOOL_PROP_TNAME:
-			if (!flags.create) {
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set at "
-				    "creation time"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1216,10 +1216,10 @@ zfs_resolve_shortname(const char *name, char *path, size_t len)
  * is done by checking all prefix expansions using either the default
  * 'zpool_default_import_paths' or the ZPOOL_IMPORT_PATH environment
  * variable.  Proper partition suffixes will be appended if this is a
- * whole disk.  When a match is found 0 is returned otherwise ENOENT.
+ * legacy whole disk.  When a match is found 0 is returned otherwise ENOENT.
  */
 static int
-zfs_strcmp_shortname(char *name, char *cmp_name, int wholedisk)
+zfs_strcmp_shortname(char *name, char *cmp_name, int append)
 {
 	int path_len, cmp_len, i = 0, error = ENOENT;
 	char *dir, *env, *envdup = NULL;
@@ -1241,7 +1241,7 @@ zfs_strcmp_shortname(char *name, char *cmp_name, int wholedisk)
 			dir[strlen(dir)-1] = '\0';
 
 		path_len = snprintf(path_name, MAXPATHLEN, "%s/%s", dir, name);
-		if (wholedisk)
+		if (append)
 			path_len = zfs_append_partition(path_name, MAXPATHLEN);
 
 		if ((path_len == cmp_len) && strcmp(path_name, cmp_name) == 0) {
@@ -1270,7 +1270,7 @@ zfs_strcmp_shortname(char *name, char *cmp_name, int wholedisk)
  * purposes and redundant slashes stripped to ensure an accurate match.
  */
 int
-zfs_strcmp_pathname(char *name, char *cmp, int wholedisk)
+zfs_strcmp_pathname(char *name, char *cmp, int append)
 {
 	int path_len, cmp_len;
 	char path_name[MAXPATHLEN];
@@ -1289,13 +1289,13 @@ zfs_strcmp_pathname(char *name, char *cmp, int wholedisk)
 	free(dup);
 
 	if (name[0] != '/')
-		return (zfs_strcmp_shortname(name, cmp_name, wholedisk));
+		return (zfs_strcmp_shortname(name, cmp_name, append));
 
 	(void) strlcpy(path_name, name, MAXPATHLEN);
 	path_len = strlen(path_name);
 	cmp_len = strlen(cmp_name);
 
-	if (wholedisk) {
+	if (append) {
 		path_len = zfs_append_partition(path_name, MAXPATHLEN);
 		if (path_len == -1)
 			return (ENOMEM);

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -181,6 +181,12 @@ zpool_prop_readonly(zpool_prop_t prop)
 	return (zpool_prop_table[prop].pd_attr == PROP_READONLY);
 }
 
+boolean_t
+zpool_prop_setonce(zpool_prop_t prop)
+{
+	return (zpool_prop_table[prop].pd_attr == PROP_ONETIME);
+}
+
 const char *
 zpool_prop_default_string(zpool_prop_t prop)
 {

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -64,6 +64,12 @@ zpool_prop_init(void)
 		{ NULL }
 	};
 
+	static zprop_index_t part_table[] = {
+		{ "legacy",	ZPOOL_PARTITION_LEGACY },
+		{ "raw",	ZPOOL_PARTITION_RAW },
+		{ NULL }
+	};
+
 	/* string properties */
 	zprop_register_string(ZPOOL_PROP_ALTROOT, "altroot", NULL, PROP_DEFAULT,
 	    ZFS_TYPE_POOL, "<path>", "ALTROOT");
@@ -128,6 +134,10 @@ zpool_prop_init(void)
 	zprop_register_index(ZPOOL_PROP_FAILUREMODE, "failmode",
 	    ZIO_FAILURE_MODE_WAIT, PROP_DEFAULT, ZFS_TYPE_POOL,
 	    "wait | continue | panic", "FAILMODE", failuremode_table);
+	zprop_register_index(ZPOOL_PROP_PARTITION, "partition",
+	    ZPOOL_PARTITION_LEGACY, PROP_ONETIME, ZFS_TYPE_POOL,
+	    "legacy | raw", "PART", part_table);
+
 
 	/* hidden properties */
 	zprop_register_hidden(ZPOOL_PROP_NAME, "name", PROP_TYPE_STRING,


### PR DESCRIPTION
### Description

zfsonlinux always partition disk when it detects the device given is a
whole disk. This legacy behavior from Illumos, however, has no apparent
benefit on Linux, but has some down sides besides confusion. E.g.
autoexpand, switching to dm device requires partprobe.

We add a pool property `partition` to be set during pool create. It
currently has two values, legacy and raw. When setting it to legacy, it
will behave as it did. When setiing it to raw, it will always use the
device as is without partitioning even if it's a whole disk.

This property applies to all commands that add disks to pool, so zpool
add/attach/replace will partition or not partition based on the property
on the target pool.
    
A pool without this property will be treated as legacy. Newly created
pool will by default have partition=legacy.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>

### Note

I use PROP_ONETIME for the property, but it seems that this is not enforced at all, so you can still modify it after the fact. But you shouldn't change it after the fact, as it would cause device name appending wrong.