### PR TITLE
pyzfs: Add constants for platform-specific errnos

### DIFF
--- a/contrib/pyzfs/libzfs_core/_constants.py
+++ b/contrib/pyzfs/libzfs_core/_constants.py
@@ -19,6 +19,19 @@ Important `libzfs_core` constants.
 """
 
 from __future__ import absolute_import, division, print_function
+import errno
+import sys
+
+
+# Compat for platform-specific errnos
+if sys.platform.startswith('freebsd'):
+    ECHRNG = errno.ENXIO
+    ECKSUM = 97  # EINTEGRITY
+    ETIME = errno.ETIMEDOUT
+else:
+    ECHRNG = errno.ECHRNG
+    ECKSUM = errno.EBADE
+    ETIME = errno.ETIME
 
 
 # https://stackoverflow.com/a/1695250

--- a/contrib/pyzfs/libzfs_core/_error_translation.py
+++ b/contrib/pyzfs/libzfs_core/_error_translation.py
@@ -33,6 +33,9 @@ import re
 import string
 from . import exceptions as lzc_exc
 from ._constants import (
+    ECHRNG,
+    ECKSUM,
+    ETIME,
     MAXNAMELEN,
     ZFS_ERR_CHECKPOINT_EXISTS,
     ZFS_ERR_DISCARDING_CHECKPOINT,
@@ -462,7 +465,7 @@ def lzc_receive_translate_errors(
         raise lzc_exc.ReadOnlyPool(_pool_name(snapname))
     if ret == errno.EAGAIN:
         raise lzc_exc.SuspendedPool(_pool_name(snapname))
-    if ret == errno.EBADE:  # ECKSUM
+    if ret == ECKSUM:
         raise lzc_exc.BadStream()
     if ret == ZFS_ERR_WRONG_PARENT:
         raise lzc_exc.WrongParent(_fs_name(snapname))
@@ -550,7 +553,7 @@ def lzc_channel_program_translate_error(ret, name, error):
         return
     if ret == errno.ENOENT:
         raise lzc_exc.PoolNotFound(name)
-    if ret == errno.ETIME:
+    if ret == ETIME:
         raise lzc_exc.ZCPTimeout()
     if ret == errno.ENOMEM:
         raise lzc_exc.ZCPMemoryError()
@@ -558,7 +561,7 @@ def lzc_channel_program_translate_error(ret, name, error):
         raise lzc_exc.ZCPSpaceError()
     if ret == errno.EPERM:
         raise lzc_exc.ZCPPermissionError()
-    if ret == errno.ECHRNG:
+    if ret == ECHRNG:
         raise lzc_exc.ZCPRuntimeError(error)
     if ret == errno.EINVAL:
         if error is None:

--- a/contrib/pyzfs/libzfs_core/exceptions.py
+++ b/contrib/pyzfs/libzfs_core/exceptions.py
@@ -21,6 +21,9 @@ from __future__ import absolute_import, division, print_function
 
 import errno
 from ._constants import (
+    ECHRNG,
+    ECKSUM,
+    ETIME,
     ZFS_ERR_CHECKPOINT_EXISTS,
     ZFS_ERR_DISCARDING_CHECKPOINT,
     ZFS_ERR_NO_CHECKPOINT,
@@ -324,7 +327,7 @@ class DestinationModified(ZFSError):
 
 
 class BadStream(ZFSError):
-    errno = errno.EBADE
+    errno = ECKSUM
     message = "Bad backup stream"
 
 
@@ -532,7 +535,7 @@ class ZCPSyntaxError(ZCPError):
 
 
 class ZCPRuntimeError(ZCPError):
-    errno = errno.ECHRNG
+    errno = ECHRNG
     message = "Channel programs encountered a runtime error"
 
     def __init__(self, details):
@@ -545,7 +548,7 @@ class ZCPLimitInvalid(ZCPError):
 
 
 class ZCPTimeout(ZCPError):
-    errno = errno.ETIME
+    errno = ETIME
     message = "Channel program timed out"
 
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD doesn't have EBADE, ECHRNG, or ETIME.

### Description
<!--- Describe your changes in detail -->
Add constants for these and set them appropriately for the platform.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
pyzfs tests are now runnable on FreeBSD (one case fails though, unrelated).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
