### PR TITLE
Fix cstyle warnings

### DIFF
--- a/contrib/pyzfs/libzfs_core/exceptions.py
+++ b/contrib/pyzfs/libzfs_core/exceptions.py
@@ -355,7 +355,7 @@ class StreamFeatureIncompatible(ZFSError):
 class StreamTruncated(ZFSError):
     errno = zfs_errno.ZFS_ERR_STREAM_TRUNCATED
     message = "incomplete stream"
-    
+
 
 class ReceivePropertyFailure(MultipleOperationsFailure):
     message = "Receiving of properties failed for one or more reasons"

--- a/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
@@ -556,7 +556,8 @@ test_recv_new(const char *dataset, int fd)
 	fnvlist_add_boolean(optional, "resumable");
 	fnvlist_add_uint64(optional, "action_handle", *action_handle);
 #endif
-	IOC_INPUT_TEST(ZFS_IOC_RECV_NEW, dataset, required, optional, ZFS_ERR_STREAM_TRUNCATED);
+	IOC_INPUT_TEST(ZFS_IOC_RECV_NEW, dataset, required, optional,
+	    ZFS_ERR_STREAM_TRUNCATED);
 
 	nvlist_free(props);
 	nvlist_free(optional);


### PR DESCRIPTION
### Motivation and Context

Keep the style checker happy.

### Description

Fix minor cstyle warnings accidentally introduced by 7145123b.

### How Has This Been Tested?

Locally running `make checkstyle`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).