### PR TITLE
ZTS: Simplify some libtest functions

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1175,7 +1175,7 @@ function partition_disk	#<slice_size> <whole_disk_name>	<total_slices>
 #	data:	    the data that will be written
 #
 #	E.g.
-#	file_fs /testdir 20 25 1024 256 0
+#	fill_fs /testdir 20 25 1024 256 0
 #
 # Note: bytes * num_writes equals the size of the testfile
 #
@@ -1188,33 +1188,12 @@ function fill_fs # destdir dirnum filenum bytes num_writes data
 	typeset -i num_writes=${5:-10240}
 	typeset data=${6:-0}
 
-	typeset -i odirnum=1
-	typeset -i idirnum=0
-	typeset -i fn=0
-	typeset -i retval=0
-
-	mkdir -p $destdir/$idirnum
-	while (($odirnum > 0)); do
-		if ((dirnum >= 0 && idirnum >= dirnum)); then
-			odirnum=0
-			break
-		fi
-		file_write -o create -f $destdir/$idirnum/$TESTFILE.$fn \
-		    -b $bytes -c $num_writes -d $data
-		retval=$?
-		if (($retval != 0)); then
-			odirnum=0
-			break
-		fi
-		if (($fn >= $filenum)); then
-			fn=0
-			((idirnum = idirnum + 1))
-			mkdir -p $destdir/$idirnum
-		else
-			((fn = fn + 1))
-		fi
+	mkdir -p $destdir/{1..$dirnum}
+	for f in $destdir/{1..$dirnum}/$TESTFILE{1..$filenum}; do
+		file_write -o create -f $f -b $bytes -c $num_writes -d $data \
+		|| return $?
 	done
-	return $retval
+	return 0
 }
 
 #
@@ -3302,7 +3281,7 @@ function get_cpu_freq
 	if is_linux; then
 		lscpu | awk '/CPU MHz/ { print $3 }'
 	elif is_freebsd; then
-		cat /var/run/dmesg.boot | grep '^CPU:' | cut -d '(' -f 2 | cut -d ')' -f 1
+		sysctl -n hw.clockrate
 	else
 		psrinfo -v 0 | awk '/processor operates at/ {print $6}'
 	fi
@@ -3360,7 +3339,7 @@ function get_max
 	shift
 
 	for i in "$@"; do
-		max=$(echo $((max > i ? max : i)))
+		max=$((max > i ? max : i))
 	done
 
 	echo $max
@@ -3372,7 +3351,7 @@ function get_min
 	shift
 
 	for i in "$@"; do
-		min=$(echo $((min < i ? min : i)))
+		min=$((min < i ? min : i))
 	done
 
 	echo $min


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Do less work, go faster.

### Description
<!--- Describe your changes in detail -->
Don't echo the results of arithmetic expressions, it's not necessary.

Use hw.clockrate sysctl to get CPU freq instead of parsing dmesg.boot
for a line that might not even be there anymore.

Reduce bookkeeping in fill_fs, making it easier to follow.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
