### PR TITLE
Adjust zvol taskq defaults

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -3694,8 +3694,9 @@ Default value: \fB0\fR.
 .ad
 .RS 12n
 Max number of threads which can handle zvol I/O requests concurrently.
+The default value of 0 will create two threads per cpu, up to 8 threads.
 .sp
-Default value: \fB32\fR.
+Default value: \fB0\fR.
 .RE
 
 .sp


### PR DESCRIPTION
### Motivation and Context

Set default values to what has been determined to work well
for a variety of workloads.  See issue #8472.

### Description

For ZFS volumes the dynamic task queue behavior has been
observed to negatively impact performance for some workloads.
Convert the taskq to use long running worked threads.

Furthermore, size the taskq based on the number of cores
in the system.  By default, create a single thread per core.
The default zvol_threads value may still be overridden at
module load time.

### How Has This Been Tested?

Locally compiled.  Manually verified the right number of taskq
threads are created by default, and that setting the `zvol_threads`
module option creates the requested number.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
