### PR TITLE
Snap -r with existing snaps can cause panic

### DIFF
--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -188,6 +188,9 @@ typedef struct dsl_dataset {
 	uint64_t ds_bookmarks_obj;  /* DMU_OTN_ZAP_METADATA */
 	avl_tree_t ds_bookmarks; /* dsl_bookmark_node_t */
 
+	/* used in snapshot check function */
+	list_node_t ds_check;
+
 	/* has internal locking: */
 	dsl_deadlist_t ds_deadlist;
 	bplist_t ds_pending_deadlist;
@@ -446,6 +449,8 @@ void dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
     dsl_dataset_t *origin_head, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check_impl(dsl_dataset_t *ds, const char *snapname,
     dmu_tx_t *tx, boolean_t recv, uint64_t cnt, cred_t *cr);
+int dsl_dataset_snapshot_reserve_space(dsl_dataset_t *ds, dmu_tx_t *tx);
+
 void dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     dmu_tx_t *tx);
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -2935,6 +2935,11 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 		}
 		error = dsl_dataset_snapshot_check_impl(origin_head,
 		    drc->drc_tosnap, tx, B_TRUE, 1, drc->drc_cred);
+		if (error != 0) {
+			dsl_dataset_rele(origin_head, FTAG);
+			return (error);
+		}
+		error = dsl_dataset_snapshot_reserve_space(origin_head, tx);
 		dsl_dataset_rele(origin_head, FTAG);
 		if (error != 0)
 			return (error);
@@ -2943,6 +2948,10 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 	} else {
 		error = dsl_dataset_snapshot_check_impl(drc->drc_ds,
 		    drc->drc_tosnap, tx, B_TRUE, 1, drc->drc_cred);
+		if (error != 0)
+			return (error);
+
+		error = dsl_dataset_snapshot_reserve_space(drc->drc_ds, tx);
 	}
 	return (error);
 }

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -804,7 +804,7 @@ tests = ['clone_001_pos', 'rollback_001_pos', 'rollback_002_pos',
     'snapshot_006_pos', 'snapshot_007_pos', 'snapshot_008_pos',
     'snapshot_009_pos', 'snapshot_010_pos', 'snapshot_011_pos',
     'snapshot_012_pos', 'snapshot_013_pos', 'snapshot_014_pos',
-    'snapshot_017_pos']
+    'snapshot_017_pos', 'snapshot_fail_existing']
 tags = ['functional', 'snapshot']
 
 [tests/functional/snapused]

--- a/tests/zfs-tests/tests/functional/snapshot/Makefile.am
+++ b/tests/zfs-tests/tests/functional/snapshot/Makefile.am
@@ -22,7 +22,8 @@ dist_pkgdata_SCRIPTS = \
 	snapshot_014_pos.ksh \
 	snapshot_015_pos.ksh \
 	snapshot_016_pos.ksh \
