### PR TITLE
Implement zfs scrub for individual dataset

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5923,7 +5923,7 @@ scrub_callback(zpool_handle_t *zhp, void *data)
 		return (1);
 	}
 
-	err = zpool_scan(zhp, cb->cb_type, cb->cb_scrub_cmd);
+	err = zpool_scan(zhp, NULL, cb->cb_type, cb->cb_scrub_cmd, 0);
 
 	return (err != 0);
 }
@@ -5983,7 +5983,7 @@ zpool_do_scrub(int argc, char **argv)
  * Print out detailed scrub status.
  */
 void
-print_scan_status(pool_scan_stat_t *ps)
+print_scan_status(pool_scan_stat_t *ps, char *dsname)
 {
 	time_t start, end, pause;
 	uint64_t total_secs_left;
@@ -6063,6 +6063,16 @@ print_scan_status(pool_scan_stat_t *ps)
 	} else if (ps->pss_func == POOL_SCAN_RESILVER) {
 		(void) printf(gettext("resilver in progress since %s"),
 		    ctime(&start));
+	}
+
+	/* If this is a dataset scan, print current dataset name. */
+	if (ps->pss_dataset_scrub) {
+		if (dsname != NULL) {
+			(void) printf(gettext("\tcurrently scanning '%s'\n"),
+			    dsname);
+		} else {
+			(void) printf(gettext("\tfinishing dataset scrub\n"));
+		}
 	}
 
 	scanned = ps->pss_examined;
@@ -6546,10 +6556,13 @@ status_callback(zpool_handle_t *zhp, void *data)
 		nvlist_t **spares, **l2cache;
 		uint_t nspares, nl2cache;
 		pool_scan_stat_t *ps = NULL;
+		char *dsname = NULL;
 
 		(void) nvlist_lookup_uint64_array(nvroot,
 		    ZPOOL_CONFIG_SCAN_STATS, (uint64_t **)&ps, &c);
-		print_scan_status(ps);
+		(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_SCAN_DSNAME,
+		    &dsname);
+		print_scan_status(ps, dsname);
 
 		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
 		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID);

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -5804,9 +5804,9 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 {
 	spa_t *spa = ztest_spa;
 
-	(void) spa_scan(spa, POOL_SCAN_SCRUB);
+	(void) spa_scan(spa, POOL_SCAN_SCRUB, NULL, 0);
 	(void) poll(NULL, 0, 100); /* wait a moment, then force a restart */
-	(void) spa_scan(spa, POOL_SCAN_SCRUB);
+	(void) spa_scan(spa, POOL_SCAN_SCRUB, NULL, 0);
 }
 
 /*
@@ -6172,7 +6172,7 @@ ztest_spa_import_export(char *oldname, char *newname)
 	 * Kick off a scrub to tickle scrub/export races.
 	 */
 	if (ztest_random(2) == 0)
