### PR TITLE
Further improve 'zpool labelclear' command

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -808,6 +808,8 @@ extern int zpool_in_use(libzfs_handle_t *, int, pool_state_t *, char **,
  * Label manipulation.
  */
 extern int zpool_clear_label(int);
+extern int zpool_clear_n_labels(int, unsigned int, unsigned int, boolean_t,
+    boolean_t);
 
 /*
  * Management interfaces for SMB ACL files

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -748,6 +748,8 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_LOAD_DATA_ERRORS	"verify_data_errors"
 #define	ZPOOL_CONFIG_REWIND_TIME	"seconds_of_rewind"
 
+#define	VDEV_LABELS				4
+
 #define	VDEV_TYPE_ROOT			"root"
 #define	VDEV_TYPE_MIRROR		"mirror"
 #define	VDEV_TYPE_REPLACING		"replacing"

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -94,6 +94,7 @@ typedef struct nvlist {
 #define	NV_VERSION	0
 
 /* nvlist pack encoding */
+#define	NV_ENCODE_INVALID	(-1)
 #define	NV_ENCODE_NATIVE	0
 #define	NV_ENCODE_XDR		1
 
@@ -150,6 +151,7 @@ void nv_alloc_fini(nv_alloc_t *);
 /* list management */
 int nvlist_alloc(nvlist_t **, uint_t, int);
 void nvlist_free(nvlist_t *);
+int nvlist_invalidate(char *, size_t);
 int nvlist_size(nvlist_t *, size_t *, int);
 int nvlist_pack(nvlist_t *, char **, size_t *, int, int);
 int nvlist_unpack(char *, size_t, nvlist_t **, int);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -441,8 +441,6 @@ typedef struct vdev_label {
  */
 #define	VDEV_LABEL_START_SIZE	(2 * sizeof (vdev_label_t) + VDEV_BOOT_SIZE)
 #define	VDEV_LABEL_END_SIZE	(2 * sizeof (vdev_label_t))
-#define	VDEV_LABELS		4
-#define	VDEV_BEST_LABEL		VDEV_LABELS
 
 #define	VDEV_ALLOC_LOAD		0
 #define	VDEV_ALLOC_ADD		1

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -137,16 +137,17 @@ label_offset(uint64_t size, int l)
 }
 
 /*
- * Given a file descriptor, clear (zero) the label information.  This function
- * is used in the appliance stack as part of the ZFS sysevent module and
- * to implement the "zpool labelclear" command.
+ * Given a file descriptor, a starting label and a number of labels to clear,
+ * invalidate or clear (zero) the label information. This function is used in
+ * the appliance stack as part of the ZFS sysevent module and to implement the
+ * "zpool labelclear" command.
  */
 int
-zpool_clear_label(int fd)
+zpool_clear_n_labels(int fd, unsigned int start, unsigned int n,
+    boolean_t force, boolean_t wipe)
 {
 	struct stat64 statbuf;
-	int l;
-	vdev_label_t *label;
+	unsigned int l, end;
 	uint64_t size;
 	int labels_cleared = 0;
 
@@ -155,60 +156,84 @@ zpool_clear_label(int fd)
 
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
-	if ((label = calloc(1, sizeof (vdev_label_t))) == NULL)
-		return (-1);
+	end = start + n;
+	if (end > VDEV_LABELS)
+	    return (-1);
 
-	for (l = 0; l < VDEV_LABELS; l++) {
+	for (l = start; l < end; l++) {
+		vdev_label_t label;
+		char *nvbuf = label.vl_vdev_phys.vp_nvlist;
+		size_t nvbuflen = sizeof (label.vl_vdev_phys.vp_nvlist);
+
 		uint64_t state, guid;
 		nvlist_t *config;
 
-		if (pread64(fd, label, sizeof (vdev_label_t),
-		    label_offset(size, l)) != sizeof (vdev_label_t)) {
-			continue;
+		if (!(force && wipe)) {
+			if (pread64(fd, &label, sizeof (vdev_label_t),
+			    label_offset(size, l)) != sizeof (vdev_label_t)) {
+				continue;
+			}
+
+			if (!force) {
+				if (nvlist_unpack(nvbuf, nvbuflen, &config, 0) != 0) {
+					continue;
+				}
+
+				/* Skip labels which do not have a valid guid. */
+				if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_GUID,
+				    &guid) != 0 || guid == 0) {
+					nvlist_free(config);
+					continue;
+				}
+
+				/* Skip labels which are not in a known valid state. */
+				if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE,
+				    &state) != 0 || state > POOL_STATE_L2CACHE) {
+					nvlist_free(config);
+					continue;
+				}
+
+				nvlist_free(config);
+			}
 		}
 
-		if (nvlist_unpack(label->vl_vdev_phys.vp_nvlist,
-		    sizeof (label->vl_vdev_phys.vp_nvlist), &config, 0) != 0) {
-			continue;
+		if (wipe) {
+			/*
+			 * A valid label was found, overwrite this label's nvlist
+			 * and uberblocks with zeros on disk.  This is done to prevent
+			 * system utilities, like blkid, from incorrectly detecting a
+			 * partial label.  The leading pad space is left untouched.
+			 */
+			memset(&label, 0, sizeof (vdev_label_t));
+		} else {
+			/*
+			 * Perform minimal on-disk change
+			 */
+			if (nvlist_invalidate(nvbuf, nvbuflen) != 0)
+			    continue;
 		}
 
-		/* Skip labels which do not have a valid guid. */
-		if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_GUID,
-		    &guid) != 0 || guid == 0) {
-			nvlist_free(config);
-			continue;
-		}
-
-		/* Skip labels which are not in a known valid state. */
-		if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE,
-		    &state) != 0 || state > POOL_STATE_L2CACHE) {
-			nvlist_free(config);
-			continue;
-		}
-
-		nvlist_free(config);
-
-		/*
-		 * A valid label was found, overwrite this label's nvlist
-		 * and uberblocks with zeros on disk.  This is done to prevent
-		 * system utilities, like blkid, from incorrectly detecting a
-		 * partial label.  The leading pad space is left untouched.
-		 */
-		memset(label, 0, sizeof (vdev_label_t));
 		size_t label_size = sizeof (vdev_label_t) - (2 * VDEV_PAD_SIZE);
 
