### PR TITLE
zpool status -vv prints error ranges

### DIFF
--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -18,7 +18,8 @@ endif
 zpool_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
-	$(top_builddir)/lib/libzfs/libzfs.la
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzpool/libzpool.la
 
 zpool_LDADD += -lm $(LIBBLKID)
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -440,6 +440,8 @@ extern int zpool_events_clear(libzfs_handle_t *, int *);
 extern int zpool_events_seek(libzfs_handle_t *, uint64_t, int);
 extern void zpool_obj_to_path(zpool_handle_t *, uint64_t, uint64_t, char *,
     size_t len);
+extern int zpool_get_block_size(zpool_handle_t *, uint64_t, uint64_t,
+    uint64_t *, uint64_t *);
 extern int zfs_ioctl(libzfs_handle_t *, int, struct zfs_cmd *);
 extern int zpool_get_physpath(zpool_handle_t *, char *, size_t);
 extern void zpool_explain_recover(libzfs_handle_t *, const char *, int,

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1359,6 +1359,8 @@ typedef enum {
 #define	ZPOOL_ERR_LIST		"error list"
 #define	ZPOOL_ERR_DATASET	"dataset"
 #define	ZPOOL_ERR_OBJECT	"object"
+#define	ZPOOL_ERR_LEVEL		"level"
+#define	ZPOOL_ERR_BLOCKID	"block id"
 
 #define	HIS_MAX_RECORD_LEN	(MAXPATHLEN + MAXPATHLEN + 1)
 

--- a/include/sys/zfs_stat.h
+++ b/include/sys/zfs_stat.h
@@ -44,6 +44,8 @@ typedef struct zfs_stat {
 	uint64_t	zs_mode;
 	uint64_t	zs_links;
 	uint64_t	zs_ctime[2];
+	uint64_t	zs_data_block_size;
+	uint64_t	zs_indirect_block_size;
 } zfs_stat_t;
 
 extern int zfs_obj_to_stats(objset_t *osp, uint64_t obj, zfs_stat_t *sb,

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -121,7 +121,8 @@ See
 .Xr date 1 .
 .It Fl v
 Displays verbose data error information, printing out a complete list of all
-data errors since the last complete pool scrub.
+data errors since the last complete pool scrub.  Passing this flag twice ('-vv')
+will print out the byte ranges for the errors within the files.
 .It Fl x
 Only display status for pools that are exhibiting errors or are otherwise
 unavailable.

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -2087,6 +2087,11 @@ zfs_obj_to_stats_impl(sa_handle_t *hdl, sa_attr_type_t *sa_table,
 	sa_bulk_attr_t bulk[4];
 	int count = 0;
 
+	dmu_object_info_t doi;
+	sa_object_info(hdl, &doi);
+	sb->zs_data_block_size = doi.doi_data_block_size;
+	sb->zs_indirect_block_size = doi.doi_metadata_block_size;
+
 	SA_ADD_BULK_ATTR(bulk, count, sa_table[ZPL_MODE], NULL,
 	    &sb->zs_mode, sizeof (sb->zs_mode));
 	SA_ADD_BULK_ATTR(bulk, count, sa_table[ZPL_GEN], NULL,

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -443,7 +443,7 @@ tests = ['zpool_split_cliargs', 'zpool_split_devices',
 tags = ['functional', 'cli_root', 'zpool_split']
 
 [tests/functional/cli_root/zpool_status]
-tests = ['zpool_status_001_pos', 'zpool_status_002_pos']
+tests = ['zpool_status_001_pos', 'zpool_status_002_pos', 'zpool_status_-v']
 tags = ['functional', 'cli_root', 'zpool_status']
 
 [tests/functional/cli_root/zpool_sync]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_status_001_pos.ksh \
-	zpool_status_002_pos.ksh
+	zpool_status_002_pos.ksh \
+	zpool_status_-v.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_-v.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_-v.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2019 Lawrence Livermore National Security, LLC.
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify correct output with 'zpool status -v' after corrupting a file
+#
+# STRATEGY:
+# 1. Create a file
+# 2. zinject checksum errors
+# 3. Read the file
+# 4. Verify we see "file corrupted" output in 'zpool status -v'
+# 5. Verify we see one of the corrupted ranges in 'zpool status -vv'
+
+verify_runnable "both"
+
+log_assert "Verify correct 'zpool status -v' output with a corrupted file"
+log_must mkfile 10m $TESTDIR/10m_file
+log_must mkfile 1m $TESTDIR/1m_file
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+
+log_must zinject -t data -e checksum -f 100 $TESTDIR/10m_file
+log_must zinject -t data -e checksum -f 100 $TESTDIR/1m_file
+
+# Try to read '1m_file'.  It should stop after the first 128k block.
+cat $TESTDIR/1m_file > /dev/null || true
+
+# Try to read the 2nd megabyte of '10m_file'
+dd if=$TESTDIR/10m_file bs=1M skip=1 count=1 || true
+
+log_must zinject -c all
+
+# Look to see that both our files report errors
+log_must eval "zpool status -v | grep '10m_file: found'"
+log_must eval "zpool status -v | grep '1m_file: found'"
+
+# Look for one of our error ranges
+log_must eval "zpool status -vv | grep '[0x100000-0x1fffff]'"
+
+log_pass "'zpool status -vv' output is correct"


### PR DESCRIPTION
### Motivation and Context
Print out the byte ranges of corruption in damaged files

### Description
Add a `-vv` option to `zpool status` to print all error'd out block ranges:
```
$ zpool status -vv
...
    NAME        STATE     READ WRITE CKSUM
    testpool    ONLINE       0     0     0
      loop0     ONLINE       0     0    20

errors: Permanent errors have been detected in the following files:

    /var/tmp/testdir/10m_file: found 9 corrupted 128K blocks
       [0x0-0x1ffff] (128K)
       [0x100000-0x1fffff] (1M)

    /var/tmp/testdir/1m_file: found 1 corrupted 128K block
       [0x0-0x1ffff] (128K)
```
This is a modification of @TulsiJain's #8902 patch, with updates added to print out the different ranges of errors, and to bring the code up to date with master.

### How Has This Been Tested?
Added test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
