### PR TITLE
Move the definition of ZPOOL_CACHE from spa.h to zfs_context_os.h

### DIFF
--- a/include/os/linux/zfs/sys/zfs_context_os.h
+++ b/include/os/linux/zfs/sys/zfs_context_os.h
@@ -27,4 +27,10 @@
 #include <linux/dcache_compat.h>
 #include <linux/utsname_compat.h>
 
+/*
+ * The location of the pool configuration repository, shared between kernel and
+ * userland.
+ */
+#define	ZPOOL_CACHE		"/etc/zfs/zpool.cache"
+
 #endif

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -36,6 +36,7 @@
 
 #include <sys/time.h>
 #include <sys/zio_priority.h>
+#include <sys/zfs_context_os.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -814,12 +815,6 @@ typedef struct zpool_load_policy {
  * is not enabled.
  */
 #define	ZFS_FRAG_INVALID	UINT64_MAX
-
-/*
- * The location of the pool configuration repository, shared between kernel and
- * userland.
- */
-#define	ZPOOL_CACHE		"/etc/zfs/zpool.cache"
 
 /*
  * vdev states are ordered from least to most healthy.

--- a/lib/libspl/include/os/linux/sys/zfs_context_os.h
+++ b/lib/libspl/include/os/linux/sys/zfs_context_os.h
@@ -22,4 +22,11 @@
 
 #ifndef ZFS_CONTEXT_OS_H
 #define	ZFS_CONTEXT_OS_H
+
+/*
+ * The location of the pool configuration repository, shared between kernel and
+ * userland.
+ */
+#define	ZPOOL_CACHE		"/etc/zfs/zpool.cache"
+
 #endif


### PR DESCRIPTION
This value is platform specific, so should reside in platform includes

Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
The path to ZPOOL_CACHE on freebsd is /boot/zfs/zpool.cache rather than /etc/zfs/zpool.cache

### Description
Move the define for ZPOOL_CACHE from `include/sys/zfs.h` to `include/os/linux/sys/zfs_context_os.h` so it can be defined differently on FreeBSD

The value had to be duplicated to `include/os/linux/spl/zfs_context_os.h` for libzpool

Is there a better approach?

### How Has This Been Tested?
ZFS pools import properly at boot, as the correct zpool.cache file is read

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
