### PR TITLE
Add a mechanism to wait for delete queue to drain

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -122,6 +122,7 @@ static int zfs_do_change_key(int argc, char **argv);
 static int zfs_do_project(int argc, char **argv);
 static int zfs_do_version(int argc, char **argv);
 static int zfs_do_redact(int argc, char **argv);
+static int zfs_do_wait(int argc, char **argv);
 
 #ifdef __FreeBSD__
 static int zfs_do_jail(int argc, char **argv);
@@ -183,7 +184,8 @@ typedef enum {
 	HELP_VERSION,
 	HELP_REDACT,
 	HELP_JAIL,
-	HELP_UNJAIL
+	HELP_UNJAIL,
+	HELP_WAIT,
 } zfs_help_t;
 
 typedef struct zfs_command {
@@ -248,6 +250,7 @@ static zfs_command_t command_table[] = {
 	{ "unload-key",	zfs_do_unload_key,	HELP_UNLOAD_KEY		},
 	{ "change-key",	zfs_do_change_key,	HELP_CHANGE_KEY		},
 	{ "redact",	zfs_do_redact,		HELP_REDACT		},
+	{ "wait",	zfs_do_wait,		HELP_WAIT		},
 
 #ifdef __FreeBSD__
 	{ "jail",	zfs_do_jail,		HELP_JAIL		},
@@ -410,6 +413,8 @@ get_usage(zfs_help_t idx)
 		return (gettext("\tjail <jailid|jailname> <filesystem>\n"));
 	case HELP_UNJAIL:
 		return (gettext("\tunjail <jailid|jailname> <filesystem>\n"));
+	case HELP_WAIT:
+		return (gettext("\twait [-t <activity>] <filesystem>\n"));
 	}
 
 	abort();
@@ -8315,6 +8320,90 @@ zfs_do_project(int argc, char **argv)
 	}
 
 	return (ret);
+}
+
+static int
+zfs_do_wait(int argc, char **argv)
+{
+	boolean_t enabled[ZFS_WAIT_NUM_ACTIVITIES];
+	int error, i;
+	char c;
+
+	/* By default, wait for all types of activity. */
+	for (i = 0; i < ZFS_WAIT_NUM_ACTIVITIES; i++)
+		enabled[i] = B_TRUE;
+
+	while ((c = getopt(argc, argv, "t:")) != -1) {
+		switch (c) {
+		case 't':
+		{
+			static char *col_subopts[] = { "deleteq", NULL };
+			char *value;
+
+			/* Reset activities array */
+			bzero(&enabled, sizeof (enabled));
+			while (*optarg != '\0') {
+				int activity = getsubopt(&optarg, col_subopts,
+				    &value);
+
+				if (activity < 0) {
+					(void) fprintf(stderr,
+					    gettext("invalid activity '%s'\n"),
+					    value);
+					usage(B_FALSE);
+				}
+
+				enabled[activity] = B_TRUE;
+			}
+			break;
+		}
+		case '?':
+			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
+			    optopt);
+			usage(B_FALSE);
+		}
+	}
+
+	argv += optind;
+	argc -= optind;
+	if (argc < 1) {
+		(void) fprintf(stderr, gettext("missing 'filesystem' "
+		    "argument\n"));
+		usage(B_FALSE);
+	}
+	if (argc > 1) {
+		(void) fprintf(stderr, gettext("too many arguments\n"));
+		usage(B_FALSE);
+	}
+
+	zfs_handle_t *zhp = zfs_open(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM);
+	if (zhp == NULL)
+		return (1);
+
+	for (;;) {
+		boolean_t missing = B_FALSE;
+		boolean_t any_waited = B_FALSE;
+
+		for (int i = 0; i < ZFS_WAIT_NUM_ACTIVITIES; i++) {
+			boolean_t waited;
+
+			if (!enabled[i])
+				continue;
+
+			error = zfs_wait_status(zhp, i, &missing, &waited);
+			if (error != 0 || missing)
+				break;
+
+			any_waited = (any_waited || waited);
+		}
+
+		if (error != 0 || missing || !any_waited)
+			break;
+	}
+
+	zfs_close(zhp);
+
+	return (error);
 }
 
 /*

--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zfs_unmount/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_unshare/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zfs_wait/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_attach/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -507,6 +507,9 @@ extern nvlist_t *zfs_get_user_props(zfs_handle_t *);
 extern nvlist_t *zfs_get_recvd_props(zfs_handle_t *);
 extern nvlist_t *zfs_get_clones_nvl(zfs_handle_t *);
 
+extern int zfs_wait_status(zfs_handle_t *, zfs_wait_activity_t,
+    boolean_t *, boolean_t *);
+
 /*
  * zfs encryption management
  */

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -133,6 +133,7 @@ int lzc_pool_checkpoint_discard(const char *);
 
 int lzc_wait(const char *, zpool_wait_activity_t, boolean_t *);
 int lzc_wait_tag(const char *, zpool_wait_activity_t, uint64_t, boolean_t *);
