### PR TITLE
zfs userspace: use zfs_path_to_zhandle so argument can be a path

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -363,16 +363,16 @@ get_usage(zfs_help_t idx)
 		return (gettext("\tuserspace [-Hinp] [-o field[,...]] "
 		    "[-s field] ...\n"
 		    "\t    [-S field] ... [-t type[,...]] "
-		    "<filesystem|snapshot>\n"));
+		    "<filesystem|snapshot|path>\n"));
 	case HELP_GROUPSPACE:
 		return (gettext("\tgroupspace [-Hinp] [-o field[,...]] "
 		    "[-s field] ...\n"
 		    "\t    [-S field] ... [-t type[,...]] "
-		    "<filesystem|snapshot>\n"));
+		    "<filesystem|snapshot|path>\n"));
 	case HELP_PROJECTSPACE:
 		return (gettext("\tprojectspace [-Hp] [-o field[,...]] "
 		    "[-s field] ... \n"
-		    "\t    [-S field] ... <filesystem|snapshot>\n"));
+		    "\t    [-S field] ... <filesystem|snapshot|path>\n"));
 	case HELP_PROJECT:
 		return (gettext("\tproject [-d|-r] <directory|file ...>\n"
 		    "\tproject -c [-0] [-d|-r] [-p id] <directory|file ...>\n"
@@ -2481,11 +2481,13 @@ zfs_do_upgrade(int argc, char **argv)
 
 /*
  * zfs userspace [-Hinp] [-o field[,...]] [-s field [-s field]...]
- *               [-S field [-S field]...] [-t type[,...]] filesystem | snapshot
+ *               [-S field [-S field]...] [-t type[,...]]
+ *               filesystem | snapshot | path
  * zfs groupspace [-Hinp] [-o field[,...]] [-s field [-s field]...]
- *                [-S field [-S field]...] [-t type[,...]] filesystem | snapshot
+ *                [-S field [-S field]...] [-t type[,...]]
+ *                filesystem | snapshot | path
  * zfs projectspace [-Hp] [-o field[,...]] [-s field [-s field]...]
- *                [-S field [-S field]...] filesystem | snapshot
+ *                [-S field [-S field]...] filesystem | snapshot | path
  *
  *	-H      Scripted mode; elide headers and separate columns by tabs.
  *	-i	Translate SID to POSIX ID.
@@ -3191,7 +3193,7 @@ zfs_do_userspace(int argc, char **argv)
 		} while (delim != NULL);
 	}
 
-	if ((zhp = zfs_open(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM |
+	if ((zhp = zfs_path_to_zhandle(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_SNAPSHOT)) == NULL)
 		return (1);
 	if (zhp->zfs_head_type != ZFS_TYPE_FILESYSTEM) {

--- a/man/man8/zfs-userspace.8
+++ b/man/man8/zfs-userspace.8
@@ -44,7 +44,7 @@
 .Oo Fl s Ar field Oc Ns ...
 .Oo Fl S Ar field Oc Ns ...
 .Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
-.Ar filesystem Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar snapshot Ns | Ns Ar path
 .Nm
 .Cm groupspace
 .Op Fl Hinp
@@ -52,14 +52,14 @@
 .Oo Fl s Ar field Oc Ns ...
 .Oo Fl S Ar field Oc Ns ...
 .Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
-.Ar filesystem Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar snapshot Ns | Ns Ar path
 .Nm
 .Cm projectspace
 .Op Fl Hp
 .Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
 .Oo Fl s Ar field Oc Ns ...
 .Oo Fl S Ar field Oc Ns ...
-.Ar filesystem Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar snapshot Ns | Ns Ar path
 .Sh DESCRIPTION
 .Bl -tag -width ""
 .It Xo
@@ -70,10 +70,11 @@
 .Oo Fl s Ar field Oc Ns ...
 .Oo Fl S Ar field Oc Ns ...
 .Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
-.Ar filesystem Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar snapshot Ns | Ns Ar path
 .Xc
-Displays space consumed by, and quotas on, each user in the specified filesystem
-or snapshot.
+Displays space consumed by, and quotas on, each user in the specified filesystem,
+snapshot, or path.
+If a path is given, the filesystem that contains that path will be used.
 This corresponds to the
 .Sy userused@ Ns Em user ,
 .Sy userobjused@ Ns Em user ,
@@ -167,7 +168,7 @@ except that the default types to display are
 .Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
 .Oo Fl s Ar field Oc Ns ...
 .Oo Fl S Ar field Oc Ns ...
-.Ar filesystem Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar snapshot Ns | Ns Ar path
 .Xc
 Displays space consumed by, and quotas on, each project in the specified
 filesystem or snapshot. This subcommand is identical to


### PR DESCRIPTION
Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
Change `zfs userspace` subcommand to use zfs_path_to_zhandle() so that the provided dataset can be a path (/usr) or a dataset (rpool/usr)

### How Has This Been Tested?
Ran the userspace command on both types of input

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
