### PR TITLE
ZTS: Test the correct filesystem_limits behavior

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -201,6 +201,8 @@ maybe = {
     'history/history_010_pos': ['SKIP', exec_reason],
     'io/mmap': ['SKIP', fio_reason],
     'largest_pool/largest_pool_001_pos': ['FAIL', known_reason],
+    'limits/filesystem_limit': ['FAIL', '8226'],
+    'limits/snapshot_limit': ['FAIL', '8226'],
     'pyzfs/pyzfs_unittest': ['SKIP', python_deps_reason],
     'no_space/enospc_002_pos': ['FAIL', enospc_reason],
     'projectquota/setup': ['SKIP', exec_reason],

--- a/tests/zfs-tests/tests/functional/limits/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/cleanup.ksh
@@ -15,5 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
+cleanup_user_group
 default_cleanup

--- a/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
@@ -15,10 +15,12 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
 #
 # DESCRIPTION:
 # ZFS 'filesystem_limit' is enforced when executing various actions
+# NOTE: the limit should *not* be enforced if the user is allowed to change it.
 #
 # STRATEGY:
 # 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
@@ -30,12 +32,33 @@ verify_runnable "both"
 
 function setup
 {
-	log_must zfs create "$DATASET_TEST"
-	log_must zfs create "$DATASET_UTIL"
+	# We can't delegate 'mount' privs under Linux: to avoid issues with
+	# commands that may need to (re)mount datasets we set mountpoint=none
+	if is_linux; then
+		log_must zfs create -o mountpoint=none "$DATASET_TEST"
+		log_must zfs create -o mountpoint=none "$DATASET_UTIL"
+	else
+		log_must zfs create "$DATASET_TEST"
+		log_must zfs create "$DATASET_UTIL"
+	fi
+	if is_freebsd; then
+		# Ensure our non-root user has the permission to create the
+		# mountpoints and mount the filesystems.
+		sysctl vfs.usermount=1
+		log_must chmod 777 $(get_prop mountpoint "$DATASET_TEST")
+		log_must chmod 777 $(get_prop mountpoint "$DATASET_UTIL")
+	fi
+	log_must zfs allow -d -l $STAFF1 'create,mount,rename,clone,receive' \
+	    "$DATASET_TEST"
+	log_must zfs allow -d -l $STAFF1 'create,mount,rename,clone,receive' \
+	    "$DATASET_UTIL"
 }
 
 function cleanup
 {
+	if is_freebsd; then
+		sysctl vfs.usermount=0
+	fi
 	destroy_dataset "$DATASET_TEST" "-Rf"
 	destroy_dataset "$DATASET_UTIL" "-Rf"
 	rm -f $ZSTREAM
@@ -50,25 +73,39 @@ ZSTREAM="$TEST_BASE_DIR/filesystem_limit.$$"
 
 # 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
 setup
+# NOTE: we allow 'canmount' to the non-root user so we can use 'log_must' with
+# 'user_run zfs create -o canmount=off' successfully
+log_must zfs allow -d -l $STAFF1 'canmount' "$DATASET_TEST"
 log_must zfs set filesystem_limit=1 "$DATASET_TEST"
-log_must zfs create "$DATASET_TEST/create"
-log_mustnot zfs create "$DATASET_TEST/create_exceed"
+log_must user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create"
+log_mustnot user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create_exceed"
 log_mustnot datasetexists "$DATASET_TEST/create_exceed"
 log_must zfs set filesystem_limit=2 "$DATASET_TEST"
 log_must zfs snapshot "$DATASET_TEST/create@snap"
-log_must zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone"
-log_mustnot zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone_exceed"
+log_must user_run $STAFF1 zfs clone -o canmount=off "$DATASET_TEST/create@snap" "$DATASET_TEST/clone"
+log_mustnot user_run $STAFF1 zfs clone -o canmount=off "$DATASET_TEST/create@snap" "$DATASET_TEST/clone_exceed"
 log_mustnot datasetexists "$DATASET_TEST/clone_exceed"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "2"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must zfs create "$DATASET_TEST/create_notenforced_root"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create_notenforced_user"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "4"
 cleanup
 
 # 2. Verify 'zfs rename' cannot move filesystems exceeding the limit
 setup
 log_must zfs set filesystem_limit=0 "$DATASET_UTIL"
 log_must zfs create "$DATASET_TEST/rename"
-log_mustnot zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_mustnot user_run $STAFF1 zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
 log_mustnot datasetexists "$DATASET_UTIL/renamed"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_UTIL")" == "0"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed_notenforced_root"
+log_must zfs rename "$DATASET_UTIL/renamed_notenforced_root" "$DATASET_TEST/rename"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_UTIL"
+log_must user_run $STAFF1 zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed_notenforced_user"
+log_must datasetexists "$DATASET_UTIL/renamed_notenforced_user"
 cleanup
 
 # 3. Verify 'zfs receive' cannot exceed the limit
@@ -77,8 +114,14 @@ log_must zfs set filesystem_limit=0 "$DATASET_TEST"
 log_must zfs create "$DATASET_UTIL/send"
 log_must zfs snapshot "$DATASET_UTIL/send@snap1"
 log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
-log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot user_run $STAFF1 eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
 log_mustnot datasetexists "$DATASET_TEST/received"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must zfs destroy -r "$DATASET_TEST/received"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must datasetexists "$DATASET_TEST/received"
 
 log_pass "'filesystem_limit' property is enforced"

--- a/tests/zfs-tests/tests/functional/limits/setup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/setup.ksh
@@ -15,7 +15,14 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
 DISK=${DISKS%% *}
+
+cleanup_user_group
+
+# Create staff group and user
+log_must add_group $STAFF_GROUP
+log_must add_user $STAFF_GROUP $STAFF1
 
 default_volume_setup $DISK

--- a/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
@@ -15,10 +15,12 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
 #
 # DESCRIPTION:
 # ZFS 'snapshot_limit' is enforced when executing various actions
+# NOTE: the limit should *not* be enforced if the user is allowed to change it.
 #
 # STRATEGY:
 # 1. Verify 'zfs snapshot' cannot exceed the snapshot_limit
@@ -31,12 +33,33 @@ verify_runnable "both"
 
 function setup
 {
-	log_must zfs create "$DATASET_TEST"
-	log_must zfs create "$DATASET_UTIL"
+	# We can't delegate 'mount' privs under Linux: to avoid issues with
+	# commands that may need to (re)mount datasets we set mountpoint=none
+	if is_linux; then
+		log_must zfs create -o mountpoint=none "$DATASET_TEST"
+		log_must zfs create -o mountpoint=none "$DATASET_UTIL"
+	else
+		log_must zfs create "$DATASET_TEST"
+		log_must zfs create "$DATASET_UTIL"
+	fi
+	if is_freebsd; then
+		# Ensure our non-root user has the permission to create the
+		# mountpoints and mount the filesystems.
+		sysctl vfs.usermount=1
+		log_must chmod 777 $(get_prop mountpoint "$DATASET_TEST")
+		log_must chmod 777 $(get_prop mountpoint "$DATASET_UTIL")
+	fi
+	log_must zfs allow -d -l $STAFF1 \
+	    'create,snapshot,rename,mount,promote,receive' "$DATASET_TEST"
+	log_must zfs allow -d -l $STAFF1 \
+	    'create,snapshot,rename,mount,promote,receive' "$DATASET_UTIL"
 }
 
 function cleanup
 {
+	if is_freebsd; then
+		sysctl vfs.usermount=0
+	fi
 	destroy_dataset "$DATASET_TEST" "-Rf"
 	destroy_dataset "$DATASET_UTIL" "-Rf"
 	rm -f $ZSTREAM
@@ -52,10 +75,15 @@ ZSTREAM="$TEST_BASE_DIR/snapshot_limit.$$"
 # 1. Verify 'zfs snapshot' cannot exceed the snapshot_limit
 setup
 log_must zfs set snapshot_limit=1 "$DATASET_TEST"
-log_must zfs snapshot "$DATASET_TEST@snap"
-log_mustnot zfs snapshot "$DATASET_TEST@snap_exceed"
+log_must user_run $STAFF1 zfs snapshot "$DATASET_TEST@snap"
+log_mustnot user_run $STAFF1 zfs snapshot "$DATASET_TEST@snap_exceed"
 log_mustnot datasetexists "$DATASET_TEST@snap_exceed"
 log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+# Verify snapshot_limit is *not* enforced for users allowed to change it
+log_must zfs snapshot "$DATASET_TEST@snap_notenforced_root"
+log_must zfs allow -l $STAFF1 'snapshot_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 zfs snapshot "$DATASET_TEST@snap_notenforced_user"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "3"
 cleanup
 
 # 2. Verify 'zfs rename' cannot move snapshots exceeding the limit
@@ -63,9 +91,19 @@ setup
 log_must zfs set snapshot_limit=0 "$DATASET_UTIL"
 log_must zfs create "$DATASET_TEST/rename"
 log_must zfs snapshot "$DATASET_TEST/rename@snap"
-log_mustnot zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_mustnot user_run $STAFF1 \
+    zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
 log_mustnot datasetexists "$DATASET_UTIL/renamed"
 log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "0"
+# Verify snapshot_limit is *not* enforced for users allowed to change it
+log_must zfs rename "$DATASET_TEST/rename" \
+    "$DATASET_UTIL/renamed_notenforced_root"
+log_must zfs create "$DATASET_TEST/rename"
+log_must zfs snapshot "$DATASET_TEST/rename@snap"
+log_must zfs allow -l $STAFF1 'snapshot_limit' "$DATASET_UTIL"
+log_must user_run $STAFF1 \
+    zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed_notenforced_user"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "2"
 cleanup
 
 # 3. Verify 'zfs promote' cannot exceed the limit
@@ -74,9 +112,15 @@ log_must zfs set snapshot_limit=0 "$DATASET_UTIL"
 log_must zfs create "$DATASET_TEST/promote"
 log_must zfs snapshot "$DATASET_TEST/promote@snap"
 log_must zfs clone "$DATASET_TEST/promote@snap" "$DATASET_UTIL/promoted"
-log_mustnot zfs promote "$DATASET_UTIL/promoted"
+log_mustnot user_run $STAFF1 zfs promote "$DATASET_UTIL/promoted"
 log_mustnot datasetexists "$DATASET_UTIL/promoted@snap"
 log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "0"
+# Verify snapshot_limit is *not* enforced for users allowed to change it
+log_must zfs promote "$DATASET_UTIL/promoted"
+log_must zfs promote "$DATASET_TEST/promote"
+log_must zfs allow -l $STAFF1 'snapshot_limit' "$DATASET_UTIL"
+log_must user_run $STAFF1 zfs promote "$DATASET_UTIL/promoted"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "1"
 cleanup
 
 # 4. Verify 'zfs receive' cannot exceed the limit
@@ -85,15 +129,26 @@ log_must zfs set snapshot_limit=0 "$DATASET_TEST"
 log_must zfs create "$DATASET_UTIL/send"
 log_must zfs snapshot "$DATASET_UTIL/send@snap1"
 log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
-log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot user_run $STAFF1 \
+    eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
 log_mustnot datasetexists "$DATASET_TEST/received"
 log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "0"
 log_must zfs set snapshot_limit=1 "$DATASET_TEST"
-log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must user_run $STAFF1 \
+    eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
 log_must zfs snapshot "$DATASET_UTIL/send@snap2"
 log_must eval "zfs send -i @snap1 $DATASET_UTIL/send@snap2 > $ZSTREAM"
-log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot user_run $STAFF1 \
+    eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
 log_mustnot datasetexists "$DATASET_TEST/received@snap2"
 log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+# Verify snapshot_limit is *not* enforced for users allowed to change it
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must zfs snapshot "$DATASET_UTIL/send@snap3"
+log_must eval "zfs send -i @snap2 $DATASET_UTIL/send@snap3 > $ZSTREAM"
+log_must zfs allow -l $STAFF1 'snapshot_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 \
+    eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "3"
 
 log_pass "'snapshot_limit' property is enforced"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue #8226: Property filesystem_limit does not work as documented

There have been previous attempts to fix the behavior on Linux, but so
far the issue is still open.  See PRs #8228, #8280.

The existing tests pass for the incorrect behavior.  This is a problem
on FreeBSD; we are failing the tests because we implement the feature
correctly.

### Description
<!--- Describe your changes in detail -->
I have adapted the tests based on the work by @loli10k in #8280 and
extended the changes to fix the snapshot_limit test as well.

Linux now fails these tests, so entries linking to the issue have been
added to the "maybe" group in zts-report.py.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS passes limits on FreeBSD now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
