### PR TITLE
Expose the number of hole blocks in a file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,10 +161,12 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/cmd/file_check/Makefile
 	tests/zfs-tests/cmd/file_trunc/Makefile
 	tests/zfs-tests/cmd/file_write/Makefile
+	tests/zfs-tests/cmd/getholes/Makefile
 	tests/zfs-tests/cmd/largest_file/Makefile
 	tests/zfs-tests/cmd/mkbusy/Makefile
 	tests/zfs-tests/cmd/mkfile/Makefile
 	tests/zfs-tests/cmd/mkfiles/Makefile
+	tests/zfs-tests/cmd/mkholes/Makefile
 	tests/zfs-tests/cmd/mktree/Makefile
 	tests/zfs-tests/cmd/mmap_exec/Makefile
 	tests/zfs-tests/cmd/mmap_libaio/Makefile
@@ -269,6 +271,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/grow_pool/Makefile
 	tests/zfs-tests/tests/functional/grow_replicas/Makefile
 	tests/zfs-tests/tests/functional/history/Makefile
+	tests/zfs-tests/tests/functional/holes/Makefile
 	tests/zfs-tests/tests/functional/hkdf/Makefile
 	tests/zfs-tests/tests/functional/inheritance/Makefile
 	tests/zfs-tests/tests/functional/inuse/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -899,6 +899,7 @@ extern int zfs_device_get_physical(struct udev_device *, char *, size_t);
 #endif
 
 extern int zfs_remap_indirects(libzfs_handle_t *hdl, const char *);
+extern int zfs_get_hole_count(const char *, uint64_t *, uint64_t *);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -1027,6 +1027,15 @@ int dmu_offset_next(objset_t *os, uint64_t object, boolean_t hole,
     uint64_t *off);
 
 /*
+ * Check if a DMU object has any dirty blocks. If so, sync out
+ * all pending transaction groups. Otherwise, this function
+ * does not alter DMU state. This could be improved to only sync
+ * out the necessary transaction groups for this particular
+ * object.
+ */
+int dmu_object_wait_synced(objset_t *os, uint64_t object);
+
+/*
  * Initial setup and final teardown.
  */
 extern void dmu_init(void);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1166,10 +1166,11 @@ typedef enum zfs_ioc {
  */
 #define	BLKZNAME		_IOR(0x12, 125, char[ZFS_MAX_DATASET_NAME_LEN])
 
+#define	ZFS_IOCTL_MAGIC 'Z'
 /*
  * zpl ioctl to get number of filled blocks
  */
-#define	ZFS_IOC_COUNT_FILLED	_IOR('f', 100, uint64_t)
+#define	ZFS_IOC_COUNT_FILLED	_IOR(ZFS_IOCTL_MAGIC, 100, uint64_t)
 
 /*
  * Internal SPA load state.  Used by FMA diagnosis engine.

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1167,6 +1167,11 @@ typedef enum zfs_ioc {
 #define	BLKZNAME		_IOR(0x12, 125, char[ZFS_MAX_DATASET_NAME_LEN])
 
 /*
+ * zpl ioctl to get number of filled blocks
+ */
+#define	ZFS_IOC_COUNT_FILLED	_IOR('f', 100, uint64_t)
+
+/*
  * Internal SPA load state.  Used by FMA diagnosis engine.
  */
 typedef enum {

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -74,6 +74,7 @@ extern int zfs_getsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
     cred_t *cr);
 extern int zfs_setsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
     cred_t *cr);
+int zfs_count_filled(struct inode *ip, uint64_t *fill_count);
 extern int zfs_getpage(struct inode *ip, struct page *pl[], int nr_pages);
 extern int zfs_putpage(struct inode *ip, struct page *pp,
     struct writeback_control *wbc);

