### PR TITLE
Handle disks without 512e sector sizes

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -148,6 +148,7 @@ typedef enum zfs_error {
 	EZFS_TRIM_NOTSUP,	/* device does not support trim */
 	EZFS_NO_RESILVER_DEFER,	/* pool doesn't support resilver_defer */
 	EZFS_EXPORT_IN_PROGRESS,	/* currently exporting the pool */
+	EZFS_BAD_BLOCK_SIZE,	/* disk block size not usable */
 	EZFS_UNKNOWN
 } zfs_error_t;
 


### PR DESCRIPTION
Disks that do not emulate 512 byte sector sizes are available today.
GPT partitions use sector offsets based on the logical disk sizes
and we cannot assume that is 512 bytes anymore.

Closes #7851
Signed-off-by: DHE <git@dehacked.net>

### Motivation and Context
The constant offsets used in partition creation assume 512 byte sectors. Worse, the asize of a disk is calculated independently also based on 512 byte sector sizes, resulting in IO past the end of the disk and corruption.

### Description
When building the partition table, read the logical disk sector size and correct partition table sector counts/offsets based on the ratio between 512 and the disk's actual size. For now we just fix the partition table created which is sufficient to let all the other parts fall into place properly.

### How Has This Been Tested?
Manually using qemu to test 4kn disks and regular 512e disks, both making new pools and importing existing pools after relabeling the disk to fix partition offsets but reusing the previously created pool.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
