### PR TITLE
Don't assert on nvlists larger than SPA_MAXBLOCKSIZE

### DIFF
--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -71,6 +71,7 @@ struct libzfs_handle {
 	char libzfs_chassis_id[256];
 	boolean_t libzfs_prop_debug;
 	regex_t libzfs_urire;
+	uint64_t libzfs_max_nvlist;
 };
 
 struct zfs_handle {

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1008,6 +1008,7 @@ libzfs_init(void)
 {
 	libzfs_handle_t *hdl;
 	int error;
+	char *env;
 
 	error = libzfs_load_module();
 	if (error) {
@@ -1054,6 +1055,15 @@ libzfs_init(void)
 
 	if (getenv("ZFS_PROP_DEBUG") != NULL) {
 		hdl->libzfs_prop_debug = B_TRUE;
+	}
+	if ((env = getenv("ZFS_SENDRECV_MAX_NVLIST")) != NULL) {
+		if ((error = zfs_nicestrtonum(hdl, env,
+		    &hdl->libzfs_max_nvlist))) {
+			errno = error;
+			return (NULL);
+		}
+	} else {
+		hdl->libzfs_max_nvlist = (SPA_MAXBLOCKSIZE * 4);
 	}
 
 	/*


### PR DESCRIPTION
Originally we asserted that all reads are less than SPA_MAXBLOCKSIZE
However, nvlists are not ZFS records, and are not limited to SPA_MAXBLOCKSIZE

Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
`zfs recv` of a -R replication stream containing a very large number of snapshots will trigger an assert() if the nvlist exceeds 16MB (SPA_MAXBLOCKSIZE). This just causes `zfs recv` to crash without a good explaination of why.

### Description
- send: Return an error if the send stream will generate an nvlist that is too large (4 * SPA_MAXBLOCKSIZE)
- recv: Add an explicit error message if the nvlist is too large (4 * SPA_MAXBLOCKSIZE)
- Create a new environment variable, ZFS_SENDRECV_MAX_NVLIST to override the default limit
- Change the assert() to only trigger on data records

### How Has This Been Tested?
The user who reported the issue has tested that large receives work
The limit was tested by running with the maximum lowered to 8kb and sending a stream with 10 filesystems each with 10 snapshots.

Sending 3000 snapshots:
```
env ZFS_SENDRECV_MAX_NVLIST=96k zfs send -RecL dirty/manysnap@snap1000 > /dev/null
warning: cannot send dirty/manysnap/child@snap1000: the size of the list of snapshots and properties is too large to be received successfully.
Select a smaller number of snapshots to send.
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
