### PR TITLE
ZTS: Misc fixes for FreeBSD

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1328,7 +1328,7 @@ function is_shared_freebsd
 {
 	typeset fs=$1
 
-	showmount -E | grep -qx $fs
+	pgrep -q mountd && showmount -E | grep -qx $fs
 }
 
 function is_shared_illumos

--- a/tests/zfs-tests/tests/functional/atime/atime_common.kshlib
+++ b/tests/zfs-tests/tests/functional/atime/atime_common.kshlib
@@ -48,7 +48,7 @@ function check_atime_updated
 		typeset before=$(stat -c %X $filename)
 		sleep 2
 	elif is_freebsd; then
-		typeset before=$(ls -luD "%Y-%m-%d %R.%s" $filename | awk '{print $7}')
+		typeset before=$(stat -f %a $filename)
 		sleep 2
 	else
 		typeset before=$(ls -Eu $filename | awk '{print $7}')
@@ -59,7 +59,7 @@ function check_atime_updated
 	if is_linux; then
 		typeset after=$(stat -c %X $filename)
 	elif is_freebsd; then
-		typeset after=$(ls -luD "%Y-%m-%d %R.%s" $filename | awk '{print $7}')
+		typeset after=$(stat -f %a $filename)
 	else
 		typeset after=$(ls -Eu $filename | awk '{print $7}')
 	fi

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
@@ -97,8 +97,16 @@ log_assert "'zfs create' should return an error with badly-formed parameters."
 
 typeset -i i=0
 while [[ $i -lt ${#args[*]} ]]; do
-	log_mustnot zfs create ${args[i]} $TESTPOOL/$TESTFS1
-	log_mustnot zfs create -p ${args[i]} $TESTPOOL/$TESTFS1
+	typeset arg=${args[i]}
+	if is_freebsd; then
+		# FreeBSD does not strictly validate share options (yet).
+		if [[ "$arg" == "-o sharenfs="* ]]; then
+			((i = i + 1))
+			continue
+		fi
+	fi
+	log_mustnot zfs create $arg $TESTPOOL/$TESTFS1
+	log_mustnot zfs create -p $arg $TESTPOOL/$TESTFS1
 	((i = i + 1))
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
@@ -81,7 +81,15 @@ log_assert "'zpool create -O' should return an error with badly formed parameter
 
 typeset -i i=0
 while (( $i < ${#args[*]} )); do
-	log_mustnot zpool create -O ${args[i]} -f $TESTPOOL $DISKS
+	typeset arg=${args[i]}
+	if is_freebsd; then
+		# FreeBSD does not strictly validate share opts (yet).
+		if [[ $arg == "-o sharenfs="* ]]; then
+			((i = i + 1))
+			continue
+		fi
+	fi
+	log_mustnot zpool create -O $arg -f $TESTPOOL $DISKS
 	((i = i + 1))
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_013_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_013_neg.ksh
@@ -60,9 +60,8 @@ function uncompress_pool
 
 function cleanup
 {
-	poolexists $POOL_NAME && log_must zpool destroy $POOL_NAME
-	[[ -e /$TESTPOOL/$POOL_FILE ]] && rm /$TESTPOOL/$POOL_FILE
-	return 0
+	poolexists $POOL_NAME && destroy_pool $POOL_NAME
+	rm -f /$TESTPOOL/$POOL_FILE
 }
 
 log_assert "'zpool import' fails for pool that was not cleanly exported"

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zdb_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zdb_001_neg.ksh
@@ -56,11 +56,7 @@ function check_zdb
 
 function cleanup
 {
-	if [ -e $TEST_BASE_DIR/zdb_001_neg.$$.txt ]
-	then
-		rm $TEST_BASE_DIR/zdb_001_neg.$$.txt
-	fi
-
+	rm -f $TEST_BASE_DIR/zdb_001_neg.$$.txt $TEST_BASE_DIR/zdb.$$
 }
 
 verify_runnable "global"

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
@@ -44,10 +44,7 @@
 
 function cleanup
 {
-	if [ -e "$TEMPFILE" ]
-	then
-		rm -f "$TEMPFILE"
-	fi
+	rm -f "$TEMPFILE"
 }
 
 log_onexit cleanup
@@ -55,7 +52,7 @@ log_assert "zfs shows a usage message when run as a user"
 
 TEMPFILE="$TEST_BASE_DIR/zfs_001_neg.$$.txt"
 
-eval "zfs > $TEMPFILE 2>&1"
+zfs > $TEMPFILE 2>&1
 log_must grep "usage: zfs command args" "$TEMPFILE"
 
 log_must eval "awk '{if (length(\$0) > 80) exit 1}' < $TEMPFILE"

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -406,14 +406,15 @@ if is_linux; then
 	def_val+=("off")
 	local_val+=("off")
 else
-	prop+=("aclmode" "" \
-		"mountpoint" "")
-	def_val+=("discard" \
-		"")
-	local_val+=("groupmask" \
-		"$TESTDIR")
+	prop+=("aclmode" "")
+	def_val+=("discard")
+	local_val+=("groupmask")
 fi
-
+if is_illumos; then
+	prop+=("mountpoint" "")
+	def_val+=("")
+	local_val+=("$TESTDIR")
+fi
 
 #
 # Global flag indicating whether the default record size had been


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
* Check for mountd in is_shared to avoid timeout when not running
* Enhance robustness of some cleanup functions
* Simplify atime lookup
* Skip sharenfs validation for now
* Don't add mountpoint property to inheritance validation on FreeBSD

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
