### PR TITLE
Added a flag -e in zpool scrub command to scrub only blocks in error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ cscope.*
 *.orig
 *.log
 venv
+# Ignore Eclipse files
+/.cproject
+/.project
 
 #
 # Module leftovers

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -125,11 +125,15 @@ typedef enum zfs_error {
 	EZFS_THREADCREATEFAILED, /* thread create failed */
 	EZFS_POSTSPLIT_ONLINE,	/* onlining a disk after splitting it */
 	EZFS_SCRUBBING,		/* currently scrubbing */
+	EZFS_ERRORSCRUBBING,	/* currently error scrubbing */
+	EZFS_ERRORSCRUB_PAUSED,	/* error scrub currently paused */
 	EZFS_NO_SCRUB,		/* no active scrub */
+	EZFS_NO_ERRORSCRUB,	/* no active error scrub */
 	EZFS_DIFF,		/* general failure of zfs diff */
 	EZFS_DIFFDATA,		/* bad zfs diff data */
 	EZFS_POOLREADONLY,	/* pool is in read-only mode */
 	EZFS_SCRUB_PAUSED,	/* scrub currently paused */
+	EZFS_SCRUB_PAUSED_TO_CANCEL,	/* scrub currently paused */
 	EZFS_ACTIVE_POOL,	/* pool is imported on a different system */
 	EZFS_CRYPTOFAILED,	/* failed to setup encryption */
 	EZFS_NO_PENDING,	/* cannot cancel, no operation is pending */

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -130,6 +130,8 @@ int lzc_reopen(const char *, boolean_t);
 int lzc_pool_checkpoint(const char *);
 int lzc_pool_checkpoint_discard(const char *);
 
+int lzc_scrub(zfs_ioc_t, const char *, nvlist_t *, nvlist_t **);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -373,6 +373,7 @@ typedef struct dmu_buf {
 #define	DMU_POOL_DDT_STATS		"DDT-statistics"
 #define	DMU_POOL_CREATION_VERSION	"creation_version"
 #define	DMU_POOL_SCAN			"scan"
+#define	DMU_POOL_ERRORSCRUB		"error_scrub"
 #define	DMU_POOL_FREE_BPOBJ		"free_bpobj"
 #define	DMU_POOL_BPTREE_OBJ		"bptree_obj"
 #define	DMU_POOL_EMPTY_BPOBJ		"empty_bpobj"

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -29,6 +29,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/zio.h>
+#include <sys/zap.h>
 #include <sys/ddt.h>
 #include <sys/bplist.h>
 
@@ -75,6 +76,21 @@ typedef enum dsl_scan_flags {
 } dsl_scan_flags_t;
 
 #define	DSL_SCAN_FLAGS_MASK (DSF_VISIT_DS_AGAIN)
+
+typedef struct dsl_errorscrub_phys {
+	uint64_t dep_func; /* pool_scan_func_t */
+	uint64_t dep_state; /* dsl_scan_state_t */
+	uint64_t dep_cursor; /* serialized zap cursor for tracing progress */
+	uint64_t dep_start_time; /* error scrub start time, unix timestamp */
+	uint64_t dep_end_time; /* error scrub end time, unix timestamp */
+	uint64_t dep_to_examine; /* total error blocks to be scrubbed */
+	uint64_t dep_examined; /* blocks scrubbed so far */
+	uint64_t dep_errors;	/* error scrub I/O error count */
+	uint64_t dep_paused_flags; /* flag for paused */
+} dsl_errorscrub_phys_t;
+
+#define	ERRORSCRUB_PHYS_NUMINTS (sizeof (dsl_errorscrub_phys_t) \
+	/ sizeof (uint64_t))
 
 /*
  * Every pool will have one dsl_scan_t and this structure will contain
@@ -148,11 +164,16 @@ typedef struct dsl_scan {
 	uint64_t scn_avg_zio_size_this_txg;
 	uint64_t scn_zios_this_txg;
 
+	/* zap cursor for tracing error scrub progress */
+	zap_cursor_t errorscrub_cursor;
 	/* members needed for syncing scan status to disk */
 	dsl_scan_phys_t scn_phys;	/* on disk representation of scan */
 	dsl_scan_phys_t scn_phys_cached;
 	avl_tree_t scn_queue;		/* queue of datasets to scan */
 	uint64_t scn_bytes_pending;	/* outstanding data to issue */
+
+	/* members needed for syncing error scrub status to disk */
+	dsl_errorscrub_phys_t errorscrub_phys;
 } dsl_scan_t;
 
 typedef struct dsl_scan_io_queue dsl_scan_io_queue_t;
