### PR TITLE
ZTS: Use default_cleanup_noexit where needed

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/cleanup.ksh
@@ -21,7 +21,7 @@
 
 verify_runnable "global"
 
-default_cleanup
+default_cleanup_noexit
 disk_cleanup
 
 log_pass

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/cleanup.ksh
@@ -16,5 +16,7 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-default_cleanup
+default_cleanup_noexit
 destroy_pool testpool2
+
+log_pass

--- a/tests/zfs-tests/tests/functional/write_dirs/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/cleanup.ksh
@@ -31,5 +31,7 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-default_cleanup
+default_cleanup_noexit
 rm -f $TEST_BASE_DIR/disk0
+
+log_pass


### PR DESCRIPTION
And add log_pass appropriately

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