-		(void) spa_scan(spa, POOL_SCAN_SCRUB);
+		(void) spa_scan(spa, POOL_SCAN_SCRUB, NULL, 0);
 
 	pool_guid = spa_guid(spa);
 	spa_close(spa, FTAG);

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zfs_rename/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_reservation/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_rollback/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zfs_scrub/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_set/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_share/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -264,7 +264,8 @@ typedef struct splitflags {
 /*
  * Functions to manipulate pool and vdev state
  */
-extern int zpool_scan(zpool_handle_t *, pool_scan_func_t, pool_scrub_cmd_t);
+extern int zpool_scan(zpool_handle_t *zhp, zfs_handle_t *zfshp,
+    pool_scan_func_t func, pool_scrub_cmd_t cmd, pool_scan_flags_t flags);
 extern int zpool_clear(zpool_handle_t *, const char *, nvlist_t *);
 extern int zpool_reguid(zpool_handle_t *);
 extern int zpool_reopen_one(zpool_handle_t *, void *);

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -70,8 +70,9 @@ typedef struct dsl_scan_phys {
 #define	SCAN_PHYS_NUMINTS (sizeof (dsl_scan_phys_t) / sizeof (uint64_t))
 
 typedef enum dsl_scan_flags {
-	DSF_VISIT_DS_AGAIN = 1<<0,
-	DSF_SCRUB_PAUSED = 1<<1,
+	DSF_VISIT_DS_AGAIN =	1ULL << 0,
+	DSF_SCRUB_PAUSED =	1ULL << 1,
+	DSF_SCRUB_DATASET =	1ULL << 2,
 } dsl_scan_flags_t;
 
 #define	DSL_SCAN_FLAGS_MASK (DSF_VISIT_DS_AGAIN)
@@ -162,7 +163,8 @@ int dsl_scan_init(struct dsl_pool *dp, uint64_t txg);
 void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
 int dsl_scan_cancel(struct dsl_pool *);
-int dsl_scan(struct dsl_pool *, pool_scan_func_t);
+int dsl_scan(struct dsl_pool *, pool_scan_func_t, char *dsname,
+    pool_scan_flags_t flags);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
 int dsl_scrub_set_pause_resume(const struct dsl_pool *dp, pool_scrub_cmd_t cmd);
 void dsl_resilver_restart(struct dsl_pool *, uint64_t txg);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -609,6 +609,7 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_ASIZE		"asize"
 #define	ZPOOL_CONFIG_DTL		"DTL"
 #define	ZPOOL_CONFIG_SCAN_STATS		"scan_stats"	/* not stored on disk */
+#define	ZPOOL_CONFIG_SCAN_DSNAME	"scan_dsname"	/* not stored on disk */
 #define	ZPOOL_CONFIG_VDEV_STATS		"vdev_stats"	/* not stored on disk */
 
 /* container nvlist of extended stats */
@@ -825,6 +826,14 @@ typedef enum mmp_state {
 } mmp_state_t;
 
 /*
+ * Scan Flags.
+ */
+typedef enum pool_scan_flags {
+	POOL_SCAN_FLAG_DATASET =	1ULL << 0,
+	POOL_SCAN_FLAG_RECURSIVE =	1ULL << 1,
+} pool_scan_flags_t;
+
+/*
  * Scan Functions.
  */
 typedef enum pool_scan_func {
@@ -881,6 +890,7 @@ typedef struct pool_scan_stat {
 	uint64_t	pss_pass_scrub_spent_paused;
 	uint64_t	pss_pass_issued; /* issued bytes per scan pass */
 	uint64_t	pss_issued;	/* total bytes checked by scanner */
+	uint64_t	pss_dataset_scrub; /* dataset scrub */
 } pool_scan_stat_t;
 
 typedef enum dsl_scan_state {

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -786,7 +786,8 @@ extern void spa_l2cache_activate(vdev_t *vd);
 extern void spa_l2cache_drop(spa_t *spa);
 
 /* scanning */
-extern int spa_scan(spa_t *spa, pool_scan_func_t func);
+extern int spa_scan(spa_t *spa, pool_scan_func_t func, char *dsname,
+    pool_scan_flags_t flags);
 extern int spa_scan_stop(spa_t *spa);
 extern int spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t flag);
 

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -199,6 +199,7 @@ struct spa {
 	uint64_t	spa_scan_pass_scrub_spent_paused; /* total paused */
 	uint64_t	spa_scan_pass_exam;	/* examined bytes per pass */
 	uint64_t	spa_scan_pass_issued;	/* issued bytes per pass */
+	uint64_t	spa_scan_cur_ds_obj;	/* current dataset scanning */
 	kmutex_t	spa_async_lock;		/* protect async state */
 	kthread_t	*spa_async_thread;	/* thread doing async task */
 	int		spa_async_suspended;	/* async tasks suspended */

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1976,16 +1976,29 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
  * Scan the pool.
  */
 int
-zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func, pool_scrub_cmd_t cmd)
+zpool_scan(zpool_handle_t *zhp, zfs_handle_t *zfshp, pool_scan_func_t func,
+    pool_scrub_cmd_t cmd, pool_scan_flags_t flags)
 {
 	zfs_cmd_t zc = {"\0"};
 	char msg[1024];
 	int err;
-	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	libzfs_handle_t *hdl;
+	char *name;
 
-	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	if (zfshp != NULL) {
+		zhp = zfshp->zpool_hdl;
+		name = zfshp->zfs_name;
+		assert(flags & POOL_SCAN_FLAG_DATASET);
+	} else {
+		name = zhp->zpool_name;
+	}
+
+	hdl = zhp->zpool_hdl;
+
+	(void) strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
 	zc.zc_cookie = func;
 	zc.zc_flags = cmd;
+	zc.zc_guid = flags;
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_SCAN, &zc) == 0)
 		return (0);

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -326,6 +326,10 @@
 .Fl i
 .Op Fl l
 .Ar filesystem
+.Nm
+.Cm scrub
+.Op Fl r
+.Ar snapshot Ns | Ns Ar filesystem Ns | Ns Ar volume
 .Sh DESCRIPTION
 The
 .Nm
@@ -4432,6 +4436,21 @@ Indicates that zfs should make
 .Ar filesystem
 inherit the key of its parent. Note that this command can only be run on an
 encryption root that has an encrypted parent.
+.El
+.It Xo
+.Nm
+.Cm scrub
+.Op Fl r
+.Ar snapshot Ns | Ns Ar filesystem Ns | Ns Ar volume
+.Xc
+Begins a scrub on a given dataset. This is similar to the
+.Nm zpool Cm scrub
+command, but it will only verify the requested dataset.
+.Bl -tag -width "-o"
+.It Fl r
+Recursively scan datasets under
+.Ar filesystem .
+This can only be used with filesystem arguments.
 .El
 .El
 .Sh EXIT STATUS

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6013,7 +6013,8 @@ spa_scan_stop(spa_t *spa)
 }
 
 int
-spa_scan(spa_t *spa, pool_scan_func_t func)
+spa_scan(spa_t *spa, pool_scan_func_t func, char *dsname,
+    pool_scan_flags_t flags)
 {
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
 
@@ -6030,7 +6031,7 @@ spa_scan(spa_t *spa, pool_scan_func_t func)
 		return (0);
 	}
 
-	return (dsl_scan(spa->spa_dsl_pool, func));
+	return (dsl_scan(spa->spa_dsl_pool, func, dsname, flags));
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2097,6 +2097,7 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 	ps->pss_pass_issued = spa->spa_scan_pass_issued;
 	ps->pss_issued =
 	    scn->scn_issued_before_pass + spa->spa_scan_pass_issued;
+	ps->pss_dataset_scrub = !!(scn->scn_phys.scn_flags & DSF_SCRUB_DATASET);
 
 	return (0);
 }

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -459,6 +459,25 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 
 		/* provide either current or previous scan information */
 		if (spa_scan_get_stats(spa, &ps) == 0) {
+			int err;
+			dsl_dataset_t *ds;
+			dsl_pool_t *dp = spa_get_dsl(spa);
+			dsl_scan_phys_t *scn_phys = &dp->dp_scan->scn_phys;
+			char dsname[ZFS_MAX_DATASET_NAME_LEN];
+
+			if (scn_phys->scn_flags & DSF_SCRUB_DATASET) {
+				dsl_pool_config_enter(dp, FTAG);
+				err = dsl_dataset_hold_obj(dp,
+				    spa->spa_scan_cur_ds_obj,
+				    FTAG, &ds);
+				if (err == 0) {
+					dsl_dataset_name(ds, dsname);
+					dsl_dataset_rele(ds, FTAG);
+					fnvlist_add_string(nv,
+					    ZPOOL_CONFIG_SCAN_DSNAME, dsname);
+				}
+				dsl_pool_config_exit(dp, FTAG);
+			}
 			fnvlist_add_uint64_array(nv,
 			    ZPOOL_CONFIG_SCAN_STATS, (uint64_t *)&ps,
 			    sizeof (pool_scan_stat_t) / sizeof (uint64_t));

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1738,12 +1738,14 @@ zfs_ioc_pool_scan(zfs_cmd_t *zc)
 	if (zc->zc_flags >= POOL_SCRUB_FLAGS_END)
 		return (SET_ERROR(EINVAL));
 
-	if (zc->zc_flags == POOL_SCRUB_PAUSE)
+	if (zc->zc_flags == POOL_SCRUB_PAUSE) {
 		error = spa_scrub_pause_resume(spa, POOL_SCRUB_PAUSE);
-	else if (zc->zc_cookie == POOL_SCAN_NONE)
+	} else if (zc->zc_cookie == POOL_SCAN_NONE) {
 		error = spa_scan_stop(spa);
-	else
-		error = spa_scan(spa, zc->zc_cookie);
+	} else {
+		error = spa_scan(spa, zc->zc_cookie, zc->zc_name,
+		    zc->zc_guid);
+	}
 
 	spa_close(spa, FTAG);
 
@@ -6404,8 +6406,6 @@ zfs_ioctl_init(void)
 
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_CREATE, zfs_ioc_pool_create,
 	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_NONE);
