### PR TITLE
making sure the last quiesced txg is synced

### DIFF
--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -556,12 +556,12 @@ txg_sync_thread(void *arg)
 			} else {
 				while (tx->tx_threads != 1)
 					txg_thread_wait(tx, &cpr,
-				            &tx->tx_exit_cv, 0);
+					    &tx->tx_exit_cv, 0);
 				if (tx->tx_quiesced_txg)
 					checked_quiescing = B_TRUE;
 				else
 					txg_thread_exit(tx, &cpr,
-				            &tx->tx_sync_thread);
+					    &tx->tx_sync_thread);
 			}
 		}
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -508,7 +508,6 @@ txg_sync_thread(void *arg)
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 	clock_t start, delta;
-	boolean_t checked_quiescing = B_FALSE;
 
 	(void) spl_fstrans_mark();
 	txg_thread_enter(tx, &cpr);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -556,12 +556,12 @@ txg_sync_thread(void *arg)
 			} else {
 				while (tx->tx_threads != 1)
 					txg_thread_wait(tx, &cpr,
-							&tx->tx_exit_cv, 0);
+				            &tx->tx_exit_cv, 0);
 				if (tx->tx_quiesced_txg)
 					checked_quiescing = B_TRUE;
 				else
 					txg_thread_exit(tx, &cpr,
-							&tx->tx_sync_thread);
+				            &tx->tx_sync_thread);
 			}
 		}
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -551,15 +551,17 @@ txg_sync_thread(void *arg)
 		}
 
 		if (tx->tx_exiting) {
-			if (checked_quiescing)
+			if (checked_quiescing) {
 				txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
-			else {
+			} else {
 				while (tx->tx_threads != 1)
-					txg_thread_wait(tx, &cpr, &tx->tx_exit_cv, 0);
+					txg_thread_wait(tx, &cpr,
+							&tx->tx_exit_cv, 0);
 				if (tx->tx_quiesced_txg)
 					checked_quiescing = B_TRUE;
 				else
-					txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
+					txg_thread_exit(tx, &cpr,
+							&tx->tx_sync_thread);
 			}
 		}
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -550,19 +550,15 @@ txg_sync_thread(void *arg)
 			txg_thread_wait(tx, &cpr, &tx->tx_quiesce_done_cv, 0);
 		}
 
+		/*
+		 * Wait until the quiesce thread has exited to ensure every
+		 * quiesced txg has been synced before exiting.
+		 */
 		if (tx->tx_exiting) {
-			if (checked_quiescing) {
+			while (tx->tx_threads != 1)
+				txg_thread_wait(tx, &cpr, &tx->tx_exit_cv, 0);
+			if (tx->tx_quiesced_txg == 0)
 				txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
-			} else {
-				while (tx->tx_threads != 1)
-					txg_thread_wait(tx, &cpr,
-					    &tx->tx_exit_cv, 0);
-				if (tx->tx_quiesced_txg)
-					checked_quiescing = B_TRUE;
-				else
-					txg_thread_exit(tx, &cpr,
-					    &tx->tx_sync_thread);
-			}
 		}
 
 		/*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
See #8233

Consider this scenario (see [txg.c](https://github.com/zfsonlinux/zfs/blob/06f3fc2a4b097545259935d54634c5c6f49ed20f/module/zfs/txg.c) ):
There is heavy write load when the pool exports.
After `txg_sync_stop`'s call of `txg_wait_synced` returns, many more txgs get processed, but right before` txg_sync_stop` gets `tx_sync_lock`, the following happens:

- `txg_sync_thread` begins waiting on `tx_sync_more_cv`.
- `txg_quiesce_thread` gets done with `txg_quiesce(dp, txg)`.
- `txg_sync_stop` gets `tx_sync_lock` first, calls `cv_broadcast`s with `tx_exiting` == 1, and waits for exits.
- `txg_sync_thread` wakes up first and exits.
- Finally, `txg_quiesce_thread` gets `tx_sync_lock`, and calls `cv_broadcast(&tx->tx_sync_more_cv)`, 
but `txg_sync_thread` is already gone, and the txg in `txg_quiesce(dp, txg)` above never gets synced.

### Description
`txg_sync_thread` now waits for `txg_quiesce_thread` to exit and maybe run one more sync before exiting.


### How Has This Been Tested?
Did not test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