-		if (pwrite64(fd, label, label_size, label_offset(size, l) +
-		    (2 * VDEV_PAD_SIZE)) == label_size) {
+		if (pwrite64(fd, (void*)&label + (2 * VDEV_PAD_SIZE), label_size,
+		    label_offset(size, l) + (2 * VDEV_PAD_SIZE)) == label_size) {
 			labels_cleared++;
 		}
 	}
-
-	free(label);
 
 	if (labels_cleared == 0)
 		return (-1);
 
 	return (0);
+}
+
+/*
+ * Given a file descriptor, clear (zero) the label information.
+ */
+int
+zpool_clear_label(int fd)
+{
+	return (zpool_clear_n_labels(fd, 0, VDEV_LABELS, B_TRUE, B_TRUE));
 }
 
 static boolean_t

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -128,7 +128,8 @@
 .Op Ar interval Op Ar count
 .Nm
 .Cm labelclear
-.Op Fl f
+.Op Fl fw
+.Op Fl Sy b Ns | Ns Sy e Ns | Ns Sy i Ar index
 .Ar device
 .Nm
 .Cm list
@@ -1854,7 +1855,8 @@ will be sampled from the end of the interval.
 .It Xo
 .Nm
 .Cm labelclear
-.Op Fl f
+.Op Fl fw
+.Op Fl Sy b Ns | Ns Sy e Ns | Ns Sy i Ar index
 .Ar device
 .Xc
 Removes ZFS label information from the specified
@@ -1862,9 +1864,29 @@ Removes ZFS label information from the specified
 The
 .Ar device
 must not be part of an active pool configuration.
+Options
+.Fl b ,
+.Fl e
+and
+.Fl i
+can be used for clearing specific labels.
+They are mutually exclusive and the last one will supersede others, if any.
 .Bl -tag -width Ds
 .It Fl f
-Treat exported or foreign devices as inactive.
+Force mode: treat exported or foreign devices as inactive.
+Specify twice to clear even seemingly-invalid labels.
+.It Fl w
+Instead of invalidating the label information, wipe label area entirely and
+replace it with zeroes.
+.It Fl b
+Only remove ZFS labels located at the beginning of
+.Ar device .
+.It Fl e
+Only remove ZFS labels located at the end of
+.Ar device .
+.It Fl i Ar index
+Remove a single label entry located at position
+.Ar index .
 .El
 .It Xo
 .Nm

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2630,6 +2630,18 @@ nvlist_common(nvlist_t *nvl, char *buf, size_t *buflen, int encoding,
 }
 
 int
+nvlist_invalidate(char *buf, size_t buflen)
+{
+	if (buf == NULL || buflen < sizeof (nvs_header_t))
+	    return (EINVAL);
+
+	nvs_header_t *nvh = (void *)buf;
+	nvh->nvh_encoding = NV_ENCODE_INVALID;
+
+	return (0);
+}
+
+int
 nvlist_size(nvlist_t *nvl, size_t *size, int encoding)
 {
 	return (nvlist_common(nvl, NULL, size, encoding, NVS_OP_GETSIZE));
@@ -3656,6 +3668,7 @@ EXPORT_SYMBOL(nvlist_prev_nvpair);
 EXPORT_SYMBOL(nvlist_empty);
 EXPORT_SYMBOL(nvlist_add_hrtime);
 
+EXPORT_SYMBOL(nvlist_invalidate);
 EXPORT_SYMBOL(nvlist_remove);
 EXPORT_SYMBOL(nvlist_remove_nvpair);
 EXPORT_SYMBOL(nvlist_remove_all);


### PR DESCRIPTION
Hello,

That patch follows : https://github.com/zfsonlinux/zfs/pull/8500 to further improve the labelclear command.

It is an updated version of my my previous patch for OpenZFS :

  https://github.com/openzfs/openzfs/pull/424

### Description

Basically, the patch adds the following :
  - ability to clear a specific label (options -b, -e and -i)
  - label invalidation using a single-byte modification (use -w to zeroe the label as before)
  - option -ff to force invalidation even for invalid labels

### How Has This Been Tested?

The patch has been tested on Debian 9 with a file-backed zpool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