@@ -162,10 +183,12 @@ void scan_fini(void);
 int dsl_scan_init(struct dsl_pool *dp, uint64_t txg);
 void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
-int dsl_scan_cancel(struct dsl_pool *);
+int dsl_scan_cancel(struct dsl_pool *, pool_scan_func_t func);
 int dsl_scan(struct dsl_pool *, pool_scan_func_t);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
-int dsl_scrub_set_pause_resume(const struct dsl_pool *dp, pool_scrub_cmd_t cmd);
+int dsl_scrub_set_pause_resume(const struct dsl_pool *dp,
+    pool_scrub_cmd_t cmd, pool_scan_func_t func);
+void dsl_errorscrub_sync(struct dsl_pool *, dmu_tx_t *);
 void dsl_resilver_restart(struct dsl_pool *, uint64_t txg);
 boolean_t dsl_scan_resilvering(struct dsl_pool *dp);
 boolean_t dsl_dataset_unstable(struct dsl_dataset *ds);
@@ -177,6 +200,7 @@ void dsl_scan_ds_clone_swapped(struct dsl_dataset *ds1, struct dsl_dataset *ds2,
     struct dmu_tx *tx);
 boolean_t dsl_scan_active(dsl_scan_t *scn);
 boolean_t dsl_scan_is_paused_scrub(const dsl_scan_t *scn);
+boolean_t dsl_errorscrub_is_paused(const dsl_scan_t *scn);
 void dsl_scan_freed(spa_t *spa, const blkptr_t *bp);
 void dsl_scan_io_queue_destroy(dsl_scan_io_queue_t *queue);
 void dsl_scan_io_queue_vdev_xfer(vdev_t *svd, vdev_t *tvd);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -899,6 +899,7 @@ typedef enum pool_scan_func {
 	POOL_SCAN_NONE,
 	POOL_SCAN_SCRUB,
 	POOL_SCAN_RESILVER,
+	POOL_ERRORSCRUB,
 	POOL_SCAN_FUNCS
 } pool_scan_func_t;
 
