### PR TITLE
vdev_id: support daisy-chained enclosures

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -34,11 +34,12 @@
 # phys_per_port 4
 # slot          bay
 #
-# #       PCI_ID  HBA PORT  CHANNEL NAME
-# channel 85:00.0 1         A
-# channel 85:00.0 0         B
-# channel 86:00.0 1         C
-# channel 86:00.0 0         D
+# #       PCI_ID  HBA PORT  ENCLOSURE  CHANNEL NAME
+# channel 85:00.0 1         0          A
+# channel 85:00.0 1         1          B
+# channel 85:00.0 0                    C
+# channel 86:00.0 1                    D
+# channel 86:00.0 0                    E
 #
 # # Custom mapping for Channel A
 #
@@ -49,7 +50,8 @@
 # slot 3          3         A
 # slot 4          6         A
 #
-# # Default mapping for B, C, and D
+# # Default mapping for channels B-E
+#
 # slot 1          4
 # slot 2          2
 # slot 3          1
@@ -61,11 +63,11 @@
 #
 # topology      sas_switch
 #
-# #       SWITCH PORT  CHANNEL NAME
-# channel 1            A
-# channel 2            B
-# channel 3            C
-# channel 4            D
+# #       SWITCH PORT  ENCLOSURE  CHANNEL NAME
+# channel 1            0          A
+# channel 1            1          B
+# channel 2                       C
+# channel 3                       D
 
 # #
 # # Example vdev_id.conf - multipath
@@ -133,13 +135,32 @@ map_channel() {
 
 	case $TOPOLOGY in
 		"sas_switch")
-		MAPPED_CHAN=`awk "\\$1 == \"channel\" && \\$2 == ${PORT} \
-			{ print \\$3; exit }" $CONFIG`
+		MAPPED_CHAN=`awk "{
+			if (\\$1 == \"channel\" && \\$4 &&
+			    \\$2 == \"${PORT}\" && \\$3 == \"${ENCLOSURE}\") {
+				print \\$4;
+				exit;
+			} else if (\\$1 == \"channel\" && !\\$4 &&
+				   \\$2 == \"${PORT}\") {
+				print \\$3;
+				exit;
+			}
+		}" $CONFIG`
 		;;
 		"sas_direct"|"scsi")
-		MAPPED_CHAN=`awk "\\$1 == \"channel\" && \
-			\\$2 == \"${PCI_ID}\" && \\$3 == ${PORT} \
-			{ print \\$4; exit }" $CONFIG`
+		MAPPED_CHAN=`awk "{
+			if (\\$1 == \"channel\" && \\$5 &&
+			    \\$2 == \"${PCI_ID}\" && \\$3 == \"${PORT}\" &&
+			    \\$4 == \"${ENCLOSURE}\") {
+				print \\$5;
+				exit;
+			} else if (\\$1 == \"channel\" && !\\$5 &&
+				   \\$2 == \"${PCI_ID}\" &&
+				   \\$3 == \"${PORT}\") {
+				print \\$4;
+				exit;
+			}
+		}" $CONFIG`
 		;;
 	esac
 	printf "%s" ${MAPPED_CHAN}
