### PR TITLE
ZTS: Speed up write_dirs cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
@@ -47,11 +47,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	for file in `find $TESTDIR -type f`; do
-		cat /dev/null > $file
-	done
-	log_must sync
-	log_must rm -rf $TESTDIR/*
+	destroy_dataset $TESTPOOL/$TESTFS
+	zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }
 
 typeset -i retval=0

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
@@ -47,11 +47,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	for file in `find $TESTDIR -type f`; do
-		cat /dev/null > $file
-	done
-	log_must sync
-	log_must rm -rf $TESTDIR/*
+	destroy_dataset $TESTPOOL/$TESTFS
+	zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }
 
 typeset -i retval=0


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The write_dirs tests fill a filesystem with a bunch of files until it
is out of space.  In cleanup the files are truncated and removed
individually.  These tests already take a while to run.

### Description
<!--- Describe your changes in detail -->
It is quicker and easier to destroy the whole dataset and create a new
one to replace it in the cleanup functions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
