### PR TITLE
Updated nfs.c to properly parse sharenfs args

### DIFF
--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -34,9 +34,14 @@
 #include <unistd.h>
 #include <libzfs.h>
 #include <libshare.h>
+#include <sys/list.h>
+#include <sys/zfs_debug.h>
+#include <stddef.h>
 #include "libshare_impl.h"
 
 static boolean_t nfs_available(void);
+
+static int nfs_enable_share_one(const char *, const char *, char *);
 
 static sa_fstype_t *nfs_fstype;
 
@@ -47,10 +52,39 @@ static sa_fstype_t *nfs_fstype;
 static int nfs_exportfs_temp_fd = -1;
 
 typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
-    void *cookie);
+                                       void *cookie);
 
 typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
-    const char *security, const char *access, void *cookie);
+                                   const char *security, const char *access, void *cookie);
+
+/* List of hosts and their options */
+/* NOTE: share path is stored elsewhere */
+typedef struct nfs_share_list_s {
+    char host[255];
+    char opts[255];
+
+    list_node_t next;
+} nfs_share_list_t;
+
+/* Global list of shares */
+list_t all_nfs_shares_list;
+
+static int
+find_option(char *opt, const char *needle) {
+    char *token, *dup;
+
+    dup = strdup(opt);
+
+    token = strtok(dup, ",");
+    while (token != NULL) {
+        if (strncmp(token, needle, strlen(needle)) == 0)
+            return (1);
+
+        token = strtok(NULL, ",");
+    }
+
+    return (SA_OK);
+}
 
 /*
  * Invokes the specified callback function for each Solaris share option
@@ -58,320 +92,310 @@ typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
  */
 static int
 foreach_nfs_shareopt(const char *shareopts,
-    nfs_shareopt_callback_t callback, void *cookie)
-{
-	char *shareopts_dup, *opt, *cur, *value;
-	int was_nul, rc;
+                     nfs_shareopt_callback_t callback, void *cookie) {
+    char *shareopts_dup, *opt, *cur, *value;
+    int was_nul, rc;
 
-	if (shareopts == NULL)
-		return (SA_OK);
+    if (shareopts == NULL)
+        return (SA_OK);
 
-	shareopts_dup = strdup(shareopts);
+    shareopts_dup = strdup(shareopts);
 
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
+    if (shareopts_dup == NULL)
+        return (SA_NO_MEMORY);
 
-	opt = shareopts_dup;
-	was_nul = 0;
+    opt = shareopts_dup;
+    was_nul = 0;
 
-	while (1) {
-		cur = opt;
+    while (1) {
+        cur = opt;
 
-		while (*cur != ',' && *cur != '\0')
-			cur++;
+        while (*cur != ',' && *cur != '\0')
+            cur++;
 
-		if (*cur == '\0')
-			was_nul = 1;
+        if (*cur == '\0')
+            was_nul = 1;
 
-		*cur = '\0';
+        *cur = '\0';
 
-		if (cur > opt) {
-			value = strchr(opt, '=');
+        if (cur > opt) {
+            value = strchr(opt, '=');
 
-			if (value != NULL) {
-				*value = '\0';
-				value++;
-			}
+            if (value != NULL) {
+                *value = '\0';
+                value++;
+            }
 
-			rc = callback(opt, value, cookie);
+            rc = callback(opt, value, cookie);
 
-			if (rc != SA_OK) {
-				free(shareopts_dup);
-				return (rc);
-			}
-		}
+            if (rc != SA_OK) {
+                free(shareopts_dup);
+                return (rc);
+            }
+        }
 
-		opt = cur + 1;
+        opt = cur + 1;
 
-		if (was_nul)
-			break;
-	}
+        if (was_nul)
+            break;
+    }
 
-	free(shareopts_dup);
+    free(shareopts_dup);
 
-	return (0);
+    return (0);
 }
 
 typedef struct nfs_host_cookie_s {
-	nfs_host_callback_t callback;
-	const char *sharepath;
-	void *cookie;
-	const char *security;
+    nfs_host_callback_t callback;
+    const char *sharepath;
+    void *cookie;
+    const char *security;
 } nfs_host_cookie_t;
 
-/*
- * Helper function for foreach_nfs_host. This function checks whether the
- * current share option is a host specification and invokes a callback
- * function with information about the host.
- */
-static int
-foreach_nfs_host_cb(const char *opt, const char *value, void *pcookie)
-{
-	int rc;
-	const char *access;
-	char *host_dup, *host, *next;
-	nfs_host_cookie_t *udata = (nfs_host_cookie_t *)pcookie;
-
-#ifdef DEBUG
-	fprintf(stderr, "foreach_nfs_host_cb: key=%s, value=%s\n", opt, value);
-#endif
-
-	if (strcmp(opt, "sec") == 0)
-		udata->security = value;
-
-	if (strcmp(opt, "rw") == 0 || strcmp(opt, "ro") == 0) {
-		if (value == NULL)
-			value = "*";
-
-		access = opt;
-
-		host_dup = strdup(value);
-
-		if (host_dup == NULL)
-			return (SA_NO_MEMORY);
-
-		host = host_dup;
-
-		do {
-			next = strchr(host, ':');
-			if (next != NULL) {
-				*next = '\0';
-				next++;
-			}
-
-			rc = udata->callback(udata->sharepath, host,
-			    udata->security, access, udata->cookie);
-
-			if (rc != SA_OK) {
-				free(host_dup);
-
-				return (rc);
-			}
-
-			host = next;
-		} while (host != NULL);
-
-		free(host_dup);
-	}
-
-	return (SA_OK);
-}
-
-/*
- * Invokes a callback function for all NFS hosts that are set for a share.
- */
-static int
-foreach_nfs_host(sa_share_impl_t impl_share, nfs_host_callback_t callback,
-    void *cookie)
-{
-	nfs_host_cookie_t udata;
-	char *shareopts;
-
-	udata.callback = callback;
-	udata.sharepath = impl_share->sharepath;
-	udata.cookie = cookie;
-	udata.security = "sys";
-
-	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
-
-	return foreach_nfs_shareopt(shareopts, foreach_nfs_host_cb,
-	    &udata);
-}
 
 /*
  * Converts a Solaris NFS host specification to its Linux equivalent.
  */
 static int
-get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
-{
-	/*
-	 * For now we just support CIDR masks (e.g. @192.168.0.0/16) and host
-	 * wildcards (e.g. *.example.org).
-	 */
-	if (solaris_hostspec[0] == '@') {
-		/*
-		 * Solaris host specifier, e.g. @192.168.0.0/16; we just need
-		 * to skip the @ in this case
-		 */
-		*plinux_hostspec = strdup(solaris_hostspec + 1);
-	} else {
-		*plinux_hostspec = strdup(solaris_hostspec);
-	}
+get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec) {
+    /*
+     * For now we just support CIDR masks (e.g. @192.168.0.0/16) and host
+     * wildcards (e.g. *.example.org).
+     */
+    if (solaris_hostspec[0] == '@') {
+        /*
+         * Solaris host specifier, e.g. @192.168.0.0/16; we just need
+         * to skip the @ in this case
+         */
+        *plinux_hostspec = strdup(solaris_hostspec + 1);
+    } else {
+        *plinux_hostspec = strdup(solaris_hostspec);
+    }
 
-	if (*plinux_hostspec == NULL) {
-		return (SA_NO_MEMORY);
-	}
+    if (*plinux_hostspec == NULL) {
+        return (SA_NO_MEMORY);
+    }
 
-	return (SA_OK);
+    return (SA_OK);
 }
 
 /*
  * Used internally by nfs_enable_share to enable sharing for a single host.
  */
 static int
