### PR TITLE
Avoid COW faults on dbuf fills

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -70,7 +70,7 @@ typedef struct arc_prune arc_prune_t;
  * parameter will be NULL.
  */
 typedef void arc_read_done_func_t(zio_t *zio, const zbookmark_phys_t *zb,
-    const blkptr_t *bp, arc_buf_t *buf, void *private);
+    int err, const blkptr_t *bp, arc_buf_t *buf, void *private);
 typedef void arc_write_done_func_t(zio_t *zio, arc_buf_t *buf, void *private);
 typedef void arc_prune_func_t(int64_t bytes, void *private);
 
@@ -157,8 +157,12 @@ typedef enum arc_flags
 	ARC_FLAG_COMPRESS_3		= 1 << 27,
 	ARC_FLAG_COMPRESS_4		= 1 << 28,
 	ARC_FLAG_COMPRESS_5		= 1 << 29,
-	ARC_FLAG_COMPRESS_6		= 1 << 30
+	ARC_FLAG_COMPRESS_6		= 1 << 30,
 
+	/*
+	 * cache lookup only
+	 */
+	ARC_FLAG_CACHED_ONLY		= 1 << 31
 } arc_flags_t;
 
 typedef enum arc_buf_flags {
@@ -259,6 +263,7 @@ arc_buf_t *arc_loan_raw_buf(spa_t *spa, uint64_t dsobj, boolean_t byteorder,
     enum zio_compress compression_type);
 void arc_return_buf(arc_buf_t *buf, void *tag);
 void arc_loan_inuse_buf(arc_buf_t *buf, void *tag);
+void arc_transfer_cache_state(arc_buf_t *from, arc_buf_t *to);
 void arc_buf_destroy(arc_buf_t *buf, void *tag);
 void arc_buf_info(arc_buf_t *buf, arc_buf_info_t *abi, int state_index);
 uint64_t arc_buf_size(arc_buf_t *buf);
@@ -268,6 +273,7 @@ void arc_release(arc_buf_t *buf, void *tag);
 int arc_released(arc_buf_t *buf);
 void arc_buf_sigsegv(int sig, siginfo_t *si, void *unused);
 void arc_buf_freeze(arc_buf_t *buf);
+boolean_t arc_buf_frozen(arc_buf_t *buf);
 void arc_buf_thaw(arc_buf_t *buf);
 #ifdef ZFS_DEBUG
 int arc_referenced(arc_buf_t *buf);

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -55,34 +55,196 @@ extern "C" {
 #define	DB_RF_NEVERWAIT		(1 << 4)
 #define	DB_RF_CACHED		(1 << 5)
 #define	DB_RF_NO_DECRYPT	(1 << 6)
+#define	DB_RF_CACHED_ONLY	(1 << 7)
 
+/* BEGIN CSTYLED */
 /*
  * The simplified state transition diagram for dbufs looks like:
  *
- *		+----> READ ----+
- *		|		|
- *		|		V
- *  (alloc)-->UNCACHED	     CACHED-->EVICTING-->(free)
- *		|		^	 ^
- *		|		|	 |
- *		+----> FILL ----+	 |
- *		|			 |
- *		|			 |
- *		+--------> NOFILL -------+
  *
- * DB_SEARCH is an invalid state for a dbuf. It is used by dbuf_free_range
- * to find all dbufs in a range of a dnode and must be less than any other
- * dbuf_states_t (see comment on dn_dbufs in dnode.h).
+ *		+-> PARTIAL_FILL <---> PARTIAL-+
+ *		|		 	  |    |
+ *		+---------->READ_FILL<----[----+
+ *		|		^	  |
+ *		|		|	  |
+ *		|		V	  |
+ *		+-----------> READ ------+[-------+
+ *		|			 ||	  |
+ *		|			 VV	  V
+ *  (alloc)-->UNCACHED----------------->FILL--->CACHED----> EVICTING-->(free)
+ *		|						^
+ *		|						|
+ *		+--------------------> NOFILL ------------------+
+ *
+ *
+ * Reader State Transitions:
+ * UNCACHED ->	READ:		Access to a block that does not have an
+ *				active dbuf.  A read is issued to media
+ *				upon an ARC or L2ARC miss.
+ *
+ * READ -> CACHED:		Data satisfied from the ARC, L2ARC, or
+ *				a read of the media.  No writes occurred.
+ *
+ * PARTIAL -> READ:		Access to a block that has been partially
+ *				written but has yet to have the read
+ *				needed to resolve the COW fault issued.
+ *				The read is issued to media.  The ARC and
+ *				L2ARC are not involved since they were
+ *				checked for a hit at the time of the first
+ *				write to this buffer.
+ *
+ * Writer State Transitions:
+ * UNCACHED ->	FILL:		Access to a block that does not have an
+ *				active dbuf.  Writer is filling the entire
+ *				block.
+ *
+ * UNCACHED -> PARTIAL_FILL:	Access to a block that does not have an
+ *				active dbuf.  Writer is filling a portion
+ *				of the block starting at the beginning or
+ *				end.  The read needed to resolve the COW
+ *				fault is deferred until we see that the
+ *				writer will not fill this whole buffer.
+ *
+ * UNCACHED -> READ_FILL:	Access to a block that does not have an
+ *				active dbuf.  Writer is filling a portion
+ *				of the block and we have enough information
+ *				to expect that the buffer will not be fully
+ *				written.  The read needed to resolve the COW
+ *				fault is issued asynchronously.
+ *
+ * READ -> READ_FILL:		Access to a block that has an active dbuf
+ *				and a read has already been issued for the
+ *				original buffer contents.  A COW fault may
+ *				not have occurred, if the buffer was not
+ *				already dirty.	Writer is filling a portion
+ *				of the buffer.
+ *
+ * PARTIAL -> PARTIAL_FILL:	Access to a block that has an active dbuf
+ *				with an outstanding COW fault.	Writer is
+ *				filling a portion of the block and we have
+ *				enough information to expect that the buffer
+ *				will eventually be fully written.
+ *
+ * PARTIAL -> READ_FILL:	Access to a block that has an active dbuf
+ *				with an outstanding COW fault.	Writer is
+ *				filling a portion of the block and we have
+ *				enough information to expect that the buffer
+ *				will not be fully written, causing a read
+ *				to be issued.
+ *
+ * PARTIAL -> FILL:		Access to a block that has an active dbuf
+ *				with an outstanding COW fault.	Writer is
+ *				filling enough of the buffer to avoid the
+ *				read for this fault entirely.
+ *
+ * READ -> FILL:		Access to a block that has an active dbuf
+ *				with an outstanding COW fault, and a read
+ *				has been issued.  Write is filling enough of
+ *				the buffer to obsolete the read.
+ *
+ * I/O Complete Transitions:
+ * FILL -> CACHED:		The thread modifying the buffer has completed
+ *				its work. The buffer can now be accessed by
+ *				other threads.
+ *
+ * PARTIAL_FILL -> PARTIAL:	The write thread modifying the buffer has
+ *				completed its work. The buffer can now be
+ *				accessed by other threads.  No read has been
+ *				issued to resolve the COW fault.
+ * 
+ * READ_FILL -> READ:		The write thread modifying the buffer has
+ *				completed its work. The buffer can now be
+ *				accessed by other threads. A read is
+ *				outstanding to resolve the COW fault.
+ *
+ * The READ, PARITIAL_FILL, and READ_FILL states indicate the data associated
+ * with a dbuf is volatile and a new client must wait for the current consumer
+ * to exit the dbuf from that state prior to accessing the data.
+ * 
+ * The PARITIAL_FILL, PARTIAL, READ_FILL, and READ states are used for
+ * deferring any reads required for resolution of Copy-On-Write faults.
+ * A PARTIAL dbuf has accumulated write data in its dirty records
+ * that must be merged into the existing data for the record once the
+ * record is read.	A READ dbuf is a dbuf for which a synchronous or
+ * async read has been issued.	If the dbuf has dirty records, this read
+ * is required to resolve the COW fault before those dirty records can be
+ * committed to disk.  The FILL variants of these two states indicate that
+ * either new write data is being added to the dirty records for this dbuf,
+ * or the read has completed and the write and read data are being merged.
+ *
+ * Writers must block on dbufs in any of the FILL states.
+ *
+ * Synchronous readers must block on dbufs in the READ,	 and any
+ * of the FILL states.	Further, a reader must transition a dbuf from the
+ * UNCACHED or PARTIAL state to the READ state by issuing a read, before
+ * blocking.
+ *
+ * The transition from PARTIAL to READ is also triggered by writers that
+ * perform a discontiguous write to the buffer, meaning that there is
+ * little chance for a latter writer to completely fill the buffer.
+ * Since the read cannot be avoided, it is issued immediately.
  */
+
 typedef enum dbuf_states {
-	DB_SEARCH = -1,
-	DB_UNCACHED,
-	DB_FILL,
-	DB_NOFILL,
-	DB_READ,
-	DB_CACHED,
-	DB_EVICTING
+	DB_SEARCH 		= 0x1000,
+
+        /*
+	 * Dbuf has no valid data.
+	 */
+	DB_UNCACHED		= 0x01,
+
+	/*
+	 * The Dbuf's contents are being modified by an active thread.
+	 * This state can be combined with PARTIAL or READ.  When
+	 * just in the DB_FILL state, the entire buffer's contents are
+	 * being supplied by the writer.  When combined with the other
+	 * states, the buffer is only being partially dirtied.
+	 */
+	DB_FILL			= 0x02,
+
+	/*
+	 * Dbuf has been partially dirtied by writers.  No read has been
+	 * issued to resolve the COW fault.
+	 */
+	DB_PARTIAL		= 0x04,
+
+	/*
+	 * A NULL DBuf associated with swap backing store.
+	 */
+	DB_NOFILL		= 0x08,
+
+	/*
+	 * A read has been issued for an uncached buffer with no
+	 * outstanding dirty data (i.e. Not PARTIAL).
+	 */
+	DB_READ			= 0x10,
+
+	/*
+	 * The entire contents of this dbuf are valid.  The buffer
+	 * may still be dirty.
+	 */
+	DB_CACHED		= 0x20,
+
+	/*
+	 * The Dbuf is in the process of being freed.
+	 */
+	DB_EVICTING		= 0x40,
+
+	/*
+	 * Dbuf has been partially dirtied by writers and a
+	 * thread is actively modifying the dbuf.
+	 */
+	DB_PARTIAL_FILL		= DB_PARTIAL|DB_FILL,
+
+	/*
+	 * Dbuf has been partially dirtied by writers, a read
+	 * has been issued to resolve the COW fault, and a
+	 * thread is actively modifying the dbuf.
+	 */
+	DB_READ_FILL		= DB_READ|DB_FILL
 } dbuf_states_t;
+
+	/* END CSTYLED */
 
 typedef enum dbuf_cached_state {
 	DB_NO_CACHE = -1,
@@ -114,6 +276,53 @@ typedef enum db_lock_type {
 	DLT_OBJSET
 } db_lock_type_t;
 
+
+typedef struct dbuf_dirty_indirect_record {
+	kmutex_t dr_mtx;	/* Protects the children. */
+	list_t dr_children;	/* List of our dirty children. */
+} dbuf_dirty_indirect_record_t;
+
+typedef struct dbuf_dirty_range {
+	list_node_t write_range_link;
+	int start;
+	int end;
+	int size;
+} dbuf_dirty_range_t;
+
+typedef struct dbuf_dirty_leaf_record {
+	/*
+	 * dr_data is set when we dirty the buffer so that we can retain the
+	 * pointer even if it gets COW'd in a subsequent transaction group.
+	 */
+	arc_buf_t *dr_data;
+	blkptr_t dr_overridden_by;
+	override_states_t dr_override_state;
+	uint8_t dr_copies;
+
+	/*
+	 * List of the ranges that dr_data's contents are valid for.
+	 * Used when not all of dr_data is valid, as it may be if writes
+	 * only cover part of it, and no read has filled in the gaps yet.
+	 */
+	list_t write_ranges;
+	boolean_t dr_nopwrite;
+	boolean_t dr_has_raw_params;
+
+	/*
+	 * If dr_has_raw_params is set, the following crypt
+	 * params will be set on the BP that's written.
+	 */
+	boolean_t dr_byteorder;
+	uint8_t	dr_salt[ZIO_DATA_SALT_LEN];
+	uint8_t	dr_iv[ZIO_DATA_IV_LEN];
+	uint8_t	dr_mac[ZIO_DATA_MAC_LEN];
+} dbuf_dirty_leaf_record_t;
+
+typedef union dbuf_dirty_record_types {
+	struct dbuf_dirty_indirect_record di;
+	struct dbuf_dirty_leaf_record dl;
+} dbuf_dirty_record_types_t;
+
 typedef struct dbuf_dirty_record {
 	/* link on our parents dirty list */
 	list_node_t dr_dirty_node;
@@ -138,40 +347,7 @@ typedef struct dbuf_dirty_record {
 
 	/* A copy of the bp that points to us */
 	blkptr_t dr_bp_copy;
-
-	union dirty_types {
-		struct dirty_indirect {
-
-			/* protect access to list */
-			kmutex_t dr_mtx;
-
-			/* Our list of dirty children */
-			list_t dr_children;
-		} di;
-		struct dirty_leaf {
-
-			/*
-			 * dr_data is set when we dirty the buffer
-			 * so that we can retain the pointer even if it
-			 * gets COW'd in a subsequent transaction group.
-			 */
-			arc_buf_t *dr_data;
-			blkptr_t dr_overridden_by;
-			override_states_t dr_override_state;
-			uint8_t dr_copies;
-			boolean_t dr_nopwrite;
-			boolean_t dr_has_raw_params;
-
-			/*
-			 * If dr_has_raw_params is set, the following crypt
-			 * params will be set on the BP that's written.
-			 */
-			boolean_t dr_byteorder;
-			uint8_t	dr_salt[ZIO_DATA_SALT_LEN];
-			uint8_t	dr_iv[ZIO_DATA_IV_LEN];
-			uint8_t	dr_mac[ZIO_DATA_MAC_LEN];
-		} dl;
-	} dt;
+	union dbuf_dirty_record_types dt;
 } dbuf_dirty_record_t;
 
 typedef struct dmu_buf_impl {
@@ -298,6 +474,9 @@ typedef struct dmu_buf_impl {
 	uint8_t db_pending_evict;
 
 	uint8_t db_dirtycnt;
+
+	uint8_t db_advice:3;
+	uint8_t db_is_ephemeral:1;
 } dmu_buf_impl_t;
 
 /* Note: the dbuf hash table is exposed only for the mdb module */
@@ -313,6 +492,7 @@ uint64_t dbuf_whichblock(const struct dnode *di, const int64_t level,
     const uint64_t offset);
 
 void dbuf_create_bonus(struct dnode *dn);
+void dbuf_dirty_record_cleanup_ranges(dbuf_dirty_record_t *dr);
 int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, dmu_tx_t *tx);
 
 void dbuf_rm_spill(struct dnode *dn, dmu_tx_t *tx);
@@ -339,6 +519,7 @@ dmu_buf_impl_t *dbuf_find(struct objset *os, uint64_t object, uint8_t level,
     uint64_t blkid);
 
 int dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags);
+void dbuf_transition_to_read(dmu_buf_impl_t *db);
 void dmu_buf_will_not_fill(dmu_buf_t *db, dmu_tx_t *tx);
 void dmu_buf_will_fill(dmu_buf_t *db, dmu_tx_t *tx);
 void dmu_buf_fill_done(dmu_buf_t *db, dmu_tx_t *tx);
@@ -379,6 +560,7 @@ void dbuf_init(void);
 void dbuf_fini(void);
 
 boolean_t dbuf_is_metadata(dmu_buf_impl_t *db);
+void dbuf_dirty_record_cleanup_ranges(dbuf_dirty_record_t *dr);
 
 static inline dbuf_dirty_record_t *
 dbuf_find_dirty_lte(dmu_buf_impl_t *db, uint64_t txg)
@@ -454,13 +636,10 @@ _NOTE(CONSTCOND) } while (0)
 	}							\
 _NOTE(CONSTCOND) } while (0)
 
