### PR TITLE
ZTS: Wait for free space between quota tests

### DIFF
--- a/tests/zfs-tests/tests/functional/quota/quota_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_001_pos.ksh
@@ -62,7 +62,8 @@ function cleanup
 	# pool, otherwise next test will fail trying to set a
 	# quota which is less than the space used.
 	#
-	sleep 5
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
@@ -61,6 +61,9 @@ function cleanup
 
 	[[ -e $TESTDIR/$TESTFILE2 ]] && \
             log_must rm $TESTDIR/$TESTFILE2
+
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_003_pos.ksh
@@ -61,11 +61,12 @@ function cleanup
 	    log_must rm $TESTDIR1/$TESTFILE1
 
 	#
-        # Need to allow time for space to be released back to
-        # pool, otherwise next test will fail trying to set a
-        # quota which is less than the space used.
-        #
-        sleep 5
+	# Need to allow time for space to be released back to
+	# pool, otherwise next test will fail trying to set a
+	# quota which is less than the space used.
+	#
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
@@ -62,6 +62,9 @@ function cleanup
 
 	[[ -e $TESTDIR1/$TESTFILE2 ]] && \
             log_must rm $TESTDIR1/$TESTFILE2
+
+	wait_freeing $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/removal/removal.kshlib
+++ b/tests/zfs-tests/tests/functional/removal/removal.kshlib
@@ -34,7 +34,7 @@ function wait_for_removal # pool
 	# The pool state changes before the TXG finishes syncing; wait for
 	# the removal to be completed on disk.
 	#
-	sync_pool
+	sync_pool $pool
 
 	log_must is_pool_removed $pool
 	return 0


### PR DESCRIPTION
And in removal tests, sync the specific pool we are waiting on.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests that exhaust free space can have side effects on later tests as the free space reclamation occurs in the background.

### Description
<!--- Describe your changes in detail -->
Use wait_freeing and sync_pool in cleanup for quota tests, instead of sleep 5.
And in removal tests, sync the specific pool we are waiting on.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
