### PR TITLE
Process manpages with Jinja templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "scripts/zfs-images"]
 	path = scripts/zfs-images
 	url = https://github.com/zfsonlinux/zfs-images
+[submodule "man/build/jinja2"]
+	path = man/build/jinja2
+	url = https://github.com/pallets/jinja.git
+	branch = 2.10.x

--- a/man/build/build-manpages.py
+++ b/man/build/build-manpages.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S python3 -I
+import argparse
+from collections import defaultdict
+import os
+import re
+import sys
+
+from jinja2 import Environment, FileSystemLoader
+
+def defines_in_header_file(path):
+    """Processes a C header file for lines beginning with #define,
+       extracting the symbol name and value for each one. Strips
+       double quotes from the value, if present.
+       Ignores all other lines.
+    """
+    with open(path, mode='r', encoding='UTF-8') as config_file:
+        for line in config_file:
+            # Find all lines that begin with '#define' (no leading whitespace)
+            # Use named groups to extract like:
+            # #define <name> <value> // OPTIONAL COMMENT
+            # whitespace-delimited name and value are kept; rest is discarded
+            defines = re.fullmatch(
+                r"""\#define\s+            # line must begin with #define
+                                           # followed by one or more whitespace
+                                           # characters; '#' in #define must be
+                                           # escaped because re.VERBOSE is set
+
+                    (?P<name>[^\s]+)\s+    # symbol name is second token
+                                           # symbol value is third token
+
+                    (?P<quot>['"]?)        # ... and may begin with an optional
+                                           #     single or double quote
+
+                    (?P<value>.*?)         # for the value, match any character
+                                           # but non-greedily until ...
+
+                    (?P=quot)\s*           # the character seen before the value,
+                                           # zero or more whitespace characters,
+                                           # or end of line
+
+                    (?://.*)?              # optionally strip //-style comment
+                                           # from the end of the line
+                 """,
+                line,
+                flags=re.VERBOSE
+            )
+            if defines is not None:
+                yield defines.group('name'), defines.group('value')
+
+
+def render_template_file(path, context):
+    """Creates a Jinja2 Environment object
+       and renders the template file at the provided path,
+       relative to the current working directory,
+       with the provided dict as context
+    """
+    env = Environment(
+        loader=FileSystemLoader(os.getcwd(), followlinks=True),
+        trim_blocks=True,
+        line_statement_prefix=r'.\" %'
+    )
+
+    template = env.get_template(path)
+
+    return template.render(**context)
+
+
+def generate_uname_from_header(header_defs):
+    if header_defs['SYSTEM_LINUX'] is not None:
+        return 'Linux'
+    elif header_defs['SYSTEM_FREEBSD'] is not None:
+        return 'FreeBSD'
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='OpenZFS manual page template processor'
+    )
+    parser.add_argument('input', help='template file to render')
+    parser.add_argument(
+        '-o', '--output',
+        default='-',
+        metavar='FILENAME',
+        help='File to write output to or "-" for standard output'
+    )
+    parser.add_argument(
+        '-c', '--zfs-config',
+        required=True,
+        help='`zfs_config.h` for the current build'
+    )
+    args = parser.parse_args()
+
+    # Set output to stdout or provided filename
+    if args.output == '-':
+        output = sys.stdout
+    else:
+        output = open(args.output, mode='w', encoding='UTF-8')
+
+    # Read all '#define' lines from provided zfs_config.h
+    # Any symbols not defined will return None rather than
+    # raise KeyError because header_defs is a defaultdict
+    header_defs_generator = defines_in_header_file(args.zfs_config)
+    context_vars = defaultdict(lambda: None)
+    context_vars.update(header_defs_generator)
+
+    # Additional values to inject into context
+    additional_context = {
+        'uname': generate_uname_from_header(context_vars),
+    }
+    context_vars.update(additional_context)
+
+    output.write(
+        render_template_file(args.input, context_vars)
+    )
+    output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/man/man8/.gitignore
+++ b/man/man8/.gitignore
@@ -1,2 +1,3 @@
 /zed.8
 /zfs-mount-generator.8
+/zfsconcepts.8

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -4,7 +4,6 @@ dist_man_MANS = \
 	vdev_id.8 \
 	zdb.8 \
 	zfs.8 \