--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -39,6 +39,8 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 
 #ifdef  __cplusplus
 extern "C" {

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -2178,3 +2178,50 @@ zprop_iter(zprop_func func, void *cb, boolean_t show_all, boolean_t ordered,
 {
 	return (zprop_iter_common(func, cb, show_all, ordered, type));
 }
+
+/*
+ * zfs_get_hole_count retrieves the number of holes (blocks which are
+ * zero-filled) in the specified file using the ZFS_IOC_COUNT_FILLED ioctl. It
+ * also optionally fetches the block size when bs is non-NULL. With hole count
+ * and block size the full space consumed by the holes of a file can be
+ * calculated.
+ *
+ * On success, zero is returned, the count argument is set to the
+ * number of holes, and the bs argument is set to the block size (if it is
+ * not NULL). On error, a non-zero errno is returned and the values in count
+ * and bs are undefined.
+ */
+int
+zfs_get_hole_count(const char *path, uint64_t *count, uint64_t *bs)
+{
+	int fd, err;
+	struct stat64 ss;
+	uint64_t fill;
+
+	fd = open(path, O_RDONLY);
+	if (fd == -1)
+		return (errno);
+
+	if (ioctl(fd, ZFS_IOC_COUNT_FILLED, &fill) == -1) {
+		err = errno;
+		(void) close(fd);
+		return (err);
+	}
+
+	if (fstat64(fd, &ss) == -1) {
+		err = errno;
+		(void) close(fd);
+		return (err);
+	}
+
+	*count = (ss.st_size + ss.st_blksize - 1) / ss.st_blksize - fill;
+	VERIFY3S(*count, >=, 0);
+	if (bs != NULL) {
+		*bs = ss.st_blksize;
+	}
+
+	if (close(fd) == -1) {
+		return (errno);
+	}
+	return (0);
+}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -2181,15 +2181,15 @@ zprop_iter(zprop_func func, void *cb, boolean_t show_all, boolean_t ordered,
 
 /*
  * zfs_get_hole_count retrieves the number of holes (blocks which are
- * zero-filled) in the specified file using the ZFS_IOC_COUNT_FILLED ioctl. It
- * also optionally fetches the block size when bs is non-NULL. With hole count
- * and block size the full space consumed by the holes of a file can be
+ * zero-filled) in the specified file using the ZFS_IOC_COUNT_FILLED ioctl.
+ * It also optionally fetches the block size when bs is non-NULL. With hole
+ * count and block size the full space consumed by the holes of a file can be
  * calculated.
  *
- * On success, zero is returned, the count argument is set to the
- * number of holes, and the bs argument is set to the block size (if it is
- * not NULL). On error, a non-zero errno is returned and the values in count
- * and bs are undefined.
+ * On success, zero is returned, the count argument is set to the number of
+ * unallocated blocks (holes), and the bs argument is set to the block size
+ * (if it is not NULL). On error, a non-zero errno is returned and the values
+ * in count and bs are undefined.
  */
 int
 zfs_get_hole_count(const char *path, uint64_t *count, uint64_t *bs)
@@ -2212,6 +2212,11 @@ zfs_get_hole_count(const char *path, uint64_t *count, uint64_t *bs)
 		err = errno;
 		(void) close(fd);
 		return (err);
+	}
+
+	if (ss.st_blksize == 0) {
+		(void) close(fd);
+		return (EINVAL);
 	}
 
 	*count = (ss.st_size + ss.st_blksize - 1) / ss.st_blksize - fill;

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2364,9 +2364,8 @@ dmu_object_wait_synced(objset_t *os, uint64_t object)
 	int error, i;
 
 	error = dnode_hold(os, object, FTAG, &dn);
-	if (error) {
+	if (error)
 		return (error);
-	}
 
 	for (i = 0; i < TXG_SIZE; i++) {
 		if (list_link_active(&dn->dn_dirty_link[i])) {
@@ -2374,9 +2373,8 @@ dmu_object_wait_synced(objset_t *os, uint64_t object)
 		}
 	}
 	dnode_rele(dn, FTAG);
-	if (i != TXG_SIZE) {
+	if (i != TXG_SIZE)
 		txg_wait_synced(dmu_objset_pool(os), 0);
-	}
 
 	return (0);
 }

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2350,6 +2350,37 @@ __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 		doi->doi_fill_count += BP_GET_FILL(&dnp->dn_blkptr[i]);
 }
 
+/*
+ * Give the ZFS object, if it contains any dirty nodes
+ * this function flushes all dirty blocks to disk. This
+ * ensures the DMU object info is updated. A more efficient
+ * future version might just find the TXG with the maximum
+ * ID and wait for that to be synced.
+ */
+int
+dmu_object_wait_synced(objset_t *os, uint64_t object)
+{
+	dnode_t *dn;
+	int error, i;
+
+	error = dnode_hold(os, object, FTAG, &dn);
+	if (error) {
+		return (error);
+	}
+
+	for (i = 0; i < TXG_SIZE; i++) {
+		if (list_link_active(&dn->dn_dirty_link[i])) {
+			break;
+		}
+	}
+	dnode_rele(dn, FTAG);
+	if (i != TXG_SIZE) {
+		txg_wait_synced(dmu_objset_pool(os), 0);
+	}
+
+	return (0);
+}
+
 void
 dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 {

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2351,11 +2351,9 @@ __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 }
 
 /*
- * Give the ZFS object, if it contains any dirty nodes
- * this function flushes all dirty blocks to disk. This
- * ensures the DMU object info is updated. A more efficient
- * future version might just find the TXG with the maximum
- * ID and wait for that to be synced.
+ * If the given object is dirty, flush all dirty blocks to disk. This ensures
+ * the DMU object info is updated. A more efficient future version might just
+ * find the TXG with the maximum ID and wait for that to be synced.
  */
 int
 dmu_object_wait_synced(objset_t *os, uint64_t object)

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -890,6 +890,38 @@ zpl_ioctl_setxattr(struct file *filp, void __user *arg)
 }
 
 static long
