### PR TITLE
WIP - Fix issues with zio deadman "continue" mode

### DIFF
--- a/include/sys/vdev_disk.h
+++ b/include/sys/vdev_disk.h
@@ -47,6 +47,7 @@ typedef struct vdev_disk {
 	ddi_devid_t		vd_devid;
 	char			*vd_minor;
 	struct block_device	*vd_bdev;
+	atomic_t		vd_dr;		/* count of dio_request_t */
 	krwlock_t		vd_lock;
 } vdev_disk_t;
 

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -82,6 +82,7 @@ typedef void	vdev_remap_cb_t(uint64_t inner_offset, vdev_t *vd,
     uint64_t offset, uint64_t size, void *arg);
 typedef void	vdev_remap_func_t(vdev_t *vd, uint64_t offset, uint64_t size,
     vdev_remap_cb_t callback, void *arg);
+typedef boolean_t vdev_abandoned_func_t(zio_t *zio);
 /*
  * Given a target vdev, translates the logical range "in" to the physical
  * range "res"
@@ -105,6 +106,7 @@ typedef const struct vdev_ops {
 	 * Used when initializing vdevs. Isn't used by leaf ops.
 	 */
 	vdev_xlation_func_t		*vdev_op_xlate;
+	vdev_abandoned_func_t		*vdev_op_abandoned;
 	char				vdev_op_type[16];
 	boolean_t			vdev_op_leaf;
 } vdev_ops_t;

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -476,6 +476,7 @@ vdev_queue_io_remove(vdev_queue_t *vq, zio_t *zio)
 	spa_t *spa = zio->io_spa;
 	spa_history_kstat_t *shk = &spa->spa_stats.io_history;
 
+	ASSERT(MUTEX_HELD(&vq->vq_lock));
 	ASSERT3U(zio->io_priority, <, ZIO_PRIORITY_NUM_QUEUEABLE);
 	avl_remove(vdev_queue_class_tree(vq, zio->io_priority), zio);
 	avl_remove(vdev_queue_type_tree(vq, zio->io_type), zio);


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Background
  The "continue" mode attempts to handle "lost" BIO completions,
  which are typically caused by flakey hardware (SAS fabrics,
  drives, etc.).  They are handled by advancing the pipeline from
  the zio_wait() path, typically moving it from the vdev_io_start
  stage to the vdev_io_done stage.

Problem # 1
  The first problem is that, at least for "disk" vdevs, the
  completion may very well be called well after the deadman bumps the
  pipeline.  It's most likely to happen when "zfs_deadan_ziotime_ms"
  is set very low.  Since the process of forcing the zio to complete
  frees the zio in zio_wait(), a long-delayed "real" completion
  will cause the same to happen and various panics can result when
  working on an already-freed zio.

Solution to Problem # 1 (disk vdevs)
  Add a new per-vdev method, vdev_op_abandoned,  which allows for
  zio_wait() to determine whether the zio should be freed due to an
  "abandoned" zio.  For "disk" vdevs, a reference count of the pending
  disk requests (dio_request_t) is kept for each leaf zio.  The new
  vdev_abandoned_func_t will check the reference count and indicate that
  the request has been abandoned if the reference count is nonzero.
  An abandoned zio will not be freed in zio_wait() and will, instead,
  be modified to an interlock pipeline in order that nothing actually
  be done, other than the completion handler, should ever be called.

Solution to Problem # 1 (file vdevs)
  WIP - to be investigated.

Problem # 2
  After a zio is bumped by the deadman, attempts to bypass the zio in
  vdev_queue_aggregate() can panic due to the zio being in the wrong
  stage.

Solution to Problem # 2
  Call vdev_queue_io_done() on the zio in the deadman prior to bumping
  the pipeline.

Problem # 3
  Zios can be dispatched multiple taskqs (this may only be possible when
  debugging with "zinject -D" to simulated delays due to the way in which
  injected delays are implemented).

  A window in zio_deadman_impl() between the check of
  "taskq_empty_ent()" and the subsequent call to zio_interrupt()
  exists during which the same zio may be dispatched elsewhere.
  As mentioned above, this may only be possible when testing with
  "zinject -D" to simulate slow devices with a delay less than or
  equal to the zio deadman timer.

Solution to Problem # 3
  The "zio_interrupt()" in "zio_deadman_impl()" is only called for
  zios with no injected delay and then only that only for those
  which are in the expected vdev_io_start stage.

### Description
  See above under the various "Solution" sections.

### How Has This Been Tested?
  Some problems were discovered on a large bare-metal system on which `zfs_deadman_failmode=continue` was set and on which all of `zio_deadman_checktime_ms`, `zio_deadman_synctime_ms` and `zio_deadman_ziotime_ms` were set to very low values (sub 10-seconds).  Other problems were uncovered during the development of the "pool abandonment" feature.

  Testing was performed with low settings of the 3 deadman timers along with injected delays (`zinject -D`) and also with forced lost completions via 293241f5.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