-	zfsconcepts.8 \
 	zfsprops.8 \
 	zfs-allow.8 \
 	zfs-bookmark.8 \
@@ -77,15 +76,27 @@ dist_man_MANS = \
 	zpool-wait.8 \
 	zstreamdump.8
 
-nodist_man_MANS = \
+nodist_sed_MANS = \
 	zed.8 \
 	zfs-mount-generator.8
 
+nodist_j2_MANS = \
+	zfsconcepts.8
+
+nodist_man_MANS = \
+	$(nodist_sed_MANS) \
+	$(nodist_j2_MANS)
+
 EXTRA_DIST = \
 	zed.8.in \
-	zfs-mount-generator.8.in
+	zfs-mount-generator.8.in \
+	zfsconcepts.8.j2
 
-$(nodist_man_MANS): %: %.in
+$(nodist_j2_MANS): %: %.j2
+	../build/build-manpages.py -c '../../zfs_config.h' \
+		-o $@ $<
+
+$(nodist_sed_MANS): %: %.in
 	-$(SED) -e 's,@zfsexecdir\@,$(zfsexecdir),g' \
 		-e 's,@runstatedir\@,$(runstatedir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \

--- a/man/man8/zfsconcepts.8.j2
+++ b/man/man8/zfsconcepts.8.j2
@@ -32,7 +32,7 @@
 .\"
 .Dd June 30, 2019
 .Dt ZFSCONCEPTS 8
-.Os Linux
+.Os {{ uname }}
 .Sh NAME
 .Nm zfsconcepts
 .Nd An overview of ZFS concepts.
@@ -172,6 +172,37 @@ option
 .Pp
 will ensure that the zfs-import completes before systemd attempts mounting
 the filesystem. See systemd.mount(5) for details.
+.\" % if SYSTEM_FREEBSD:
+.Ss Jails
+.No A Tn ZFS
+dataset can be attached to a jail by using the
+.Qq Nm Cm jail
+subcommand. You cannot attach a dataset to one jail and the children of the
+same dataset to another jail. You can also not attach the root file system
+of the jail or any dataset which needs to be mounted before the zfs rc script
+is run inside the jail, as it would be attached unmounted until it is
+mounted from the rc script inside the jail. To allow management of the
+dataset from within a jail, the
+.Sy jailed
+property has to be set and the jail needs access to the
+.Pa /dev/zfs
+device. The
+.Sy quota
+property cannot be changed from within a jail. See
+.Xr jail 8
+for information on how to allow mounting
+.Tn ZFS
+datasets from within a jail.
+.Pp
+.No A Tn ZFS
+dataset can be detached from a jail using the
+.Qq Nm Cm unjail
+subcommand.
+.Pp
+After a dataset is attached to a jail and the jailed property is set, a jailed
+file system cannot be mounted outside the jail, since the jail administrator
+might have set the mount point to an unacceptable value.
+.\" % endif
 .Ss Deduplication
 Deduplication is the process for removing redundant data at the block level,
 reducing the total amount of data stored. If a file system has the


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a **DRAFT PoC** PR for an idea of how to preprocess manual pages to support
different content on different OpenZFS platforms. It uses Python and the `jinja2` module for templating. I chose a Python-based solution since it is already in use for the test suite. A simpler module than Jinja could get the job done, but Jinja is well-supported and, as it is used by Ansible, likely to stay supported for a long time.

**The only documentation content modified so far is adding a `Jails` section to `zfsconcepts.8` and updating its `.Os` line to be dynamically-templated.**

### Description
<!--- Describe your changes in detail -->
- Added jinja2 python module as git submodule so we freeze what version doc builds depend on
- Add `build-manpages.py` script, which gets build configuration from `zfs_config.h` and injects all `#define` symbols into the template context. It also adds a `uname` variable based on `SYSTEM_*` from `zfs_config.h`
- Example Jinja build of `zfsconcepts.8` manpage; NOT COMPLETE, just PoC
- Modified Makefile to process `.j2` manpages with `build-manpages.py`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
- Currently, manually tested. Please do suggest ideas for automated testing.
- Templated (`*.j2`) manpages validate successfully with `mandoc -Tlint -Werror`, so this could be rolled into `make mancheck`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
