### PR TITLE
zpool import progress indicator

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -172,6 +172,7 @@ int for_each_vdev_cb(void *zhp, nvlist_t *nv, pool_vdev_iter_f func,
 int for_each_vdev_in_nvlist(nvlist_t *nvroot, pool_vdev_iter_f func,
     void *data);
 void update_vdevs_config_dev_sysfs_path(nvlist_t *config);
+int kstat_read(char *path_suffix, char *kstat_buf, size_t buflen);
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -252,3 +252,27 @@ void
 update_vdevs_config_dev_sysfs_path(nvlist_t *config)
 {
 }
+
+#define	KSTAT_PREFIX "kstat.zfs."
+/*
+ * Read the contents of a kstat into a buffer.  Handles only
+ * kstats which are directly below "zfs".
+ */
+int
+kstat_read(char *name_suffix, char *kstat_buf, size_t buflen)
+{
+	char name[MAXPATHLEN];
+	int rc;
+
+	if (strlcpy(name, KSTAT_PREFIX, sizeof (name)) >= sizeof (name))
+		return (-ENAMETOOLONG);
+	if (strlcat(name, name_suffix, sizeof (name)) >= sizeof (name))
+		return (-ENAMETOOLONG);
+
+	/* sysctlbyname() changes buflen to bytes received */
+	rc = sysctlbyname(name, kstat_buf, &buflen, NULL, 0);
+	if (rc < 0)
+		return (-errno);
+
+	return (buflen);
+}

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -206,18 +206,20 @@ function import_no_activity_check # pool opts
 {
 	typeset pool=$1
 	typeset opts=$2
-
-	typeset max_duration=$((MMP_TEST_DURATION_DEFAULT-1))
+	typeset tmpfile=$(mktemp)
 
 	SECONDS=0
-	zpool import $opts $pool
+	zpool import $opts -v $pool > $tmpfile 2>&1
 	typeset rc=$?
+	cat $tmpfile
 
-	if [[ $SECONDS -gt $max_duration ]]; then
-		log_fail "ERROR: import_no_activity_check unexpected activity \
-check (${SECONDS}s gt $max_duration)"
+	if grep "Multihost is checking" $tmpfile; then
+		log_note $(grep "Multihost is checking" $tmpfile)
+		log_fail "ERROR: import_no_activity_check unexpected \
+activity check reported"
 	fi
 
+	rm $tmpfile
 	return $rc
 }
 
@@ -225,17 +227,25 @@ function import_activity_check # pool opts act_test_duration
 {
 	typeset pool=$1
 	typeset opts=$2
-	typeset min_duration=${3:-$MMP_TEST_DURATION_DEFAULT}
+	typeset min_duration=${4:-$MMP_TEST_DURATION_DEFAULT}
+	typeset tmpfile=$(mktemp)
 
 	SECONDS=0
-	zpool import $opts $pool
+	zpool import -v $opts $pool > $tmpfile 2>&1
 	typeset rc=$?
+	cat $tmpfile
 
 	if [[ $SECONDS -le $min_duration ]]; then
 		log_fail "ERROR: import_activity_check expected activity check \
 (${SECONDS}s le min_duration $min_duration)"
 	fi
 
+	if ! grep "use .zpool import -f" $tmpfile && ! grep "Multihost is checking" $tmpfile; then
+		log_fail "ERROR: import_activity_check expected \
+Multihost status message"
+	fi
+
+	rm $tmpfile
 	return $rc
 }
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -62,6 +62,7 @@ for opt in "" "-f"; do
 done
 
 # 3. Verify multihost=off and hostids differ (no activity check)
+log_note "3. Verify multihost=off and hostids differ"
 log_must zpool export -F $TESTPOOL
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
@@ -69,12 +70,14 @@ log_mustnot import_no_activity_check $TESTPOOL ""
 log_must import_no_activity_check $TESTPOOL "-f"
 
 # 4. Verify multihost=off and hostid zero allowed (no activity check)
+log_note "4. Verify multihost=off and hostid zero allowed"
 log_must zpool export -F $TESTPOOL
 log_must mmp_clear_hostid
 log_mustnot import_no_activity_check $TESTPOOL ""
 log_must import_no_activity_check $TESTPOOL "-f"
 
 # 5. Verify multihost=on and hostids match (no activity check)
+log_note "5. Verify multihost=on and hostids match"
 log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
 log_must zpool set multihost=on $TESTPOOL
 
@@ -84,6 +87,7 @@ for opt in "" "-f"; do
 done
 
 # 6. Verify multihost=on and hostids differ (activity check)
+log_note "6. Verify multihost=on and hostids differ"
 log_must zpool export -F $TESTPOOL
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
@@ -91,16 +95,19 @@ log_mustnot import_activity_check $TESTPOOL ""
 log_must import_activity_check $TESTPOOL "-f"
 
 # 7. Verify mmp_write and mmp_fail are set correctly
+log_note "7. Verify mmp_write and mmp_fail are set correctly"
 log_must zpool export -F $TESTPOOL
 log_must verify_mmp_write_fail_present ${DISK[0]}
 
 # 8. Verify multihost=on and hostid zero fails (no activity check)
+log_note "8. Verify multihost=on and hostid zero fails (no activity check)"
 log_must mmp_clear_hostid
 MMP_IMPORTED_MSG="Set a unique system hostid"
 log_must check_pool_import $TESTPOOL "-f" "action" "$MMP_IMPORTED_MSG"
 log_mustnot import_no_activity_check $TESTPOOL "-f"
 
 # 9. Verify activity check duration based on mmp_write and mmp_fail
+log_note "9. Verify activity check duration based on mmp_write and mmp_fail"
 # Specify a short test via tunables but import pool imported while
 # tunables set to default duration.
 log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_MIN


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When an import requires a long MMP activity check, or when the user
requests pool recovery, the import make take a long time.  The user may
not know why, or be able to tell whether the import is progressing or is
hung.

### Description
<!--- Describe your changes in detail -->

A previous commit added a kstat which lists all imports currently
 being processed by the
kernel (currently only one at a time is possible, but the kstat allows
for more than one).  The kstat is at
/proc/spl/kstat/zfs/import_progress.

In the zpool utility, create an additional thread which periodically
checks the contents of this kstat.  If the import does not finish
quickly, it reports the following on stderr:
* Name and guid of pool being imported
* User-friendly version of spa_load_state
* spa_load_max_txg

If one or more of these values change, the thread prints a new record.

A new record will be printed to stderr with a maximum frequency of one
per second so as not to spam the user.  As a result the printed output
may reflect only some of the import states transitioned through.

Sample output:

	Pool tank1 (guid 4591991398949870326):
	Checking for a remote import.
	Check will complete by Tue Apr 16 08:43:58 2019

	Pool tank1 (guid 4591991398949870326):
	Checking for a remote import.
	Check will complete by Tue Apr 16 08:44:43 2019
	Recovering Pool max txg 745

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Hand testing with and without multihost check triggered, and with and without zpool -FX -T <num> arguments.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
