### PR TITLE
ZTS: Add zts-report exceptions for FreeBSD

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -121,11 +121,11 @@ fio_reason = 'Fio v2.3 or newer required'
 trim_reason = 'DISKS must support discard (TRIM/UNMAP)'
 
 #
-# Some tests are not applicable to Linux or need to be updated to operate
-# in the manor required by Linux.  Any tests which are skipped for this
+# Some tests are not applicable to a platform or need to be updated to operate
+# in the manor required by the platform.  Any tests which are skipped for this
 # reason will be suppressed in the final analysis output.
 #
-na_reason = "N/A on Linux"
+na_reason = "Not applicable"
 
 summary = {
     'total': float(0),
@@ -153,11 +153,17 @@ known = {
     'cli_user/misc/zfs_unshare_001_neg': ['SKIP', na_reason],
     'privilege/setup': ['SKIP', na_reason],
     'refreserv/refreserv_004_pos': ['FAIL', known_reason],
-    'removal/removal_with_zdb': ['SKIP', known_reason],
     'rootpool/setup': ['SKIP', na_reason],
     'rsend/rsend_008_pos': ['SKIP', '6066'],
     'vdev_zaps/vdev_zaps_007_pos': ['FAIL', known_reason],
 }
+
+if sys.platform.startswith('freebsd'):
+    known.update({
+        'link_count/link_count_001': ['SKIP', na_reason],
+        'removal/removal_condense_export': ['FAIL', known_reason],
+        'upgrade/upgrade_userobj_001_pos': ['FAIL', known_reason],
+    })
 
 #
 # These tests may occasionally fail or be skipped.  We want there failures
@@ -205,6 +211,7 @@ maybe = {
     'no_space/enospc_002_pos': ['FAIL', enospc_reason],
     'projectquota/setup': ['SKIP', exec_reason],
     'redundancy/redundancy_004_neg': ['FAIL', '7290'],
+    'removal/removal_with_zdb': ['SKIP', known_reason],
     'reservation/reservation_008_pos': ['FAIL', '7741'],
     'reservation/reservation_018_pos': ['FAIL', '5642'],
     'rsend/rsend_019_pos': ['FAIL', '6086'],
@@ -298,7 +305,7 @@ if __name__ == "__main__":
         issue_url = 'https://github.com/openzfs/zfs/issues/'
 
         # Include the reason why the result is expected, given the following:
-        # 1. Suppress test results which set the "N/A on Linux" reason.
+        # 1. Suppress test results which set the "Not applicable" reason.
         # 2. Numerical reasons are assumed to be GitHub issue numbers.
         # 3. When an entire test group is skipped only report the setup reason.
         if test in known:

--- a/tests/zfs-tests/tests/functional/link_count/link_count_001.ksh
+++ b/tests/zfs-tests/tests/functional/link_count/link_count_001.ksh
@@ -49,6 +49,10 @@ log_assert "Verify file link count is zero on zfs"
 export ITERS=10
 export NUMFILES=10000
 
+if is_freebsd; then
+	log_unsupported "Not applicable on FreeBSD"
+fi
+
 # Detect and make sure this test must be executed on a multi-process system
 if ! is_mp; then
 	log_unsupported "This test requires a multi-processor system."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are three tests we expect to fail only on FreeBSD.
* link_count never exits and eventually times out:
   - @amotin tells me this test is probably not applicable to us
   - Skip on FreeBSD
* userobj feature does not activate immediately after pool upgrade
   - low impact; we are aware of this issue
* removal does not appear to condense on export
   - low impact; we are aware of this issue

### Description
<!--- Describe your changes in detail -->
Update zts-report to add exceptions for known test failures/skips on FreeBSD.
Additionally removal_with_zdb passes on FreeBSD, so it is moved to "maybe".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
