### PR TITLE
Remove checks for null out value in encryption paths

### DIFF
--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -68,8 +68,7 @@ ccm_mode_encrypt_contiguous_blocks(ccm_ctx_t *ctx, char *data, size_t length,
 	}
 
 	lastp = (uint8_t *)ctx->ccm_cb;
-	if (out != NULL)
-		crypto_init_ptrs(out, &iov_or_mp, &offset);
+	crypto_init_ptrs(out, &iov_or_mp, &offset);
 
 	mac_buf = (uint8_t *)ctx->ccm_mac_buf;
 
@@ -126,31 +125,22 @@ ccm_mode_encrypt_contiguous_blocks(ccm_ctx_t *ctx, char *data, size_t length,
 
 		ctx->ccm_processed_data_len += block_size;
 
-		if (out == NULL) {
-			if (ctx->ccm_remainder_len > 0) {
-				bcopy(blockp, ctx->ccm_copy_to,
-				    ctx->ccm_remainder_len);
-				bcopy(blockp + ctx->ccm_remainder_len, datap,
-				    need);
-			}
-		} else {
-			crypto_get_ptrs(out, &iov_or_mp, &offset, &out_data_1,
-			    &out_data_1_len, &out_data_2, block_size);
+		crypto_get_ptrs(out, &iov_or_mp, &offset, &out_data_1,
+		    &out_data_1_len, &out_data_2, block_size);
 
-			/* copy block to where it belongs */
-			if (out_data_1_len == block_size) {
-				copy_block(lastp, out_data_1);
-			} else {
-				bcopy(lastp, out_data_1, out_data_1_len);
-				if (out_data_2 != NULL) {
-					bcopy(lastp + out_data_1_len,
-					    out_data_2,
-					    block_size - out_data_1_len);
-				}
+		/* copy block to where it belongs */
+		if (out_data_1_len == block_size) {
+			copy_block(lastp, out_data_1);
+		} else {
+			bcopy(lastp, out_data_1, out_data_1_len);
+			if (out_data_2 != NULL) {
+				bcopy(lastp + out_data_1_len,
+				    out_data_2,
+				    block_size - out_data_1_len);
 			}
-			/* update offset */
-			out->cd_offset += block_size;
 		}
+		/* update offset */
+		out->cd_offset += block_size;
 
 		/* Update pointer to next block of data to be processed. */
 		if (ctx->ccm_remainder_len != 0) {

--- a/module/icp/algs/modes/ctr.c
+++ b/module/icp/algs/modes/ctr.c
@@ -61,8 +61,7 @@ ctr_mode_contiguous_blocks(ctr_ctx_t *ctx, char *data, size_t length,
 	}
 
 	lastp = (uint8_t *)ctx->ctr_cb;
-	if (out != NULL)
-		crypto_init_ptrs(out, &iov_or_mp, &offset);
+	crypto_init_ptrs(out, &iov_or_mp, &offset);
 
 	do {
 		/* Unprocessed data from last call. */
@@ -111,26 +110,17 @@ ctr_mode_contiguous_blocks(ctr_ctx_t *ctx, char *data, size_t length,
 		 */
 		xor_block(blockp, lastp);
 
-		if (out == NULL) {
-			if (ctx->ctr_remainder_len > 0) {
-				bcopy(lastp, ctx->ctr_copy_to,
-				    ctx->ctr_remainder_len);
-				bcopy(lastp + ctx->ctr_remainder_len, datap,
-				    need);
-			}
-		} else {
-			crypto_get_ptrs(out, &iov_or_mp, &offset, &out_data_1,
-			    &out_data_1_len, &out_data_2, block_size);
+		crypto_get_ptrs(out, &iov_or_mp, &offset, &out_data_1,
+		    &out_data_1_len, &out_data_2, block_size);
 
-			/* copy block to where it belongs */
-			bcopy(lastp, out_data_1, out_data_1_len);
-			if (out_data_2 != NULL) {
-				bcopy(lastp + out_data_1_len, out_data_2,
-				    block_size - out_data_1_len);
-			}
-			/* update offset */
-			out->cd_offset += block_size;
+		/* copy block to where it belongs */
+		bcopy(lastp, out_data_1, out_data_1_len);
+		if (out_data_2 != NULL) {
+			bcopy(lastp + out_data_1_len, out_data_2,
+			    block_size - out_data_1_len);
 		}
+		/* update offset */
+		out->cd_offset += block_size;
 
 		/* Update pointer to next block of data to be processed. */
 		if (ctx->ctr_remainder_len != 0) {

--- a/module/icp/api/kcf_cipher.c
+++ b/module/icp/api/kcf_cipher.c
@@ -30,9 +30,6 @@
 #include <sys/crypto/spi.h>
 #include <sys/crypto/sched_impl.h>
 
-#define	CRYPTO_OPS_OFFSET(f)		offsetof(crypto_ops_t, co_##f)
-#define	CRYPTO_CIPHER_OFFSET(f)		offsetof(crypto_cipher_ops_t, f)
-
 /*
  * Encryption and decryption routines.
  */

--- a/module/icp/api/kcf_digest.c
+++ b/module/icp/api/kcf_digest.c
@@ -30,9 +30,6 @@
 #include <sys/crypto/spi.h>
 #include <sys/crypto/sched_impl.h>
 
-#define	CRYPTO_OPS_OFFSET(f)		offsetof(crypto_ops_t, co_##f)
-#define	CRYPTO_DIGEST_OFFSET(f)		offsetof(crypto_digest_ops_t, f)
-
 /*
  * Message digest routines
  */

--- a/module/icp/api/kcf_mac.c
+++ b/module/icp/api/kcf_mac.c
@@ -30,9 +30,6 @@
 #include <sys/crypto/spi.h>
 #include <sys/crypto/sched_impl.h>
 
-#define	CRYPTO_OPS_OFFSET(f)		offsetof(crypto_ops_t, co_##f)
-#define	CRYPTO_MAC_OFFSET(f)		offsetof(crypto_mac_ops_t, f)
-
 /*
  * Message authentication codes routines.
  */

--- a/module/icp/core/kcf_prov_lib.c
+++ b/module/icp/core/kcf_prov_lib.c
@@ -149,6 +149,7 @@ crypto_update_iov(void *ctx, crypto_data_t *input, crypto_data_t *output,
 	common_ctx_t *common_ctx = ctx;
 	int rv;
 
+	ASSERT(input != output);
 	if (input->cd_miscdata != NULL) {
 		copy_block((uint8_t *)input->cd_miscdata,
 		    &common_ctx->cc_iv[0]);
@@ -158,7 +159,7 @@ crypto_update_iov(void *ctx, crypto_data_t *input, crypto_data_t *output,
 		return (CRYPTO_ARGUMENTS_BAD);
 
 	rv = (cipher)(ctx, input->cd_raw.iov_base + input->cd_offset,
-	    input->cd_length, (input == output) ? NULL : output);
+	    input->cd_length, output);
 
 	return (rv);
 }
@@ -175,6 +176,7 @@ crypto_update_uio(void *ctx, crypto_data_t *input, crypto_data_t *output,
 	uint_t vec_idx;
 	size_t cur_len;
 
+	ASSERT(input != output);
 	if (input->cd_miscdata != NULL) {
 		copy_block((uint8_t *)input->cd_miscdata,
 		    &common_ctx->cc_iv[0]);
@@ -208,7 +210,7 @@ crypto_update_uio(void *ctx, crypto_data_t *input, crypto_data_t *output,
 		    offset, length);
 
 		int rv = (cipher)(ctx, uiop->uio_iov[vec_idx].iov_base + offset,
-		    cur_len, (input == output) ? NULL : output);
+		    cur_len, output);
 
 		if (rv != CRYPTO_SUCCESS) {
 			return (rv);

--- a/module/icp/include/sys/crypto/ioctl.h
+++ b/module/icp/include/sys/crypto/ioctl.h
@@ -241,9 +241,6 @@ typedef struct crypto_logout32 {
 #define	CRYPTO_LOGIN			CRYPTO(40)
 #define	CRYPTO_LOGOUT			CRYPTO(41)
 
-/* flag for encrypt and decrypt operations */
-#define	CRYPTO_INPLACE_OPERATION	0x00000001
-
 /*
  * Cryptographic Ioctls
  */

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -92,11 +92,6 @@ static crypto_mech_info_t aes_mech_info_tab[] = {
 	    AES_MIN_KEY_BYTES, AES_MAX_KEY_BYTES, CRYPTO_KEYSIZE_UNIT_IN_BYTES}
 };
 
-/* operations are in-place if the output buffer is NULL */
-#define	AES_ARG_INPLACE(input, output)				\
-	if ((output) == NULL)					\
-		(output) = (input);
-
 static void aes_provider_status(crypto_provider_handle_t, uint_t *);
 
 static crypto_control_ops_t aes_control_ops = {
@@ -413,7 +408,7 @@ aes_encrypt(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 	    == 0) && (plaintext->cd_length & (AES_BLOCK_LEN - 1)) != 0)
 		return (CRYPTO_DATA_LEN_RANGE);
 
-	AES_ARG_INPLACE(plaintext, ciphertext);
+	ASSERT(ciphertext != NULL);
 
 	/*
 	 * We need to just return the length needed to store the output.
@@ -530,7 +525,7 @@ aes_decrypt(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 		return (CRYPTO_ENCRYPTED_DATA_LEN_RANGE);
 	}
 
-	AES_ARG_INPLACE(ciphertext, plaintext);
+	ASSERT(plaintext != NULL);
 
 	/*
 	 * Return length needed to store the output.
@@ -635,7 +630,7 @@ aes_encrypt_update(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 	ASSERT(ctx->cc_provider_private != NULL);
 	aes_ctx = ctx->cc_provider_private;
 
-	AES_ARG_INPLACE(plaintext, ciphertext);
+	ASSERT(ciphertext != NULL);
 
 	/* compute number of bytes that will hold the ciphertext */
 	out_len = aes_ctx->ac_remainder_len;
@@ -705,7 +700,7 @@ aes_decrypt_update(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 	ASSERT(ctx->cc_provider_private != NULL);
 	aes_ctx = ctx->cc_provider_private;
 
-	AES_ARG_INPLACE(ciphertext, plaintext);
+	ASSERT(plaintext != NULL);
 
 	/*
 	 * Compute number of bytes that will hold the plaintext.
@@ -947,7 +942,7 @@ aes_encrypt_atomic(crypto_provider_handle_t provider,
 	size_t length_needed;
 	int ret;
 
-	AES_ARG_INPLACE(plaintext, ciphertext);
+	ASSERT(ciphertext != NULL);
 
 	/*
 	 * CTR, CCM, GCM, and GMAC modes do not require that plaintext
@@ -1073,7 +1068,7 @@ aes_decrypt_atomic(crypto_provider_handle_t provider,
 	size_t length_needed;
 	int ret;
 
-	AES_ARG_INPLACE(ciphertext, plaintext);
+	ASSERT(plaintext != NULL);
 
 	/*
 	 * CCM, GCM, CTR, and GMAC modes do not require that ciphertext


### PR DESCRIPTION
### Motivation and Context

This change is driven by the discussion in #9661 and the new AES GCM optimizations that were recently added that assume `out != NULL` in these code paths. Investigation found that these code paths are dead and can be cleaned up.

Resolves #9661

### Description

There were two callsites in `crypto_update_iov` & `crypto_update_uio` where a potential `NULL` value for `out` was passed down. This was happening when the input & output were the same values. 

All calls of these two methods are in `module/icp/io/aes.c` in `aes_encrypt_update`, `aes_decrypt_update`, `aes_encrypt_atomic` & `aes_decrypt_atomic`. These are set as function pointers in the `crypto_cipher_ops_t` configuration for the AES module. 

Going back to all calls into these functions, it shows there none of them have the same `plaintext` & `ciphertext` passed in. Taking `crypto_encrypt` & `crypto_decrypt` specifically, these are called in `module/os/linux/zfs/zio_crypt.c` with a different `plaindata` and `cipherdata` allocated on the stack there. 

All other functions are never used, I guess due to it being a generic encryption interface in `icp`, where the `zfs` module never needs all of these and only uses `crypto_encrypt` & `crypto_decrypt`. 

I added the assertions as a safety mechanism for now. I don't know if that's considered a good practice in cases like this, or that I should remove these?

### How Has This Been Tested?

This build successfully and tests locally seem to pass. Different local runs show different unrelated tests sometimes failing, I guess those are inconsistent then. 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
