### PR TITLE
Add statechange event when drive is replaced

### DIFF
--- a/tests/zfs-tests/tests/functional/events/events_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/events/events_001_pos.ksh
@@ -121,6 +121,7 @@ run_and_verify -p "$MPOOL" -d 10 \
     -e "sysevent.fs.zfs.vdev_attach" \
     -e "sysevent.fs.zfs.resilver_start" \
     -e "sysevent.fs.zfs.resilver_finish" \
+    -e "resource.fs.zfs.statechange" \
     -e "sysevent.fs.zfs.vdev_remove" \
     -e "sysevent.fs.zfs.history_event" \
     -e "sysevent.fs.zfs.config_sync" \


### PR DESCRIPTION
### Motivation and Context

Fix #9437
Fix [LU-12836](https://jira.whamcloud.com/browse/LU-12836)

### Description
When the `zpool online` command is used to bring a faulted or offline drive back online, a `resource.fs.zfs.statechange` event is generated. When the `zpool replace` command is used to bring a faulted or offline drive back online, a `statechange` event is *not* generated. Add the missing `statechange` event after resilvering has finished. The new sequence of events looks like
this:
```
    sysevent.fs.zfs.vdev_attach
    sysevent.fs.zfs.resilver_start
    sysevent.fs.zfs.history_event (scan setup)
    sysevent.fs.zfs.history_event (scan done)
    sysevent.fs.zfs.resilver_finish
    sysevent.fs.zfs.config_sync
  + resource.fs.zfs.statechange
    sysevent.fs.zfs.vdev_remove
    sysevent.fs.zfs.history_event (vdev attach)
    sysevent.fs.zfs.config_sync
    sysevent.fs.zfs.history_event (detach)
```

The `statechange` event looks like this:
```
Oct 16 2019 12:04:08.424390273 resource.fs.zfs.statechange
        version = 0x0
        class = "resource.fs.zfs.statechange"
        pool = "ost04"
        pool_guid = 0x8159dca79b3945a4
        pool_state = 0x0
        pool_context = 0x0
        vdev_guid = 0x8159dca79b3945a4
        vdev_state = "ONLINE" (0x7)
        vdev_laststate = "UNKNOWN" (0x0)
        time = 0x5da74d88 0x194bae81
        eid = 0x3c
```

### How Has This Been Tested?

Updated test `events_001_pos.ksh` to verify the `statechange` event is generated. Ran the full set of functional tests using the updated ZFS Test suite on CentOS 7.6 using the [CentOS 7 v1905.1 Vagrant image](https://app.vagrantup.com/centos/boxes/7). See [cvoltz/zfs-test-suite](https://github.com/cvoltz/zfs-test-suite) for scripts which use Ansible and Vagrant to provision a Vagrant VM, using libvirt, to build and run the ZFS test suite on a specified branch of a specified repository.

Also tested the patch with Lustre 2.12.2-1 and ZFS 0.7.13-1 using the [test-degraded-drive](https://jira.whamcloud.com/secure/attachment/33623/test-degraded-drive) test script. See the [LU-12836](https://jira.whamcloud.com/browse/LU-12836) ticket for details.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).