### PR TITLE
ZTS: Fix non-portable date format

### DIFF
--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -379,7 +379,7 @@ function verify_send
 	typeset dtst=$3
 
 	typeset oldval
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset snap=$dtst@snap.$stamp
 
 	typeset -i ret=1
@@ -408,7 +408,7 @@ function verify_fs_receive
 	typeset fs=$3
 
 	typeset dtst
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset newfs=$fs/newfs.$stamp
 	typeset newvol=$fs/newvol.$stamp
 	typeset bak_user=$TEST_BASE_DIR/bak.$user.$stamp
@@ -480,7 +480,7 @@ function verify_userprop
 	typeset perm=$2
 	typeset dtst=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 
 	user_run $user zfs set "$user:ts=$stamp" $dtst
 	zpool sync ${dtst%%/*}
@@ -565,7 +565,7 @@ function verify_fs_create
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset newfs=$fs/nfs.$stamp
 	typeset newvol=$fs/nvol.$stamp
 
@@ -693,7 +693,7 @@ function verify_fs_snapshot
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset snap=$fs@snap.$stamp
 	typeset mntpt=$(get_prop mountpoint $fs)
 
@@ -737,7 +737,7 @@ function verify_fs_rollback
 	typeset fs=$3
 
 	typeset oldval
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset snap=$fs@snap.$stamp
 	typeset mntpt=$(get_prop mountpoint $fs)
 
@@ -770,7 +770,7 @@ function verify_fs_clone
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset clone=$basefs/cfs.$stamp
@@ -815,7 +815,7 @@ function verify_fs_rename
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset renamefs=$basefs/nfs.$stamp
@@ -898,7 +898,7 @@ function verify_fs_mount
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset mntpt=$(get_prop mountpoint $fs)
 	typeset newmntpt=$TEST_BASE_DIR/mnt.$stamp
 
@@ -966,7 +966,7 @@ function verify_fs_mountpoint
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset mntpt=$(get_prop mountpoint $fs)
 	typeset newmntpt=$TEST_BASE_DIR/mnt.$stamp
 
@@ -1005,7 +1005,7 @@ function verify_fs_promote
 	typeset perm=$2
 	typeset fs=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset clone=$basefs/cfs.$stamp
@@ -1061,7 +1061,7 @@ function verify_fs_canmount
 	typeset fs=$3
 
 	typeset oldval
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 
 	if ! ismounted $fs ; then
 		set -A modes "on" "off"
@@ -1372,7 +1372,7 @@ function verify_vol_snapshot
 	typeset perm=$2
 	typeset vol=$3
 
-	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 
@@ -1397,7 +1397,7 @@ function verify_vol_rollback
 	typeset perm=$2
 	typeset vol=$3
 
-	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 
@@ -1432,7 +1432,7 @@ function verify_vol_clone
 	typeset perm=$2
 	typeset vol=$3
 
-	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp
@@ -1478,7 +1478,7 @@ function verify_vol_rename
 	typeset perm=$2
 	typeset vol=$3
 
-	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp
@@ -1525,7 +1525,7 @@ function verify_vol_promote
 	typeset perm=$2
 	typeset vol=$3
 
-	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
+	typeset stamp=${perm}.${user}.$RANDOM
 	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp

--- a/tests/zfs-tests/tests/functional/delegate/zfs_allow_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/zfs_allow_009_neg.ksh
@@ -51,7 +51,6 @@ longset="set123456789012345678901234567890123456789012345678901234567890123"
 for dtst in $DATASETS ; do
 	log_mustnot eval "zfs allow -s @$longset $dtst"
 	# Create non-existent permission set
-	typeset timestamp=$(date +'%F-%R:%S')
 	log_mustnot zfs allow -s @non-existent $dtst
 	log_mustnot zfs allow $STAFF "atime,created,mounted" $dtst
 	log_mustnot zfs allow $dtst $TESTPOOL


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The delegate tests use `date(1)` to generate snapshot names, using
the format '%F-%T-%N' to get nanosecond resolution (since multiple
snapshots may be taken in the same second).  '%N' is not portable, and
causes tests to fail on FreeBSD.

### Description
<!--- Describe your changes in detail -->
Since the only purpose these timestamps serve is to create a unique
name, simply use $RANDOM instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
