### PR TITLE
Enable overlay mounts by default

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -474,8 +474,8 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 	}
 
 	/*
-	 * Overlay mounts are disabled by default but may be enabled
-	 * via the 'overlay' property or the 'zfs mount -O' option.
+	 * Overlay mounts are enabled by default but may be disabled
+	 * via the 'overlay' property. The -O flag remains for compatibility.
 	 */
 	if (!(flags & MS_OVERLAY)) {
 		if (zfs_prop_get(zhp, ZFS_PROP_OVERLAY, overlay,
@@ -489,7 +489,7 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 	/*
 	 * Determine if the mountpoint is empty.  If so, refuse to perform the
 	 * mount.  We don't perform this check if 'remount' is
-	 * specified or if overlay option(-O) is given
+	 * specified or if overlay option (-O) is given
 	 */
 	if ((flags & MS_OVERLAY) == 0 && !remount &&
 	    !dir_is_empty(mountpoint)) {

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -1157,14 +1157,16 @@ See
 for more information on
 .Sy nbmand
 mounts. This property is not used on Linux.
-.It Sy overlay Ns = Ns Sy off Ns | Ns Sy on
+.It Sy overlay Ns = Ns Sy on Ns | Ns Sy off
 Allow mounting on a busy directory or a directory which already contains
-files or directories. This is the default mount behavior for Linux file systems.
-For consistency with OpenZFS on other platforms overlay mounts are
-.Sy off
-by default. Set to
+files or directories.
+This is the default mount behavior for Linux and FreeBSD file systems.
+On these platforms the property is
 .Sy on
-to enable overlay mounts.
+by default.
+Set to
+.Sy off
+to disable overlay mounts for consistency with OpenZFS on other platforms.
 .It Sy primarycache Ns = Ns Sy all Ns | Ns Sy none Ns | Ns Sy metadata
 Controls what is cached in the primary cache
 .Pq ARC .

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -406,7 +406,7 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_NBMAND, "nbmand", 0, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT, "on | off", "NBMAND",
 	    boolean_table);
-	zprop_register_index(ZFS_PROP_OVERLAY, "overlay", 0, PROP_INHERIT,
+	zprop_register_index(ZFS_PROP_OVERLAY, "overlay", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM, "on | off", "OVERLAY", boolean_table);
 
 	/* default index properties */

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -181,7 +181,7 @@ tags = ['functional', 'cli_root', 'zfs_load-key']
 tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_004_pos', 'zfs_mount_005_pos', 'zfs_mount_007_pos',
     'zfs_mount_009_neg', 'zfs_mount_010_neg', 'zfs_mount_011_neg',
-    'zfs_mount_012_neg', 'zfs_mount_all_001_pos', 'zfs_mount_encrypted',
+    'zfs_mount_012_pos', 'zfs_mount_all_001_pos', 'zfs_mount_encrypted',
     'zfs_mount_remount', 'zfs_mount_all_fail', 'zfs_mount_all_mountpoints',
     'zfs_mount_test_race']
 tags = ['functional', 'cli_root', 'zfs_mount']

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
@@ -13,7 +13,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_mount_009_neg.ksh \
 	zfs_mount_010_neg.ksh \
 	zfs_mount_011_neg.ksh \
-	zfs_mount_012_neg.ksh \
+	zfs_mount_012_pos.ksh \
 	zfs_mount_all_001_pos.ksh \
 	zfs_mount_all_fail.ksh \
 	zfs_mount_all_mountpoints.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
@@ -73,7 +73,8 @@ log_must mkfile 1M $testfile $testfile1
 
 log_must zfs unmount $fs1
 log_must zfs set mountpoint=$mntpnt $fs1
-log_mustnot zfs mount $fs1
+log_must zfs mount $fs1
+log_must zfs unmount $fs1
 log_must zfs mount -O $fs1
 
 # Create new file in override mountpoint

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_012_pos.ksh
@@ -18,9 +18,6 @@
 
 #
 # DESCRIPTION:
-#  Linux:
-#   Verify that zfs mount fails with a non-empty directory
-#  FreeSD:
 #   Verify that zfs mount succeeds with a non-empty directory
 #
 
@@ -34,18 +31,12 @@
 # 6. Unmount the dataset
 # 7. Create a file in the directory created in step 2
 # 8. Attempt to mount the dataset
-# 9. Verify the mount fails
+# 9. Verify the mount succeeds
 #
 
 verify_runnable "both"
 
-if is_linux; then
-	behaves="fails"
-else
-	behaves="succeeds"
-fi
-
-log_assert "zfs mount $behaves with non-empty directory"
+log_assert "zfs mount succeeds with non-empty directory"
 
 fs=$TESTPOOL/$TESTFS
 
@@ -55,12 +46,8 @@ log_must zfs set mountpoint=$TESTDIR $fs
 log_must zfs mount $fs
 log_must zfs umount $fs
 log_must touch $TESTDIR/testfile.$$
-if is_linux; then
-	log_mustnot zfs mount $fs
-else
-	log_must zfs mount $fs
-	log_must zfs umount $fs
-fi
+log_must zfs mount $fs
+log_must zfs umount $fs
 log_must rm -rf $TESTDIR
 
-log_pass "zfs mount $behaves with non-empty directory as expected."
+log_pass "zfs mount succeeds with non-empty directory as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
@@ -30,8 +30,8 @@
 #       1. Create zfs filesystems
 #       2. Unmount a leaf filesystem
 #       3. Create a file in the above filesystem's mountpoint
-#       4. Verify that 'zfs mount -a' fails to mount the above if on Linux
-#          or succeeds if on FreeBSD
+#       4. Verify that 'zfs mount -a' succeeds if overlay=on and
+#          fails to mount the above if overlay=off
 #       5. Verify that all other filesystems were mounted
 #
 
@@ -83,17 +83,18 @@ done
 # Create a stray file in one filesystem's mountpoint
 touch $path/0/strayfile
 
-# Verify that zfs mount -a fails on Linux or succeeds on FreeBSD
 export __ZFS_POOL_RESTRICT="$TESTPOOL"
-if is_linux; then
-	log_mustnot zfs $mountall
-	log_mustnot mounted "$TESTPOOL/0"
-	typeset behaved="failed"
-else
-	log_must zfs $mountall
-	log_must mounted "$TESTPOOL/0"
-	typeset behaved="succeeded"
-fi
+
+# Verify that zfs mount -a succeeds with overlay=on (default)
+log_must zfs $mountall
+log_must mounted "$TESTPOOL/0"
+log_must zfs $unmountall
+
+# Verify that zfs mount -a succeeds with overlay=off
+log_must zfs set overlay=off "$TESTPOOL/0"
+log_mustnot zfs $mountall
+log_mustnot mounted "$TESTPOOL/0"
+
 unset __ZFS_POOL_RESTRICT
 
 # All other filesystems should be mounted
@@ -101,4 +102,4 @@ for ((i=1; i<$fscount; i++)); do
 	log_must mounted "$TESTPOOL/$i"
 done
 
-log_pass "'zfs $mountall' $behaved as expected."
+log_pass "'zfs $mountall' behaves as expected."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Filesystems allow overlay mounts by default on FreeBSD and Linux.
ZFS on Linux introduced an overlay property to control this behavior,
with the default set to "off" for compatibility with illumos.

### Description
<!--- Describe your changes in detail -->
Respect the native convention by switching the default to overlay=on,
while retaining the option to turn the property off for compatibility
with other operating systems' conventions.

Update documentation and tests accordingly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passing ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