-	snapshot_017_pos.ksh
+	snapshot_017_pos.ksh \
+	snapshot_fail_existing.ksh
 
 dist_pkgdata_DATA = \
 	snapshot.cfg

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_fail_existing.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_fail_existing.ksh
@@ -1,0 +1,189 @@
+#! /bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2019 by Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/snapshot/snapshot.cfg
+
+#
+# DESCRIPTION:
+#	Create a snapshot from regular filesystem, volume,
+#	or filesystem upon volume, Build a clone file system
+#	from the snapshot.  Then test that snapshot -r handles
+#	the case of an already existing snap.
+#
+# STRATEGY:
+# 	1. Create snapshot use 3 combination:
+#		- Regular filesystem
+#		- Regular volume
+#		- Filesystem upon volume
+# 	2. Clone a new file system from the snapshot
+# 	3. Verify snap -r fails
+#
+
+verify_runnable "both"
+
+# Setup array, 4 elements as a group, refer to:
+# i+0: name of a snapshot
+# i+1: mountpoint of the snapshot
+# i+2: clone created from the snapshot
+# i+3: mountpoint of the clone
+
+set -A args "$SNAPFS" "$SNAPDIR" "$TESTPOOL/$TESTCLONE" "$TESTDIR.0" \
+	"$SNAPFS1" "$SNAPDIR3" "$TESTPOOL/$TESTCLONE1" "" \
+	"$SNAPFS2" "$SNAPDIR2" "$TESTPOOL1/$TESTCLONE2" "$TESTDIR.2"
+
+function setup_all
+{
+	create_pool $TESTPOOL1 ${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
+	log_must zfs create $TESTPOOL1/$TESTFS
+	log_must zfs set mountpoint=$TESTDIR2 $TESTPOOL1/$TESTFS
+
+	return 0
+}
+
+function cleanup_all
+{
+	typeset -i i=0
+	typeset ds
+	typeset snap
+
+	for ds in $ctr/$TESTVOL1 $ctr/$TESTCLONE \
+		$TESTPOOL1/$TESTCLONE1 $TESTPOOL1/$TESTCLONE2 \
+		$TESTPOOL1/$TESTFS;
+	do
+		destroy_dataset $ds "-rf"
+	done
+
+	destroy_pool $TESTPOOL1
+
+	for ds in $TESTPOOL/$TESTCLONE1 $TESTPOOL/$TESTVOL \
+		$TESTPOOL/$TESTCLONE $TESTPOOL/$TESTFS;
+	do
+		destroy_dataset $ds "-rf"
+	done
+
+	for snap in $ctr/$TESTFS1@$TESTSNAP1 \
+		$snappool $snapvol $snapctr $snapctrvol \
+		$snapctrclone $snapctrfs
+	do
+		snapexists $snap && destroy_dataset $snap "-rf"
+	done
+
+	while (( i < ${#args[*]} )); do
+		snapexists ${args[i]} && \
+			destroy_dataset "${args[i]}" "-Rf"
+
+		[[ -d ${args[i+3]} ]] && \
+			log_must rm -rf ${args[i+3]}
+
+		[[ -d ${args[i+1]} ]] && \
+			log_must rm -rf ${args[i+1]}
+
+		(( i = i + 4 ))
+	done
+
+	[[ -d $TESTDIR2 ]] && \
+		log_must rm -rf $TESTDIR2
+
+	return 0
+}
+
+log_assert "Verify a cloned file system is writable."
+
+log_onexit cleanup_all
+
+setup_all
+
+[[ -n $TESTDIR ]] && \
+    log_must rm -rf $TESTDIR/* > /dev/null 2>&1
+
+typeset -i COUNT=10
+typeset -i i=0
+
+for mtpt in $TESTDIR $TESTDIR2 ; do
+	log_note "Populate the $mtpt directory (prior to snapshot)"
+	typeset -i j=1
+	while [[ $j -le $COUNT ]]; do
+		log_must file_write -o create -f $mtpt/before_file$j \
+			-b $BLOCKSZ -c $NUM_WRITES -d $j
+
+		(( j = j + 1 ))
+	done
+done
+
+while (( i < ${#args[*]} )); do
+	#
+	# Take a snapshot of the test file system.
+	#
+	log_must zfs snapshot ${args[i]}
+
+	#
+	# Clone a new file system from the snapshot
+	#
+	log_must zfs clone ${args[i]} ${args[i+2]}
+	if [[ -n ${args[i+3]} ]] ; then
+		log_must zfs set mountpoint=${args[i+3]} ${args[i+2]}
+
+		FILE_COUNT=`ls -Al ${args[i+3]} | grep -v "total" \
+		    | grep -v "\.zfs" | wc -l`
+		if [[ $FILE_COUNT -ne $COUNT ]]; then
+			ls -Al ${args[i+3]}
+			log_fail "AFTER: ${args[i+3]} contains $FILE_COUNT files(s)."
+		fi
+
+		log_note "Verify the ${args[i+3]} directory is writable"
+		j=1
+		while [[ $j -le $COUNT ]]; do
+			log_must file_write -o create -f ${args[i+3]}/after_file$j \
+			-b $BLOCKSZ -c $NUM_WRITES -d $j
+			(( j = j + 1 ))
+		done
+
+		FILE_COUNT=`ls -Al ${args[i+3]}/after* | grep -v "total" | wc -l`
+		if [[ $FILE_COUNT -ne $COUNT ]]; then
+			ls -Al ${args[i+3]}
+			log_fail "${args[i+3]} contains $FILE_COUNT after* files(s)."
+		fi
+	fi
+
+	(( i = i + 4 ))
+done
+
+# Set up to take the snap -r that we expect to fail.
+ctr=$TESTPOOL/$TESTCTR
+ctrfs=$ctr/$TESTFS1
+ctrclone=$ctr/$TESTCLONE
+ctrvol=$ctr/$TESTVOL1
+snappool=$SNAPPOOL
+snapfs=$SNAPFS
+snapctr=$ctr@$TESTSNAP
+snapvol=$SNAPFS1
+snapctrvol=$ctrvol@$TESTSNAP
+snapctrclone=$ctrclone@$TESTSNAP
+snapctrfs=$SNAPCTR
+
+log_must zfs snapshot $ctrfs@$TESTSNAP1
+log_must zfs clone $ctrfs@$TESTSNAP1 $ctrclone
+if is_global_zone; then
+	log_must zfs create -V $VOLSIZE $ctrvol
+else
+	log_must zfs create $ctrvol
+fi
+
+log_mustnot zfs snapshot -r $snappool
+
+log_pass "Snapshot -r fails as expected."


### PR DESCRIPTION
Certain arrangment of existing snaps with the same name as specified in new snap -r command can create a situation during sync phase with entries in dp_dirty_dirs but no dirty dbufs in the MOS.

Also when zfs tests are destroying datasets and then the pool there is a race condition between
dmu_objset_evict and dbuf_evict_one, resulting in a hang.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>
Fixes #8380

### Motivation and Context
Every time that testpool/testvol@testsnap is left behind by clone_001_pos cleanup, snapshot_009_pos fails in the same way.  It fails trying to zfs snapshot -r testpool@testsnap because testpool/testvol already has that snapshot. dsl_dataset_snapshot_check returns EEXIST and the recursive snap is not taken. 

While performing dsl_dataset_snapshot_check on the other descendant datasets of testpool, we call dsl_dataset_reserve_space and this dirties some dsl_dir_t which get on the list dp_dirty_dirs. But, because the snapshot is not taken due to the EEXIST, we don't dirty the meta object set (MOS). This is not compatible with the code in spa_sync_iterate_to_convergence, which enforces a rule and ASSERTs that if we haven't dirtied the MOS, we cannot have any entries in dp_dirty_dirs.

Ideally, when the test executes zfs snapshot -r testpool@testsnap it should fail up front (by finding testpool/testvol@testsnap and complaining) without generating the sync tasks that are doomed to fail. But it doesn't happen that way.

The panic is sometimes reproducible with the zfs test suite (before fix #8409).  Then when a
new test procedure was added to always reproduce it, the eviction issue was discovered.

In the zfs test script final steps, we create a zvol, fail the snap -r as expected, and go right into destroying datasets in the cleanup function. What I see is that dbuf_evict_one code is picking off a zvol dbuf before zvol_create_minor is finished. With the db_state of DB_EVICTING on the original 0:0:0 dbuf, continuation of the zvol_create_minor code holds a new dbuf 0:0:0 into dn_dbufs with the same bookmark and state of DB_CACHED. During objset eviction, this arrangement causes issues with the avl_insert_here insertion sort (dbuf_compare) resulting in the panic. 

### Description
Don't reserve space in dsl_dataset_snapshot_check_impl. Just use that code to find the errors if any (in this case EEXIST). Then if no errors are found, dirty the dsl_dir_t by reserving the space in a second loop through the to-be-taken snaps.

For the eviction race, handle the case where dn_dbufs has two entries for the same db_level and db_blkid, but with different db_states (i.e. DB_EVICTING and DB_CACHED) by walking backward to find the correct insertion point.

### How Has This Been Tested?
Looping the snapshot portion of the zfs test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
