### PR TITLE
Issue 10132 - changed decimals to integers in the arcstat script

### DIFF
--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -335,15 +335,7 @@ def init():
 
     argv = sys.argv[i:]
     sint = int(argv[0]) if argv else sint
-    count = int(argv[1]) if len(argv) > 1 else count
-
-    if len(argv) > 1:
-        sint = int(argv[0])
-        count = int(argv[1])
-
-    elif len(argv) > 0:
-        sint = int(argv[0])
-        count = 0
+    count = int(argv[1]) if len(argv) > 1 else 0
 
     if hflag or (xflag and desired_cols):
         usage()

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -335,7 +335,7 @@ def init():
 
     argv = sys.argv[i:]
     sint = int(argv[0]) if argv else sint
-    count = int(argv[1]) if len(argv) > 1 else 0
+    count = int(argv[1]) if len(argv) > 1 else (0 if len(argv) > 0 else 1)
 
     if hflag or (xflag and desired_cols):
         usage()

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -51,7 +51,6 @@ import getopt
 import re
 import copy
 
-from decimal import Decimal
 from signal import signal, SIGINT, SIGWINCH, SIG_DFL
 
 
@@ -139,7 +138,7 @@ if sys.platform.startswith('freebsd'):
 
             name, value = s.name, s.value
             # Trims 'kstat.zfs.misc.arcstats' from the name
-            kstat[name[24:]] = Decimal(value)
+            kstat[name[24:]] = int(value)
 
 elif sys.platform.startswith('linux'):
     def kstat_update():
@@ -158,7 +157,7 @@ elif sys.platform.startswith('linux'):
                 continue
 
             name, unused, value = s.split()
-            kstat[name] = Decimal(value)
+            kstat[name] = int(value)
 
 
 def detailed_usage():
@@ -335,15 +334,15 @@ def init():
         i += 1
 
     argv = sys.argv[i:]
-    sint = Decimal(argv[0]) if argv else sint
+    sint = int(argv[0]) if argv else sint
     count = int(argv[1]) if len(argv) > 1 else count
 
     if len(argv) > 1:
-        sint = Decimal(argv[0])
+        sint = int(argv[0])
         count = int(argv[1])
 
     elif len(argv) > 0:
-        sint = Decimal(argv[0])
+        sint = int(argv[0])
         count = 0
 
     if hflag or (xflag and desired_cols):


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
The pull request fixes deprecation warning reported here: https://github.com/openzfs/zfs/issues/10132

### Description
I changed time interval and kstat values from decimals to integers, because they are always integers.

### How Has This Been Tested?
I tested it on Ubuntu 20.04 by simple running the script.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