-nfs_enable_share_one(const char *sharepath, const char *host,
-    const char *security, const char *access, void *pcookie)
-{
-	int rc;
-	char *linuxhost, *hostpath, *opts;
-	const char *linux_opts = (const char *)pcookie;
-	char *argv[6];
+nfs_enable_share_one(const char *sharepath, const char *host, char *opts) {
+    int rc;
+    char *hostpath;
+    char *argv[6];
 
-	/* exportfs -i -o sec=XX,rX,<opts> <host>:<sharepath> */
+    /* exportfs -i -o sec=XX,rX,<opts> <host>:<sharepath> */
 
-	rc = get_linux_hostspec(host, &linuxhost);
+    hostpath = malloc(strlen(host) + 1 +
+                      strlen(sharepath) + 1);
+    if (hostpath == NULL)
+        return (SA_NO_MEMORY);
+    sprintf(hostpath, "%s:%s", host, sharepath);
 
-	if (rc < 0)
-		exit(1);
+    argv[0] = "/usr/sbin/exportfs";
+    argv[1] = "-i";
+    argv[2] = "-o";
+    argv[3] = opts;
+    argv[4] = hostpath;
+    argv[5] = NULL;
 
-	hostpath = malloc(strlen(linuxhost) + 1 + strlen(sharepath) + 1);
+    rc = libzfs_run_process(argv[0], argv, 0);
 
-	if (hostpath == NULL) {
-		free(linuxhost);
+    free(hostpath);
 
-		exit(1);
-	}
-
-	sprintf(hostpath, "%s:%s", linuxhost, sharepath);
-
-	free(linuxhost);
-
-	if (linux_opts == NULL)
-		linux_opts = "";
-
-	opts = malloc(4 + strlen(security) + 4 + strlen(linux_opts) + 1);
-
-	if (opts == NULL)
-		exit(1);
-
-	sprintf(opts, "sec=%s,%s,%s", security, access, linux_opts);
-
-#ifdef DEBUG
-	fprintf(stderr, "sharing %s with opts %s\n", hostpath, opts);
-#endif
-
-	argv[0] = "/usr/sbin/exportfs";
-	argv[1] = "-i";
-	argv[2] = "-o";
-	argv[3] = opts;
-	argv[4] = hostpath;
-	argv[5] = NULL;
-
-	rc = libzfs_run_process(argv[0], argv, 0);
-
-	free(hostpath);
-	free(opts);
-
-	if (rc < 0)
-		return (SA_SYSTEM_ERR);
-	else
-		return (SA_OK);
+    if (rc < 0)
+        return (SA_SYSTEM_ERR);
+    else
+        return (SA_OK);
 }
 
 /*
  * Adds a Linux share option to an array of NFS options.
  */
 static int
-add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
-{
-	size_t len = 0;
-	char *new_linux_opts;
+add_linux_shareopt(char **plinux_opts, const char *key, const char *value) {
+    size_t len = 0;
+    char *new_linux_opts;
 
-	if (*plinux_opts != NULL)
-		len = strlen(*plinux_opts);
+    if (*plinux_opts != NULL) {
+        len = strlen(*plinux_opts);
 
-	new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
-	    (value ? 1 + strlen(value) : 0) + 1);
+        /* Skip value that already exist */
+        if (find_option(*plinux_opts, key))
+            return (SA_OK);
+    }
 
-	if (new_linux_opts == NULL)
-		return (SA_NO_MEMORY);
+    new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
+                                           (value ? 1 + strlen(value) : 0) + 1);
 
-	new_linux_opts[len] = '\0';
+    if (new_linux_opts == NULL)
+        return (SA_NO_MEMORY);
 
-	if (len > 0)
-		strcat(new_linux_opts, ",");
+    new_linux_opts[len] = '\0';
 
-	strcat(new_linux_opts, key);
+    if (len > 0)
+        strcat(new_linux_opts, ",");
 
-	if (value != NULL) {
-		strcat(new_linux_opts, "=");
-		strcat(new_linux_opts, value);
-	}
+    strcat(new_linux_opts, key);
 
-	*plinux_opts = new_linux_opts;
+    if (value != NULL) {
+        strcat(new_linux_opts, "=");
+        strcat(new_linux_opts, value);
+    }
 
-	return (SA_OK);
+    *plinux_opts = new_linux_opts;
+
+    return (SA_OK);
+}
+
+static int
+update_host_list(void *cookie) {
+    char **plinux_opts = (char **) cookie;
+    nfs_share_list_t *cur_share, *new_share;
+
+    /* Get the last entry in the list. */
+    cur_share = list_tail(&all_nfs_shares_list);
+    if (cur_share == NULL)
+        return (SA_OK);
+
+    /* Create a new object list */
+    new_share = (nfs_share_list_t *)
+            malloc(sizeof(nfs_share_list_t));
+    if (new_share == NULL)
+        return (SA_NO_MEMORY);
+    list_link_init(&new_share->next);
+
+    /* If the current list is empty, the new list is 'world'. */
+    if (cur_share == NULL)
+        strcpy(new_share->host, "*");
+    else
+        strcpy(new_share->host, cur_share->host);
+    sprintf(new_share->opts, "%s", *plinux_opts);
+
+    /* Replace the old head with this new object */
+    if (cur_share->host != NULL)
+        list_link_replace(&cur_share->next, &new_share->next);
+    else
+        list_insert_tail(&all_nfs_shares_list, new_share);
+
+    return (SA_OK);
 }
 
 /*
  * Validates and converts a single Solaris share option to its Linux
- * equivalent.
+ * equivalent, verifies that the option is valid and then stores it
+ * in "cookie"..
  */
 static int
