### PR TITLE
ZTS: Eliminate partitioning from zpool_add

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/cleanup.ksh
@@ -32,11 +32,4 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
 
-DISK=${DISKS%% *}
-if is_mpath_device $DISK; then
-        delete_partitions
-fi
-
-cleanup_devices $DISKS
-
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
@@ -34,28 +34,4 @@
 
 verify_runnable "global"
 
-if ! is_physical_device $DISKS; then
-	log_unsupported "This directory cannot be run on raw files."
-fi
-
-disk1=${DISKS%% *}
-if is_mpath_device $disk1; then
-        delete_partitions
-fi
-
-if [[ -n $DISK ]]; then
-	#
-        # Use 'zpool create' to clean up the information in
-        # in the given disk to avoid slice overlapping.
-        #
-	cleanup_devices $DISK
-
-        partition_disk $SIZE $DISK 7
-else
-	for disk in `echo $DISKSARRAY`; do
-		cleanup_devices $disk
-		partition_disk $SIZE $disk 7
-	done
-fi
-
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
@@ -28,57 +28,12 @@
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
-export DISK_ARRAY_NUM=0
-export DISK_ARRAY_LIMIT=4
-export DISKSARRAY=""
-
-function set_disks
-{
-        set -A disk_array $(find_disks $DISKS)
-
-        if (( ${#disk_array[*]} <= 1 )); then
-                export DISK=${DISKS%% *}
-        else
-                export DISK=""
-                typeset -i i=0
-                while (( i < ${#disk_array[*]} )); do
-                        export DISK${i}="${disk_array[$i]}"
-                        DISKSARRAY="$DISKSARRAY ${disk_array[$i]}"
-                        (( i = i + 1 ))
-                        (( i>$DISK_ARRAY_LIMIT )) && break
-                done
-                export DISK_ARRAY_NUM=$i
-                export DISKSARRAY
-        fi
-
-	if (( $DISK_ARRAY_NUM == 0 )); then
-		export disk=$DISK
-	else
-		export disk=$DISK0
-	fi
-
-}
-
-set_disks
-
 export SIZE="$(((MINVDEVSIZE / (1024 * 1024)) * 2))m"
-
-if is_linux || is_freebsd; then
-	set_device_dir
-	set_slice_prefix
-	export SLICE0=1
-	export SLICE1=2
-	export SLICE3=4
-	export SLICE4=5
-	export SLICE5=6
-	export SLICE6=7
-else
-	export SLICE0=0
-	export SLICE1=1
-	export SLICE3=3
-	export SLICE4=4
-	export SLICE5=5
-	export SLICE6=6
-fi
-
 export VOLSIZE=$MINVDEVSIZE
+
+echo $DISKS | read DISK0 DISK1 DISK2
+
+if is_linux; then
+	export DISK_ARRAY_NUM=3
+	set_device_dir
+fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
@@ -109,20 +109,3 @@ function save_dump_dev
 	fi
 	echo $dumpdev
 }
-
-#
-# Common cleanup routine for partitions used in testing
-#
-function partition_cleanup
-{
-
-	if [[ -n $DISK ]]; then
-		partition_disk $SIZE $DISK 7
-	else
-		typeset disk=""
-		for disk in $DISK0 $DISK1; do
-			partition_disk $SIZE $disk 7
-		done
-	fi
-
-}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_002_pos.ksh
@@ -48,10 +48,7 @@ verify_runnable "global"
 
 function cleanup
 {
-        poolexists $TESTPOOL && \
-                destroy_pool $TESTPOOL
-
-	partition_cleanup
+        poolexists $TESTPOOL && destroy_pool $TESTPOOL
 }
 
 log_assert "'zpool add -f <pool> <vdev> ...' can successfully add" \
@@ -59,14 +56,13 @@ log_assert "'zpool add -f <pool> <vdev> ...' can successfully add" \
 
 log_onexit cleanup
 
-create_pool "$TESTPOOL" mirror "${disk}${SLICE_PREFIX}${SLICE0}" \
-	"${disk}${SLICE_PREFIX}${SLICE1}"
-log_must poolexists "$TESTPOOL"
+create_pool $TESTPOOL mirror $DISK0 $DISK1
+log_must poolexists $TESTPOOL
 
-log_mustnot zpool add "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE3}
-log_mustnot vdevs_in_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE3}"
+log_mustnot zpool add $TESTPOOL $DISK2
+log_mustnot vdevs_in_pool $TESTPOOL $DISK2
 
-log_must zpool add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE3}
-log_must vdevs_in_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE3}"
+log_must zpool add -f $TESTPOOL $DISK2
+log_must vdevs_in_pool $TESTPOOL $DISK2
 
 log_pass "'zpool add -f <pool> <vdev> ...' executes successfully."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
@@ -50,16 +50,12 @@ verify_runnable "global"
 
 function cleanup
 {
-	poolexists "$TESTPOOL" && \
-		destroy_pool "$TESTPOOL"
-	poolexists "$TESTPOOL1" && \
-		destroy_pool "$TESTPOOL1"
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	poolexists $TESTPOOL1 && destroy_pool $TESTPOOL1
 
 	if [[ -n $saved_dump_dev ]]; then
 		log_must eval "dumpadm -u -d $saved_dump_dev > /dev/null"
 	fi
-
-	partition_cleanup
 }
 
 log_assert "'zpool add' should fail with inapplicable scenarios."
@@ -69,27 +65,27 @@ log_onexit cleanup
 mnttab_dev=$(find_mnttab_dev)
 vfstab_dev=$(find_vfstab_dev)
 saved_dump_dev=$(save_dump_dev)
-dump_dev=${disk}${SLICE_PREFIX}${SLICE3}
+dump_dev=$DISK2
 
-create_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE0}"
-log_must poolexists "$TESTPOOL"
+create_pool $TESTPOOL $DISK0
+log_must poolexists $TESTPOOL
 
-create_pool "$TESTPOOL1" "${disk}${SLICE_PREFIX}${SLICE1}"
-log_must poolexists "$TESTPOOL1"
+create_pool $TESTPOOL1 $DISK1
+log_must poolexists $TESTPOOL1
 
 unset NOINUSE_CHECK
-log_mustnot zpool add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE1}
-log_mustnot zpool add -f "$TESTPOOL" $mnttab_dev
+log_mustnot zpool add -f $TESTPOOL $DISK1
+log_mustnot zpool add -f $TESTPOOL $mnttab_dev
 if is_linux; then
