### PR TITLE
Reduce duration of spa_namespace_lock held during pool config update.

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -392,6 +392,7 @@ struct spa {
 	uint64_t	spa_multihost;		/* multihost aware (mmp) */
 	mmp_thread_t	spa_mmp;		/* multihost mmp thread */
 
+	kmutex_t	spa_config_update_lock;	/* Lock to serialize config updates */
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements
 	 * because zfs_refcount_t changes size based on compilation options.

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -662,6 +662,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	spa_set_deadman_failmode(spa, zfs_deadman_failmode);
 
 	zfs_refcount_create(&spa->spa_refcount);
+	mutex_init(&spa->spa_config_update_lock, NULL, MUTEX_DEFAULT, NULL);
 	spa_config_lock_init(spa);
 	spa_stats_init(spa);
 
@@ -805,6 +806,7 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_suspend_lock);
 	mutex_destroy(&spa->spa_vdev_top_lock);
 	mutex_destroy(&spa->spa_feat_stats_lock);
+	mutex_destroy(&spa->spa_config_update_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
The main goal of this PR is to give away the namespace lock while waiting for txg to get fully synced. When the amount of dirty data is a lot (max 4GB) and the throughput is really low, txg_sync can take minutes and can cause important operations like importing another pool to stall behind it. 
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Consider the following use case:
1. Running 3 VMs with each having a pool.
2. We do a zpool add on one of the pool in 1st VM in order to expand the pool
3. spa_config_update is called which holds the spa_namespace_lock for 2 txgs
4. spa_syncs are taking minutes because of slow backend. 
5. 2nd VM crashes and causes the pool to move to the first node.
6. pool import stalls waiting for spa_namespace_lock.
7. This drastically increases HA times and can also cause kernel panic (as panic on hung task is enabled) if it takes more than 120 sec to acquire the lock.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Possible fix:
Serialize config updates within the pool with local lock and take namespace lock only when updating the global pool config. This way we don't have to hold spa_namespace_lock while we are waiting for txg to sync.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
- Ran zfs test suite and didnt see any deadlocks, panics etc.
- Ran zpool add, import, export combinations in parallel and didn't notice any deadlocks or panics.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