+zpl_ioctl_count_filled(struct file *filep, void __user *arg)
+{
+	struct inode *ip = file_inode(filep);
+	znode_t *zp = ITOZ(ip);
+	zfsvfs_t *zfsvfs = ITOZSB(ip);
+	uint64_t ndata;
+	int error;
+	dmu_object_info_t doi;
+
+	ZFS_ENTER(zfsvfs);
+	ZFS_VERIFY_ZP(zp);
+
+	error = -dmu_object_wait_synced(zfsvfs->z_os, zp->z_id);
+	if (error != 0) {
+		ZFS_EXIT(zfsvfs);
+		return (error);
+	}
+
+	error = -dmu_object_info(zfsvfs->z_os, zp->z_id, &doi);
+	if (error != 0) {
+		ZFS_EXIT(zfsvfs);
+		return (error);
+	}
+
+	ndata = doi.doi_fill_count;
+	error = copy_to_user(arg, &ndata, sizeof (ndata));
+	ZFS_EXIT(zfsvfs);
+	return (error);
+
+}
+
+static long
 zpl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	switch (cmd) {
@@ -901,6 +933,8 @@ zpl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		return (zpl_ioctl_getxattr(filp, (void *)arg));
 	case ZFS_IOC_FSSETXATTR:
 		return (zpl_ioctl_setxattr(filp, (void *)arg));
+	case ZFS_IOC_COUNT_FILLED:
+		return (zpl_ioctl_count_filled(filp, (void *)arg));
 	default:
 		return (-ENOTTY);
 	}

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -893,32 +893,15 @@ static long
 zpl_ioctl_count_filled(struct file *filep, void __user *arg)
 {
 	struct inode *ip = file_inode(filep);
-	znode_t *zp = ITOZ(ip);
-	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	uint64_t ndata;
 	int error;
-	dmu_object_info_t doi;
 
-	ZFS_ENTER(zfsvfs);
-	ZFS_VERIFY_ZP(zp);
-
-	error = -dmu_object_wait_synced(zfsvfs->z_os, zp->z_id);
-	if (error != 0) {
-		ZFS_EXIT(zfsvfs);
-		return (error);
+	error = -zfs_count_filled(ip, &ndata);
+	if (error == 0) {
+		error = copy_to_user(arg, &ndata, sizeof (ndata));
 	}
 
-	error = -dmu_object_info(zfsvfs->z_os, zp->z_id, &doi);
-	if (error != 0) {
-		ZFS_EXIT(zfsvfs);
-		return (error);
-	}
-
-	ndata = doi.doi_fill_count;
-	error = copy_to_user(arg, &ndata, sizeof (ndata));
-	ZFS_EXIT(zfsvfs);
 	return (error);
-
 }
 
 static long

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -563,6 +563,10 @@ tags = ['functional', 'history']
 tests = ['run_hkdf_test']
 tags = ['functional', 'hkdf']
 
+[tests/functional/holes]
+tests = ['holes_sanity']
+tags = ['functional', 'holes']
+
 [tests/functional/inheritance]
 tests = ['inherit_001_pos']
 pre =

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -8,10 +8,12 @@ SUBDIRS = \
 	file_check \
 	file_trunc \
 	file_write \
+	getholes \
 	largest_file \
 	mkbusy \
 	mkfile \
 	mkfiles \
+	mkholes \
 	mktree \
 	mmap_exec \
 	mmap_libaio \

--- a/tests/zfs-tests/cmd/getholes/Makefile.am
+++ b/tests/zfs-tests/cmd/getholes/Makefile.am
@@ -1,0 +1,13 @@
+include $(top_srcdir)/config/Rules.am
+
+pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/bin
+
+DEFAULT_INCLUDES += \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/lib/libspl/include
+
+pkgexec_PROGRAMS = getholes
+getholes_SOURCES = getholes.c
+getholes_LDADD = \
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libspl/libspl.la

--- a/tests/zfs-tests/cmd/getholes/getholes.c
+++ b/tests/zfs-tests/cmd/getholes/getholes.c
@@ -1,0 +1,209 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+#include "../file_common.h"
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <libzfs.h>
+#include <umem.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/list.h>
+#include <sys/stat.h>
+
+#define	PRINT_HOLE 0x1
+#define	PRINT_DATA 0x2
+#define	PRINT_VERBOSE 0x4
+
+static void
+usage(char *msg, int exit_value)
+{
+	(void) fprintf(stderr, "getholes [-dhv] filename\n");
+	(void) fprintf(stderr, "%s\n", msg);
+	exit(exit_value);
+}
+
+typedef struct segment {
+	list_node_t	seg_node;
+	int		seg_type;
+	off_t		seg_offset;
+	off_t		seg_len;
+} seg_t;
+
+/*
+ * Return an appropriate whence value, depending on whether the file begins
+ * with a holes or data.
+ */
+static int
+starts_with_hole(int fd)
+{
+	off_t	off;
+
+	if ((off = lseek(fd, 0, SEEK_HOLE)) == -1) {
+		/* ENXIO means no holes were found */
+		if (errno == ENXIO)
+			return (SEEK_DATA);
+		perror("lseek failed");
+		exit(1);
+	}
+
+	return (off == 0 ? SEEK_HOLE : SEEK_DATA);
+}
+
+static void
+print_list(list_t *seg_list, char *fname, int options)
+{
+	uint64_t	lz_holes, bs = 0;
+	uint64_t	hole_blks_seen = 0, data_blks_seen = 0;
+	seg_t		*seg;
+
+	if (zfs_get_hole_count(fname, &lz_holes, &bs) != 0) {
+		perror("zfs_get_hole_count");
+		exit(1);
+	}
+
+	while ((seg = list_remove_head(seg_list)) != NULL) {
+		if (options & PRINT_VERBOSE)
+			(void) fprintf(stdout, "%c %llu:%llu\n",
+			    seg->seg_type == SEEK_HOLE ? 'h' : 'd',
+			    (long long)seg->seg_offset,
+			    (long long)seg->seg_len);
+
+		if (seg->seg_type == SEEK_HOLE) {
+			hole_blks_seen += seg->seg_len / bs;
+		} else {
+			data_blks_seen += seg->seg_len / bs;
+		}
+		umem_free(seg, sizeof (seg_t));
+	}
+
+	/* Verify libzfs sees the same number of hole blocks found manually. */
+	if (lz_holes != hole_blks_seen) {
+		(void) fprintf(stderr, "Counted %llu holes, but libzfs found "
+		    "%llu\n",
+		    (long long)hole_blks_seen,
+		    (long long)lz_holes);
+		exit(1);
+	}
+
+	if (options & PRINT_HOLE && options & PRINT_DATA) {
+		(void) fprintf(stdout, "datablks: %llu\n",
+		    (long long)data_blks_seen);
+		(void) fprintf(stdout, "holeblks: %llu\n",
+		    (long long)hole_blks_seen);
+		return;
+	}
+
+	if (options & PRINT_DATA)
+		(void) fprintf(stdout, "%llu\n", (long long)data_blks_seen);
+	if (options & PRINT_HOLE)
+		(void) fprintf(stdout, "%llu\n", (long long)hole_blks_seen);
+}
+
+int
+main(int argc, char *argv[])
+{
+	off_t		len, off = 0;
+	int		c, fd, options = 0, whence = SEEK_DATA;
+	struct stat	statbuf;
+	char		*fname;
+	list_t		seg_list;
+	seg_t		*seg = NULL;
+
+	list_create(&seg_list, sizeof (seg_t), offsetof(seg_t, seg_node));
+
+	while ((c = getopt(argc, argv, "dhv")) != -1) {
+		switch (c) {
+		case 'd':
+			options |= PRINT_DATA;
+			break;
+		case 'h':
+			options |= PRINT_HOLE;
+			break;
+		case 'v':
+			options |= PRINT_VERBOSE;
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1)
+		usage("Incorrect number of arguments.", 1);
+
+	if ((fname = argv[0]) == NULL)
+		usage("No filename provided.", 1);
+
+	if ((fd = open(fname, O_LARGEFILE | O_RDONLY)) < 0) {
+		perror("open failed");
+		exit(1);
+	}
+
+	if (fstat(fd, &statbuf) != 0) {
+		perror("fstat failed");
+		exit(1);
+	}
+	len = statbuf.st_size;
+
+	/*
+	 * Note: on Linux, SEEK_HOLE/DATA doesn't work right by default.
+	 * Specifically, if the object is dirty, it says that there are no
+	 * holes.  We can work around this by forcing a txg to sync.
+	 * Another workaround would be to set the zfs_dmu_offset_next_sync
+	 * module parameter.
+	 */
+	if (system("zpool sync") != 0) {
+		perror("zpool sync failed");
+		exit(1);
+	}
+
+	whence = starts_with_hole(fd);
+	while ((off = lseek(fd, off, whence)) != -1) {
+		seg_t	*s;
+
+		seg = umem_alloc(sizeof (seg_t), UMEM_DEFAULT);
+		seg->seg_type = whence;
+		seg->seg_offset = off;
+
+		list_insert_tail(&seg_list, seg);
+		if ((s = list_prev(&seg_list, seg)) != NULL)
+			s->seg_len = seg->seg_offset - s->seg_offset;
+
+		whence = whence == SEEK_HOLE ? SEEK_DATA : SEEK_HOLE;
+	}
+	if (errno != ENXIO) {
+		perror("lseek failed");
+		exit(1);
+	}
+	(void) close(fd);
+
+	/*
+	 * If this file ends with a hole block, then populate the length of
+	 * the last segment, otherwise this is the end of the file, so
+	 * discard the remaining zero length segment.
+	 */
+	if (seg && seg->seg_offset != len) {
+		seg->seg_len = len - seg->seg_offset;
+	} else {
+		(void) list_remove_tail(&seg_list);
+	}
+
+	print_list(&seg_list, fname, options);
+	list_destroy(&seg_list);
+	return (0);
+}

--- a/tests/zfs-tests/cmd/getholes/getholes.c
+++ b/tests/zfs-tests/cmd/getholes/getholes.c
@@ -36,7 +36,7 @@
 static void
 usage(char *msg, int exit_value)
 {
-	(void) fprintf(stderr, "getholes [-dhv] filename\n");
+	(void) fprintf(stderr, "getholes [-dhnv] filename\n");
 	(void) fprintf(stderr, "%s\n", msg);
 	exit(exit_value);
 }
@@ -75,10 +75,18 @@ print_list(list_t *seg_list, char *fname, int options)
 	uint64_t	hole_blks_seen = 0, data_blks_seen = 0;
 	seg_t		*seg;
 
-	if (!(options & NO_VERIFY) &&
-	    zfs_get_hole_count(fname, &lz_holes, &bs) != 0) {
-		perror("zfs_get_hole_count");
-		exit(1);
+	if (options & NO_VERIFY) {
+		struct stat ss;
+		if (stat(fname, &ss) != 0) {
+			perror("stat");
+			exit(1);
+		}
+		bs = ss.st_blksize;
+	} else {
+		if (zfs_get_hole_count(fname, &lz_holes, &bs) != 0) {
+			perror("zfs_get_hole_count");
+			exit(1);
+		}
 	}
 
 	while ((seg = list_remove_head(seg_list)) != NULL) {
@@ -220,7 +228,7 @@ int
 main(int argc, char *argv[])
 {
 	fprintf(stderr,
-	    "error: SEEK_DATA / SEEK_HOLE not supported by this kernel\n");
+	    "error: SEEK_DATA / SEEK_HOLE not supported\n");
 	return (1);
 }
 #endif

--- a/tests/zfs-tests/cmd/getholes/getholes.c
+++ b/tests/zfs-tests/cmd/getholes/getholes.c
@@ -30,6 +30,8 @@
 #define	PRINT_DATA 0x2
 #define	PRINT_VERBOSE 0x4
 
+#ifdef SEEK_HOLE
+
 static void
 usage(char *msg, int exit_value)
 {
@@ -207,3 +209,13 @@ main(int argc, char *argv[])
 	list_destroy(&seg_list);
 	return (0);
 }
+
+#else
+int
+main(int argc, char *argv[])
+{
+	fprintf(stderr,
+	    "error: SEEK_DATA / SEEK_HOLE not supported by this kernel\n");
+	return (1);
+}
+#endif

--- a/tests/zfs-tests/cmd/mkholes/Makefile.am
+++ b/tests/zfs-tests/cmd/mkholes/Makefile.am
@@ -1,0 +1,11 @@
+include $(top_srcdir)/config/Rules.am
+
+pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/bin
+
+DEFAULT_INCLUDES += \
+	-I$(top_srcdir)/lib/libspl/include
+
+pkgexec_PROGRAMS = mkholes
+mkholes_SOURCES = mkholes.c
+mkholes_LDADD = \
+	$(top_builddir)/lib/libspl/libspl.la

--- a/tests/zfs-tests/cmd/mkholes/mkholes.c
+++ b/tests/zfs-tests/cmd/mkholes/mkholes.c
@@ -1,0 +1,232 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2018 by Delphix. All rights reserved.
+ */
+
+#include "../file_common.h"
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <umem.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/list.h>
+
+typedef enum {
+	SEG_HOLE,
+	SEG_DATA,
+	SEG_TYPES
+} seg_type_t;
+
+typedef struct segment {
+	list_node_t	seg_node;
+	seg_type_t	seg_type;
+	off_t		seg_offset;
+	off_t		seg_len;
+} seg_t;
+
+static int
+no_memory(void)
+{
+	(void) fprintf(stderr, "malloc failed\n");
+	return (0);
+}
+
+static void
+usage(char *msg, int exit_value)
+{
+	(void) fprintf(stderr, "mkholes [-d|h offset:length] ... filename\n");
+	(void) fprintf(stderr, "%s\n", msg);
+	exit(exit_value);
+}
+
+static char *
+get_random_buffer(size_t len)
+{
+	int	rand_fd;
+	char	*buf;
+
+	buf = umem_alloc(len, UMEM_NOFAIL);
+
+	/*
+	 * Fill the buffer from /dev/urandom to counteract the
+	 * effects of compression.
+	 */
+	if ((rand_fd = open("/dev/urandom", O_RDONLY)) < 0) {
+		perror("open /dev/urandom failed");
+		exit(1);
+	}
+
+	if (read(rand_fd, buf, len) < 0) {
+		perror("read /dev/urandom failed");
+		exit(1);
+	}
+
+	(void) close(rand_fd);
+
+	return (buf);
+}
+
+static void
+push_segment(list_t *seg_list, seg_type_t seg_type, char *optarg)
+{
+	char		*off_str, *len_str;
+	static off_t	file_size = 0;
+	off_t		off, len;
+	seg_t		*seg;
+
+	off_str = strtok(optarg, ":");
+	len_str = strtok(NULL, ":");
+
+	if (off_str == NULL || len_str == NULL)
+		usage("Bad offset or length", 1);
+
+	off = strtoull(off_str, NULL, 0);
+	len = strtoull(len_str, NULL, 0);
+
+	if (file_size >= off + len)
+		usage("Ranges must ascend and may not overlap.", 1);
+	file_size = off + len;
+
+	seg = umem_alloc(sizeof (seg_t), UMEM_NOFAIL);
+	seg->seg_type = seg_type;
+	seg->seg_offset = off;
+	seg->seg_len = len;
+
+	list_insert_tail(seg_list, seg);
+}
+
+static void
+freesp(int fd, off_t off, off_t len)
+{
+#if defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE)
+	struct stat ss;
+	if (fstat(fd, &ss) < 0) {
+		perror("fstat");
+		exit(1);
+	}
+	if (off + len > ss.st_size) {
+		if (ftruncate(fd, off + len) < 0) {
+			perror("ftruncate");
+			exit(1);
+		}
+	}
+	if (fallocate(fd,
+	    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+	    off, len) < 0) {
+		perror("fallocate");
+		exit(1);
+	}
+#else /* !(defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE)) */
+	fprintf(stderr, "FALLOC_FL_PUNCH_HOLE unsupported");
+	exit(1);
+#endif /* defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE) */
+}
+
+int
+main(int argc, char *argv[])
+{
+	int	c, fd;
+	char	*fname;
+	list_t	seg_list;
+	seg_t	*seg;
+
+	umem_nofail_callback(no_memory);
+	list_create(&seg_list, sizeof (seg_t), offsetof(seg_t, seg_node));
+
+	while ((c = getopt(argc, argv, "d:h:")) != -1) {
+		switch (c) {
+		case 'd':
+			push_segment(&seg_list, SEG_DATA, optarg);
+			break;
+		case 'h':
+			push_segment(&seg_list, SEG_HOLE, optarg);
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if ((fname = argv[0]) == NULL)
+		usage("No filename specified", 1);
+	fname = argv[0];
+
+	if ((fd = open(fname, O_LARGEFILE | O_RDWR | O_CREAT | O_SYNC,
+	    00666)) < 0) {
+		perror("open failed");
+		exit(1);
+	}
+
+	while ((seg = list_remove_head(&seg_list)) != NULL) {
+		char	*buf, *vbuf;
+		off_t	off = seg->seg_offset;
+		off_t	len = seg->seg_len;
+
+		if (seg->seg_type == SEG_HOLE) {
+			off_t bytes_read = 0;
+			ssize_t readlen = 1024 * 1024 * 16;
+
+			freesp(fd, off, len);
+
+			buf = (char *)umem_alloc(readlen, UMEM_NOFAIL);
+			vbuf = (char *)umem_zalloc(readlen, UMEM_NOFAIL);
+			while (bytes_read < len) {
+				ssize_t bytes = pread(fd, buf, readlen, off);
+				if (bytes <= 0) {
+					perror("pread hole failed");
+					exit(1);
+				}
+
+				if (memcmp(buf, vbuf, bytes) != 0) {
+					(void) fprintf(stderr, "Read back hole "
+					    "didn't match.\n");
+					exit(1);
+				}
+				bytes_read += bytes;
+				off += bytes;
+			}
+
+			umem_free(buf, readlen);
+			umem_free(vbuf, readlen);
+			umem_free(seg, sizeof (seg_t));
+		} else if (seg->seg_type == SEG_DATA) {
+			buf = get_random_buffer(len);
+			vbuf = (char *)umem_alloc(len, UMEM_NOFAIL);
+			if ((pwrite(fd, buf, len, off)) < 0) {
+				perror("pwrite failed");
+				exit(1);
+			}
+
+			if ((pread(fd, vbuf, len, off)) != len) {
+				perror("pread failed");
+				exit(1);
+			}
+
+			if (memcmp(buf, vbuf, len) != 0) {
+				(void) fprintf(stderr, "Read back buf didn't "
+				    "match.\n");
+				exit(1);
+			}
+
+			umem_free(buf, len);
+			umem_free(vbuf, len);
+			umem_free(seg, sizeof (seg_t));
+		}
+	}
+
+	(void) close(fd);
+	return (0);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -158,10 +158,12 @@ export ZFSTEST_FILES='chg_usr_exec
     file_check
     file_trunc
     file_write
+    getholes
     largest_file
     mkbusy
     mkfile
     mkfiles
+    mkholes
     mktree
     mmap_exec
     mmap_libaio

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -25,6 +25,7 @@ SUBDIRS = \
 	grow_pool \
 	grow_replicas \
 	history \
+	holes \
 	hkdf \
 	inheritance \
 	inuse \

--- a/tests/zfs-tests/tests/functional/holes/Makefile.am
+++ b/tests/zfs-tests/tests/functional/holes/Makefile.am
@@ -1,0 +1,8 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/holes
+dist_pkgdata_SCRIPTS = \
+	setup.ksh \
+	cleanup.ksh \
+	holes_sanity.ksh
+
+dist_pkgdata_DATA = \
+	holes.shlib

--- a/tests/zfs-tests/tests/functional/holes/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/holes/cleanup.ksh
@@ -1,0 +1,20 @@
+#!/usr/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/holes/holes.shlib
+++ b/tests/zfs-tests/tests/functional/holes/holes.shlib
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+#
+
+# testfile The file to examine.
+# hole_blks The expected number of holes.
+# data_blks The expected number of data blocks.
+function verify_holes_and_data_blocks
+{
+	typeset testfile=$1
+	typeset -i hole_blks=$2
+	typeset -i data_blks=$3
+	typeset -i failures=0
+
+	found_hole_blks=$(getholes -h $testfile)
+	found_data_blks=$(getholes -d $testfile)
+	if [[ $found_hole_blks -ne $hole_blks ]] then;
+		log_note "Found $found_hole_blks, not $hole_blks hole blocks."
+		((failures++))
+	fi
+
+	if [[ $found_data_blks -ne $data_blks ]] then;
+		log_note "Found $found_data_blks, not $data_blks data blocks."
+		((failures++))
+	fi
+
+	[[ $failures -eq 0 ]] || log_fail "Wrong number of data/hole blocks."
+}

--- a/tests/zfs-tests/tests/functional/holes/holes_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/holes/holes_sanity.ksh
@@ -1,0 +1,85 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+#
+
+#
+# Description:
+# Verify that holes can be written and read back correctly in ZFS.
+#
+# Strategy:
+# 1. Create a testfile with varying holes and data throughout the file.
+# 2. Verify that each created file has the correct number of holes and
+# data blocks as seen by both lseek and libzfs.
+# 3. Do the same verification for a largefile.
+# 4. Repeat for each recsize.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/holes/holes.shlib
+
+verify_runnable "both"
+testfile="$TESTDIR/testfile"
+
+for bs in 1024 4096 16384 65536 262144; do
+	log_must zfs set recsize=$bs $TESTPOOL/$TESTFS
+
+	#
+	# Create combinations of holes and data to verify holes ending files
+	# and the like. (hhh, hhd, hdh...)
+	#
+	log_must mkholes -h 0:$((bs * 6)) $testfile
+	verify_holes_and_data_blocks $testfile 6 0
+	log_must rm $testfile
+
+	log_must mkholes -h 0:$((bs * 4)) -d $((bs * 4)):$((bs * 2)) $testfile
+	verify_holes_and_data_blocks $testfile 4 2
+	log_must rm $testfile
+
+	log_must mkholes -h 0:$((bs * 2)) -d $((bs * 2)):$((bs * 2)) \
+	    -h $((bs * 4)):$((bs * 2)) $testfile
+	verify_holes_and_data_blocks $testfile 4 2
+	log_must rm $testfile
+
+	log_must mkholes -h 0:$((bs * 2)) -d $((bs * 2)):$((bs * 4)) $testfile
+	verify_holes_and_data_blocks $testfile 2 4
+	log_must rm $testfile
+
+	log_must mkholes -d 0:$((bs * 2)) -h $((bs * 2)):$((bs * 4)) $testfile
+	verify_holes_and_data_blocks $testfile 4 2
+	log_must rm $testfile
+
+	log_must mkholes -d 0:$((bs * 2)) -h $((bs * 2)):$((bs * 2)) \
+	    -d $((bs * 4)):$((bs * 2)) $testfile
+	verify_holes_and_data_blocks $testfile 2 4
+	log_must rm $testfile
+
+	log_must mkholes -d 0:$((bs * 4)) -h $((bs * 4)):$((bs * 2)) $testfile
+	verify_holes_and_data_blocks $testfile 2 4
+	log_must rm $testfile
+
+	log_must mkholes -d 0:$((bs * 6)) $testfile
+	verify_holes_and_data_blocks $testfile 0 6
+	log_must rm $testfile
+
+	# Verify holes are correctly seen past the largefile limit.
+	len=$((1024**3 * 5))
+	nblks=$((len / bs))
+	log_must mkholes -h 0:$len -d $len:$bs $testfile
+	verify_holes_and_data_blocks $testfile $nblks 1
+	log_must rm $testfile
+done
+
+log_pass "Basic hole tests pass."

--- a/tests/zfs-tests/tests/functional/holes/setup.ksh
+++ b/tests/zfs-tests/tests/functional/holes/setup.ksh
@@ -1,0 +1,21 @@
+#!/usr/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/holes/setup.ksh
+++ b/tests/zfs-tests/tests/functional/holes/setup.ksh
@@ -17,5 +17,9 @@
 
 . $STF_SUITE/include/libtest.shlib
 
+if ! getholes /etc/hosts; then
+	log_unsupported "The kernel does not support SEEK_DATA / SEEK_HOLE"
+fi
+
 DISK=${DISKS%% *}
 default_setup $DISK

--- a/tests/zfs-tests/tests/functional/holes/setup.ksh
+++ b/tests/zfs-tests/tests/functional/holes/setup.ksh
@@ -17,7 +17,7 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-if ! getholes /etc/hosts; then
+if ! getholes -n /etc/hosts; then
 	log_unsupported "The kernel does not support SEEK_DATA / SEEK_HOLE"
 fi
 

--- a/tests/zfs-tests/tests/functional/holes/setup.ksh
+++ b/tests/zfs-tests/tests/functional/holes/setup.ksh
@@ -22,4 +22,10 @@ if ! getholes -n /etc/hosts; then
 fi
 
 DISK=${DISKS%% *}
-default_setup $DISK
+default_setup_noexit $DISK
+
+if ! mkholes -h 0:1024 $TESTDIR/setup_test; then
+	log_unsupported "The kernel does not support FALLOC_FL_PUNCH_HOLE"
+fi
+log_must rm $TESTDIR/setup_test
+log_pass


### PR DESCRIPTION
### Description
We would like to expose the number of hole (sparse) blocks in a file.
This can be useful to for example if you want to fill in the holes with
some data; knowing the number of holes in advances allows you to report
progress on hole filling. We could use SEEK_HOLE to do that but it would
be O(n) where n is the number of holes present in the file.

We would like to get feedback on this approach - is this an OK way to do it, and if so what additional work is needed to get it integrated.

Work by @grwilson 

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