@@ -908,6 +909,7 @@ typedef enum pool_scan_func {
 typedef enum pool_scrub_cmd {
 	POOL_SCRUB_NORMAL = 0,
 	POOL_SCRUB_PAUSE,
+	POOL_ERRORSCRUB_STOP,
 	POOL_SCRUB_FLAGS_END
 } pool_scrub_cmd_t;
 
@@ -962,6 +964,20 @@ typedef struct pool_scan_stat {
 	uint64_t	pss_pass_scrub_spent_paused;
 	uint64_t	pss_pass_issued; /* issued bytes per scan pass */
 	uint64_t	pss_issued;	/* total bytes checked by scanner */
+
+	/* error scrub values stored on disk */
+	uint64_t	pss_error_scrub_func;	/* pool_scan_func_t */
+	uint64_t	pss_error_scrub_state;	/* dsl_scan_state_t */
+	uint64_t	pss_error_scrub_start;	/* error scrub start time */
+	uint64_t	pss_error_scrub_end;	/* error scrub end time */
+	uint64_t	pss_error_scrub_examined; /* error blocks issued I/O */
+	/* error blocks to be issued I/O */
+	uint64_t	pss_error_scrub_to_be_examined;
+
+	/* error scrub values not stored on disk */
+	/* error scrub pause time in milliseconds */
+	uint64_t	pss_pass_error_scrub_pause;
+
 } pool_scan_stat_t;
 
 typedef struct pool_removal_stat {
@@ -983,6 +999,7 @@ typedef enum dsl_scan_state {
 	DSS_SCANNING,
 	DSS_FINISHED,
 	DSS_CANCELED,
+	DSS_ERRORSCRUBING,
 	DSS_NUM_STATES
 } dsl_scan_state_t;
 
@@ -1277,6 +1294,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_TRIM,			/* 0x5a50 */
 	ZFS_IOC_REDACT,				/* 0x5a51 */
 	ZFS_IOC_GET_BOOKMARK_PROPS,		/* 0x5a52 */
+	ZFS_IOC_POOL_SCRUB,			/* 0x5a53 */
 
 	/*
 	 * Linux - 3/64 numbers reserved.

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -863,8 +863,9 @@ extern void spa_l2cache_drop(spa_t *spa);
 
 /* scanning */
 extern int spa_scan(spa_t *spa, pool_scan_func_t func);
-extern int spa_scan_stop(spa_t *spa);
-extern int spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t flag);
+extern int spa_scan_stop(spa_t *spa, pool_scan_func_t func);
+extern int spa_scrub_pause_resume(spa_t *spa, pool_scan_func_t func,
+    pool_scrub_cmd_t flag);
 
 /* spa syncing */
 extern void spa_sync(spa_t *spa, uint64_t txg); /* only for DMU use */
@@ -1175,6 +1176,7 @@ extern void zfs_post_remove(spa_t *spa, vdev_t *vd);
 extern void zfs_post_state_change(spa_t *spa, vdev_t *vd, uint64_t laststate);
 extern void zfs_post_autoreplace(spa_t *spa, vdev_t *vd);
 extern uint64_t spa_get_errlog_size(spa_t *spa);
+extern uint64_t spa_get_last_errlog_size(spa_t *spa);
 extern int spa_get_errlog(spa_t *spa, void *uaddr, size_t *count);
 extern void spa_errlog_rotate(spa_t *spa);
 extern void spa_errlog_drain(spa_t *spa);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -287,6 +287,10 @@ struct spa {
 	uint64_t	spa_scan_pass_exam;	/* examined bytes per pass */
 	uint64_t	spa_scan_pass_issued;	/* issued bytes per pass */
 
+	/* error scrub pause time in milliseconds */
+	uint64_t	spa_scan_pass_errorscrub_pause;
+	/* total error scrub paused time in milliseconds */
+	uint64_t	spa_scan_pass_errorscrub_spent_paused;
 	/*
 	 * We are in the middle of a resilver, and another resilver
 	 * is needed once this one completes. This is set iff any

--- a/include/sys/sysevent/eventdefs.h
+++ b/include/sys/sysevent/eventdefs.h
@@ -123,6 +123,11 @@ extern "C" {
 #define	ESC_ZFS_TRIM_CANCEL		"trim_cancel"
 #define	ESC_ZFS_TRIM_RESUME		"trim_resume"
 #define	ESC_ZFS_TRIM_SUSPEND		"trim_suspend"
+#define	ESC_ZFS_ERRORSCRUB_START	"error_scrub_start"
+#define	ESC_ZFS_ERRORSCRUB_FINISH	"error_scrub_finish"
+#define	ESC_ZFS_ERRORSCRUB_ABORT	"error_scrub_abort"
+#define	ESC_ZFS_ERRORSCRUB_RESUME	"error_scrub_resume"
+#define	ESC_ZFS_ERRORSCRUB_PAUSED	"error_scrub_paused"
 
 /*
  * datalink subclass definitions.

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -253,12 +253,25 @@ libzfs_error_description(libzfs_handle_t *hdl)
 		    "into a new one"));
 	case EZFS_SCRUB_PAUSED:
 		return (dgettext(TEXT_DOMAIN, "scrub is paused; "
-		    "use 'zpool scrub' to resume"));
+		    "use 'zpool scrub' to resume scrub"));
+	case EZFS_SCRUB_PAUSED_TO_CANCEL:
+		return (dgettext(TEXT_DOMAIN, "scrub is paused; "
+		    "use 'zpool scrub' to resume or 'zpool scrub -s' to "
+		    "cancel scrub"));
 	case EZFS_SCRUBBING:
 		return (dgettext(TEXT_DOMAIN, "currently scrubbing; "
-		    "use 'zpool scrub -s' to cancel current scrub"));
+		    "use 'zpool scrub -s' to cancel scrub"));
+	case EZFS_ERRORSCRUBBING:
+		return (dgettext(TEXT_DOMAIN, "currently error scrubbing; "
+		    "use 'zpool scrub -e -s' to cancel error scrub"));
+	case EZFS_ERRORSCRUB_PAUSED:
+		return (dgettext(TEXT_DOMAIN, "error scrub is paused; "
+		    "use 'zpool scrub -e' to resume error scrub"));
 	case EZFS_NO_SCRUB:
 		return (dgettext(TEXT_DOMAIN, "there is no active scrub"));
+	case EZFS_NO_ERRORSCRUB:
+		return (dgettext(TEXT_DOMAIN, "there is no active error "
+		    "scrub"));
 	case EZFS_DIFF:
 		return (dgettext(TEXT_DOMAIN, "unable to generate diffs"));
 	case EZFS_DIFFDATA:

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -172,6 +172,7 @@
 .Nm
 .Cm scrub
 .Op Fl s | Fl p
+.Op Fl e
 .Ar pool Ns ...
 .Nm
 .Cm trim
@@ -2149,6 +2150,7 @@ The only property supported at the moment is
 .Nm
 .Cm scrub
 .Op Fl s | Fl p
+.Op Fl e
 .Ar pool Ns ...
 .Xc
 Begins a scrub or resumes a paused scrub.
@@ -2183,14 +2185,33 @@ resilver completes.
 Note that, due to changes in pool data on a live system, it is possible for
 scrubs to progress slightly beyond 100% completion. During this period, no
 completion time estimate will be provided.
+.Pp
+Flag
+.Fl e
+allows scrub only blocks in error log. Just like regular scrub,
+error scrub can also be paused, resumed and cancelled in the same way. Like
+regular scrubbing and resilvering, error scrubbing is also I/O-intensive
+operation. So you can't run error scrub with either regular scrubbing or
+resilvering being running. Additionally, you also can't run error scrub
+if regular scrub is in paused state either.
 .Bl -tag -width Ds
 .It Fl s
-Stop scrubbing.
+Stop scrubbing. If along with
+.Fl s,
+.Fl e
+is also passed. If any, error scrub would get stopped.
 .El
 .Bl -tag -width Ds
 .It Fl p
-Pause scrubbing.
-Scrub pause state and progress are periodically synced to disk.
+Pause scrubbing. If along with
+.Fl p,
+.Fl e
+is also passed. If any, scrub would get paused and can be resumed later
+on with
+.Fl e
+in
+.Nm zpool Cm scrub
+command. Scrub pause state and progress are periodically synced to disk.
 If the system is restarted or pool is exported during a paused scrub,
 even after import, scrub will remain paused until it is resumed.
 Once resumed the scrub will pick up from the place where it was last
@@ -2198,6 +2219,15 @@ checkpointed to disk.
 To resume a paused scrub issue
 .Nm zpool Cm scrub
 again.
+.El
+.Bl -tag -width Ds
+.It Fl e
+Only scrub blocks in the error log. Error blocks scrub can also be paused and
+cancelled with flag
+.Fl p
+and
+.Fl s
+respectively.
 .El
 .It Xo
 .Nm

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7749,23 +7749,24 @@ spa_vdev_setfru(spa_t *spa, uint64_t guid, const char *newfru)
  * ==========================================================================
  */
 int
-spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t cmd)
+spa_scrub_pause_resume(spa_t *spa, pool_scan_func_t func, pool_scrub_cmd_t cmd)
 {
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
 
 	if (dsl_scan_resilvering(spa->spa_dsl_pool))
 		return (SET_ERROR(EBUSY));
 
-	return (dsl_scrub_set_pause_resume(spa->spa_dsl_pool, cmd));
+	return (dsl_scrub_set_pause_resume(spa->spa_dsl_pool, cmd, func));
 }
 
 int
-spa_scan_stop(spa_t *spa)
+spa_scan_stop(spa_t *spa, pool_scan_func_t func)
 {
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
 	if (dsl_scan_resilvering(spa->spa_dsl_pool))
 		return (SET_ERROR(EBUSY));
-	return (dsl_scan_cancel(spa->spa_dsl_pool));
+
+	return (dsl_scan_cancel(spa->spa_dsl_pool, func));
 }
 
 int
@@ -8759,6 +8760,7 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 
 		ddt_sync(spa, txg);
 		dsl_scan_sync(dp, tx);
+		dsl_errorscrub_sync(dp, tx);
 		svr_sync(spa, tx);
 		spa_sync_upgrades(spa, tx);
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2452,9 +2452,18 @@ spa_scan_stat_init(spa_t *spa)
 		spa->spa_scan_pass_scrub_pause = spa->spa_scan_pass_start;
 	else
 		spa->spa_scan_pass_scrub_pause = 0;
+
+	if (dsl_errorscrub_is_paused(spa->spa_dsl_pool->dp_scan))
+		spa->spa_scan_pass_errorscrub_pause = spa->spa_scan_pass_start;
+	else
+		spa->spa_scan_pass_errorscrub_pause = 0;
+
 	spa->spa_scan_pass_scrub_spent_paused = 0;
 	spa->spa_scan_pass_exam = 0;
 	spa->spa_scan_pass_issued = 0;
+
+	// error scrub stats
+	spa->spa_scan_pass_errorscrub_spent_paused = 0;
 	vdev_scan_stat_init(spa->spa_root_vdev);
 }
 
