### PR TITLE
ZTS: Wait for free space between write_dirs tests

### DIFF
--- a/tests/zfs-tests/tests/functional/write_dirs/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/cleanup.ksh
@@ -32,3 +32,4 @@
 . $STF_SUITE/include/libtest.shlib
 
 default_cleanup
+rm -f $TEST_BASE_DIR/disk0

--- a/tests/zfs-tests/tests/functional/write_dirs/setup.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/setup.ksh
@@ -33,4 +33,6 @@
 
 verify_runnable "global"
 
-default_setup "$DISKS"
+DISK=$TEST_BASE_DIR/disk0
+truncate -s 2G $DISK
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
@@ -48,6 +48,8 @@ verify_runnable "both"
 function cleanup
 {
 	destroy_dataset $TESTPOOL/$TESTFS
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 	zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }
 

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
@@ -48,6 +48,8 @@ verify_runnable "both"
 function cleanup
 {
 	destroy_dataset $TESTPOOL/$TESTFS
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 	zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleanup for write_dirs involves destroying a dataset filling a pool
and then recreating the dataset for the next test.  Due to the
asynchronous nature of free space accounting, recreating the dataset
can fail for lack of space, causing problems for the next test.

### Description
<!--- Describe your changes in detail -->
Add wait_freeing $TESTPOOL to wait for the space to be freed and then
sync_pool $TESTPOOL to update the space accounting before attempting
to recreate the test filesystem.

Only use a single disk to create the pool.  Make it a small file so it
does not take too long to fill.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