+int lzc_wait_fs(const char *, zfs_wait_activity_t, boolean_t *);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -120,8 +120,10 @@ struct dsl_dir {
 	dsl_deadlist_t dd_livelist;
 	bplist_t dd_pending_frees;
 	bplist_t dd_pending_allocs;
+
 	kmutex_t dd_activity_lock;
 	kcondvar_t dd_activity_cv;
+	boolean_t dd_activity_cancelled;
 
 	/* protected by dd_lock; keep at end of struct for better locality */
 	char dd_myname[ZFS_MAX_DATASET_NAME_LEN];
@@ -194,7 +196,7 @@ boolean_t dsl_dir_is_zapified(dsl_dir_t *dd);
 void dsl_dir_livelist_open(dsl_dir_t *dd, uint64_t obj);
 void dsl_dir_livelist_close(dsl_dir_t *dd);
 void dsl_dir_remove_livelist(dsl_dir_t *dd, dmu_tx_t *tx, boolean_t total);
-int dsl_dir_wait(dsl_dir_t *dd, zfs_wait_activity_t activity,
+int dsl_dir_wait(dsl_dir_t *dd, dsl_dataset_t *ds, zfs_wait_activity_t activity,
     boolean_t *waited);
 
 /* internal reserved dir name */

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -120,6 +120,8 @@ struct dsl_dir {
 	dsl_deadlist_t dd_livelist;
 	bplist_t dd_pending_frees;
 	bplist_t dd_pending_allocs;
+	kmutex_t dd_activity_lock;
+	kcondvar_t dd_activity_cv;
 
 	/* protected by dd_lock; keep at end of struct for better locality */
 	char dd_myname[ZFS_MAX_DATASET_NAME_LEN];
@@ -192,6 +194,8 @@ boolean_t dsl_dir_is_zapified(dsl_dir_t *dd);
 void dsl_dir_livelist_open(dsl_dir_t *dd, uint64_t obj);
 void dsl_dir_livelist_close(dsl_dir_t *dd);
 void dsl_dir_remove_livelist(dsl_dir_t *dd, dmu_tx_t *tx, boolean_t total);
+int dsl_dir_wait(dsl_dir_t *dd, zfs_wait_activity_t activity,
+    boolean_t *waited);
 
 /* internal reserved dir name */
 #define	MOS_DIR_NAME "$MOS"

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -124,7 +124,7 @@ struct dsl_dir {
 	kmutex_t dd_activity_lock;
 	kcondvar_t dd_activity_cv;
 	boolean_t dd_activity_cancelled;
-	uint64_t dd_activity_count;
+	uint64_t dd_activity_waiters;
 
 	/* protected by dd_lock; keep at end of struct for better locality */
 	char dd_myname[ZFS_MAX_DATASET_NAME_LEN];

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -124,6 +124,7 @@ struct dsl_dir {
 	kmutex_t dd_activity_lock;
 	kcondvar_t dd_activity_cv;
 	boolean_t dd_activity_cancelled;
+	uint64_t dd_activity_count;
 
 	/* protected by dd_lock; keep at end of struct for better locality */
 	char dd_myname[ZFS_MAX_DATASET_NAME_LEN];
@@ -198,6 +199,7 @@ void dsl_dir_livelist_close(dsl_dir_t *dd);
 void dsl_dir_remove_livelist(dsl_dir_t *dd, dmu_tx_t *tx, boolean_t total);
 int dsl_dir_wait(dsl_dir_t *dd, dsl_dataset_t *ds, zfs_wait_activity_t activity,
     boolean_t *waited);
+void dsl_dir_cancel_waiters(dsl_dir_t *dd);
 
 /* internal reserved dir name */
 #define	MOS_DIR_NAME "$MOS"

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1282,7 +1282,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_REDACT,				/* 0x5a51 */
 	ZFS_IOC_GET_BOOKMARK_PROPS,		/* 0x5a52 */
 	ZFS_IOC_WAIT,				/* 0x5a53 */
-	ZFS_IOC_WAIT_FS,			/* 0x5a53 */
+	ZFS_IOC_WAIT_FS,			/* 0x5a54 */
 
 	/*
 	 * Per-platform (Optional) - 6/128 numbers reserved.
@@ -1422,7 +1422,7 @@ typedef enum {
 #define	ZPOOL_WAIT_WAITED		"wait_waited"
 
 /*
- * The following are names used when invoking ZFS_IOC_FS_WAIT.
+ * The following are names used when invoking ZFS_IOC_WAIT_FS.
  */
 #define	ZFS_WAIT_ACTIVITY		"wait_activity"
 #define	ZFS_WAIT_WAITED			"wait_waited"

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1282,6 +1282,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_REDACT,				/* 0x5a51 */
 	ZFS_IOC_GET_BOOKMARK_PROPS,		/* 0x5a52 */
 	ZFS_IOC_WAIT,				/* 0x5a53 */
+	ZFS_IOC_WAIT_FS,			/* 0x5a53 */
 
 	/*
 	 * Per-platform (Optional) - 6/128 numbers reserved.
@@ -1358,6 +1359,11 @@ typedef enum {
 	ZPOOL_WAIT_NUM_ACTIVITIES
 } zpool_wait_activity_t;
 
+typedef enum {
+	ZFS_WAIT_DELETEQ,
+	ZFS_WAIT_NUM_ACTIVITIES
+} zfs_wait_activity_t;
+
 /*
  * Bookmark name values.
  */
@@ -1414,6 +1420,12 @@ typedef enum {
 #define	ZPOOL_WAIT_ACTIVITY		"wait_activity"
 #define	ZPOOL_WAIT_TAG			"wait_tag"
 #define	ZPOOL_WAIT_WAITED		"wait_waited"
+
+/*
+ * The following are names used when invoking ZFS_IOC_FS_WAIT.
+ */
+#define	ZFS_WAIT_ACTIVITY		"wait_activity"
+#define	ZFS_WAIT_WAITED			"wait_waited"
 
 /*
  * Flags for ZFS_IOC_VDEV_SET_STATE

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -1621,3 +1621,23 @@ lzc_wait_tag(const char *pool, zpool_wait_activity_t activity, uint64_t tag,
 {
 	return (wait_common(pool, activity, B_TRUE, tag, waited));
 }
+
+int
+lzc_wait_fs(const char *fs, zfs_wait_activity_t activity, boolean_t *waited)
+{
+	nvlist_t *args = fnvlist_alloc();
+	nvlist_t *result = NULL;
+
+	fnvlist_add_int32(args, ZFS_WAIT_ACTIVITY, activity);
+
+	int error = lzc_ioctl(ZFS_IOC_WAIT_FS, fs, args, &result);
+
+	if (error == 0 && waited != NULL)
+		*waited = fnvlist_lookup_boolean_value(result,
+		    ZFS_WAIT_WAITED);
+
+	fnvlist_free(args);
+	fnvlist_free(result);
+
+	return (error);
+}

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -41,6 +41,7 @@ dist_man_MANS = \
 	zfs-unmount.8 \
 	zfs-upgrade.8 \
 	zfs-userspace.8 \
+	zfs-wait.8 \
 	zgenhostid.8 \
 	zinject.8 \
 	zpool.8 \

--- a/man/man8/zfs-wait.8
+++ b/man/man8/zfs-wait.8
@@ -1,0 +1,63 @@
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
+.\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+.\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
+.\" Copyright (c) 2017 Datto Inc.
+.\" Copyright (c) 2018 George Melikov. All Rights Reserved.
+.\" Copyright 2017 Nexenta Systems, Inc.
+.\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\"
+.Dd August 9, 2019
+.Dt ZFS-WAIT 8
+.Os Linux
+.Sh NAME
+.Nm zfs Ns Pf - Cm wait
+.Nd Wait for background activity to stop in a ZFS filesystem
+.Sh SYNOPSIS
+.Nm
+.Cm wait
+.Op Fl t Ar activity Ns Oo , Ns Ar activity Ns Oc Ns ...
+.Ar fs
+.Sh DESCRIPTION
+.Bl -tag -width Ds
+.It Xo
+.Nm
+.Cm wait
+.Op Fl t Ar activity Ns Oo , Ns Ar activity Ns Oc Ns ...
+.Ar fs
+.Xc
+Waits until all background activity of the given types has ceased in the given
+filesystem.
+The activity could cease because it has completed or because the filesystem has
+been destroyed.
+If no activities are specified, the command waits until background activity of
+every type listed below has ceased.
+If there is no activity of the given types in progress, the command returns
+immediately.
+.Pp
+These are the possible values for
+.Ar activity ,
+along with what each one waits for:
+.Bd -literal
+        deleteq       The filesystem's internal delete queue to empty
+.Ed

--- a/man/man8/zfs-wait.8
+++ b/man/man8/zfs-wait.8
@@ -49,7 +49,7 @@
 Waits until all background activity of the given types has ceased in the given
 filesystem.
 The activity could cease because it has completed or because the filesystem has
-been destroyed.
+been destroyed or unmounted.
 If no activities are specified, the command waits until background activity of
 every type listed below has ceased.
 If there is no activity of the given types in progress, the command returns

--- a/man/man8/zfs-wait.8
+++ b/man/man8/zfs-wait.8
@@ -61,3 +61,11 @@ along with what each one waits for:
 .Bd -literal
         deleteq       The filesystem's internal delete queue to empty
 .Ed
+.Pp
+Note that the internal delete queue does not finish draining until
+all large files have had time to be fully destroyed and all open file
+handles to unlinked files are closed.
+.El
+.El
+.Sh SEE ALSO
+.Xr lsof  8

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -282,7 +282,7 @@ Attaches a filesystem to a jail.
 Detaches a filesystem from a jail.
 .El
 .Ss Waiting
-.Bl -tag -width""
+.Bl -tag -width ""
 .It Xr zfs-wait 8
 Wait for background activity in a filesystem to complete.
 .El

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -281,6 +281,11 @@ Attaches a filesystem to a jail.
 .It Xr zfs-unjail 8
 Detaches a filesystem from a jail.
 .El
+.Ss Waiting
+.Bl -tag -width""
+.It Xr zfs-wait 8
+Wait for background activity in a filesystem to complete.
+.El
 .Sh EXIT STATUS
 The
 .Nm

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -52,6 +52,8 @@
 #include <sys/zfs_fuid.h>
 #include <sys/sa.h>
 #include <sys/zfs_sa.h>
+#include <sys/dmu_objset.h>
+#include <sys/dsl_dir.h>
 
 /*
  * zfs_match_find() is used by zfs_dirent_lock() to perform zap lookups
@@ -739,6 +741,8 @@ zfs_rmnode(znode_t *zp)
 		zfs_unlinked_add(xzp, tx);
 	}
 
+	mutex_enter(&os->os_dsl_dataset->ds_dir->dd_activity_lock);
+
 	/*
 	 * Remove this znode from the unlinked set.  If a has rollback has
 	 * occurred while a file is open and unlinked.  Then when the file
@@ -748,6 +752,13 @@ zfs_rmnode(znode_t *zp)
 	error = zap_remove_int(zfsvfs->z_os, zfsvfs->z_unlinkedobj,
 	    zp->z_id, tx);
 	VERIFY(error == 0 || error == ENOENT);
+
+	uint64_t count;
+	if (zap_count(os, zfsvfs->z_unlinkedobj, &count) == 0 && count == 0) {
+		cv_broadcast(&os->os_dsl_dataset->ds_dir->dd_activity_cv);
+	}
+
+	mutex_exit(&os->os_dsl_dataset->ds_dir->dd_activity_lock);
 
 	dataset_kstats_update_nunlinked_kstat(&zfsvfs->z_kstat, 1);
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1427,8 +1427,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	}
 	dmu_objset_evict_dbufs(zfsvfs->z_os);
 	dsl_dir_t *dd = os->os_dsl_dataset->ds_dir;
-	dd->dd_activity_cancelled = B_TRUE;
-	cv_broadcast(&dd->dd_activity_cv);
+	dsl_dir_cancel_waiters(dd);
 
 	return (0);
 }

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -55,6 +55,7 @@
 #include <sys/zfs_quota.h>
 #include <sys/sunddi.h>
 #include <sys/dmu_objset.h>
+#include <sys/dsl_dir.h>
 #include <sys/spa_boot.h>
 #include <sys/objlist.h>
 #include <sys/zpl.h>
@@ -872,6 +873,8 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 			    "num_entries in unlinked set: %llu",
 			    zs.zs_num_entries);
 			zfs_unlinked_drain(zfsvfs);
+			dsl_dir_t *dd = zfsvfs->z_os->os_dsl_dataset->ds_dir;
+			dd->dd_activity_cancelled = B_FALSE;
 		}
 
 		/*
@@ -1423,6 +1426,9 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 		txg_wait_synced(dmu_objset_pool(zfsvfs->z_os), 0);
 	}
 	dmu_objset_evict_dbufs(zfsvfs->z_os);
+	dsl_dir_t *dd = os->os_dsl_dataset->ds_dir;
+	dd->dd_activity_cancelled = B_TRUE;
+	cv_broadcast(&dd->dd_activity_cv);
 
 	return (0);
 }
@@ -1813,6 +1819,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	if (err != 0)
 		goto bail;
 
+	ds->ds_dir->dd_activity_cancelled = B_FALSE;
 	VERIFY(zfsvfs_setup(zfsvfs, B_FALSE) == 0);
 
 	zfs_set_fuid_feature(zfsvfs);

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -3241,8 +3241,6 @@ dsl_dataset_rollback_sync(void *arg, dmu_tx_t *tx)
 
 	VERIFY0(dsl_dataset_hold(dp, ddra->ddra_fsname, FTAG, &ds));
 
-	dsl_dir_cancel_waiters(ds->ds_dir);
-
 	dsl_dataset_name(ds->ds_prev, namebuf);
 	fnvlist_add_string(ddra->ddra_result, "target", namebuf);
 

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -766,7 +766,7 @@ dsl_destroy_head_check_impl(dsl_dataset_t *ds, int expected_holds)
 	if (zfs_refcount_count(&ds->ds_longholds) != expected_holds)
 		return (SET_ERROR(EBUSY));
 
-	ASSERT0(ds->ds_dir->dd_activity_count);
+	ASSERT0(ds->ds_dir->dd_activity_waiters);
 
 	mos = ds->ds_dir->dd_pool->dp_meta_objset;
 

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -763,14 +763,10 @@ dsl_destroy_head_check_impl(dsl_dataset_t *ds, int expected_holds)
 	if (ds->ds_is_snapshot)
 		return (SET_ERROR(EINVAL));
 
-	dsl_dir_t *dd = ds->ds_dir;
-	mutex_enter(&dd->dd_activity_lock);
-	if (zfs_refcount_count(&ds->ds_longholds) != expected_holds +
-	    dd->dd_activity_count) {
-		mutex_exit(&dd->dd_activity_lock);
+	if (zfs_refcount_count(&ds->ds_longholds) != expected_holds)
 		return (SET_ERROR(EBUSY));
-	}
-	mutex_exit(&dd->dd_activity_lock);
+
+	ASSERT0(ds->ds_dir->dd_activity_count);
 
 	mos = ds->ds_dir->dd_pool->dp_meta_objset;
 

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2310,6 +2310,7 @@ dsl_dir_activity_in_progress(dsl_dir_t *dd, dsl_dataset_t *ds,
 			break;
 
 		if (dmu_objset_type(os) != DMU_OST_ZFS ||
+		    dmu_objset_get_user(os) == NULL || 
 		    zfs_get_vfs_flag_unmounted(os)) {
 			*in_progress = B_FALSE;
 			return (0);
@@ -2392,5 +2393,4 @@ dsl_dir_cancel_waiters(dsl_dir_t *dd)
 #if defined(_KERNEL)
 EXPORT_SYMBOL(dsl_dir_set_quota);
 EXPORT_SYMBOL(dsl_dir_set_reservation);
-EXPORT_SYMBOL(dsl_dir_cancel_waiters);
 #endif

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -207,6 +207,8 @@ dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
 		}
 
 		mutex_init(&dd->dd_lock, NULL, MUTEX_DEFAULT, NULL);
+		mutex_init(&dd->dd_activity_lock, NULL, MUTEX_DEFAULT, NULL);
+		cv_init(&dd->dd_activity_cv, NULL, CV_DEFAULT, NULL);
 		dsl_prop_init(dd);
 
 		dsl_dir_snap_cmtime_update(dd);
@@ -280,6 +282,8 @@ dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
 			if (dsl_deadlist_is_open(&dd->dd_livelist))
 				dsl_dir_livelist_close(dd);
 			dsl_prop_fini(dd);
+			cv_destroy(&dd->dd_activity_cv);
+			mutex_destroy(&dd->dd_activity_lock);
 			mutex_destroy(&dd->dd_lock);
 			kmem_free(dd, sizeof (dsl_dir_t));
 			dd = winner;
@@ -2280,6 +2284,76 @@ dsl_dir_remove_livelist(dsl_dir_t *dd, dmu_tx_t *tx, boolean_t total)
 	} else {
 		ASSERT3U(err, !=, ENOENT);
 	}
+}
+
+static int
+dsl_dir_activity_in_progress(dsl_dir_t *dd, zfs_wait_activity_t activity,
+    boolean_t *in_progress)
+{
+	int error = 0;
+	zfs_dbgmsg("progress %px %d", dd, activity);
+
+	ASSERT(MUTEX_HELD(&dd->dd_activity_lock));
+
+	switch (activity) {
+	case ZFS_WAIT_DELETEQ: {
+		dsl_dataset_t *ds;
+		error = dsl_dataset_hold_obj(dd->dd_pool,
+		    dsl_dir_phys(dd)->dd_head_dataset_obj, FTAG, &ds);
+		if (error != 0)
+			break;
+		objset_t *os;
+		error = dmu_objset_from_ds(ds, &os);
+		if (error != 0)
+			break;
+
+		uint64_t count, unlinked_obj;
+		zfs_dbgmsg("os %px", os);
+		error = zap_lookup(os, MASTER_NODE_OBJ, ZFS_UNLINKED_SET, 8, 1,
+		    &unlinked_obj);
+		if (error != 0) {
+			dsl_dataset_rele(ds, FTAG);
+			break;
+		}
+		zfs_dbgmsg("obj %ld", unlinked_obj);
+		error = zap_count(os, unlinked_obj, &count);
+
+		if (error == 0)
+			*in_progress = (count != 0);
+
+		dsl_dataset_rele(ds, FTAG);
+		break;
+	}
+	default:
+		panic("unrecognized value for activity %d", activity);
+	}
+
+	return (error);
+}
+
+int
+dsl_dir_wait(dsl_dir_t *dd, zfs_wait_activity_t activity, boolean_t *waited)
+{
+	int error = 0;
+	boolean_t in_progress;
+	zfs_dbgmsg("waiting %px %d", dd, activity);
+	mutex_enter(&dd->dd_activity_lock);
+	for (;;) {
+		error = dsl_dir_activity_in_progress(dd, activity,
+		    &in_progress);
+		if (error != 0 || !in_progress)
+			break;
+
+		*waited = B_TRUE;
+
+		if (cv_wait_sig(&dd->dd_activity_cv, &dd->dd_activity_lock) ==
+		    0) {
+			error = EINTR;
+			break;
+		}
+	}
+	mutex_exit(&dd->dd_activity_lock);
+	return (error);
 }
 
 #if defined(_KERNEL)

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2364,9 +2364,12 @@ dsl_dir_wait(dsl_dir_t *dd, dsl_dataset_t *ds, zfs_wait_activity_t activity,
 {
 	int error = 0;
 	boolean_t in_progress;
+	dsl_pool_t *dp = dd->dd_pool;
 	for (;;) {
+		dsl_pool_config_enter(dp, FTAG);
 		error = dsl_dir_activity_in_progress(dd, ds, activity,
 		    &in_progress);
+		dsl_pool_config_exit(dp, FTAG);
 		if (error != 0 || !in_progress)
 			break;
 

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2325,7 +2325,7 @@ dsl_dir_activity_in_progress(dsl_dir_t *dd, dsl_dataset_t *ds,
 		if (error != 0)
 			break;
 
-		if (readonly) {
+		if (readonly || !spa_writeable(dd->dd_pool->dp_spa)) {
 			*in_progress = B_FALSE;
 			return (0);
 		}
@@ -2374,7 +2374,7 @@ dsl_dir_wait(dsl_dir_t *dd, dsl_dataset_t *ds, zfs_wait_activity_t activity,
 
 		if (cv_wait_sig(&dd->dd_activity_cv, &dd->dd_activity_lock) ==
 		    0 || dd->dd_activity_cancelled) {
-			error = EINTR;
+			error = SET_ERROR(EINTR);
 			break;
 		}
 	}

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2309,9 +2309,11 @@ dsl_dir_activity_in_progress(dsl_dir_t *dd, dsl_dataset_t *ds,
 		if (error != 0)
 			break;
 
+		mutex_enter(&os->os_user_ptr_lock);
+		void *user = dmu_objset_get_user(os);
+		mutex_exit(&os->os_user_ptr_lock);
 		if (dmu_objset_type(os) != DMU_OST_ZFS ||
-		    dmu_objset_get_user(os) == NULL || 
-		    zfs_get_vfs_flag_unmounted(os)) {
+		    user == NULL || zfs_get_vfs_flag_unmounted(os)) {
 			*in_progress = B_FALSE;
 			return (0);
 		}

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2387,7 +2387,7 @@ dsl_dir_cancel_waiters(dsl_dir_t *dd)
 	mutex_enter(&dd->dd_activity_lock);
 	dd->dd_activity_cancelled = B_TRUE;
 	cv_broadcast(&dd->dd_activity_cv);
-	while (dd->dd_activity_count > 0)
+	while (dd->dd_activity_waiters > 0)
 		cv_wait(&dd->dd_activity_cv, &dd->dd_activity_lock);
 	mutex_exit(&dd->dd_activity_lock);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4118,7 +4118,7 @@ zfs_ioc_wait_fs(const char *name, nvlist_t *innvl, nvlist_t *outnvl)
 
 	dd = ds->ds_dir;
 	mutex_enter(&dd->dd_activity_lock);
-	dd->dd_activity_count++;
+	dd->dd_activity_waiters++;
 
 	dsl_dataset_long_hold(ds, FTAG);
 	dsl_pool_rele(dp, FTAG);
@@ -4126,8 +4126,8 @@ zfs_ioc_wait_fs(const char *name, nvlist_t *innvl, nvlist_t *outnvl)
 	error = dsl_dir_wait(dd, ds, activity, &waited);
 
 	dsl_dataset_long_rele(ds, FTAG);
-	dd->dd_activity_count--;
-	if (dd->dd_activity_count == 0)
+	dd->dd_activity_waiters--;
+	if (dd->dd_activity_waiters == 0)
 		cv_signal(&dd->dd_activity_cv);
 	mutex_exit(&dd->dd_activity_lock);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4103,10 +4103,10 @@ zfs_ioc_wait_fs(const char *name, nvlist_t *innvl, nvlist_t *outnvl)
 	dsl_dataset_t *ds;
 
 	if (nvlist_lookup_int32(innvl, ZFS_WAIT_ACTIVITY, &activity) != 0)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	if (activity >= ZFS_WAIT_NUM_ACTIVITIES || activity < 0)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	if ((error = dsl_pool_hold(name, FTAG, &dp)) != 0)
 		return (error);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4111,17 +4111,12 @@ zfs_ioc_wait_fs(const char *name, nvlist_t *innvl, nvlist_t *outnvl)
 	if ((error = dsl_pool_hold(name, FTAG, &dp)) != 0)
 		return (error);
 
-	if ((error = dsl_dir_hold(dp, name, FTAG, &dd, NULL)) != 0) {
+	if ((error = dsl_dataset_hold(dp, name, FTAG, &ds)) != 0) {
 		dsl_pool_rele(dp, FTAG);
 		return (error);
 	}
 
-	if ((error = dsl_dataset_hold_obj(dd->dd_pool,
-	    dsl_dir_phys(dd)->dd_head_dataset_obj, FTAG, &ds)) != 0) {
-		dsl_pool_rele(dp, FTAG);
-		dsl_dir_rele(dd, FTAG);
-		return (error);
-	}
+	dd = ds->ds_dir;
 	mutex_enter(&dd->dd_activity_lock);
 	dd->dd_activity_count++;
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4132,7 +4132,6 @@ zfs_ioc_wait_fs(const char *name, nvlist_t *innvl, nvlist_t *outnvl)
 	mutex_exit(&dd->dd_activity_lock);
 
 	dsl_dataset_rele(ds, FTAG);
-	dsl_dir_rele(dd, FTAG);
 
 	if (error == 0)
 		fnvlist_add_boolean_value(outnvl, ZFS_WAIT_WAITED, waited);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -288,6 +288,10 @@ tests = ['zfs_upgrade_001_pos', 'zfs_upgrade_002_pos', 'zfs_upgrade_003_pos',
     'zfs_upgrade_007_neg']
 tags = ['functional', 'cli_root', 'zfs_upgrade']
 
+[tests/functional/cli_root/zfs_wait]
+tests = ['zfs_wait_deleteq']
+tags = ['functional', 'cli_root', 'zfs_wait']
+
 [tests/functional/cli_root/zpool]
 tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos', 'zpool_colors']
 tags = ['functional', 'cli_root', 'zpool']

--- a/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
@@ -740,6 +740,18 @@ test_wait(const char *pool)
 }
 
 static void
+test_wait_fs(const char *dataset)
+{
+	nvlist_t *required = fnvlist_alloc();
+
+	fnvlist_add_int32(required, "wait_activity", 2);
+
+	IOC_INPUT_TEST(ZFS_IOC_WAIT_FS, dataset, required, NULL, EINVAL);
+
+	nvlist_free(required);
+}
+
+static void
 zfs_ioc_input_tests(const char *pool)
 {
 	char filepath[] = "/tmp/ioc_test_file_XXXXXX";
@@ -826,6 +838,7 @@ zfs_ioc_input_tests(const char *pool)
 	test_vdev_trim(pool);
 
 	test_wait(pool);
+	test_wait_fs(dataset);
 
 	/*
 	 * cleanup
@@ -980,6 +993,7 @@ validate_ioc_values(void)
 	CHECK(ZFS_IOC_BASE + 81 == ZFS_IOC_REDACT);
 	CHECK(ZFS_IOC_BASE + 82 == ZFS_IOC_GET_BOOKMARK_PROPS);
 	CHECK(ZFS_IOC_BASE + 83 == ZFS_IOC_WAIT);
+	CHECK(ZFS_IOC_BASE + 84 == ZFS_IOC_WAIT_FS);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 1 == ZFS_IOC_EVENTS_NEXT);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 2 == ZFS_IOC_EVENTS_CLEAR);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 3 == ZFS_IOC_EVENTS_SEEK);

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -32,6 +32,7 @@ SUBDIRS = \
 	zfs_unmount \
 	zfs_unshare \
 	zfs_upgrade \
+	zfs_wait \
 	zpool \
 	zpool_add \
 	zpool_attach \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/Makefile.am
@@ -1,0 +1,8 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_wait
+dist_pkgdata_SCRIPTS = \
+	setup.ksh \
+	cleanup.ksh \
+	zfs_wait_deleteq.ksh
+
+dist_pkgdata_DATA = \
+	zfs_wait.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/cleanup.ksh
@@ -1,0 +1,20 @@
+#!/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/setup.ksh
@@ -1,0 +1,21 @@
+#!/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait.kshlib
@@ -34,18 +34,6 @@ typeset -r DISK3=${disk_array[2]}
 #
 typeset -r WAIT_EXIT_GRACE=2.0
 
-function add_io_delay # pool
-{
-	for disk in $(get_disklist $1); do
-		log_must zinject -d $disk -D20:1 $1
-	done
-}
-
-function remove_io_delay
-{
-	log_must zinject -c all
-}
-
 function proc_exists # pid
 {
 	ps -p $1 >/dev/null

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait.kshlib
@@ -1,0 +1,92 @@
+#!/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018, 2019 by Delphix. All rights reserved.
+#
+
+typeset -a disk_array=($(find_disks $DISKS))
+
+typeset -r DISK1=${disk_array[0]}
+typeset -r DISK2=${disk_array[1]}
+typeset -r DISK3=${disk_array[2]}
+
+#
+# When the condition it is waiting for becomes true, 'zfs wait' should return
+# promptly. We want to enforce this, but any check will be racey because it will
+# take some small but indeterminate amount of time for the waiting thread to be
+# woken up and for the process to exit.
+#
+# To deal with this, we provide a grace period after the condition becomes true
+# during which 'zfs wait' can exit. If it hasn't exited by the time the grace
+# period expires we assume something is wrong and fail the test. While there is
+# no value that can really be correct, the idea is we choose something large
+# enough that it shouldn't cause issues in practice.
+#
+typeset -r WAIT_EXIT_GRACE=2.0
+
+function add_io_delay # pool
+{
+	for disk in $(get_disklist $1); do
+		log_must zinject -d $disk -D20:1 $1
+	done
+}
+
+function remove_io_delay
+{
+	log_must zinject -c all
+}
+
+function proc_exists # pid
+{
+	ps -p $1 >/dev/null
+}
+
+function proc_must_exist # pid
+{
+	proc_exists $1 || log_fail "zpool process exited too soon"
+}
+
+function proc_must_not_exist # pid
+{
+	proc_exists $1 && log_fail "zpool process took too long to exit"
+}
+
+function get_time
+{
+	date +'%H:%M:%S'
+}
+
+function kill_if_running
+{
+	typeset pid=$1
+	[[ $pid ]] && proc_exists $pid && log_must kill -s TERM $pid
+}
+
+# Log a command and then start it running in the background
+function log_bkgrnd
+{
+	log_note "$(get_time) Starting cmd in background '$@'"
+	"$@" &
+}
+
+# Check that a background process has completed and exited with a status of 0
+function bkgrnd_proc_succeeded
+{
+	typeset pid=$1
+
+	log_must sleep $WAIT_EXIT_GRACE
+
+	proc_must_not_exist $pid
+	wait $pid || log_fail "process exited with status $?"
+	log_note "$(get_time) wait completed successfully"
+}

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait_deleteq.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait_deleteq.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_wait/zfs_wait.kshlib
+
+#
+# DESCRIPTION:
+# 'zfs wait' works when waiting for checkpoint discard to complete.
+#
+# STRATEGY:
+# 1. Create a file
+# 2. Open a file descriptor pointing to that file.
+# 3. Delete the file.
+# 4. Start a background process waiting for the delete queue to empty.
+# 5. Verify that the command doesn't return immediately.
+# 6. Close the open file descriptor.
+# 7. Verify that the command returns soon after the descriptor is closedd.
+#
+
+function cleanup
+{
+	kill_if_running $pid
+	exec 3<&-
+}
+
+
+typeset -r TESTFILE="/$TESTPOOL/testfile"
+typeset pid
+
+log_onexit cleanup
+
+log_must touch $TESTFILE
+exec 3<> $TESTFILE
+log_must rm $TESTFILE
+log_bkgrnd zfs wait -t deleteq $TESTPOOL
+pid=$!
+proc_must_exist $pid
+
+exec 3<&-
+log_must sleep 0.5
+bkgrnd_proc_succeeded $pid
+
+log_pass "'zfs wait -t discard' and 'zpool checkpoint -dw' work."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait_deleteq.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_wait/zfs_wait_deleteq.ksh
@@ -28,7 +28,7 @@
 # 4. Start a background process waiting for the delete queue to empty.
 # 5. Verify that the command doesn't return immediately.
 # 6. Close the open file descriptor.
-# 7. Verify that the command returns soon after the descriptor is closedd.
+# 7. Verify that the command returns soon after the descriptor is closed.
 #
 
 function cleanup
@@ -54,4 +54,4 @@ exec 3<&-
 log_must sleep 0.5
 bkgrnd_proc_succeeded $pid
 
-log_pass "'zfs wait -t discard' and 'zpool checkpoint -dw' work."
+log_pass "'zfs wait -t discard' works."


### PR DESCRIPTION
### Motivation and Context
When doing redacted send/recv, many workflows involve deleting files that contain sensitive data. Because of the way zfs handles file deletions, snapshots taken quickly after a rm operation can sometimes still contain the file in question, especially if the file is very large. This can result in issues for redacted send/recv users who expect the deleted files to be redacted in the send streams, and not appear in their clones.

### Description
This PR duplicates much of the `zpool wait` related logic into a `zfs wait` command. I would be open to a proposal to combine a bunch of this logic if people would prefer that, though some changes would need to be made to correctly dispatch the waiting in the kernel into the appropriate dsl_dir_wait or spa_wait as needed.

### How Has This Been Tested?
New zfs-test added, and tested manually with files being held open by file descriptors. Verified that if there is nothing in the delete queue, the command returns immediately.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