@@ -2466,8 +2475,11 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 {
 	dsl_scan_t *scn = spa->spa_dsl_pool ? spa->spa_dsl_pool->dp_scan : NULL;
 
-	if (scn == NULL || scn->scn_phys.scn_func == POOL_SCAN_NONE)
+	if (scn == NULL || (scn->scn_phys.scn_func == POOL_SCAN_NONE &&
+	    scn->errorscrub_phys.dep_func == POOL_SCAN_NONE)) {
 		return (SET_ERROR(ENOENT));
+	}
+
 	bzero(ps, sizeof (pool_scan_stat_t));
 
 	/* data stored on disk */
@@ -2489,6 +2501,18 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 	ps->pss_pass_issued = spa->spa_scan_pass_issued;
 	ps->pss_issued =
 	    scn->scn_issued_before_pass + spa->spa_scan_pass_issued;
+
+	/* error scrub data stored on disk */
+	ps->pss_error_scrub_func = scn->errorscrub_phys.dep_func;
+	ps->pss_error_scrub_state = scn->errorscrub_phys.dep_state;
+	ps->pss_error_scrub_start = scn->errorscrub_phys.dep_start_time;
+	ps->pss_error_scrub_end = scn->errorscrub_phys.dep_end_time;
+	ps->pss_error_scrub_examined = scn->errorscrub_phys.dep_examined;
+	ps->pss_error_scrub_to_be_examined =
+	    scn->errorscrub_phys.dep_to_examine;
+
+	/* error scrub data not stored on disk */
+	ps->pss_pass_error_scrub_pause = spa->spa_scan_pass_errorscrub_pause;
 
 	return (0);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1739,15 +1739,57 @@ zfs_ioc_pool_scan(zfs_cmd_t *zc)
 	if ((error = spa_open(zc->zc_name, &spa, FTAG)) != 0)
 		return (error);
 
-	if (zc->zc_flags == POOL_SCRUB_PAUSE)
-		error = spa_scrub_pause_resume(spa, POOL_SCRUB_PAUSE);
-	else if (zc->zc_cookie == POOL_SCAN_NONE)
-		error = spa_scan_stop(spa);
+	if (zc->zc_flags == POOL_SCRUB_PAUSE) {
+		error = spa_scrub_pause_resume(spa, zc->zc_cookie,
+		    POOL_SCRUB_PAUSE);
+	} else if (zc->zc_cookie == POOL_SCAN_NONE)
+		error = spa_scan_stop(spa, zc->zc_cookie);
 	else
 		error = spa_scan(spa, zc->zc_cookie);
 
 	spa_close(spa, FTAG);
 
+	return (error);
+}
+
+/*
+ * inputs:
+ * poolname             name of the pool
+ * scan_type            scan func (pool_scan_func_t)
+ * scan_command         scrub pause/resume flag (pool_scrub_cmd_t)
+ */
+static const zfs_ioc_key_t zfs_keys_pool_scrub[] = {
+	{"scan_type",		DATA_TYPE_UINT64,	0},
+	{"scan_command",	DATA_TYPE_UINT64,	0},
+};
+
+static int
+zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
+{
+	spa_t *spa;
+	int error;
+	pool_scan_func_t scan_type =
+	    (pool_scan_func_t)fnvlist_lookup_uint64(innvl, "scan_type");
+	pool_scrub_cmd_t scan_cmd =
+	    (pool_scrub_cmd_t)fnvlist_lookup_uint64(innvl, "scan_command");
+
+	if (scan_cmd >= POOL_SCRUB_FLAGS_END)
+		return (SET_ERROR(EINVAL));
+
+	if ((error = spa_open(poolname, &spa, FTAG)) != 0)
+		return (error);
+
+	if (scan_cmd == POOL_SCRUB_PAUSE) {
+		error = spa_scrub_pause_resume(spa, scan_type,
+		    POOL_SCRUB_PAUSE);
+	} else if (scan_cmd == POOL_ERRORSCRUB_STOP)
+		error = spa_scan_stop(spa, scan_type);
+	else if (scan_type == POOL_SCAN_NONE)
+		error = spa_scan_stop(spa, scan_type);
+	else
+		error = spa_scan(spa, scan_type);
+
+	spa_close(spa, FTAG);
 	return (error);
 }
 
