### PR TITLE
Fix missing dkms modules after upgrades (try 2)

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -72,6 +72,24 @@ echo -e "support or upgrade DKMS to a more current version."
 exit 1
 
 %preun
+# Are we doing an upgrade?
+if [ $1 -ne 0 ] ; then
+	# Yes we are.  Are we upgrading to a new ZFS version?
+	NEWEST_VER=$(dkms status zfs | sed 's/,//g' | sort -r -V | awk '/installed/{print $2; exit}')
+	if [ "$NEWEST_VER" != "%{version}" ] ; then
+		# Yes, it's a new ZFS version.  We'll uninstall the old module
+		# later on in this script.
+		true
+	else
+		# No, it's probably an upgrade of the same ZFS version
+		# to a new distro (zfs-dkms-0.7.12.fc28->zfs-dkms-0.7.12.fc29).
+		# Don't remove our modules, since the rebuild for the new
+		# distro will automatically delete the old modules.
+		exit 0
+	fi
+fi
+
+# If we're here then we're doing an uninstall (not upgrade).
 CONFIG_H="/var/lib/dkms/%{module}/%{version}/*/*/%{module}_config.h"
 SPEC_META_ALIAS="@PACKAGE@-@VERSION@-@RELEASE@"
 DKMS_META_ALIAS=`cat $CONFIG_H 2>/dev/null |


### PR DESCRIPTION
### Motivation and Context
Make dkms upgrades work correctly when upgrading Fedora.  This PR is a refactored version of https://github.com/zfsonlinux/zfs/pull/8160.

### Description
If you were upgrading from say, fc28->fc29, on ZFS version X, the RPMs macros would get called like this:
```
%post X.fc29
   - This is the step where fc29 gets built by dkms.
     As part of the build, dkms automatically removes the previous
     modules before building the new ones.  It then builds the new
     modules.
%preun X.fc28
   - Right before this step, X.fc29 is be built and installed, but
     since it has the same X, it's files get inadvertently removed
     by fc28's uninstall.
%postun X.fc28
```
This has the unfortunate side effect that the newly built f29 modules get removed by the f28 `%preun` step, giving you no modules.

This patch updates `%preun X.fc28` to see if we're upgrading or uninstalling.  If we're uninstalling, then remove our files. If we're upgrading, check to see if were updating to a new version (0.7.11 -> 0.7.12) or upgrading the same version to a new OS (zfs-dkms.0.7.12.fc28 -> zfs-dkms.0.7.12.fc29).  If we're upgrading versions then uninstall the old files.  If we're upgrading the OS, then do nothing, since we know our old modules are just going to get overwritten when they're rebuilt for the new OS.

Fixes: #6902

### How Has This Been Tested?
Did some unit tests using a reproducer similar to (https://github.com/zfsonlinux/zfs/issues/8089#issuecomment-436440183).  Also did the following:

1. Installed pristine Fedora 28.
2. Installed dkms packages with this fix.
3. Upgraded to Fedora 29.
4. Verified that dkms modules recompiled and worked on Fedora 29.

Also:

1. Installed 0.7.12 dkms packages with this fix on Fedora 29.
2. Installed newest dkms containing a needed fix (https://github.com/dell/dkms/pull/60).
3. Upgraded to fake "0.7.13" dkms packages correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [1] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