-#define	DBUF_VERIFY(db)	dbuf_verify(db)
-
 #else
 
 #define	dprintf_dbuf(db, fmt, ...)
 #define	dprintf_dbuf_bp(db, bp, fmt, ...)
-#define	DBUF_VERIFY(db)
 
 #endif
 

--- a/include/sys/dmu_traverse.h
+++ b/include/sys/dmu_traverse.h
@@ -62,14 +62,14 @@ typedef int (blkptr_cb_t)(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 #define	TRAVERSE_VISIT_NO_CHILDREN	-1
 
 int traverse_dataset(struct dsl_dataset *ds,
-    uint64_t txg_start, int flags, blkptr_cb_t func, void *arg);
+    uint64_t txg_start, arc_flags_t flags, blkptr_cb_t func, void *arg);
 int traverse_dataset_resume(struct dsl_dataset *ds, uint64_t txg_start,
-    zbookmark_phys_t *resume, int flags, blkptr_cb_t func, void *arg);
+    zbookmark_phys_t *resume, arc_flags_t flags, blkptr_cb_t func, void *arg);
 int traverse_dataset_destroyed(spa_t *spa, blkptr_t *blkptr,
-    uint64_t txg_start, zbookmark_phys_t *resume, int flags,
+    uint64_t txg_start, zbookmark_phys_t *resume, arc_flags_t flags,
     blkptr_cb_t func, void *arg);
 int traverse_pool(spa_t *spa,
-    uint64_t txg_start, int flags, blkptr_cb_t func, void *arg);
+    uint64_t txg_start, arc_flags_t flags, blkptr_cb_t func, void *arg);
 
 /*
  * Note that this calculation cannot overflow with the current maximum indirect

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -116,6 +116,10 @@ extern "C" {
 #define	DNODES_PER_LEVEL_SHIFT	(DN_MAX_INDBLKSHIFT - SPA_BLKPTRSHIFT)
 #define	DNODES_PER_LEVEL	(1ULL << DNODES_PER_LEVEL_SHIFT)
 
+/* Next level for a given dnode and txg */
+#define	DN_NEXT_LEVEL(dn, txg) \
+	(dn)->dn_next_nlevels[(txg) & TXG_MASK]
+
 #define	DN_MAX_LEVELS	(DIV_ROUND_UP(DN_MAX_OFFSET_SHIFT - SPA_MINBLOCKSHIFT, \
 	DN_MIN_INDBLKSHIFT - SPA_BLKPTRSHIFT) + 1)
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1774,6 +1774,96 @@ dbuf_unoverride(dbuf_dirty_record_t *dr)
 }
 
 /*
+ * Disassociate the frontend for any older transaction groups of a
+ * dbuf that is inside a range being freed.  The primary purpose is to
+ * ensure that the state of any dirty records affected by the operation
+ * remain consistent.
+ */
+static void
+dbuf_free_range_disassociate_frontend(dmu_buf_impl_t *db, dnode_t *dn,
+    dmu_tx_t *tx)
+{
+	uint64_t txg = tx->tx_txg;
+	dbuf_dirty_record_t *dr = list_head(&db->db_dirty_records);
+
+	ASSERT(dr != NULL);
+
+	if (dr->dr_txg == txg) {
+		/*
+		 * This buffer is "in-use", re-adjust the file
+		 * size to reflect that this buffer may
+		 * contain new data when we sync.
+		 */
+		if (db->db_blkid != DMU_SPILL_BLKID &&
+		    db->db_blkid > dn->dn_maxblkid)
+			dn->dn_maxblkid = db->db_blkid;
+		dbuf_unoverride(dr);
+	} else {
+		/*
+		 * This dbuf is not dirty in the open context.
+		 * Either uncache it (if its not referenced in
+		 * the open context) or reset its contents to
+		 * empty.
+		 */
+		dbuf_fix_old_data(db, txg);
+	}
+}
+
+
+static boolean_t
+dbuf_free_range_already_freed(dmu_buf_impl_t *db)
+{
+	/* XXX add comment about why these are OK */
+	if (db->db_state == DB_UNCACHED || db->db_state == DB_NOFILL ||
+	    db->db_state == DB_EVICTING) {
+		ASSERT(db->db.db_data == NULL);
+		mutex_exit(&db->db_mtx);
+		return (B_TRUE);
+	}
+	return (B_FALSE);
+}
+
+static boolean_t
+dbuf_free_range_filler_will_free(dmu_buf_impl_t *db)
+{
+	if (db->db_state == DB_FILL || db->db_state == DB_READ) {
+		/*
+		 * If the buffer is currently being filled, then its
+		 * contents cannot be directly cleared.  Signal the filler
+		 * to have dbuf_fill_done perform the clear just before
+		 * transitioning the buffer to the CACHED state.
+		 */
+		db->db_freed_in_flight = TRUE;
+		mutex_exit(&db->db_mtx);
+		return (B_TRUE);
+	}
+	return (B_FALSE);
+}
+
+/*
+ * If a dbuf has no users, clear it.  Returns whether it was cleared.
+ */
+static boolean_t
+dbuf_clear_successful(dmu_buf_impl_t *db)
+{
+
+	if (zfs_refcount_count(&db->db_holds) != 0)
+		return (B_FALSE);
+
+	/* All consumers are finished, so evict the buffer */
+	ASSERT(db->db_buf != NULL);
+	dbuf_destroy(db);
+	return (B_TRUE);
+}
+
+/*
+ * Free a range of data blocks in a dnode.
+ *
+ * dn	Dnode which the range applies to.
+ * start	Starting block id of the range, inclusive.
+ * end	Ending block id of the range, inclusive.
+ * tx		Transaction to apply the free operation too.
+ *
  * Evict (if its unreferenced) or clear (if its referenced) any level-0
  * data blocks in the free range, so that any future readers will find
  * empty blocks.
@@ -1784,9 +1874,7 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 {
 	dmu_buf_impl_t *db_search;
 	dmu_buf_impl_t *db, *db_next;
-	uint64_t txg = tx->tx_txg;
 	avl_index_t where;
-	dbuf_dirty_record_t *dr;
 
 	if (end_blkid > dn->dn_maxblkid &&
 	    !(start_blkid == DMU_SPILL_BLKID || end_blkid == DMU_SPILL_BLKID))
@@ -1819,49 +1907,15 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 			/* mutex has been dropped and dbuf destroyed */
 			continue;
 		}