@@ -6887,6 +6929,11 @@ zfs_ioctl_init(void)
 	    zfs_ioc_pool_trim, zfs_secpolicy_config, POOL_NAME,
 	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_TRUE, B_TRUE,
 	    zfs_keys_pool_trim, ARRAY_SIZE(zfs_keys_pool_trim));
+
+	zfs_ioctl_register("scrub", ZFS_IOC_POOL_SCRUB,
+	    zfs_ioc_pool_scrub, zfs_secpolicy_config, POOL_NAME,
+	    POOL_CHECK_NONE, B_TRUE, B_TRUE,
+	    zfs_keys_pool_scrub, ARRAY_SIZE(zfs_keys_pool_scrub));
 
 	/* IOCTLS that use the legacy function signature */
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -447,7 +447,9 @@ tags = ['functional', 'cli_root', 'zpool_resilver']
 tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
     'zpool_scrub_004_pos', 'zpool_scrub_005_pos',
     'zpool_scrub_encrypted_unloaded', 'zpool_scrub_print_repairing',
-    'zpool_scrub_offline_device', 'zpool_scrub_multiple_copies']
+    'zpool_scrub_offline_device', 'zpool_scrub_multiple_copies',
+    'zpool_error_scrub_001_pos', 'zpool_error_scrub_002_pos',
+    'zpool_error_scrub_003_pos']
 tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]

