### PR TITLE
zfs-destroy: Allow callers to limit destruction for safer automation

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -599,6 +599,48 @@ usage(boolean_t requested)
 	exit(requested ? 0 : 2);
 }
 
+static zfs_type_t
+getopt_object_types(void)
+{
+	char *value;
+	zfs_type_t types = 0;
+
+	while (*optarg != '\0') {
+		static char *type_subopts[] = { "filesystem",
+		    "volume", "snapshot", "snap", "bookmark",
+		    "all", NULL };
+		switch (getsubopt(&optarg, type_subopts,
+		    &value)) {
+
+		case 0:
+			types |= ZFS_TYPE_FILESYSTEM;
+			break;
+		case 1:
+			types |= ZFS_TYPE_VOLUME;
+			break;
+		case 2:
+		case 3:
+			types |= ZFS_TYPE_SNAPSHOT;
+			break;
+		case 4:
+			types |= ZFS_TYPE_BOOKMARK;
+			break;
+
+		case 5:
+			types = ZFS_TYPE_DATASET |
+			    ZFS_TYPE_BOOKMARK;
+			break;
+		default:
+			(void) fprintf(stderr,
+			    gettext("invalid type '%s'\n"),
+			    value);
+			usage(B_FALSE);
+		}
+	}
+
+	return (types);
+}
+
 /*
  * Take a property=value argument string and add it to the given nvlist.
  * Modifies the argument inplace.
@@ -1978,40 +2020,8 @@ zfs_do_get(int argc, char **argv)
 			break;
 
 		case 't':
-			types = 0;
+			types = getopt_object_types();
 			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
-			while (*optarg != '\0') {
-				static char *type_subopts[] = { "filesystem",
-				    "volume", "snapshot", "snap", "bookmark",
-				    "all", NULL };
-
-				switch (getsubopt(&optarg, type_subopts,
-				    &value)) {
-				case 0:
-					types |= ZFS_TYPE_FILESYSTEM;
-					break;
-				case 1:
-					types |= ZFS_TYPE_VOLUME;
-					break;
-				case 2:
-				case 3:
-					types |= ZFS_TYPE_SNAPSHOT;
-					break;
-				case 4:
-					types |= ZFS_TYPE_BOOKMARK;
-					break;
-				case 5:
-					types = ZFS_TYPE_DATASET |
-					    ZFS_TYPE_BOOKMARK;
-					break;
-
-				default:
-					(void) fprintf(stderr,
-					    gettext("invalid type '%s'\n"),
-					    value);
-					usage(B_FALSE);
-				}
-			}
 			break;
 
 		case '?':
@@ -3428,7 +3438,6 @@ zfs_do_list(int argc, char **argv)
 	boolean_t types_specified = B_FALSE;
 	char *fields = NULL;
 	list_cbdata_t cb = { 0 };
-	char *value;
 	int limit = 0;
 	int ret = 0;
 	zfs_sort_column_t *sortcol = NULL;
@@ -3470,40 +3479,9 @@ zfs_do_list(int argc, char **argv)
 			}
 			break;
 		case 't':
-			types = 0;
+			types = getopt_object_types();
 			types_specified = B_TRUE;
 			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
-			while (*optarg != '\0') {
-				static char *type_subopts[] = { "filesystem",
-				    "volume", "snapshot", "snap", "bookmark",
-				    "all", NULL };
-
-				switch (getsubopt(&optarg, type_subopts,
-				    &value)) {
-				case 0:
-					types |= ZFS_TYPE_FILESYSTEM;
-					break;
-				case 1:
-					types |= ZFS_TYPE_VOLUME;
-					break;
-				case 2:
-				case 3:
-					types |= ZFS_TYPE_SNAPSHOT;
-					break;
-				case 4:
-					types |= ZFS_TYPE_BOOKMARK;
-					break;
-				case 5:
-					types = ZFS_TYPE_DATASET |
-					    ZFS_TYPE_BOOKMARK;
-					break;
-				default:
-					(void) fprintf(stderr,
-					    gettext("invalid type '%s'\n"),
-					    value);
-					usage(B_FALSE);
-				}
-			}
 			break;
 		case ':':
 			(void) fprintf(stderr, gettext("missing argument for "

--- a/man/man8/zfs-destroy.8
+++ b/man/man8/zfs-destroy.8
@@ -40,14 +40,16 @@
 .Nm
 .Cm destroy
 .Op Fl Rfnprv
+.Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume
 .Nm
 .Cm destroy
 .Op Fl Rdnprv
+.Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
 .Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns ...
 .Nm
-.Cm destroy
+.Cm destroy Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
 .Sh DESCRIPTION
 .Bl -tag -width ""
@@ -55,6 +57,7 @@
 .Nm
 .Cm destroy
 .Op Fl Rfnprv
+.Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume
 .Xc
 Destroys the given dataset.
@@ -62,6 +65,7 @@ By default, the command unshares any file systems that are currently shared,
 unmounts any file systems that are currently mounted, and refuses to destroy a
 dataset that has active dependents
 .Pq children or clones .
+.Pp
 .Bl -tag -width "-R"
 .It Fl R
 Recursively destroy all dependents, including cloned file systems outside the
@@ -85,6 +89,8 @@ flags to determine what data would be deleted.
 Print machine-parsable verbose information about the deleted data.
 .It Fl r
 Recursively destroy all children.
+.It Fl t Ar type Ns Op Ar ,...
+Restrict the types of objects which are allowed to be deleted.
 .It Fl v
 Print verbose information about the deleted data.
 .El
@@ -95,10 +101,17 @@ or the
 .Fl R
 options, as they can destroy large portions of a pool and cause unexpected
 behavior for mounted file systems in use.
+.Pp
+If you explicitly do not want a to destroy a filesystem or volume, the
+.Fl t
+option can restrict
+.Nm zfs destroy
+to only destroying snapshots or bookmarks.
 .It Xo
 .Nm
 .Cm destroy
 .Op Fl Rdnprv
+.Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
 .Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns ...
 .Xc
@@ -156,6 +169,8 @@ Print machine-parsable verbose information about the deleted data.
 Destroy
 .Pq or mark for deferred deletion
 all snapshots with this name in descendent file systems.
+.It Fl t Ar type Ns Op Ar ,...
+Restrict the types of objects which are allowed to be deleted.
 .It Fl v
 Print verbose information about the deleted data.
 .Pp
@@ -165,13 +180,22 @@ or the
 .Fl R
 options, as they can destroy large portions of a pool and cause unexpected
 behavior for mounted file systems in use.
+.Pp
+If you explicitly want to only destroy a snapshot or volume, the
+.Fl t
+option makes
+.Nm zfs destroy Fl r
+safer by only allowing the destruction of snapshots or bookmarks.
 .El
 .It Xo
 .Nm
-.Cm destroy
+.Cm destroy Op Fl t Ar type Ns Op Ar ,...
 .Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
 .Xc
 The given bookmark is destroyed.
+.Bl -tag -width ""
+.It Fl t Ar type Ns Op Ar ,...
+Restrict the types of objects which are allowed to be deleted.
 .El
 .Sh SEE ALSO
 .Xr zfs-create 8 ,

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -149,8 +149,9 @@ tests = ['zfs_clone_livelist_condense_and_disable',
     'zfs_destroy_007_neg', 'zfs_destroy_008_pos', 'zfs_destroy_009_pos',
     'zfs_destroy_010_pos', 'zfs_destroy_011_pos', 'zfs_destroy_012_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
-    'zfs_destroy_016_pos', 'zfs_destroy_clone_livelist',
-    'zfs_destroy_dev_removal', 'zfs_destroy_dev_removal_condense']
+    'zfs_destroy_016_pos', 'zfs_destroy_017_pos',
+    'zfs_destroy_clone_livelist', 'zfs_destroy_dev_removal',
+    'zfs_destroy_dev_removal_condense']
 tags = ['functional', 'cli_root', 'zfs_destroy']
 
 [tests/functional/cli_root/zfs_diff]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
@@ -20,6 +20,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_destroy_014_pos.ksh \
 	zfs_destroy_015_pos.ksh \
 	zfs_destroy_016_pos.ksh \
+	zfs_destroy_017_pos.ksh \
 	zfs_destroy_clone_livelist.ksh \
 	zfs_destroy_dev_removal.ksh \
 	zfs_destroy_dev_removal_condense.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_017_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_017_pos.ksh
@@ -1,0 +1,289 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_destroy/zfs_destroy.cfg
+. $STF_SUITE/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+
+################################################################################
+#
+# 'zfs destroy -t snapshot -r <snap>' should recursively destroy
+# snapshots, and fail to recursively destroy filesystems
+#
+# 1. Create a hierarchy of filesystems, volumes, snapshots, and
+# bookmarks:
+#
+#   tank
+#   ├── #bookmark
+#   ├── @snapshot
+#   ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+#   ├── filesystem-with-snapshot
+#   │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+#           └── @snapshot
+#
+# 2. Test recursively deleting objects of different types:
+#    filesystems, volumes, snapshots, and bookmarks
+# 3. Assert that the matching types are deleted and other types are
+#    present
+#
+################################################################################
+
+log_assert "'zfs destroy -t snapshot <snap>' only deletes snapshots"
+log_onexit cleanup_testenv
+
+destroyroot="$TESTPOOL/$TESTFS1"
+
+function cleanup
+{
+	if datasetexists "$destroyroot"; then
+		log_must zfs destroy -r "$destroyroot"
+	fi
+}
+
+function setup_hierarchy
+{
+	cleanup
+
+	#   tank
+	log_must zfs create "$destroyroot"
+	log_must zfs create "$destroyroot/tank"
+
+	#   ├── #bookmark
+	log_must zfs snapshot "$destroyroot/tank@bookmark"
+	log_must zfs bookmark "$destroyroot/tank@bookmark" \
+		 "$destroyroot/tank#bookmark"
+	log_must zfs destroy "$destroyroot/tank@bookmark"
+
+	#   ├── @snapshot
+	log_must zfs snapshot "$destroyroot/tank@snapshot"
+
+	#   ├── filesystem
+	log_must zfs create "$destroyroot/tank/filesystem"
+
+	#   ├── filesystem-with-bookmark
+	#   │   └── #bookmark
+	log_must zfs create "$destroyroot/tank/filesystem-with-bookmark"
+	log_must zfs snapshot "$destroyroot/tank/filesystem-with-bookmark@bookmark"
+	log_must zfs bookmark "$destroyroot/tank/filesystem-with-bookmark@bookmark" \
+		 "$destroyroot/tank/filesystem-with-bookmark#bookmark"
+	log_must zfs destroy "$destroyroot/tank/filesystem-with-bookmark@bookmark"
+
+	#   ├── filesystem-with-snapshot
+	#   │   └── @snapshot
+	log_must zfs create "$destroyroot/tank/filesystem-with-snapshot"
+	log_must zfs snapshot "$destroyroot/tank/filesystem-with-snapshot@snapshot"
+
+	#   ├── filesystem-with-volume
+	#   │    └── volume
+	log_must zfs create "$destroyroot/tank/filesystem-with-volume"
+	log_must zfs create -V 10M  "$destroyroot/tank/filesystem-with-volume/volume"
+
+	#   └── filesystem-with-snapshotted-volume
+	#       └── volume
+	#           └── @snapshot
+	log_must zfs create "$destroyroot/tank/filesystem-with-snapshotted-volume"
+	log_must zfs create -V 10M  "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+	log_must zfs snapshot  "$destroyroot/tank/filesystem-with-snapshotted-volume/volume@snapshot"
+
+}
+
+# Verify boundaries of recursively deleting filesystems
+#   tank
+#   ├── #bookmark
+#   ├── @snapshot
+# x ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+#   ├── filesystem-with-snapshot
+#   │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+#           └── @snapshot
+setup_hierarchy
+log_mustnot zfs destroy -t filesystem "$destroyroot/tank/filesystem-with-snapshot"
+log_must zfs destroy -t filesystem -r "$destroyroot/tank/filesystem-with-volume"
+log_must zfs destroy -t filesystem -r "$destroyroot/tank"
+log_mustnot zfs get name "$destroyroot/tank/filesystem"
+
+# Verify boundaries of recursively deleting volumes
+#   tank
+#   ├── #bookmark
+#   ├── @snapshot
+#   ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+#   ├── filesystem-with-snapshot
+#   │   └── @snapshot
+#   ├── filesystem-with-volume
+# x │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+#           └── @snapshot
+setup_hierarchy
+log_mustnot zfs destroy -t volume -r "$destroyroot/tank/filesystem"
+log_mustnot zfs destroy -t volume "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_must zfs destroy -t volume "$destroyroot/tank/filesystem-with-volume/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-volume/volume"
+
+# Verify boundaries of recursively deleting snapshots
+#   tank
+#   ├── #bookmark
+# x ├── @snapshot
+#   ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+#   ├── filesystem-with-snapshot
+# x │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+# x         └── @snapshot
+setup_hierarchy
+log_mustnot zfs destroy -t snapshot "$destroyroot/tank/filesystem"
+log_mustnot zfs destroy -t snapshot "$destroyroot/tank/filesystem-with-volume/volume"
+log_must zfs destroy -t snapshot -r "$destroyroot/tank@snapshot"
+
+log_must zfs get name "$destroyroot/tank"
+log_mustnot zfs get name "$destroyroot/tank@snapshot"
+
+log_must zfs get name "$destroyroot/tank/filesystem-with-snapshot"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshot@snapshot"
+
+log_must zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume@snapshot"
+
+
+# Verify boundaries of recursively deleting bookmarks
+#   tank
+# x ├── #bookmark
+#   ├── @snapshot
+#   ├── filesystem
+#   ├── filesystem-with-bookmark
+# x │   └── #bookmark
+#   ├── filesystem-with-snapshot
+#   │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+#           └── @snapshot
+setup_hierarchy
+log_mustnot zfs destroy -t bookmark "$destroyroot/tank@snapshot"
+log_mustnot zfs destroy -t bookmark "$destroyroot/tank/filesystem"
+log_must zfs destroy -t bookmark "$destroyroot/tank#bookmark"
+log_must zfs destroy -t bookmark "$destroyroot/tank/filesystem-with-bookmark#bookmark"
+
+log_must zfs get name "$destroyroot/tank"
+log_mustnot zfs get name "$destroyroot/tank#bookmark"
+
+log_must zfs get name "$destroyroot/tank/filesystem-with-bookmark"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-bookmark#bookmark"
+
+# Verify boundaries of recursively deleting all
+# x tank
+# x ├── #bookmark
+# x ├── @snapshot
+# x ├── filesystem
+# x ├── filesystem-with-bookmark
+# x │   └── #bookmark
+# x ├── filesystem-with-snapshot
+# x │   └── @snapshot
+# x ├── filesystem-with-volume
+# x │    └── volume
+# x └── filesystem-with-snapshotted-volume
+# x     └── volume
+# x         └── @snapshot
+setup_hierarchy
+log_must zfs destroy -t all -r "$destroyroot/tank"
+log_mustnot zfs get name "$destroyroot/tank"
+log_mustnot zfs get name "$destroyroot/tank#bookmark"
+log_mustnot zfs get name "$destroyroot/tank@snapshot"
+log_mustnot zfs get name "$destroyroot/tank/filesystem"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-bookmark"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshot/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+
+# Verify boundaries of recursively deleting volumes and snapshots
+#   tank
+#   ├── #bookmark
+#   ├── @snapshot
+#   ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+#   ├── filesystem-with-snapshot
+#   │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+# x     └── volume
+# x         └── @snapshot
+setup_hierarchy
+log_must zfs destroy -t volume,snapshot -r \
+	 "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume@snapshot"
+
+# Verify boundaries of recursively deleting filesystems and snapshots
+#   tank
+#   ├── #bookmark
+# x ├── @snapshot
+# x ├── filesystem
+#   ├── filesystem-with-bookmark
+#   │   └── #bookmark
+# x ├── filesystem-with-snapshot
+# x │   └── @snapshot
+#   ├── filesystem-with-volume
+#   │    └── volume
+#   └── filesystem-with-snapshotted-volume
+#       └── volume
+# x         └── @snapshot
+setup_hierarchy
+log_must zfs destroy -t filesystem,snapshot -r "$destroyroot/tank"
+log_must zfs get name "$destroyroot/tank"
+log_must zfs get name "$destroyroot/tank#bookmark"
+log_mustnot zfs get name "$destroyroot/tank@snapshot"
+log_mustnot zfs get name "$destroyroot/tank/filesystem"
+log_must zfs get name "$destroyroot/tank/filesystem-with-bookmark"
+log_must zfs get name "$destroyroot/tank/filesystem-with-bookmark#bookmark"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshot/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_must zfs get name "$destroyroot/tank/filesystem-with-volume"
+log_must zfs get name "$destroyroot/tank/filesystem-with-volume/volume"
+log_must zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume"
+log_must zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume"
+log_mustnot zfs get name "$destroyroot/tank/filesystem-with-snapshotted-volume/volume@snapshot"
+
+
+log_pass "'zfs destroy -t snapshot <snap>' only deletes snapshots"


### PR DESCRIPTION
### Motivation and Context

After creating recursive snapshots with `zfs snapshot -r`, it is
tempting to use `zfs destroy -r` to clean up. However, as the man page
correctly points out, it is extremely dangerous:

    Extreme care should be taken when applying either the -r or the
    -R options, as they can destroy large portions of a pool and
    cause unexpected behavior for mounted file systems in use.

As an author of script-based automation, this gives me great
heart-burn. This becomes a pretty tricky validation problem with
fairly dire failure modes.

### Description

Instead, this patch makes it possible for automation authors and
fumbling typists to tell ZFS what they *intend* to destroy *before*
they pass `-r`, and *before* they start typing in any sort of dataset
names:

    # zfs destroy -t snapshot -r tank@initial-installation

At this time it also supports `-t bookmark`.

I considered trying to support additional types like volume and
filesystem, however my little bit of C experience made that a fairly
spooky proposition.

In particular, any combination of `-rR` and `-t volume|filesystem`
seemed like a potentially complicated set of expected behavior. ("What
should happen if I `zfs destroy -t volume -r rpool`?")

Closes zfsonlinux/zfs#9522.

Signed-off-by: Graham Christensen <graham@grahamc.com>

### How Has This Been Tested?

Linux: 4.19.93

```
$ zfs --version
zfs-0.8.2-1
zfs-kmod-0.8.2-1
```

I did not test this very thoroughly. I wrote the test in the commit, however was not comfortable running the ZFS test suite.My testing was essentially running:

```
$ ./cmd/zfs/zfs destroy -t filesystem rpool/local/old-root
```

with different `-t` values and different dataset values and making sure they either failed with permission denied (running them as an unprivileged user) or a refusal because of the `-t` option.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] (I _think_) My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] (I _think_) I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