+		if (dbuf_free_range_already_freed(db) ||
+		    dbuf_free_range_filler_will_free(db) ||
+		    dbuf_clear_successful(db))
+			continue; /* db_mtx already exited */
 
-		if (db->db_state == DB_UNCACHED ||
-		    db->db_state == DB_NOFILL ||
-		    db->db_state == DB_EVICTING) {
-			ASSERT(db->db.db_data == NULL);
-			mutex_exit(&db->db_mtx);
-			continue;
-		}
-		if (db->db_state == DB_READ || db->db_state == DB_FILL) {
-			/* will be handled in dbuf_read_done or dbuf_rele */
-			db->db_freed_in_flight = TRUE;
-			mutex_exit(&db->db_mtx);
-			continue;
-		}
-		if (zfs_refcount_count(&db->db_holds) == 0) {
-			ASSERT(db->db_buf);
-			dbuf_destroy(db);
-			continue;
-		}
 		/* The dbuf is referenced */
+		if (!list_is_empty(&db->db_dirty_records))
+			dbuf_free_range_disassociate_frontend(db, dn, tx);
 
-		dr = list_head(&db->db_dirty_records);
-		if (dr != NULL) {
-			if (dr->dr_txg == txg) {
-				/*
-				 * This buffer is "in-use", re-adjust the file
-				 * size to reflect that this buffer may
-				 * contain new data when we sync.
-				 */
-				if (db->db_blkid != DMU_SPILL_BLKID &&
-				    db->db_blkid > dn->dn_maxblkid)
-					dn->dn_maxblkid = db->db_blkid;
-				dbuf_unoverride(dr);
-			} else {
-				/*
-				 * This dbuf is not dirty in the open context.
-				 * Either uncache it (if its not referenced in
-				 * the open context) or reset its contents to
-				 * empty.
-				 */
-				dbuf_fix_old_data(db, txg);
-			}
-		}
 		/* clear the contents if its cached */
 		if (db->db_state == DB_CACHED) {
 			ASSERT(db->db.db_data != NULL);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -565,8 +565,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 		for (i = 0; i < nblks; i++) {
 			dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbp[i];
 			mutex_enter(&db->db_mtx);
-			while (db->db_state == DB_READ ||
-			    db->db_state == DB_FILL)
+			while (db->db_state & (DB_READ|DB_FILL))
 				cv_wait(&db->db_changed, &db->db_mtx);
 			if (db->db_state == DB_UNCACHED)
 				err = SET_ERROR(EIO);

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -541,6 +541,7 @@ dnode_undirty_dbufs(list_t *list)
 		ASSERT(list_head(&db->db_dirty_records) == dr);
 		list_remove_head(&db->db_dirty_records);
 		ASSERT(list_is_empty(&db->db_dirty_records));
+		dbuf_dirty_record_cleanup_ranges(dr);
 		db->db_dirtycnt -= 1;
 		if (db->db_level == 0) {
 			ASSERT(db->db_blkid == DMU_BONUS_BLKID ||

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1575,8 +1575,8 @@ dsl_scan_prefetch_dnode(dsl_scan_t *scn, dnode_phys_t *dnp,
 }
 
 void
-dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *private)
+dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb,
+    int err, const blkptr_t *bp, arc_buf_t *buf, void *private)
 {
 	scan_prefetch_ctx_t *spc = private;
 	dsl_scan_t *scn = spc->spc_scn;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This is the final piece of COW fault avoidance. We track    
partial buffer fills and skip the read from disk if the whole   
buffer is overwritten before the txg happens.    

async COW part 6
    
Signed-off-by: Matt Macy <mmacy@FreeBSD.org>   

Adapted from work in 2011 by Will Andrews at SpectraLogic
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
