### PR TITLE
Add longjmp support for Thumb-2

### DIFF
--- a/module/lua/setjmp/setjmp_arm.S
+++ b/module/lua/setjmp/setjmp_arm.S
@@ -31,12 +31,19 @@
 
 #if defined(__arm__) && !defined(__aarch64__)
 
+#if defined(__thumb2__)
+#define	_FUNC_MODE	.code 16; .thumb_func
+#else
+#define	_FUNC_MODE	.code 32
+#endif
+
 #define	ENTRY(x) \
 	.text; \
+	.syntax unified; \
 	.align 2; \
 	.global x; \
 	.type x,#function; \
-	.code 32; \
+	_FUNC_MODE; \
 x:
 
 #define	END(x) \
@@ -49,13 +56,23 @@ x:
  * setjump + longjmp
  */
 ENTRY(setjmp)
+#if defined(__thumb2__)
+	mov	ip, sp
+	stmia	r0, {r4-r12,r14}
+#else
 	stmia	r0, {r4-r14}
+#endif
 	mov	r0, #0x00000000
 	RET
 END(setjmp)
 
 ENTRY(longjmp)
+#if defined(__thumb2__)
+	ldmia	r0, {r4-r12,r14}
+	mov	sp, ip
+#else
 	ldmia	r0, {r4-r14}
+#endif
 	mov	r0, #0x00000001
 	RET
 END(longjmp)


### PR DESCRIPTION
### Motivation and Context

Issue #9957.  The longjmp() implementation is incompatible with Thumb-2
only kernels which prevents the use of ZFS on this hardware.

### Description

When a Thumb-2 kernel is being used, then longjmp must be implemented
using the Thumb-2 instruction set in module/lua/setjmp/setjmp_arm.S.

Original-patch-by: @jsrlabs

### How Has This Been Tested?

The original version of this patch was tested by @jsrlabs.  I don't have
access to the required hardware to properly test the updated patch.
@jsrlabs, @awehrfritz, @rdolbeau would you mind reviewing and
testing the proposed change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