-       log_mustnot zpool add "$TESTPOOL" $vfstab_dev
+       log_mustnot zpool add $TESTPOOL $vfstab_dev
 else
-       log_mustnot zpool add -f "$TESTPOOL" $vfstab_dev
+       log_mustnot zpool add -f $TESTPOOL $vfstab_dev
 fi
 
 if is_illumos; then
 	log_must eval "new_fs ${DEV_DSKDIR}/$dump_dev > /dev/null 2>&1"
 	log_must eval "dumpadm -u -d ${DEV_DSKDIR}/$dump_dev > /dev/null"
-	log_mustnot zpool add -f "$TESTPOOL" $dump_dev
+	log_mustnot zpool add -f $TESTPOOL $dump_dev
 fi
 
 log_pass "'zpool add' should fail with inapplicable scenarios."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
@@ -46,14 +46,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	poolexists $TESTPOOL1 && \
-		destroy_pool $TESTPOOL1
-
-	poolexists $TESTPOOL && \
-		destroy_pool $TESTPOOL
-
-	[[ -d $TESTDIR ]] && log_must rm -rf $TESTDIR
-	partition_cleanup
+	poolexists $TESTPOOL1 && destroy_pool $TESTPOOL1
+	rm -rf $TESTDIR
 }
 
 log_assert "Adding a large number of file based vdevs to a zpool works."
@@ -66,12 +60,12 @@ create_pool "$TESTPOOL1" "$TESTDIR/file.00"
 vdevs_list=$(echo $TESTDIR/file.{01..16})
 log_must truncate -s $MINVDEVSIZE $vdevs_list
 
