### PR TITLE
ZTS: Another round of changes for FreeBSD

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -74,14 +74,33 @@ function block_device_wait
 {
 	if is_linux; then
 		udevadm trigger $*
-		typeset local start=$SECONDS
+		typeset start=$SECONDS
 		udevadm settle
-		typeset local elapsed=$((SECONDS - start))
+		typeset elapsed=$((SECONDS - start))
 		[[ $elapsed > 60 ]] && \
 		    log_note udevadm settle time too long: $elapsed
 	elif is_freebsd; then
-		sleep 3
+		if [[ ${#@} -eq 0 ]]; then
+			sleep 3
+			return
+		fi
 	fi
+	# Poll for the given paths to appear, but give up eventually.
+	typeset -i i
+	for (( i = 0; i < 5; ++i )); do
+		typeset missing=false
+		typeset dev
+		for dev in "${@}"; do
+			if ! [[ -f $dev ]]; then
+				missing=true
+				break
+			fi
+		done
+		if ! $missing; then
+			break
+		fi
+		sleep ${#@}
+	done
 }
 
 #

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -612,8 +612,8 @@ function default_cleanup_noexit
 				then
 					destroy_pool $pool
 				fi
-				ALL_POOLS=$(get_all_pools)
 			done
+			ALL_POOLS=$(get_all_pools)
 		done
 
 		zfs mount -a
@@ -3315,13 +3315,7 @@ function user_run
 	shift
 
 	log_note "user:$user $@"
-	if is_freebsd; then
-		eval "su \$user -c \"$@\"" > $TEST_BASE_DIR/out 2>$TEST_BASE_DIR/err
-		return $?
-	else
-		eval su - \$user -c \"$@\" > $TEST_BASE_DIR/out 2>$TEST_BASE_DIR/err
-		return $?
-	fi
+	eval su - \$user -c \"$@\" > $TEST_BASE_DIR/out 2>$TEST_BASE_DIR/err
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_keylocation.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_keylocation.ksh
@@ -64,9 +64,10 @@ log_must zfs create -o encryption=on -o keyformat=passphrase \
 	-o keylocation=file:///$TESTPOOL/pkey $TESTPOOL/$TESTFS1
 
 log_mustnot zfs set keylocation=none $TESTPOOL/$TESTFS1
-if is_linux; then
+if true; then
 	log_mustnot zfs set keylocation=/$TESTPOOL/pkey $TESTPOOL/$TESTFS1
 else
+	### SOON: ###
 	# file:///$TESTPOOL/pkey and /$TESTPOOL/pkey are equivalent on FreeBSD
 	# thanks to libfetch. Eventually we want to make the other platforms
 	# work this way as well, either by porting libfetch or by other means.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
@@ -84,7 +84,7 @@ while (( $i < ${#args[*]} )); do
 	typeset arg=${args[i]}
 	if is_freebsd; then
 		# FreeBSD does not strictly validate share opts (yet).
-		if [[ $arg == "-o sharenfs="* ]]; then
+		if [[ $arg == "sharenfs="* ]]; then
 			((i = i + 1))
 			continue
 		fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
@@ -138,7 +138,7 @@ for option in "" "-Df"; do
 				if ((nfs_share_bit == 1)); then
 					log_note "Set sharenfs=on $pool"
 					log_must zfs set sharenfs=on $pool
-					log_must is_shared $pool
+					! is_freebsd && log_must is_shared $pool
 					f_share="true"
 					nfs_flag="sharenfs=on"
 				fi
@@ -181,19 +181,21 @@ for option in "" "-Df"; do
 					for fs in $mount_fs; do
 						log_must ismounted $pool/$fs
 						[[ -n $f_share ]] && \
+						    ! is_freebsd && \
 						    log_must is_shared $pool/$fs
 					done
 
 					for fs in $nomount_fs; do
 						log_mustnot ismounted $pool/$fs
-						log_mustnot is_shared $pool/$fs
+						! is_freebsd && \
+						    log_mustnot is_shared $pool/$fs
 					done
 					((guid_bit = guid_bit + 1))
 				done
 				# reset nfsshare=off
 				if [[ -n $f_share ]]; then
 					log_must zfs set sharenfs=off $pool
-					log_mustnot is_shared $pool
+					! is_freebsd && log_mustnot is_shared $pool
 				fi
 				((nfs_share_bit = nfs_share_bit + 1))
 			done

--- a/tests/zfs-tests/tests/functional/large_files/large_files_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/large_files/large_files_002_pos.ksh
@@ -51,7 +51,7 @@ log_must ulimit -f 1024
 log_mustnot sh -c 'dd if=/dev/zero of=$TESTDIR/ulimit_write_file bs=1M count=2'
 log_must rm $TESTDIR/ulimit_write_file
 # FreeBSD allows the sparse file because space has not been allocated.
-if !is_freebsd; then
+if ! is_freebsd; then
 	log_mustnot sh -c 'truncate -s2M $TESTDIR/ulimit_trunc_file'
 	log_must rm $TESTDIR/ulimit_trunc_file
 fi

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted.kshlib
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted.kshlib
@@ -63,11 +63,11 @@ function setup_embedded
 	typeset recsize
 	typeset mntpnt=$(get_prop mountpoint $sendfs)
 	for recsize in 512 1024 2048 4096 8192 16384; do
-		if is_linux; then
+		if is_illumos; then
+			log_must mkholes -d $((recsize - 8)):8 $mntpnt/$recsize
+		else
 			log_must dd if=/dev/urandom of=$mntpnt/$recsize bs=8 \
 			    count=1 seek=$(((recsize / 8) - 1))
-		else
-			log_must mkholes -d $((recsize - 8)):8 $mntpnt/$recsize
 		fi
 	done
 }
@@ -79,7 +79,12 @@ function setup_holes
 	typeset mntpnt=$(get_prop mountpoint $sendfs)
 	typeset M=$((1024 * 1024))
 
-	if is_linux; then
+	if is_illumos; then
+		log_must mkholes -d 0:$((8 * M)) $mntpnt/f1
+		log_must mkholes -d 0:$M -d $((7 * M)):$M $mntpnt/f2
+		log_must mkholes -d $M:$((6 * M)) -h $((7 * M)):$M $mntpnt/f3
+		log_must mkholes -h 0:$((8 * M)) $mntpnt/f4
+	else
 		log_must dd if=/dev/urandom of=$mntpnt/f1 bs=8M count=1
 
 		log_must dd if=/dev/urandom of=$mntpnt/f2 bs=1M count=1
@@ -87,14 +92,9 @@ function setup_holes
 		    conv=notrunc
 
 		log_must dd if=/dev/urandom of=$mntpnt/f3 bs=1M count=6 seek=1
-		log_must truncate $mntpnt/f3 --size=$((8 * M))
+		log_must truncate -s $((8 * M)) $mntpnt/f3
 
-		log_must truncate $mntpnt/f4 --size=$((8 * M))
-	else
-		log_must mkholes -d 0:$((8 * M)) $mntpnt/f1
-		log_must mkholes -d 0:$M -d $((7 * M)):$M $mntpnt/f2
-		log_must mkholes -d $M:$((6 * M)) -h $((7 * M)):$M $mntpnt/f3
-		log_must mkholes -h 0:$((8 * M)) $mntpnt/f4
+		log_must truncate -s $((8 * M)) $mntpnt/f4
 	fi
 
 	log_must zfs create $sendfs/manyrm
@@ -237,15 +237,11 @@ function redacted_cleanup
 	typeset ds_list=$@
 	typeset ds
 
-	# Verify the receiving pool can still be exported and imported.
-	log_must zpool export $POOL2
-	log_must zpool import $POOL2
-
 	for ds in $ds_list; do
-		datasetexists $ds && log_must zfs destroy -R $ds
+		zfs destroy -R $ds
 	done
 
-	log_must set_tunable32 ALLOW_REDACTED_DATASET_MOUNT 0
+	set_tunable32 ALLOW_REDACTED_DATASET_MOUNT 0
 	rm -f $(get_prop mountpoint $POOL)/tmp/*
 }
 

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_holes.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_holes.ksh
@@ -46,11 +46,11 @@ typeset M=$((1024 * 1024))
 log_onexit redacted_cleanup $sendfs $recvfs
 
 # Write holes at the start and end of a non-sparse file.
-if is_linux; then
+if is_illumos; then
+	log_must mkholes -h 0:$M -h $((7 * M)):$M $clone_mnt/f1
+else
 	log_must dd if=/dev/zero of=$clone_mnt/f1 bs=1M count=1 conv=notrunc
 	log_must dd if=/dev/zero of=$clone_mnt/f1 bs=1M count=1 conv=notrunc seek=7
-else
-	log_must mkholes -h 0:$M -h $((7 * M)):$M $clone_mnt/f1
 fi
 log_must zfs snapshot $clone@snap1
 log_must zfs redact $sendfs@snap book1 $clone@snap1
@@ -72,11 +72,11 @@ log_must zfs rollback -R $clone@snap
 log_must zfs destroy -R $recvfs
 
 # Write data into the middle of a hole.
-if is_linux; then
+if is_illumos; then
+	log_must mkholes -d $((3 * M)):$((2 * M)) $clone_mnt/f2
+else
 	log_must dd if=/dev/urandom of=$clone_mnt/f2 bs=1M count=2 seek=3 \
 	    conv=notrunc
-else
-	log_must mkholes -d $((3 * M)):$((2 * M)) $clone_mnt/f2
 fi
 log_must zfs snapshot $clone@snap1
 log_must zfs redact $sendfs@snap book3 $clone@snap1

--- a/tests/zfs-tests/tests/functional/rsend/send_hole_birth.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_hole_birth.ksh
@@ -81,7 +81,7 @@ log_must truncate -s 1G /$sendfs/file1
 log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
 log_must zfs snapshot $sendfs@snap1
 
-log_must truncate -s 4194304 /$sendfs/file1
+log_must truncate -s 4M /$sendfs/file1
 log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 \
     conv=notrunc
 log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix miscellaneous problems with tests on FreeBSD.

### Description
<!--- Describe your changes in detail -->
Highlights:
* is_linux -> is_illumos swaps
* make block_device_wait more clever when paths are given
* slightly optimize default_cleanup_noexit
* remove platform differences in user_run
* temporarily expect non-libfetch behavior for keylocation=/foo/bar
* fix sharenfs exceptions
* don't test multihost property
* fix misc broken platform checks
* clear zinjected faults in removal_resume_export callback

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