--- a/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
@@ -677,6 +677,16 @@ test_vdev_trim(const char *pool)
 	nvlist_free(required);
 }
 
+static void
+test_scrub(const char *pool)
+{
+	nvlist_t *required = fnvlist_alloc();
+	fnvlist_add_uint64(required, "scan_type", 1ULL << 30);
+	fnvlist_add_uint64(required, "scan_command", 1ULL << 31);
+	IOC_INPUT_TEST(ZFS_IOC_POOL_SCRUB, pool, required, NULL, EINVAL);
+	nvlist_free(required);
+}
+
 static int
 zfs_destroy(const char *dataset)
 {
@@ -804,6 +814,8 @@ zfs_ioc_input_tests(const char *pool)
 
 	test_vdev_initialize(pool);
 	test_vdev_trim(pool);
+
+	test_scrub(pool);
 
 	/*
 	 * cleanup
@@ -954,6 +966,7 @@ validate_ioc_values(void)
 	CHECK(ZFS_IOC_BASE + 80 == ZFS_IOC_POOL_TRIM);
 	CHECK(ZFS_IOC_BASE + 81 == ZFS_IOC_REDACT);
 	CHECK(ZFS_IOC_BASE + 82 == ZFS_IOC_GET_BOOKMARK_PROPS);
+	CHECK(ZFS_IOC_BASE + 83 == ZFS_IOC_POOL_SCRUB);
 	CHECK(LINUX_IOC_BASE + 1 == ZFS_IOC_EVENTS_NEXT);
 	CHECK(LINUX_IOC_BASE + 2 == ZFS_IOC_EVENTS_CLEAR);
 	CHECK(LINUX_IOC_BASE + 3 == ZFS_IOC_EVENTS_SEEK);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2193,6 +2193,12 @@ function is_pool_scrubbing #pool <verbose>
 	return $?
 }
 
+function is_pool_error_scrubbing #pool <verbose>
+{
+	check_pool_status "$1" "scrub" "error scrub in progress since " $2
+	return $?
+}
+
 function is_pool_scrubbed #pool <verbose>
 {
 	check_pool_status "$1" "scan" "scrub repaired" $2
@@ -2205,9 +2211,21 @@ function is_pool_scrub_stopped #pool <verbose>
 	return $?
 }
 
+function is_pool_error_scrub_stopped #pool <verbose>
+{
+	check_pool_status "$1" "scrub" "error scrub canceled on " $2
+	return $?
+}	
+
 function is_pool_scrub_paused #pool <verbose>
 {
 	check_pool_status "$1" "scan" "scrub paused since " $2
+	return $?
+}
+
+function is_pool_error_scrub_paused #pool <verbose>
+{
+	check_pool_status "$1" "scrub" "error scrub paused since " $2
 	return $?
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/Makefile.am
@@ -10,7 +10,10 @@ dist_pkgdata_SCRIPTS = \
 	zpool_scrub_encrypted_unloaded.ksh \
 	zpool_scrub_offline_device.ksh \
 	zpool_scrub_print_repairing.ksh \
-	zpool_scrub_multiple_copies.ksh
+	zpool_scrub_multiple_copies.ksh \
+	zpool_error_scrub_001_pos.ksh \
+	zpool_error_scrub_002_pos.ksh \
+	zpool_error_scrub_003_pos.ksh
 
 dist_pkgdata_DATA = \
 	zpool_scrub.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_001_pos.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+# Use is subject to license terms.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify scrub -e, scrub -e -p, and scrub -e -s show the right status.
+#
+# STRATEGY:
+#	1. Create a pool and create a 10MB file in it.
+#	2. Start a error scrub (-e) and verify it's doing a scrub.
+#	3. Pause error scrub (-e, -p) and verify it's paused.
+#	4. Try to pause a paused error scrub (-e, -p) and make sure that fails.
+#	5. Resume the paused error scrub and verify again it's doing a scrub.
+#	6. Verify zpool scrub -s -e succeed when the system is error scrubbing.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must set_tunable32 zfs_scan_suspend_progress 0
+	log_must zinject -c all
+	rm -f $TESTDIR/10m_file
+}
+
+log_onexit cleanup
+
+log_assert "Verify scrub -e, -e -p, and -e -s show the right status."
+
+log_must mkfile 10m $TESTDIR/10m_file
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+log_must zinject -t data -e checksum -f 100 $TESTDIR/10m_file
+
+# create some error blocks
+dd if=$TESTDIR/10m_file bs=1M count=1 || true
+
+# sync error blocks to disk
+log_must sync_pool $TESTPOOL
+
+log_must set_tunable32 zfs_scan_suspend_progress 1
+log_must zpool scrub -e $TESTPOOL
+log_must is_pool_error_scrubbing $TESTPOOL true
+log_must zpool scrub -e -p $TESTPOOL
+log_must is_pool_error_scrub_paused $TESTPOOL true
+log_mustnot zpool scrub -e -p $TESTPOOL
+log_must is_pool_error_scrub_paused $TESTPOOL true
+log_must zpool scrub -e $TESTPOOL
+log_must is_pool_error_scrubbing $TESTPOOL true
+log_must zpool scrub -e -s $TESTPOOL
+log_must is_pool_error_scrub_stopped $TESTPOOL true
+
+log_pass "Verified scrub -e, -s -e, and -p -e show expected status."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_002_pos.ksh
@@ -1,0 +1,98 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+# Use is subject to license terms.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify regular scrub and error scrub can't run at the same time.
+#
+# STRATEGY:
+#	1. Create a pool and create a 10MB file in it.
+#	2. Start a scrub and verify it's doing a scrub.
+# 	3. Start a error scrub (-e) and verify it fails.
+#	4. Pause scrub (-p) and verify it's paused.
+#	5. Start a error scrub (-e) verify it fails again.
+#	5. Resume the paused scrub, verify it and cancel it.
+#	6. Start a error scrub (-e) and verify it's doing error scrub.
+# 	7. Start a scrub and verify it fails.
+# 	8. Cancel error scrub (-e) and verify it is canceled.
+# 	9. Start scrub, verify it, cancel it and verify it.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must set_tunable32 zfs_scan_suspend_progress 0
+	log_must zinject -c all
+	rm -f $TESTDIR/10m_file
+}
+
+log_onexit cleanup
+
+log_assert "Verify regular scrub and error scrub can't run at the same time."
+
+log_must mkfile 10m $TESTDIR/10m_file
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+log_must zinject -t data -e checksum -f 100 $TESTDIR/10m_file
+
+# create some error blocks before error scrub is requested.
+dd if=$TESTDIR/10m_file bs=1M count=1 || true
+# sync error blocks to disk
+log_must sync_pool $TESTPOOL
+
+log_must set_tunable32 zfs_scan_suspend_progress 1
+
+log_must zpool scrub $TESTPOOL
+log_must is_pool_scrubbing $TESTPOOL true
+log_mustnot zpool scrub -e $TESTPOOL
+log_must zpool scrub -p $TESTPOOL
+log_must is_pool_scrub_paused $TESTPOOL true
+log_mustnot zpool scrub -e $TESTPOOL
+log_must zpool scrub $TESTPOOL
+log_must is_pool_scrubbing $TESTPOOL true
+log_must zpool scrub -s $TESTPOOL
+log_must is_pool_scrub_stopped $TESTPOOL true
+
+# create some error blocks before error scrub is requested.
+dd if=$TESTDIR/10m_file bs=1M count=1 || true
+# sync error blocks to disk
+log_must sync_pool $TESTPOOL
+
+log_must zpool scrub -e $TESTPOOL
+log_must is_pool_error_scrubbing $TESTPOOL true
+log_mustnot zpool scrub $TESTPOOL
+log_must zpool scrub -e -s $TESTPOOL
+log_must is_pool_error_scrub_stopped $TESTPOOL true
+
+log_must zpool scrub $TESTPOOL
+log_must is_pool_scrubbing $TESTPOOL true
+log_must zpool scrub -s $TESTPOOL
+log_must is_pool_scrub_stopped $TESTPOOL true
+
+log_pass "Verified regular scrub and error scrub can't run at the same time."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_error_scrub_003_pos.ksh
@@ -1,0 +1,70 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+# Use is subject to license terms.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify error scrub clears the errorlog, if errors no longer exists.
+#
+# STRATEGY:
+#	1. Create a pool and create a 10MB file in it.
+#	2. Zinject errors and read using dd to log errors to disk.
+#	3. Make sure file name is mentioned in the list of error files.
+#	4. Start error scrub and wait for it finish.
+#	5. Make sure file name is not mentioned in the list of error files.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	rm -f $TESTDIR/10m_file
+}
+
+log_onexit cleanup
+
+log_assert "Verify error scrub clears the errorlog, if errors no longer exists."
+
+log_must mkfile 10m $TESTDIR/10m_file
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+log_must zinject -t data -e checksum -f 100 $TESTDIR/10m_file
+
+# create some error blocks
+dd if=$TESTDIR/10m_file bs=1M count=1 || true
+
+# sync error blocks to disk
+log_must sync_pool $TESTPOOL
+
+log_must eval "zpool status -v $TESTPOOL | grep '10m_file'"
+log_must zinject -c all
+log_must zpool scrub -e $TESTPOOL
+
+log_mustnot eval "zpool status -v $TESTPOOL | grep '10m_file'"
+
+log_pass "Verify error scrub clears the errorlog, if errors no longer exists."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Added a flag `-e` in `zpool scrub` to scrub only blocks in error log, an user can pause, resume and cancel error scrub by passing additional command line arguments `-p -s` just like regular scrub. 
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, we have `zpool scrub <pool_name> `command which initiates scrubbing the entire pool, a very I/O intensive process. So, here I am working on a new `flag -e ` which scrubs only blocks in  error log (synced to disk). The motivation behind this change is that if we read the same block again error might go away because a). block has been rewritten b). block is not longer reference by any dataset. This error might get resolved by regular scrub but it reads the entire pool not only error blocks. 
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
This involves adding a new flag, creating new libzfs interfaces, a new ioctl, and the actual iteration and read-issuing logic. Error scrubbing is executed in multiple txg to make sure pool performance is not affected.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
