### PR TITLE
Make spa_history_zone platform-dependent in kernel

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -447,6 +447,7 @@ extern void spa_event_post(sysevent_t *ev);
 extern int param_set_deadman_failmode_common(const char *val);
 extern void spa_set_deadman_synctime(hrtime_t ns);
 extern void spa_set_deadman_ziotime(hrtime_t ns);
+extern const char *spa_history_zone(void);
 
 #ifdef	__cplusplus
 }

--- a/module/os/linux/zfs/spa_misc_os.c
+++ b/module/os/linux/zfs/spa_misc_os.c
@@ -102,3 +102,9 @@ param_set_slop_shift(const char *buf, zfs_kernel_param_t *kp)
 
 	return (0);
 }
+
+const char *
+spa_history_zone(void)
+{
+	return ("linux");
+}

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -180,16 +180,6 @@ spa_history_write(spa_t *spa, void *buf, uint64_t len, spa_history_phys_t *shpp,
 	return (0);
 }
 
-static char *
-spa_history_zone(void)
-{
-#ifdef _KERNEL
-	return ("linux");
-#else
-	return (NULL);
-#endif
-}
-
 /*
  * Post a history sysevent.
  *
@@ -621,6 +611,14 @@ spa_history_log_version(spa_t *spa, const char *operation, dmu_tx_t *tx)
 	    (u_longlong_t)spa_version(spa), ZFS_META_GITREV,
 	    u->nodename, u->release, u->version, u->machine);
 }
+
+#ifndef _KERNEL
+const char *
+spa_history_zone(void)
+{
+	return (NULL);
+}
+#endif
 
 #if defined(_KERNEL)
 EXPORT_SYMBOL(spa_history_create_obj);

--- a/tests/zfs-tests/tests/functional/history/history_common.kshlib
+++ b/tests/zfs-tests/tests/functional/history/history_common.kshlib
@@ -51,11 +51,11 @@ function run_and_verify
 	fullcmd="$1"
 	flags="$2"
 
-	if is_linux; then
+	if is_illumos; then
+		histcmd=$(echo $fullcmd | sed 's/\/usr\/sbin\///g')
+	else
 		histcmd=$(echo $fullcmd | sed 's/^.*\/\(zpool .*\).*$/\1/')
 		histcmd=$(echo $histcmd | sed 's/^.*\/\(zfs .*\).*$/\1/')
-	else
-		histcmd=$(echo $fullcmd | sed 's/\/usr\/sbin\///g')
 	fi
 
 	cmd=$(echo $histcmd | awk '{print $1}')
@@ -112,10 +112,11 @@ function verify_long
 	typeset suffix=""
 	if is_linux; then
 		suffix=":linux"
+	elif is_freebsd; then
+		suffix=":freebsd"
 	fi
 
-	grep "$cmd \[user $uid ($user) on $hname$suffix\]" \
-	    $NEW_HISTORY >/dev/null 2>&1
+	grep -q "$cmd \[user $uid ($user) on $hname$suffix\]" $NEW_HISTORY
 	if [[ $? != 0 ]]; then
 		log_note "Couldn't find long information for \"$cmd\""
 		return 1


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This function should only return "linux" on Linux.

### Description
<!--- Describe your changes in detail -->
Move the kernel part of the function out of common code.
Fix the tests for FreeBSD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passed the history tests on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
