### PR TITLE
Fix --enable-linux-builtin when modules are disabled

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -461,15 +461,13 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_MODULE], [
 	ZFS_LINUX_TRY_COMPILE([], [], [
 		AC_MSG_RESULT([yes])
 	],[
-		AC_MSG_RESULT([no])
 		if test "x$enable_linux_builtin" != xyes; then
+			AC_MSG_RESULT([no])
 			AC_MSG_ERROR([
 	*** Unable to build an empty module.
 			])
 		else
-			AC_MSG_ERROR([
-	*** Unable to build an empty module.
-	*** Please run 'make scripts' inside the kernel source tree.])
+			AC_MSG_RESULT([unneeded, using --enable-linux-builtin])
 		fi
 	])
 ])


### PR DESCRIPTION
### Motivation and Context
Fixes: #9887

### Description
This allows `--enable-linux-builtin` to work when `CONFIG_MODULES` is not set in the kernel.

### How Has This Been Tested?
Manually tested on Fedora 31.  Verified the patch fixed the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