-	zfs_ioctl_register_pool_modify(ZFS_IOC_POOL_SCAN,
-	    zfs_ioc_pool_scan);
 	zfs_ioctl_register_pool_modify(ZFS_IOC_POOL_UPGRADE,
 	    zfs_ioc_pool_upgrade);
 	zfs_ioctl_register_pool_modify(ZFS_IOC_VDEV_ADD,
@@ -6516,6 +6516,8 @@ zfs_ioctl_init(void)
 	    zfs_ioc_inherit_prop, zfs_secpolicy_inherit_prop);
 	zfs_ioctl_register_dataset_modify(ZFS_IOC_SET_FSACL, zfs_ioc_set_fsacl,
 	    zfs_secpolicy_set_fsacl);
+	zfs_ioctl_register_dataset_modify(ZFS_IOC_POOL_SCAN,
+	    zfs_ioc_pool_scan, zfs_secpolicy_config);
 
 	zfs_ioctl_register_dataset_nolog(ZFS_IOC_SHARE, zfs_ioc_share,
 	    zfs_secpolicy_share, POOL_CHECK_NONE);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2008,6 +2008,25 @@ function wait_vdev_state # pool disk state timeout
 }
 
 #
+# Compare the expected amount to scrub to the scrub total
+# from zpool status.
+#
+function is_dataset_scrubbing #pool #amount <verbose>
+{
+	typeset pool=$1
+	typeset verbose=${3:-false}
+
+	scan=$(zpool status "$pool" 2>/dev/null | grep "scanned" \
+		| awk '{print $9}')
+	if [[ $verbose == true ]]; then
+		log_note "expecting dataset scrub total $2 got $scan"
+	fi
+
+	echo $scan |grep "$2" > /dev/null 2>&1
+	return $?
+}
+
+#
 # Check the output of 'zpool status -v <pool>',
 # and to see if the content of <token> contain the <keyword> specified.
 #
