### PR TITLE
ZTS: Use correct signal numbers for status checks

### DIFF
--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -165,6 +165,29 @@ function log_mustnot_expect
 	(( $? != 0 )) && log_fail
 }
 
+# Exit status encoding is platform-dependent
+case $(uname) in
+Darwin|FreeBSD)
+	EXIT_SIGNAL=128
+	SIGBUS=10
+	SIGSEGV=11
+	;;
+illumos)
+	EXIT_SIGNAL=256
+	SIGBUS=7
+	SIGSEGV=11
+	;;
+Linux|*)
+	EXIT_SIGNAL=128
+	SIGBUS=7
+	SIGSEGV=11
+	;;
+esac
+EXIT_SUCCESS=0
+EXIT_NOTFOUND=127
+EXIT_SIGBUS=$((EXIT_SIGNAL + SIGBUS))
+EXIT_SIGSEGV=$((EXIT_SIGNAL + SIGSEGV))
+
 # Execute and print command with status where success equals non-zero result
 # or output includes expected keyword
 #
@@ -191,19 +214,19 @@ function log_neg_expect
 	out="cat $logfile"
 
 	# unexpected status
-	if (( $status == 0 )); then
+	if (( $status == EXIT_SUCCESS )); then
 		 print -u2 $($out)
 		_printerror "$@" "unexpectedly exited $status"
 	# missing binary
-	elif (( $status == 127 )); then
+	elif (( $status == EXIT_NOTFOUND )); then
 		print -u2 $($out)
 		_printerror "$@" "unexpectedly exited $status (File not found)"
-	# bus error - core dump (256+signal, SIGBUS=7)
-	elif (( $status == 263 )); then
+	# bus error - core dump
+	elif (( $status == EXIT_SIGBUS )); then
 		print -u2 $($out)
 		_printerror "$@" "unexpectedly exited $status (Bus Error)"
-	# segmentation violation - core dump (256+signal, SIGSEGV=11)
-	elif (( $status == 267 )); then
+	# segmentation violation - core dump
+	elif (( $status == EXIT_SIGSEGV )); then
 		print -u2 $($out)
 		_printerror "$@" "unexpectedly exited $status (SEGV)"
 	else


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Different operating systems encode exit status in different ways.
The logapi shell library assumes the Solaris meaning of exit codes,
which is not correct on other platforms.

### Description
<!--- Describe your changes in detail -->
Define the needed constants according to the platform we are running
on and use those to decode process exit status.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
