### PR TITLE
The module parameter zfs_autoimport_disable has been deprecated

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1061,17 +1061,6 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_autoimport_disable\fR (int)
-.ad
-.RS 12n
-Disable pool import at module load by ignoring the cache file (typically \fB/etc/zfs/zpool.cache\fR).
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
 \fBzfs_checksums_per_second\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -66,7 +66,6 @@ static uint64_t spa_config_generation = 1;
  * userland pools when doing testing.
  */
 char *spa_config_path = ZPOOL_CACHE;
-int zfs_autoimport_disable = 1;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -84,11 +83,6 @@ spa_config_load(void)
 	zfs_file_attr_t zfa;
 	uint64_t fsize;
 	int err;
-
-#ifdef _KERNEL
-	if (zfs_autoimport_disable)
-		return;
-#endif
 
 	/*
 	 * Open the configuration file.
@@ -607,7 +601,4 @@ EXPORT_SYMBOL(spa_config_update);
 ZFS_MODULE_PARAM(zfs_spa, spa_, config_path, STRING, ZMOD_RD,
 	"SPA config file (/etc/zfs/zpool.cache)");
 #endif
-
-ZFS_MODULE_PARAM(zfs, zfs_, autoimport_disable, INT, ZMOD_RW,
-	"Disable pool import at module load");
 /* END CSTYLED */


### PR DESCRIPTION
Remove it and its documentation

Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
In PR #9683 @behlendorf suggested removing the zfs_autoimport_disable feature, as it has already been deprecated in a previous release.

### Description
Remove the zfs_autoimport_disable  module parameter and its documentation

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