@@ -2039,6 +2058,7 @@ function check_pool_status # pool token keyword <verbose>
 #	is_pool_scrub_stopped - to check if the pool is scrub stopped
 #	is_pool_scrub_paused - to check if the pool has scrub paused
 #
+
 function is_pool_resilvering #pool <verbose>
 {
 	check_pool_status "$1" "scan" "resilver in progress since " $2

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -22,6 +22,7 @@ SUBDIRS = \
 	zfs_rename \
 	zfs_reservation \
 	zfs_rollback \
+	zfs_scrub \
 	zfs_send \
 	zfs_set \
 	zfs_share \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/Makefile.am
@@ -1,0 +1,7 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_scrub
+dist_pkgdata_SCRIPTS = \
+	zfs_scrub.cfg \
+	setup.ksh \
+	cleanup.ksh \
+	zfs_scrub_001_neg.ksh \
+	zfs_scrub_002_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/cleanup.ksh
@@ -1,0 +1,33 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+verify_runnable "global"
+
+log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
+destroy_mirrors

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/setup.ksh
@@ -1,0 +1,43 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_scrub/zfs_scrub.cfg
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+default_mirror_setup_noexit $DISK1 $DISK2
+
+log_must zfs create $TESTPOOL/$TESTFS2
+
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+log_must file_write -b 1048576 -c 256 -o create -d 0 -f $mntpnt/bigfile
+
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS2)
+log_must file_write -b 1048576 -c 512 -o create -d 0 -f $mntpnt/bigfile
+
+log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub.cfg
@@ -1,0 +1,30 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+export DISK1=${DISKS%% *}
+export DISK2=$(echo $DISKS | awk '{print $2}')
+
+export ZFS_SCAN_VDEV_LIMIT_SLOW=$((128*1024))
+export ZFS_SCAN_VDEV_LIMIT_DEFAULT=$((4*1024*1024))

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub_001_neg.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# A badly formed parameter passed to 'zfs scrub' should
+# return an error.
+#
+# STRATEGY:
+# 1. Create an array containing bad 'zfs scrub' parameters.
+# 2. For each element, execute the sub-command.
+# 3. Verify it returns an error.
+#
+
+verify_runnable "global"
+
+set -A args "" "-?" "blah blah" "-%" "--?" "-*" "-=" \
+    "-a" "-b" "-c" "-d" "-e" "-f" "-g" "-h" "-i" "-j" "-k" "-l" \
+    "-m" "-n" "-o" "-p" "-q" "-s" "-t" "-u" "-v" "-w" "-x" "-y" "-z" \
+    "-A" "-B" "-C" "-D" "-E" "-F" "-G" "-H" "-I" "-J" "-K" "-L" \
+    "-M" "-N" "-O" "-P" "-Q" "-R" "-S" "-T" "-U" "-V" "-W" "-X" "-W" "-Z"
+
+
+log_assert "Execute 'zfs scrub' using invalid parameters."
+
+typeset -i i=0
+while [[ $i -lt ${#args[*]} ]]; do
+	log_mustnot zfs scrub ${args[i]}
+
+	((i = i + 1))
+done
+
+log_pass "Badly formed 'zfs scrub' parameters fail as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_scrub/zfs_scrub_002_pos.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify scrub shows the right status.
+#
+# STRATEGY:
+#	1. Create pool and create 2 filesystems in it.
+#	2. Write 256M to testfs1 and 512M to testfs2.
+#	3. zfs scrub testfs2 and verify it's doing a dataset scrub.
+#	4. Verify zpool scrub -s succeeds when the dataset is scrubbing.
+#
+# NOTES:
+#	A 10ms delay is added to the ZIOs in order to ensure that the
+#	scrub does not complete before it has a chance to be cancelled.
+#	This can occur when testing with small pools or very fast hardware.
+#
+#	We expect zpool status to report 512M scrubbing, which matches the
+#	bytes in testfs2.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+}
+
+log_onexit cleanup
+
+log_assert "Verify scrub and scrub -s show the right status."
+
+log_must zinject -d $DISK1 -D20:1 $TESTPOOL
+log_must zfs scrub $TESTPOOL/$TESTFS2
+log_must is_dataset_scrubbing $TESTPOOL "512M" true
+log_must zpool scrub -s $TESTPOOL
+log_must is_pool_scrub_stopped $TESTPOOL true
+
+log_pass "Verified scrub and -s show expected status."


### PR DESCRIPTION
Co-authored-by: Tom Caputi <tcaputi@datto.com>
Co-authored-by: Rebecca Mahany <rmahany@datto.com>
Co-authored-by: Paul Zuchowski <pzuchowski@datto.com>
Signed-off-by: Tom Caputi <tcaputi@datto.com>
Signed-off-by: Rebecca Mahany <rmahany@datto.com>
Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>


### Description
In a large pool with many datasets, it may be advantageous to scrub a single dataset containing important data. Use most of the existing scrub code but initiate it via the zfs command instead of the zpool command.

### Motivation and Context
With many datasets in a pool, Datto requires the ability to tell the owner of a given dataset that their data has been scrubbed.  With zpool scrub that can't be said until the entire pool is scrubbed.

### How Has This Been Tested?
Verified through zpool status output that only the requested dataset is scrubbed. Developed zfstests to exercise the new command and verify outputs.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
