### PR TITLE
ZTS: Exit status 256+signum is actually baked in to ksh

### DIFF
--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -165,26 +165,20 @@ function log_mustnot_expect
 	(( $? != 0 )) && log_fail
 }
 
-# Exit status encoding is platform-dependent
+# Signal numbers are platform-dependent
 case $(uname) in
 Darwin|FreeBSD)
-	EXIT_SIGNAL=128
 	SIGBUS=10
 	SIGSEGV=11
 	;;
-illumos)
-	EXIT_SIGNAL=256
-	SIGBUS=7
-	SIGSEGV=11
-	;;
-Linux|*)
-	EXIT_SIGNAL=128
+illumos|Linux|*)
 	SIGBUS=7
 	SIGSEGV=11
 	;;
 esac
 EXIT_SUCCESS=0
 EXIT_NOTFOUND=127
+EXIT_SIGNAL=256
 EXIT_SIGBUS=$((EXIT_SIGNAL + SIGBUS))
 EXIT_SIGSEGV=$((EXIT_SIGNAL + SIGSEGV))
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While #10121 did fix the signal numbers for FreeBSD/Darwin, it
incorrectly changed the expected encoding of exit status for commands
that exited on a signal.  The encoding 256+signum is a feature of the
shell.  Only the signal numbers themselves are platform-dependent.

### Description
<!--- Describe your changes in detail -->
Always use the encoding 256+signum when checking exit status for
signal exits.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
