### PR TITLE
Bugfix/fix uio partial copies

### DIFF
--- a/module/os/linux/zfs/zfs_vnops.c
+++ b/module/os/linux/zfs/zfs_vnops.c
@@ -830,19 +830,12 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 			if (error == EFAULT) {
 				dmu_tx_commit(tx);
 				/*
-				/ This is the only special case in the loop
-				/ where we "continue" to the next iteration,
-				/ and if we execute this code, we did a partial copy.
-				/ Account for bytes written, otherwise we end up
-				/ with invalid sizes/offsets at the next iteration.
-				/ Also, this needs to be done before the following
-				/ uio_prefault. Otherwise, in case we're writing
-				/ the last chunk, we we try to prefault n bytes
-				/ (<max_blksz), but n could be bigger than the
-				/ data itself, generate an EFAULT, and make
-				/ the loop break early without completing the
-				/ last chunk.
-				*/
+				 * Account for partial writes before
+				 * continuing the loop.
+				 * Update needs to occur before the next
+				 * uio_prefaultpages, or prefaultpages may
+				 * error, and we may break the loop early.
+				 */
 				if (tx_bytes != uio->uio_resid)
 					n -= tx_bytes - uio->uio_resid;
 				if (uio_prefaultpages(MIN(n, max_blksz), uio)) {

--- a/module/zcommon/zfs_uio.c
+++ b/module/zcommon/zfs_uio.c
@@ -99,11 +99,11 @@ uiomove_iov(void *p, size_t n, enum uio_rw rw, struct uio *uio)
 				if (b_left > 0) {
 					unsigned long c_bytes =
 					    cnt - b_left;
-					uio->uio_skip += copied_bytes;
+					uio->uio_skip += c_bytes;
 					ASSERT3U(uio->uio_skip, <,
 					    iov->iov_len);
-					uio->uio_resid -= copied_bytes;
-					uio->uio_loffset += copied_bytes;
+					uio->uio_resid -= c_bytes;
+					uio->uio_loffset += c_bytes;
 					return (EFAULT);
 				}
 			}

--- a/module/zcommon/zfs_uio.c
+++ b/module/zcommon/zfs_uio.c
@@ -94,13 +94,11 @@ uiomove_iov(void *p, size_t n, enum uio_rw rw, struct uio *uio)
 				}
 				if (bytes_left > 0) {
 					unsigned long copied_bytes = cnt - bytes_left;
-					skip += copied_bytes;
-					if (skip == iov->iov_len) {
-						skip = 0;
-						uio->uio_iov = (++iov);
-						uio->uio_iovcnt--;
-					}
-					uio->uio_skip += skip;
+					/*
+					 * This is the partial write case, skip cannot reach iov->iov_len
+					 * so we don't handle its zeroing
+					*/
+					uio->uio_skip += copied_bytes;
 					uio->uio_resid -= copied_bytes;
 					uio->uio_loffset += copied_bytes;
 					return (EFAULT);


### PR DESCRIPTION
In zfs_write(), the loop continues to the next iteration without accounting for partial copies occurring in uiomove_iov when copy_from_user/__copy_from_user_inatomic return a non-zero status.
This results in "zfs: accessing past end of object..." in the kernel log, and the write failing.

### Motivation and Context
On some workloads, writing to disk results in "zfs: accessing past end of object".
See issue #8673.

### Description
In zfs_write(), the loop continues to the next iteration without accounting for partial copies occurring in uiomove_iov (which does not update the uio struct) when copy_from_user/__copy_from_user_inatomic return a non-zero status, which indicates the bytes left to copy.

### How Has This Been Tested?
I had a reproducer workload: compiling GCC in a musl chroot, from a glibc host system. The bug would happen at random, at different parts and times of the build.
Before the provided PR, I was never able to compile GCC successfully in the chroot.
I had a couple revisions of the patch that worked partially, before reaching the ones submitted in this PR.
After applying the fixes in this PR, I was able to compile GCC 11 times in a row without any breakage.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
