### PR TITLE
zloop.sh should call ZDB with pool name

### DIFF
--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -118,7 +118,7 @@ function store_core
 		foundcrashes=$((foundcrashes + 1))
 
 		# zdb debugging
-		zdbcmd="$ZDB -U "$workdir/zpool.cache" -dddMmDDG $ZTEST"
+		zdbcmd="$ZDB -U "$workdir/zpool.cache" -dddMmDDG ztest"
 		zdbdebug=$($zdbcmd 2>&1)
 		echo -e "$zdbcmd\n" >>ztest.zdb
 		echo "$zdbdebug" >>ztest.zdb


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Commit 54007c79 introduced an error, changing
```$ZDB <options> ztest```
to
```$ZDB <options> $ZTEST```
  This final argument indicates the pool name, not the script, and so should not have been changed.

Without the patch, ztest.zdb always contains
```
$ tail /var/tmp/zloop/zloop-200310-222725/ztest.zdb
/home/olaf/zfs/bin/zdb -U /var/tmp/zloop-run/zpool.cache -dddMmDDG /home/olaf/zfs/bin/ztest

failed to hold dataset '/home/olaf/zfs/bin/ztest': No such file or directory
zdb: can't open '/home/olaf/zfs/bin/ztest': No such file or directory
```

### Description
<!--- Describe your changes in detail -->
Change "$ZTEST" to "ztest"

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Introduced a null pointer dereference in ztest_dmu_read_write_zcopy() and then ran zloop.  With the patch, ztest.zdb contains the expected output:
```
$ head /var/tmp/zloop/zloop-200310-222030/ztest.zdb
/home/olaf/zfs/bin/zdb -U /var/tmp/zloop-run/zpool.cache -dddMmDDG ztest

All DDTs are empty

Metaslabs:
        vdev          0      ms_unflushed_phys object 91
        metaslabs    11   offset                spacemap          free
        ---------------   -------------------   ---------------   ------------
        metaslab      0   offset            0   spacemap     93   free     507M
space map object 93:
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
