### PR TITLE
ZTS: Adapt casenorm tests for FreeBSD

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -145,12 +145,8 @@ summary = {
 # reasons listed above can be used.
 #
 known = {
-    'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],
-    'casenorm/sensitive_formd_delete': ['FAIL', '7633'],
     'casenorm/mixed_none_lookup_ci': ['FAIL', '7633'],
-    'casenorm/mixed_formd_lookup': ['FAIL', '7633'],
     'casenorm/mixed_formd_lookup_ci': ['FAIL', '7633'],
-    'casenorm/mixed_formd_delete': ['FAIL', '7633'],
     'cli_root/zfs_receive/zfs_receive_004_neg': ['FAIL', known_reason],
     'cli_root/zfs_unshare/zfs_unshare_002_pos': ['SKIP', na_reason],
     'cli_root/zfs_unshare/zfs_unshare_006_pos': ['SKIP', na_reason],
@@ -177,6 +173,10 @@ known = {
 #
 maybe = {
     'cache/cache_010_neg': ['FAIL', known_reason],
+    'casenorm/mixed_formd_lookup': ['FAIL', '7633'],
+    'casenorm/mixed_formd_delete': ['FAIL', '7633'],
+    'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],
+    'casenorm/sensitive_formd_delete': ['FAIL', '7633'],
     'chattr/setup': ['SKIP', exec_reason],
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/casenorm/casenorm.kshlib
+++ b/tests/zfs-tests/tests/functional/casenorm/casenorm.kshlib
@@ -65,10 +65,10 @@ function lookup_file
 {
 	typeset name=$1
 
-	if is_linux; then
-		test -f "${TESTDIR}/${name}" >/dev/null 2>&1
-	else
+	if is_illumos; then
 		zlook -l $TESTDIR $name >/dev/null 2>&1
+	else
+		test -f "${TESTDIR}/${name}" >/dev/null 2>&1
 	fi
 }
 
@@ -76,10 +76,10 @@ function lookup_file_ci
 {
 	typeset name=$1
 
-	if is_linux; then
-		test -f "${TESTDIR}/${name}" >/dev/null 2>&1
-	else
+	if is_illumos; then
 		zlook -il $TESTDIR $name >/dev/null 2>&1
+	else
+		test -f "${TESTDIR}/${name}" >/dev/null 2>&1
 	fi
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Several casenorm tests pass on FreeBSD but are expected to fail on Linux.

### Description
<!--- Describe your changes in detail -->
Move the passing tests from "fail" to "maybe" so that passing on FreeBSD is not unexpected.

Invert platform logic so FreeBSD doesn't use illumos-only zlook.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