-log_must zpool add -f "$TESTPOOL1" $vdevs_list
-log_must vdevs_in_pool "$TESTPOOL1" "$vdevs_list"
+log_must zpool add -f $TESTPOOL1 $vdevs_list
+log_must vdevs_in_pool $TESTPOOL1 "$vdevs_list"
 
 # Attempt to add a file based vdev that's too small.
 log_must truncate -s 32m $TESTDIR/broken_file
-log_mustnot zpool add -f "$TESTPOOL1" ${TESTDIR}/broken_file
-log_mustnot vdevs_in_pool "$TESTPOOL1" "${TESTDIR}/broken_file"
+log_mustnot zpool add -f $TESTPOOL1 ${TESTDIR}/broken_file
+log_mustnot vdevs_in_pool $TESTPOOL1 ${TESTDIR}/broken_file
 
 log_pass "Adding a large number of file based vdevs to a zpool works."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_007_neg.ksh
@@ -46,10 +46,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	poolexists "$TESTPOOL" && \
-		destroy_pool "$TESTPOOL"
-
-	partition_cleanup
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 }
 
 log_assert "'zpool add' should return an error with badly-formed parameters."
@@ -57,10 +54,10 @@ log_assert "'zpool add' should return an error with badly-formed parameters."
 log_onexit cleanup
 
 set -A args "" "-f" "-n" "-?" "-nf" "-fn" "-f -n" "--f" "-blah" \
-	"-? $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE1}"
+	"-? $TESTPOOL $DISK1"
 
-create_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE0}"
-log_must poolexists "$TESTPOOL"
+create_pool $TESTPOOL $DISK0
+log_must poolexists $TESTPOOL
 
 typeset -i i=0
 while (( $i < ${#args[*]} )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_008_neg.ksh
@@ -46,22 +46,18 @@ verify_runnable "global"
 
 function cleanup
 {
-
-        poolexists "$TESTPOOL" && \
-                destroy_pool "$TESTPOOL"
-
-	partition_cleanup
+        poolexists $TESTPOOL && destroy_pool $TESTPOOL
 }
 
 log_assert "'zpool add' should return an error with nonexistent pools and vdevs"
 
 log_onexit cleanup
 
-set -A args "" "-f nonexistent_pool ${disk}${SLICE_PREFIX}${SLICE1}" \
+set -A args "" "-f nonexistent_pool $DISK1" \
 	"-f $TESTPOOL nonexistent_vdev"
 
-create_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE0}"
-log_must poolexists "$TESTPOOL"
+create_pool $TESTPOOL $DISK0
+log_must poolexists $TESTPOOL
 
 typeset -i i=0
 while (( $i < ${#args[*]} )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_009_neg.ksh
@@ -47,12 +47,7 @@ verify_runnable "global"
 
 function cleanup
 {
-
-        poolexists "$TESTPOOL" && \
-                destroy_pool "$TESTPOOL"
-
-	partition_cleanup
-
+        poolexists $TESTPOOL && destroy_pool $TESTPOOL
 }
 
 log_assert "'zpool add' should fail if vdevs are the same or vdev is " \
@@ -60,12 +55,11 @@ log_assert "'zpool add' should fail if vdevs are the same or vdev is " \
 
 log_onexit cleanup
 
-create_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE0}"
-log_must poolexists "$TESTPOOL"
+create_pool $TESTPOOL $DISK0
+log_must poolexists $TESTPOOL
 
-log_mustnot zpool add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE1} \
-	${disk}${SLICE_PREFIX}${SLICE1}
-log_mustnot zpool add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE0}
+log_mustnot zpool add -f $TESTPOOL $DISK1 $DISK1
+log_mustnot zpool add -f $TESTPOOL $DISK0
 
 log_pass "'zpool add' get fail as expected if vdevs are the same or vdev is " \
 	"contained in the given pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_010_pos.ksh
@@ -51,7 +51,7 @@ function cleanup
 
 	typeset -i i=0
 	while ((i < 10)); do
-		log_must rm -f $TEST_BASE_DIR/vdev$i
+		rm -f $TEST_BASE_DIR/vdev$i
 		((i += 1))
 	done
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplify tests.

### Description
<!--- Describe your changes in detail -->
Use file vdevs if we are short on $DISKS.

Also fixed vol recursion for FreeBSD in 004.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
zpool_add tests all passed on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