@@ -299,7 +320,8 @@ sas_handler() {
 		return
 	fi
 
-	CHAN=`map_channel $PCI_ID $PORT`
+	ENCLOSURE=`echo $end_device_dir | awk -F: '{gsub(/.*\//,""); print $2}'`
+	CHAN=`map_channel $PCI_ID $PORT $ENCLOSURE`
 	SLOT=`map_slot $SLOT $CHAN`
 	if [ -z "$CHAN" ] ; then
 		return

--- a/etc/zfs/vdev_id.conf.sas_direct.example
+++ b/etc/zfs/vdev_id.conf.sas_direct.example
@@ -5,11 +5,18 @@ phys_per_port 4
 # Additionally create /dev/by-enclousure/ symlinks for enclosure devices
 enclosure_symlinks	yes
 
-#       PCI_ID  HBA PORT  CHANNEL NAME
-channel 85:00.0 1         A
-channel 85:00.0 0         B
-channel 86:00.0 1         C
-channel 86:00.0 0         D
+# In this example, enclosure "B" is daisy-chained off of
+# enclosure "A", so we specify an enclosure number to
+# distinguish between them.  Daisy-chained enclosures are
+# numbered starting from 0. The other channels are not
+# daisy-chained so the enclosure number is omitted.
+
+#       PCI_ID  HBA PORT  ENCLOSURE  CHANNEL NAME
+channel 85:00.0 1         0          A
+channel 85:00.0 1         1          B
+channel 85:00.0 0                    C
+channel 86:00.0 1                    D
+channel 86:00.0 0                    E
 
 
 # Custom mapping for Channel A
@@ -21,7 +28,7 @@ slot 2          10        A
 slot 3          3         A
 slot 4          6         A
 
-# Default mapping for B, C, and D
+# Default mapping for channels B-E
 slot 1          4
 slot 2          2
 slot 3          1

--- a/etc/zfs/vdev_id.conf.sas_switch.example
+++ b/etc/zfs/vdev_id.conf.sas_switch.example
@@ -1,7 +1,13 @@
 topology      sas_switch
 
-#       SWITCH PORT  CHANNEL NAME
-channel 1            A
-channel 2            B
-channel 3            C
-channel 4            D
+# In this example, enclosure "B" is daisy-chained off of
+# enclosure "A", so we specify an enclosure number to
+# distinguish between them.  Daisy-chained enclosures are
+# numbered starting from 0. The other channels are not
+# daisy-chained so the enclosure number is omitted.
+
+#       SWITCH PORT  ENCLOSURE  CHANNEL NAME
+channel 1            0          A
+channel 1            1          B
+channel 2                       C
+channel 3                       D

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -34,7 +34,7 @@ L2ARC device with an alias.
 defined by udev.  This may be an absolute path or the base filename.
 
 .TP
-\fIchannel\fR [pci_slot] <port> <name>
+\fIchannel\fR [pci_slot] <port> [enclosure_id] <name>
 Maps a physical path to a channel name (typically representing a single
 disk enclosure).
 
@@ -58,6 +58,11 @@ This argument is not used in sas_switch mode.
 
 \fIport\fR - specifies the numeric identifier of the HBA or SAS switch port
 connected to the disk enclosure being mapped.
+
+\fIenclosure_id\fR - specifies the numeric identifier of an enclosure in
+a daisy-chained configuration.  Daisy-chained enclosures are numbered
+starting from 0.  This parameter may be omitted for enclosures that are
+not daisy-chained.
 
 \fIname\fR - specifies the name of the channel.
 
@@ -132,11 +137,18 @@ arbitrary slot re-mapping.
 	phys_per_port 4
 	slot          bay
 
-	#       PCI_SLOT HBA PORT  CHANNEL NAME
-	channel 85:00.0  1         A
-	channel 85:00.0  0         B
-	channel 86:00.0  1         C
-	channel 86:00.0  0         D
+	# In this example, enclosure "B" is daisy-chained off of
+	# enclosure "A", so we specify an enclosure number to
+	# distinguish between them.  Daisy-chained enclosures are
+	# numbered starting from 0. The other channels are not
+	# daisy-chained so the enclosure number is omitted.
+
+	#       PCI_SLOT HBA PORT  ENCLOSURE  CHANNEL NAME
+	channel 85:00.0  1         0          A
+	channel 85:00.0  1         1          B
+	channel 85:00.0  0                    C
+	channel 86:00.0  1                    D
+	channel 86:00.0  0                    E
 
 	# Custom mapping for Channel A
 
@@ -147,7 +159,7 @@ arbitrary slot re-mapping.
 	slot 3          3         A
 	slot 4          6         A
 
-	# Default mapping for B, C, and D
+	# Default mapping for channels B-E
 
 	slot 1          4
 	slot 2          2
@@ -162,11 +174,17 @@ keyword takes only two arguments in this example.
 .nf
 	topology      sas_switch
 
-	#       SWITCH PORT  CHANNEL NAME
-	channel 1            A
-	channel 2            B
-	channel 3            C
-	channel 4            D
+	# In this example, enclosure "B" is daisy-chained off of
+	# enclosure "A", so we specify an enclosure number to
+	# distinguish between them.  Daisy-chained enclosures are
+	# numbered starting from 0. The other channels are not
+	# daisy-chained so the enclosure number is omitted.
+
+	#       SWITCH PORT  ENCLOSURE  CHANNEL NAME
+	channel 1            0          A
+	channel 1            1          B
+	channel 2                       C
+	channel 3                       D
 .fi
 .P
 A multipath configuration.  Note that channel names have multiple


### PR DESCRIPTION
Disks in enclosures in daisy-chained configurations will currently get
conflicting names when using the sas_direct and sas_switch topologies.
This is because the "channel" keyword syntax lacks sufficient location
information to distinguish between enclosures connected the same
physical port.  The channel keyword now supports an optional numeric
enclosure_id parameter to identify the position of an enclosure in a
daisy-chained configuration.  Daisy-chained enclosures are numbered
starting from 0.

Original-version-by: Ned Bass <bass6@llnl.gov>
Signed-off-by: DHE <git@dehacked.net>
Fixes #2074

### Motivation and Context
To assist in using vdev_id when enclosures are daisy-chained, this version of vdev_id supports additional qualification of an enclosure location along a daisy-chain path.

It's worth noting that hardware enclosures with front and back rows of disks are implemented internally as daisy-chained enclosures so this affects users of, say, <a href="https://www.supermicro.com/products/chassis/4U/847/SC847E26-RJBOD1">this supermicro JBOD enclosure</a> (I have a bunch of them).

### Description
Adds an enclosure identifier column indicating its distance away from the controller port in SAS modes.

Reposted from #4886 because it was closed a long time and Github broke on it.

### How Has This Been Tested?
Manually tested a bit with "vdev_id -d sdx" on an system with 2 of the above supermicros daisy-chained (total of 4 expanders in a line)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