-get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
-{
-	char **plinux_opts = (char **)cookie;
+get_linux_shareopts_cb(const char *key, const char *value, void *cookie) {
+    char **plinux_opts = (char **) cookie;
+    nfs_share_list_t *opts = NULL;
 
-	/* host-specific options, these are taken care of elsewhere */
-	if (strcmp(key, "ro") == 0 || strcmp(key, "rw") == 0 ||
-	    strcmp(key, "sec") == 0)
-		return (SA_OK);
+// TODO: Make sure that a 'sec=yyy' (or any other option) BEFORE a/any
+//       'rw[=@xxx]' or 'ro[=@xxx]' works.
+    if (strcmp(key, "ro") == 0 || strcmp(key, "rw") == 0) {
+        opts = (nfs_share_list_t *) malloc(sizeof(nfs_share_list_t));
+        if (opts == NULL)
+            return (SA_NO_MEMORY);
 
-	if (strcmp(key, "anon") == 0)
-		key = "anonuid";
+        list_link_init(&opts->next);
 
-	if (strcmp(key, "root_mapping") == 0) {
-		(void) add_linux_shareopt(plinux_opts, "root_squash", NULL);
-		key = "anonuid";
-	}
+        if (*plinux_opts != NULL) {
+            /*
+             * We're in a new host list, so update the
+             * previous host definition
+             */
+            update_host_list(cookie);
 
-	if (strcmp(key, "nosub") == 0)
-		key = "subtree_check";
+            /*
+             * Zero the current list of options
+             * so that the next host definition
+             * starts with an empty option list
+             */
+            *plinux_opts = NULL;
+        }
 
-	if (strcmp(key, "insecure") != 0 && strcmp(key, "secure") != 0 &&
-	    strcmp(key, "async") != 0 && strcmp(key, "sync") != 0 &&
-	    strcmp(key, "no_wdelay") != 0 && strcmp(key, "wdelay") != 0 &&
-	    strcmp(key, "nohide") != 0 && strcmp(key, "hide") != 0 &&
-	    strcmp(key, "crossmnt") != 0 &&
-	    strcmp(key, "no_subtree_check") != 0 &&
-	    strcmp(key, "subtree_check") != 0 &&
-	    strcmp(key, "insecure_locks") != 0 &&
-	    strcmp(key, "secure_locks") != 0 &&
-	    strcmp(key, "no_auth_nlm") != 0 && strcmp(key, "auth_nlm") != 0 &&
-	    strcmp(key, "no_acl") != 0 && strcmp(key, "mountpoint") != 0 &&
-	    strcmp(key, "mp") != 0 && strcmp(key, "fsuid") != 0 &&
-	    strcmp(key, "refer") != 0 && strcmp(key, "replicas") != 0 &&
-	    strcmp(key, "root_squash") != 0 &&
-	    strcmp(key, "no_root_squash") != 0 &&
-	    strcmp(key, "all_squash") != 0 &&
-	    strcmp(key, "no_all_squash") != 0 && strcmp(key, "fsid") != 0 &&
-	    strcmp(key, "anonuid") != 0 && strcmp(key, "anongid") != 0) {
-		return (SA_SYNTAX_ERR);
-	}
+        /* Start a new host opts definition */
+        if (value && value[0] == '@') {
+            int rc;
+            char *host;
 
-	(void) add_linux_shareopt(plinux_opts, key, value);
+            /*
+             * Extract the host or network address from the
+             * 'rw=@...' value.
+             */
+            rc = get_linux_hostspec(value, &host);
+            if (rc < 0)
+                return (rc);
 
-	return (SA_OK);
+            strncpy(opts->host, host, sizeof(opts->host));
+            opts->opts[0] = '\0';
+
+            /*
+             * Make sure we don't add the '@...' to the options
+             * list by setting the value to NULL after we're
+             * done with it.
+             */
+            value = NULL;
+        } else {
+            strcpy(opts->host, "*");
+            opts->opts[0] = '\0';
+        }
+        list_insert_tail(&all_nfs_shares_list, opts);
+    }
+
+    if (strcmp(key, "anon") == 0)
+        key = "anonuid";
+
+    if (strcmp(key, "root_mapping") == 0) {
+        (void) add_linux_shareopt(plinux_opts, "root_squash", NULL);
+        key = "anonuid";
+    }
+
+    if (strcmp(key, "nosub") == 0)
+        key = "subtree_check";
+
+    if (strcmp(key, "rw") != 0 &&
+        strcmp(key, "ro") != 0 &&
+        strcmp(key, "sec") != 0 &&
+        strcmp(key, "insecure") != 0 &&
+        strcmp(key, "secure") != 0 &&
+        strcmp(key, "async") != 0 &&
+        strcmp(key, "sync") != 0 &&
+        strcmp(key, "no_wdelay") != 0 &&
+        strcmp(key, "wdelay") != 0 &&
+        strcmp(key, "nohide") != 0 &&
+        strcmp(key, "hide") != 0 &&
+        strcmp(key, "crossmnt") != 0 &&
+        strcmp(key, "no_subtree_check") != 0 &&
+        strcmp(key, "subtree_check") != 0 &&
+        strcmp(key, "insecure_locks") != 0 &&
+        strcmp(key, "secure_locks") != 0 &&
+        strcmp(key, "no_auth_nlm") != 0 &&
+        strcmp(key, "auth_nlm") != 0 &&
+        strcmp(key, "no_acl") != 0 &&
+        strcmp(key, "mountpoint") != 0 &&
+        strcmp(key, "mp") != 0 &&
+        strcmp(key, "fsuid") != 0 &&
+        strcmp(key, "refer") != 0 &&
+        strcmp(key, "replicas") != 0 &&
+        strcmp(key, "root_squash") != 0 &&
+        strcmp(key, "no_root_squash") != 0 &&
+        strcmp(key, "all_squash") != 0 &&
+        strcmp(key, "no_all_squash") != 0 &&
+        strcmp(key, "fsid") != 0 &&
+        strcmp(key, "anonuid") != 0 &&
+        strcmp(key, "anongid") != 0) {
+        return (SA_SYNTAX_ERR);
+    }
+
+    (void) add_linux_shareopt(plinux_opts, key, value);
+
+    return (SA_OK);
 }
 
 /*
@@ -379,207 +403,238 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
  * converts them to a NULL-terminated array of Linux NFS options.
  */
 static int
-get_linux_shareopts(const char *shareopts, char **plinux_opts)
-{
-	int rc;
+get_linux_shareopts(const char *shareopts, char **plinux_opts) {
+    int rc;
 
-	assert(plinux_opts != NULL);
+            assert(plinux_opts != NULL);
 
-	*plinux_opts = NULL;
+    /* Create global list of share host(s) and options */
+    list_create(&all_nfs_shares_list, sizeof(nfs_share_list_t),
+                offsetof(nfs_share_list_t, next));
 
-	/* default options for Solaris shares */
-	(void) add_linux_shareopt(plinux_opts, "no_subtree_check", NULL);
-	(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
-	(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
+    if (strncmp(shareopts, "rw\0", 3) == 0) {
+        /*
+         * 'sharenfs=on' => use default options for Solaris shares.
+         * The 'on' part is changed in nfs_update_shareopts() to 'rw'.
+         */
+        (void) add_linux_shareopt(plinux_opts, "no_subtree_check",
+                                  NULL);
+        (void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
+        (void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
+// TODO: Make sure a 'sharenfs=zzz' WITHOUT a 'rw[=@xxx]' or 'ro[=@xxx]' works
+//	} else if(strcmp(shareopts, "ro\0") != 0) {
+//		/* 'else' only: Doesn't work if there's a 'ro[=@xxx]' somewhere. */
+//		/* 'else if(strcmp(shareopts, "ro\0") == 0)': Doesn't work if there's ONLY a 'ro'. */
+    }
+    rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,
+                              plinux_opts);
 
-	rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,
-	    plinux_opts);
+    if (rc != SA_OK) {
+        free(*plinux_opts);
+        *plinux_opts = NULL;
+    }
 
-	if (rc != SA_OK) {
-		free(*plinux_opts);
-		*plinux_opts = NULL;
-	}
+    update_host_list(plinux_opts);
 
-	return (rc);
+    return (rc);
 }
 
 /*
  * Enables NFS sharing for the specified share.
  */
 static int
-nfs_enable_share(sa_share_impl_t impl_share)
-{
-	char *shareopts, *linux_opts;
-	int rc;
+nfs_enable_share(sa_share_impl_t impl_share) {
+    int rc = SA_OK;
+    char *shareopts, *linux_opts;
+    nfs_share_list_t *share;
 
-	if (!nfs_available()) {
-		return (SA_SYSTEM_ERR);
-	}
+    if (!nfs_available())
+        return (SA_SYSTEM_ERR);
 
-	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
+    shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
+    if (shareopts == NULL)
+        return (SA_OK);
 
-	if (shareopts == NULL)
-		return (SA_OK);
+    linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+    if (!linux_opts)
+        return (SA_NO_MEMORY);
 
-	rc = get_linux_shareopts(shareopts, &linux_opts);
+    rc = get_linux_shareopts(shareopts, &linux_opts);
+    if (rc != SA_OK)
+        return (rc);
 
-	if (rc != SA_OK)
-		return (rc);
+    for (share = list_head(&all_nfs_shares_list);
+         share != NULL;
+         share = list_next(&all_nfs_shares_list, share)) {
 
-	rc = foreach_nfs_host(impl_share, nfs_enable_share_one, linux_opts);
+        rc = nfs_enable_share_one(impl_share->sharepath,
+                                  share->host, share->opts);
+    }
 
-	free(linux_opts);
+    free(linux_opts);
 
-	return (rc);
+    return (rc);
 }
 
 /*
  * Used internally by nfs_disable_share to disable sharing for a single host.
  */
 static int
-nfs_disable_share_one(const char *sharepath, const char *host,
-    const char *security, const char *access, void *cookie)
-{
-	int rc;
-	char *linuxhost, *hostpath;
-	char *argv[4];
+nfs_disable_share_one(const char *sharepath, const char *host, char *opts) {
+    int rc;
+    char *hostpath;
+    char *argv[4];
 
-	rc = get_linux_hostspec(host, &linuxhost);
+    /* exportfs -u <host>:<sharepath> */
 
-	if (rc < 0)
-		exit(1);
+    hostpath = malloc(strlen(host) + 1 + strlen(sharepath) + 1);
+    if (hostpath == NULL)
+        return (SA_NO_MEMORY);
+    sprintf(hostpath, "%s:%s", host, sharepath);
 
-	hostpath = malloc(strlen(linuxhost) + 1 + strlen(sharepath) + 1);
+    argv[0] = "/usr/sbin/exportfs";
+    argv[1] = "-u";
+    argv[2] = hostpath;
+    argv[3] = NULL;
 
-	if (hostpath == NULL) {
-		free(linuxhost);
-		exit(1);
-	}
+    rc = libzfs_run_process(argv[0], argv, 0);
 
-	sprintf(hostpath, "%s:%s", linuxhost, sharepath);
+    free(hostpath);
 
-	free(linuxhost);
-
-#ifdef DEBUG
-	fprintf(stderr, "unsharing %s\n", hostpath);
-#endif
-
-	argv[0] = "/usr/sbin/exportfs";
-	argv[1] = "-u";
-	argv[2] = hostpath;
-	argv[3] = NULL;
-
-	rc = libzfs_run_process(argv[0], argv, 0);
-
-	free(hostpath);
-
-	if (rc < 0)
-		return (SA_SYSTEM_ERR);
-	else
-		return (SA_OK);
+    if (rc < 0)
+        return (SA_SYSTEM_ERR);
+    else
+        return (SA_OK);
 }
 
 /*
  * Disables NFS sharing for the specified share.
  */
 static int
-nfs_disable_share(sa_share_impl_t impl_share)
-{
-	if (!nfs_available()) {
-		/*
-		 * The share can't possibly be active, so nothing
-		 * needs to be done to disable it.
-		 */
-		return (SA_OK);
-	}
+nfs_disable_share(sa_share_impl_t impl_share) {
+    int rc = SA_OK;
+    char *shareopts, *linux_opts;
+    nfs_share_list_t *share;
 
-	return (foreach_nfs_host(impl_share, nfs_disable_share_one, NULL));
+    if (!nfs_available()) {
+        /*
+         * The share can't possibly be active, so nothing
+         * needs to be done to disable it.
+         */
+        return (SA_OK);
+    }
+
+    shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
+    if (shareopts == NULL)
+        return (SA_OK);
+
+    linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+    if (!linux_opts)
+        return (SA_NO_MEMORY);
+
+    rc = get_linux_shareopts(shareopts, &linux_opts);
+    if (rc != SA_OK)
+        return (rc);
+
+    for (share = list_head(&all_nfs_shares_list);
+         share != NULL;
+         share = list_next(&all_nfs_shares_list, share)) {
+
+        rc = nfs_disable_share_one(impl_share->sharepath,
+                                   share->host, NULL);
+    }
+
+    free(linux_opts);
+
+    return (rc);
 }
 
 /*
  * Checks whether the specified NFS share options are syntactically correct.
  */
 static int
-nfs_validate_shareopts(const char *shareopts)
-{
-	char *linux_opts;
-	int rc;
+nfs_validate_shareopts(const char *shareopts) {
+    char *linux_opts;
+    int rc;
 
-	rc = get_linux_shareopts(shareopts, &linux_opts);
+    linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+    if (!linux_opts)
+        return (SA_NO_MEMORY);
 
-	if (rc != SA_OK)
-		return (rc);
+    rc = get_linux_shareopts(shareopts, &linux_opts);
 
-	free(linux_opts);
+    if (rc != SA_OK)
+        return (rc);
 
-	return (SA_OK);
+    free(linux_opts);
+
+    return (SA_OK);
 }
 
 /*
  * Checks whether a share is currently active.
  */
 static boolean_t
-nfs_is_share_active(sa_share_impl_t impl_share)
-{
-	int fd;
-	char line[512];
-	char *tab, *cur;
-	FILE *nfs_exportfs_temp_fp;
+nfs_is_share_active(sa_share_impl_t impl_share) {
+    int fd;
+    char line[512];
+    char *tab, *cur;
+    FILE *nfs_exportfs_temp_fp;
 
-	if (!nfs_available())
-		return (B_FALSE);
+    if (!nfs_available())
+        return (B_FALSE);
 
-	if ((fd = dup(nfs_exportfs_temp_fd)) == -1)
-		return (B_FALSE);
+    if ((fd = dup(nfs_exportfs_temp_fd)) == -1)
+        return (B_FALSE);
 
-	nfs_exportfs_temp_fp = fdopen(fd, "r");
+    nfs_exportfs_temp_fp = fdopen(fd, "r");
 
-	if (nfs_exportfs_temp_fp == NULL)
-		return (B_FALSE);
+    if (nfs_exportfs_temp_fp == NULL)
+        return (B_FALSE);
 
-	if (fseek(nfs_exportfs_temp_fp, 0, SEEK_SET) < 0) {
-		fclose(nfs_exportfs_temp_fp);
-		return (B_FALSE);
-	}
+    if (fseek(nfs_exportfs_temp_fp, 0, SEEK_SET) < 0) {
+        fclose(nfs_exportfs_temp_fp);
+        return (B_FALSE);
+    }
 
-	while (fgets(line, sizeof (line), nfs_exportfs_temp_fp) != NULL) {
-		/*
-		 * exportfs uses separate lines for the share path
-		 * and the export options when the share path is longer
-		 * than a certain amount of characters; this ignores
-		 * the option lines
-		 */
-		if (line[0] == '\t')
-			continue;
+    while (fgets(line, sizeof(line), nfs_exportfs_temp_fp) != NULL) {
+        /*
+         * exportfs uses separate lines for the share path
+         * and the export options when the share path is longer
+         * than a certain amount of characters; this ignores
+         * the option lines
+         */
+        if (line[0] == '\t')
+            continue;
 
-		tab = strchr(line, '\t');
+        tab = strchr(line, '\t');
 
-		if (tab != NULL) {
-			*tab = '\0';
-			cur = tab - 1;
-		} else {
-			/*
-			 * there's no tab character, which means the
-			 * NFS options are on a separate line; we just
-			 * need to remove the new-line character
-			 * at the end of the line
-			 */
-			cur = line + strlen(line) - 1;
-		}
+        if (tab != NULL) {
+            *tab = '\0';
+            cur = tab - 1;
+        } else {
+            /*
+             * there's no tab character, which means the
+             * NFS options are on a separate line; we just
+             * need to remove the new-line character
+             * at the end of the line
+             */
+            cur = line + strlen(line) - 1;
+        }
 
-		/* remove trailing spaces and new-line characters */
-		while (cur >= line && (*cur == ' ' || *cur == '\n'))
-			*cur-- = '\0';
+        /* remove trailing spaces and new-line characters */
+        while (cur >= line && (*cur == ' ' || *cur == '\n'))
+            *cur-- = '\0';
 
-		if (strcmp(line, impl_share->sharepath) == 0) {
-			fclose(nfs_exportfs_temp_fp);
-			return (B_TRUE);
-		}
-	}
+        if (strcmp(line, impl_share->sharepath) == 0) {
+            fclose(nfs_exportfs_temp_fp);
+            return (B_TRUE);
+        }
+    }
 
-	fclose(nfs_exportfs_temp_fp);
+    fclose(nfs_exportfs_temp_fp);
 
-	return (B_FALSE);
+    return (B_FALSE);
 }
 
 /*
@@ -590,40 +645,39 @@ nfs_is_share_active(sa_share_impl_t impl_share)
  */
 static int
 nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
-    const char *shareopts)
-{
-	char *shareopts_dup;
-	boolean_t needs_reshare = B_FALSE;
-	char *old_shareopts;
+                     const char *shareopts) {
+    char *shareopts_dup;
+    boolean_t needs_reshare = B_FALSE;
+    char *old_shareopts;
 
-	FSINFO(impl_share, nfs_fstype)->active =
-	    nfs_is_share_active(impl_share);
+    FSINFO(impl_share, nfs_fstype)->active =
+            nfs_is_share_active(impl_share);
 
-	old_shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
+    old_shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
 
-	if (strcmp(shareopts, "on") == 0)
-		shareopts = "rw,crossmnt";
+    if (strcmp(shareopts, "on") == 0)
+        shareopts = "rw,crossmnt";
 
-	if (FSINFO(impl_share, nfs_fstype)->active && old_shareopts != NULL &&
-	    strcmp(old_shareopts, shareopts) != 0) {
-		needs_reshare = B_TRUE;
-		nfs_disable_share(impl_share);
-	}
+    if (FSINFO(impl_share, nfs_fstype)->active && old_shareopts != NULL &&
+        strcmp(old_shareopts, shareopts) != 0) {
+        needs_reshare = B_TRUE;
+        nfs_disable_share(impl_share);
+    }
 
-	shareopts_dup = strdup(shareopts);
+    shareopts_dup = strdup(shareopts);
 
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
+    if (shareopts_dup == NULL)
+        return (SA_NO_MEMORY);
 
-	if (old_shareopts != NULL)
-		free(old_shareopts);
+    if (old_shareopts != NULL)
+        free(old_shareopts);
 
-	FSINFO(impl_share, nfs_fstype)->shareopts = shareopts_dup;
+    FSINFO(impl_share, nfs_fstype)->shareopts = shareopts_dup;
 
-	if (needs_reshare)
-		nfs_enable_share(impl_share);
+    if (needs_reshare)
+        nfs_enable_share(impl_share);
 
-	return (SA_OK);
+    return (SA_OK);
 }
 
 /*
@@ -631,19 +685,18 @@ nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
  * clean up shares that are about to be free()'d.
  */
 static void
-nfs_clear_shareopts(sa_share_impl_t impl_share)
-{
-	free(FSINFO(impl_share, nfs_fstype)->shareopts);
-	FSINFO(impl_share, nfs_fstype)->shareopts = NULL;
+nfs_clear_shareopts(sa_share_impl_t impl_share) {
+    free(FSINFO(impl_share, nfs_fstype)->shareopts);
+    FSINFO(impl_share, nfs_fstype)->shareopts = NULL;
 }
 
 static const sa_share_ops_t nfs_shareops = {
-	.enable_share = nfs_enable_share,
-	.disable_share = nfs_disable_share,
+        .enable_share = nfs_enable_share,
+        .disable_share = nfs_disable_share,
 
-	.validate_shareopts = nfs_validate_shareopts,
-	.update_shareopts = nfs_update_shareopts,
-	.clear_shareopts = nfs_clear_shareopts,
+        .validate_shareopts = nfs_validate_shareopts,
+        .update_shareopts = nfs_update_shareopts,
+        .clear_shareopts = nfs_clear_shareopts,
 };
 
 /*
@@ -659,88 +712,85 @@ static const sa_share_ops_t nfs_shareops = {
  *        there is no libshare_nfs_fini() function.
  */
 static int
-nfs_check_exportfs(void)
-{
-	pid_t pid;
-	int rc, status;
-	static char nfs_exportfs_tempfile[] = "/tmp/exportfs.XXXXXX";
+nfs_check_exportfs(void) {
+    pid_t pid;
+    int rc, status;
+    static char nfs_exportfs_tempfile[] = "/tmp/exportfs.XXXXXX";
 
-	/*
-	 * Close any existing temporary copies of output from exportfs.
-	 * We have already called unlink() so file will be deleted.
-	 */
-	if (nfs_exportfs_temp_fd >= 0)
-		close(nfs_exportfs_temp_fd);
+    /*
+     * Close any existing temporary copies of output from exportfs.
+     * We have already called unlink() so file will be deleted.
+     */
+    if (nfs_exportfs_temp_fd >= 0)
+        close(nfs_exportfs_temp_fd);
 
-	nfs_exportfs_temp_fd = mkstemp(nfs_exportfs_tempfile);
+    nfs_exportfs_temp_fd = mkstemp(nfs_exportfs_tempfile);
 
-	if (nfs_exportfs_temp_fd < 0)
-		return (SA_SYSTEM_ERR);
+    if (nfs_exportfs_temp_fd < 0)
+        return (SA_SYSTEM_ERR);
 
-	unlink(nfs_exportfs_tempfile);
+    unlink(nfs_exportfs_tempfile);
 
-	(void) fcntl(nfs_exportfs_temp_fd, F_SETFD, FD_CLOEXEC);
+    (void) fcntl(nfs_exportfs_temp_fd, F_SETFD, FD_CLOEXEC);
 
-	pid = fork();
+    pid = fork();
 
-	if (pid < 0) {
-		(void) close(nfs_exportfs_temp_fd);
-		nfs_exportfs_temp_fd = -1;
-		return (SA_SYSTEM_ERR);
-	}
+    if (pid < 0) {
+        (void) close(nfs_exportfs_temp_fd);
+        nfs_exportfs_temp_fd = -1;
+        return (SA_SYSTEM_ERR);
+    }
 
-	if (pid > 0) {
-		while ((rc = waitpid(pid, &status, 0)) <= 0 &&
-		    errno == EINTR) { }
+    if (pid > 0) {
+        while ((rc = waitpid(pid, &status, 0)) <= 0 &&
+               errno == EINTR) {}
 
-		if (rc <= 0) {
-			(void) close(nfs_exportfs_temp_fd);
-			nfs_exportfs_temp_fd = -1;
-			return (SA_SYSTEM_ERR);
-		}
+        if (rc <= 0) {
+            (void) close(nfs_exportfs_temp_fd);
+            nfs_exportfs_temp_fd = -1;
+            return (SA_SYSTEM_ERR);
+        }
 
-		if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-			(void) close(nfs_exportfs_temp_fd);
-			nfs_exportfs_temp_fd = -1;
-			return (SA_CONFIG_ERR);
-		}
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            (void) close(nfs_exportfs_temp_fd);
+            nfs_exportfs_temp_fd = -1;
+            return (SA_CONFIG_ERR);
+        }
 
-		return (SA_OK);
-	}
+        return (SA_OK);
+    }
 
-	/* child */
+    /* child */
 
-	/* exportfs -v */
+    /* exportfs -v */
 
-	if (dup2(nfs_exportfs_temp_fd, STDOUT_FILENO) < 0)
-		exit(1);
+    if (dup2(nfs_exportfs_temp_fd, STDOUT_FILENO) < 0)
+        exit(1);
 
-	rc = execlp("/usr/sbin/exportfs", "exportfs", "-v", NULL);
+    rc = execlp("/usr/sbin/exportfs", "exportfs", "-v", NULL);
 
-	if (rc < 0) {
-		exit(1);
-	}
+    if (rc < 0) {
+        exit(1);
+    }
 
-	exit(0);
+    exit(0);
 }
 
 /*
  * Provides a convenient wrapper for determining nfs availability
  */
 static boolean_t
-nfs_available(void)
-{
-	if (nfs_exportfs_temp_fd == -1)
-		(void) nfs_check_exportfs();
+nfs_available(void) {
+    if (nfs_exportfs_temp_fd == -1)
+        (void) nfs_check_exportfs();
 
-	return ((nfs_exportfs_temp_fd != -1) ? B_TRUE : B_FALSE);
+    return ((nfs_exportfs_temp_fd != -1) ? B_TRUE : B_FALSE);
 }
 
 /*
  * Initializes the NFS functionality of libshare.
  */
 void
-libshare_nfs_init(void)
-{
-	nfs_fstype = register_fstype("nfs", &nfs_shareops);
+libshare_nfs_init(void) {
+    nfs_fstype = register_fstype("nfs", &nfs_shareops);
 }

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -237,7 +237,7 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
 	}
 
 	new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
-            (value ? 1 + strlen(value) : 0)
+	    (value ? 1 + strlen(value) : 0)
 	    + 1);
 
 	if (new_linux_opts == NULL)
@@ -476,7 +476,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
 	    share = list_next(&all_nfs_shares_list, share)) {
 
 		rc = nfs_enable_share_one(impl_share->sharepath,
-                    share->host, share->opts);
+		    share->host, share->opts);
 	}
 
 	free(linux_opts);

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -55,7 +55,8 @@ typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
                                        void *cookie);
 
 typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
-                                   const char *security, const char *access, void *cookie);
+                                   const char *security, const char *access,
+                                   void *cookie);
 
 /* List of hosts and their options */
 /* NOTE: share path is stored elsewhere */
@@ -70,7 +71,8 @@ typedef struct nfs_share_list_s {
 list_t all_nfs_shares_list;
 
 static int
-find_option(char *opt, const char *needle) {
+find_option(char *opt, const char *needle)
+{
     char *token, *dup;
 
     dup = strdup(opt);
@@ -92,7 +94,8 @@ find_option(char *opt, const char *needle) {
  */
 static int
 foreach_nfs_shareopt(const char *shareopts,
-                     nfs_shareopt_callback_t callback, void *cookie) {
+                     nfs_shareopt_callback_t callback, void *cookie)
+{
     char *shareopts_dup, *opt, *cur, *value;
     int was_nul, rc;
 
@@ -157,7 +160,8 @@ typedef struct nfs_host_cookie_s {
  * Converts a Solaris NFS host specification to its Linux equivalent.
  */
 static int
-get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec) {
+get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
+{
     /*
      * For now we just support CIDR masks (e.g. @192.168.0.0/16) and host
      * wildcards (e.g. *.example.org).
@@ -183,7 +187,8 @@ get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec) {
  * Used internally by nfs_enable_share to enable sharing for a single host.
  */
 static int
-nfs_enable_share_one(const char *sharepath, const char *host, char *opts) {
+nfs_enable_share_one(const char *sharepath, const char *host, char *opts)
+{
     int rc;
     char *hostpath;
     char *argv[6];
@@ -217,7 +222,8 @@ nfs_enable_share_one(const char *sharepath, const char *host, char *opts) {
  * Adds a Linux share option to an array of NFS options.
  */
 static int
-add_linux_shareopt(char **plinux_opts, const char *key, const char *value) {
+add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
+{
     size_t len = 0;
     char *new_linux_opts;
 
@@ -230,7 +236,7 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value) {
     }
 
     new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
-                                           (value ? 1 + strlen(value) : 0) + 1);
+                             (value ? 1 + strlen(value) : 0) + 1);
 
     if (new_linux_opts == NULL)
         return (SA_NO_MEMORY);
@@ -253,7 +259,8 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value) {
 }
 
 static int
-update_host_list(void *cookie) {
+update_host_list(void *cookie)
+{
     char **plinux_opts = (char **) cookie;
     nfs_share_list_t *cur_share, *new_share;
 
@@ -264,7 +271,7 @@ update_host_list(void *cookie) {
 
     /* Create a new object list */
     new_share = (nfs_share_list_t *)
-            malloc(sizeof(nfs_share_list_t));
+                malloc(sizeof(nfs_share_list_t));
     if (new_share == NULL)
         return (SA_NO_MEMORY);
     list_link_init(&new_share->next);
@@ -291,7 +298,8 @@ update_host_list(void *cookie) {
  * in "cookie"..
  */
 static int
-get_linux_shareopts_cb(const char *key, const char *value, void *cookie) {
+get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
+{
     char **plinux_opts = (char **) cookie;
     nfs_share_list_t *opts = NULL;
 
@@ -403,10 +411,11 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie) {
  * converts them to a NULL-terminated array of Linux NFS options.
  */
 static int
-get_linux_shareopts(const char *shareopts, char **plinux_opts) {
+get_linux_shareopts(const char *shareopts, char **plinux_opts)
+{
     int rc;
 
-            assert(plinux_opts != NULL);
+    assert(plinux_opts != NULL);
 
     /* Create global list of share host(s) and options */
     list_create(&all_nfs_shares_list, sizeof(nfs_share_list_t),
@@ -422,9 +431,9 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts) {
         (void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
         (void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
 // TODO: Make sure a 'sharenfs=zzz' WITHOUT a 'rw[=@xxx]' or 'ro[=@xxx]' works
-//	} else if(strcmp(shareopts, "ro\0") != 0) {
-//		/* 'else' only: Doesn't work if there's a 'ro[=@xxx]' somewhere. */
-//		/* 'else if(strcmp(shareopts, "ro\0") == 0)': Doesn't work if there's ONLY a 'ro'. */
+//  } else if(strcmp(shareopts, "ro\0") != 0) {
+//      /* 'else' only: Doesn't work if there's a 'ro[=@xxx]' somewhere. */
+//      /* 'else if(strcmp(shareopts, "ro\0") == 0)': Doesn't work if there's ONLY a 'ro'. */
     }
     rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,
                               plinux_opts);
@@ -443,7 +452,8 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts) {
  * Enables NFS sharing for the specified share.
  */
 static int
-nfs_enable_share(sa_share_impl_t impl_share) {
+nfs_enable_share(sa_share_impl_t impl_share)
+{
     int rc = SA_OK;
     char *shareopts, *linux_opts;
     nfs_share_list_t *share;
@@ -480,7 +490,8 @@ nfs_enable_share(sa_share_impl_t impl_share) {
  * Used internally by nfs_disable_share to disable sharing for a single host.
  */
 static int
-nfs_disable_share_one(const char *sharepath, const char *host, char *opts) {
+nfs_disable_share_one(const char *sharepath, const char *host, char *opts)
+{
     int rc;
     char *hostpath;
     char *argv[4];
@@ -511,7 +522,8 @@ nfs_disable_share_one(const char *sharepath, const char *host, char *opts) {
  * Disables NFS sharing for the specified share.
  */
 static int
-nfs_disable_share(sa_share_impl_t impl_share) {
+nfs_disable_share(sa_share_impl_t impl_share)
+{
     int rc = SA_OK;
     char *shareopts, *linux_opts;
     nfs_share_list_t *share;
@@ -553,7 +565,8 @@ nfs_disable_share(sa_share_impl_t impl_share) {
  * Checks whether the specified NFS share options are syntactically correct.
  */
 static int
-nfs_validate_shareopts(const char *shareopts) {
+nfs_validate_shareopts(const char *shareopts)
+{
     char *linux_opts;
     int rc;
 
@@ -575,7 +588,8 @@ nfs_validate_shareopts(const char *shareopts) {
  * Checks whether a share is currently active.
  */
 static boolean_t
-nfs_is_share_active(sa_share_impl_t impl_share) {
+nfs_is_share_active(sa_share_impl_t impl_share)
+{
     int fd;
     char line[512];
     char *tab, *cur;
@@ -645,13 +659,14 @@ nfs_is_share_active(sa_share_impl_t impl_share) {
  */
 static int
 nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
-                     const char *shareopts) {
+                     const char *shareopts)
+{
     char *shareopts_dup;
     boolean_t needs_reshare = B_FALSE;
     char *old_shareopts;
 
     FSINFO(impl_share, nfs_fstype)->active =
-            nfs_is_share_active(impl_share);
+        nfs_is_share_active(impl_share);
 
     old_shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
 
@@ -685,18 +700,19 @@ nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
  * clean up shares that are about to be free()'d.
  */
 static void
-nfs_clear_shareopts(sa_share_impl_t impl_share) {
+nfs_clear_shareopts(sa_share_impl_t impl_share)
+{
     free(FSINFO(impl_share, nfs_fstype)->shareopts);
     FSINFO(impl_share, nfs_fstype)->shareopts = NULL;
 }
 
 static const sa_share_ops_t nfs_shareops = {
-        .enable_share = nfs_enable_share,
-        .disable_share = nfs_disable_share,
+    .enable_share = nfs_enable_share,
+    .disable_share = nfs_disable_share,
 
-        .validate_shareopts = nfs_validate_shareopts,
-        .update_shareopts = nfs_update_shareopts,
-        .clear_shareopts = nfs_clear_shareopts,
+    .validate_shareopts = nfs_validate_shareopts,
+    .update_shareopts = nfs_update_shareopts,
+    .clear_shareopts = nfs_clear_shareopts,
 };
 
 /*
@@ -712,7 +728,8 @@ static const sa_share_ops_t nfs_shareops = {
  *        there is no libshare_nfs_fini() function.
  */
 static int
-nfs_check_exportfs(void) {
+nfs_check_exportfs(void)
+{
     pid_t pid;
     int rc, status;
     static char nfs_exportfs_tempfile[] = "/tmp/exportfs.XXXXXX";
@@ -780,7 +797,8 @@ nfs_check_exportfs(void) {
  * Provides a convenient wrapper for determining nfs availability
  */
 static boolean_t
-nfs_available(void) {
+nfs_available(void)
+{
     if (nfs_exportfs_temp_fd == -1)
         (void) nfs_check_exportfs();
 
@@ -791,6 +809,7 @@ nfs_available(void) {
  * Initializes the NFS functionality of libshare.
  */
 void
-libshare_nfs_init(void) {
+libshare_nfs_init(void)
+{
     nfs_fstype = register_fstype("nfs", &nfs_shareops);
 }

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -62,8 +62,7 @@ typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
 
 /* List of hosts and their options */
 /* NOTE: share path is stored elsewhere */
-typedef struct nfs_share_list_s
-{
+typedef struct nfs_share_list_s {
 	char host[255];
 	char opts[255];
 
@@ -97,7 +96,7 @@ find_option(char *opt, const char *needle)
  */
 static int
 foreach_nfs_shareopt(const char *shareopts,
-	nfs_shareopt_callback_t callback, void *cookie)
+    nfs_shareopt_callback_t callback, void *cookie)
 {
 	char *shareopts_dup, *opt, *cur, *value;
 	int was_nul, rc;
@@ -151,8 +150,7 @@ foreach_nfs_shareopt(const char *shareopts,
 	return (0);
 }
 
-typedef struct nfs_host_cookie_s
-{
+typedef struct nfs_host_cookie_s {
 	nfs_host_callback_t callback;
 	const char *sharepath;
 	void *cookie;
@@ -175,8 +173,7 @@ get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
 		 * to skip the @ in this case
 		 */
 		*plinux_hostspec = strdup(solaris_hostspec + 1);
-	}
-	else {
+	} else {
 		*plinux_hostspec = strdup(solaris_hostspec);
 	}
 
@@ -200,7 +197,7 @@ nfs_enable_share_one(const char *sharepath, const char *host, char *opts)
 	/* exportfs -i -o sec=XX,rX,<opts> <host>:<sharepath> */
 
 	hostpath = malloc(strlen(host) + 1 +
-		strlen(sharepath) + 1);
+	    strlen(sharepath) + 1);
 	if (hostpath == NULL)
 		return (SA_NO_MEMORY);
 	sprintf(hostpath, "%s:%s", host, sharepath);
@@ -240,8 +237,8 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
 	}
 
 	new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
-		(value ? 1 + strlen(value) : 0)
-		+ 1);
+            (value ? 1 + strlen(value) : 0)
+	    + 1);
 
 	if (new_linux_opts == NULL)
 		return (SA_NO_MEMORY);
@@ -266,7 +263,7 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
 static int
 update_host_list(void *cookie)
 {
-	char **plinux_opts = (char **) cookie;
+	char **plinux_opts = (char **)cookie;
 	nfs_share_list_t *cur_share, *new_share;
 
 	/* Get the last entry in the list. */
@@ -275,8 +272,7 @@ update_host_list(void *cookie)
 		return (SA_OK);
 
 	/* Create a new object list */
-	new_share = (nfs_share_list_t *)
-		malloc(sizeof(nfs_share_list_t));
+	new_share = (nfs_share_list_t *)malloc(sizeof (nfs_share_list_t));
 	if (new_share == NULL)
 		return (SA_NO_MEMORY);
 	list_link_init(&new_share->next);
@@ -305,18 +301,14 @@ update_host_list(void *cookie)
 static int
 get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 {
-	char **plinux_opts = (char **) cookie;
+	char **plinux_opts = (char **)cookie;
 	nfs_share_list_t *opts = NULL;
 
-#ifdef DEBUG
-	fprintf(stderr, "Before cb processing => key = %s, value = %s, plinux_opts = %s\n", key, value, *plinux_opts);
-#endif
-
 // TODO: Make sure that a 'sec=yyy' (or any other option) BEFORE a/any
-//		 'rw[=@xxx]' or 'ro[=@xxx]' works.
+//  'rw[=@xxx]' or 'ro[=@xxx]' works.
 	if (strcmp(key, "ro") == 0 || strcmp(key, "rw") == 0) {
 
-		opts = (nfs_share_list_t *) malloc(sizeof(nfs_share_list_t));
+		opts = (nfs_share_list_t *)malloc(sizeof (nfs_share_list_t));
 
 		if (opts == NULL)
 			return (SA_NO_MEMORY);
@@ -343,7 +335,7 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 		 * when we encounter a new host.
 		 */
 		(void) add_linux_shareopt(plinux_opts, "no_subtree_check",
-								  NULL);
+		    NULL);
 		(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
 		(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
 
@@ -360,7 +352,7 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 			if (rc < 0)
 				return (rc);
 
-			strncpy(opts->host, host, sizeof(opts->host));
+			strncpy(opts->host, host, sizeof (opts->host));
 			opts->opts[0] = '\0';
 
 			/*
@@ -369,8 +361,7 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 			 * done with it.
 			 */
 			value = NULL;
-		}
-		else {
+		} else {
 			strcpy(opts->host, "*");
 			opts->opts[0] = '\0';
 		}
@@ -389,42 +380,39 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 		key = "subtree_check";
 
 	if (strcmp(key, "rw") != 0 &&
-		strcmp(key, "ro") != 0 &&
-		strcmp(key, "sec") != 0 &&
-		strcmp(key, "insecure") != 0 &&
-		strcmp(key, "secure") != 0 &&
-		strcmp(key, "async") != 0 &&
-		strcmp(key, "sync") != 0 &&
-		strcmp(key, "no_wdelay") != 0 &&
-		strcmp(key, "wdelay") != 0 &&
-		strcmp(key, "nohide") != 0 &&
-		strcmp(key, "hide") != 0 &&
-		strcmp(key, "crossmnt") != 0 &&
-		strcmp(key, "no_subtree_check") != 0 &&
-		strcmp(key, "subtree_check") != 0 &&
-		strcmp(key, "insecure_locks") != 0 &&
-		strcmp(key, "secure_locks") != 0 &&
-		strcmp(key, "no_auth_nlm") != 0 &&
-		strcmp(key, "auth_nlm") != 0 &&
-		strcmp(key, "no_acl") != 0 &&
-		strcmp(key, "mountpoint") != 0 &&
-		strcmp(key, "mp") != 0 &&
-		strcmp(key, "fsuid") != 0 &&
-		strcmp(key, "refer") != 0 &&
-		strcmp(key, "replicas") != 0 &&
-		strcmp(key, "root_squash") != 0 &&
-		strcmp(key, "no_root_squash") != 0 &&
-		strcmp(key, "all_squash") != 0 &&
-		strcmp(key, "no_all_squash") != 0 &&
-		strcmp(key, "fsid") != 0 &&
-		strcmp(key, "anonuid") != 0 &&
-		strcmp(key, "anongid") != 0) {
+	    strcmp(key, "ro") != 0 &&
+	    strcmp(key, "sec") != 0 &&
+	    strcmp(key, "insecure") != 0 &&
+	    strcmp(key, "secure") != 0 &&
+	    strcmp(key, "async") != 0 &&
+	    strcmp(key, "sync") != 0 &&
+	    strcmp(key, "no_wdelay") != 0 &&
+	    strcmp(key, "wdelay") != 0 &&
+	    strcmp(key, "nohide") != 0 &&
+	    strcmp(key, "hide") != 0 &&
+	    strcmp(key, "crossmnt") != 0 &&
+	    strcmp(key, "no_subtree_check") != 0 &&
+	    strcmp(key, "subtree_check") != 0 &&
+	    strcmp(key, "insecure_locks") != 0 &&
+	    strcmp(key, "secure_locks") != 0 &&
+	    strcmp(key, "no_auth_nlm") != 0 &&
+	    strcmp(key, "auth_nlm") != 0 &&
+	    strcmp(key, "no_acl") != 0 &&
+	    strcmp(key, "mountpoint") != 0 &&
+	    strcmp(key, "mp") != 0 &&
+	    strcmp(key, "fsuid") != 0 &&
+	    strcmp(key, "refer") != 0 &&
+	    strcmp(key, "replicas") != 0 &&
+	    strcmp(key, "root_squash") != 0 &&
+	    strcmp(key, "no_root_squash") != 0 &&
+	    strcmp(key, "all_squash") != 0 &&
+	    strcmp(key, "no_all_squash") != 0 &&
+	    strcmp(key, "fsid") != 0 &&
+	    strcmp(key, "anonuid") != 0 &&
+	    strcmp(key, "anongid") != 0) {
 		return (SA_SYNTAX_ERR);
 	}
 
-#ifdef DEBUG
-	fprintf(stderr, "After cb processing => key = %s, value = %s, plinux_opts = %s\n", key, value, *plinux_opts);
-#endif
 	(void) add_linux_shareopt(plinux_opts, key, value);
 
 	return (SA_OK);
@@ -439,17 +427,14 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
 {
 	int rc;
 
-		assert(plinux_opts != NULL);
+	assert(plinux_opts != NULL);
 
 	/* Create global list of share host(s) and options */
-	list_create(&all_nfs_shares_list, sizeof(nfs_share_list_t),
-				offsetof(nfs_share_list_t, next));
+	list_create(&all_nfs_shares_list, sizeof (nfs_share_list_t),
+	    offsetof(nfs_share_list_t, next));
 
-#ifdef DEBUG
-	fprintf(stderr, "shareopts: %s, before nfs shareopts plinuxopts: %s\n", shareopts, *plinux_opts);
-#endif
 	rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,
-							  plinux_opts);
+	    plinux_opts);
 
 	if (rc != SA_OK) {
 		free(*plinux_opts);
@@ -478,7 +463,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
 	if (shareopts == NULL)
 		return (SA_OK);
 
-	linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
 	if (!linux_opts)
 		return (SA_NO_MEMORY);
 
@@ -487,11 +472,11 @@ nfs_enable_share(sa_share_impl_t impl_share)
 		return (rc);
 
 	for (share = list_head(&all_nfs_shares_list);
-		 share != NULL;
-		 share = list_next(&all_nfs_shares_list, share)) {
+	    share != NULL;
+	    share = list_next(&all_nfs_shares_list, share)) {
 
 		rc = nfs_enable_share_one(impl_share->sharepath,
-								  share->host, share->opts);
+                    share->host, share->opts);
 	}
 
 	free(linux_opts);
@@ -553,7 +538,7 @@ nfs_disable_share(sa_share_impl_t impl_share)
 	if (shareopts == NULL)
 		return (SA_OK);
 
-	linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
 	if (!linux_opts)
 		return (SA_NO_MEMORY);
 
@@ -562,11 +547,11 @@ nfs_disable_share(sa_share_impl_t impl_share)
 		return (rc);
 
 	for (share = list_head(&all_nfs_shares_list);
-		 share != NULL;
-		 share = list_next(&all_nfs_shares_list, share)) {
+	    share != NULL;
+	    share = list_next(&all_nfs_shares_list, share)) {
 
 		rc = nfs_disable_share_one(impl_share->sharepath,
-								   share->host, NULL);
+		    share->host, NULL);
 	}
 
 	free(linux_opts);
@@ -583,7 +568,7 @@ nfs_validate_shareopts(const char *shareopts)
 	char *linux_opts;
 	int rc;
 
-	linux_opts = calloc(sizeof(nfs_share_list_t), 1);
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
 	if (!linux_opts)
 		return (SA_NO_MEMORY);
 
@@ -624,7 +609,7 @@ nfs_is_share_active(sa_share_impl_t impl_share)
 		return (B_FALSE);
 	}
 
-	while (fgets(line, sizeof(line), nfs_exportfs_temp_fp) != NULL) {
+	while (fgets(line, sizeof (line), nfs_exportfs_temp_fp) != NULL) {
 		/*
 		 * exportfs uses separate lines for the share path
 		 * and the export options when the share path is longer
@@ -639,8 +624,7 @@ nfs_is_share_active(sa_share_impl_t impl_share)
 		if (tab != NULL) {
 			*tab = '\0';
 			cur = tab - 1;
-		}
-		else {
+		} else {
 			/*
 			 * there's no tab character, which means the
 			 * NFS options are on a separate line; we just
@@ -673,14 +657,14 @@ nfs_is_share_active(sa_share_impl_t impl_share)
  */
 static int
 nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
-	const char *shareopts)
+    const char *shareopts)
 {
 	char *shareopts_dup;
 	boolean_t needs_reshare = B_FALSE;
 	char *old_shareopts;
 
 	FSINFO(impl_share, nfs_fstype)->active =
-		nfs_is_share_active(impl_share);
+	    nfs_is_share_active(impl_share);
 
 	old_shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
 
@@ -688,7 +672,7 @@ nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
 		shareopts = "rw,crossmnt";
 
 	if (FSINFO(impl_share, nfs_fstype)->active && old_shareopts != NULL &&
-		strcmp(old_shareopts, shareopts) != 0) {
+	    strcmp(old_shareopts, shareopts) != 0) {
 		needs_reshare = B_TRUE;
 		nfs_disable_share(impl_share);
 	}
@@ -736,10 +720,10 @@ static const sa_share_ops_t nfs_shareops = {
  * To update this temporary copy simply call this function again.
  *
  * TODO : Use /var/lib/nfs/etab instead of our private copy.
- *		  But must implement locking to prevent concurrent access.
+ *        But must implement locking to prevent concurrent access.
  *
  * TODO : The temporary file descriptor is never closed since
- *		  there is no libshare_nfs_fini() function.
+ *        there is no libshare_nfs_fini() function.
  */
 static int
 nfs_check_exportfs(void)
@@ -774,7 +758,7 @@ nfs_check_exportfs(void)
 
 	if (pid > 0) {
 		while ((rc = waitpid(pid, &status, 0)) <= 0 &&
-			errno == EINTR) {}
+		    errno == EINTR) {}
 
 		if (rc <= 0) {
 			(void) close(nfs_exportfs_temp_fd);


### PR DESCRIPTION




Signed-off-by: Dipack P Panjabi <dpanjabi@hudson-trading.com>
Closes #2773

### Description
<!--- Describe your changes in detail -->
In the current iteration of the sharenfs option parsing,
it cannot distinguish between options set for different hosts.
Ex: sharenfs="rw=@host1,root_squash,rw=@host2,no_root_squash"
sets both hosts to NOT have their root user access squashed,
which is incorrect.

In this commit, I have just reproduced Turbo's (@FranzUrbo) work,
and rebased it against current master.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested by simply a running a command as follows:
```
zfs set sharenfs="rw=@host1,root_squash,rw=@host2,no_root_squash" pool1/d1
```
and checking the output of `exportfs -v`.

<!--- Include details of your testing environment, and the tests you ran to -->
Tested on a Debian 9.9 VM, with the changes applied to commit 43a8536260e76dab4a615164f9e6d6397c6b7778 

<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
