### PR TITLE
Systemd mount generator: don't fail keyload from file if already loaded

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -151,13 +151,9 @@ process_line() {
         else
           keymountdep="RequiresMountsFor='${p_keyloc#file://}'"
         fi
-        keyloadcmd="@sbindir@/zfs load-key '${dataset}'"
+        keyloadscript="@sbindir@/zfs load-key \"${dataset}\""
       elif [ "${p_keyloc}" = "prompt" ] ; then
-        keyloadcmd="\
-/bin/sh -c '\
-set -eu;\
-keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";\
-[ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;\
+        keyloadscript="\
 count=0;\
 while [ \$\$count -lt 3 ];do\
   systemd-ask-password --id=\"zfs:${dataset}\"\
@@ -165,11 +161,19 @@ while [ \$\$count -lt 3 ];do\
     @sbindir@/zfs load-key \"${dataset}\" && exit 0;\
   count=\$\$((count + 1));\
 done;\
-exit 1'"
+exit 1"
       else
         printf 'zfs-mount-generator: (%s) invalid keylocation\n' \
           "${dataset}" >/dev/kmsg
       fi
+      keyloadcmd="\
+/bin/sh -c '\
+set -eu;\
+keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";\
+[ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;\
+${keyloadscript}'"
+
+
 
       # Generate the key-load .service unit
       #


### PR DESCRIPTION
### Motivation and Context

Previously the generated keyload units for encryption roots with
keylocation=file://* didn't contain the code to detect if the key
was already loaded and would be marked failed in such situations.

This would lead to systemd marking the system as degraded, for example if an initcpio hook already loaded an encryption key in order to mount the rootfs.

-> No more red text during startup! (make sure not to boot with plymouth or the `quiet` kernel arg)


### Description

Move the code to check whether the key is already loaded
from keylocation=prompt handling to the general key loading code.

### How Has This Been Tested?
Manually confirmed the resulting unit files behave correctly tolerate a key already being loaded.
[Simple reproducer script here](https://gist.github.com/InsanePrawn/f32c2fdfdec2b858b5107b27668fa508)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
