### PR TITLE
zts: Fix and change testcase cache_010_neg

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -49,7 +49,7 @@ post =
 [tests/functional/cache]
 tests = ['cache_001_pos', 'cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg', 'cache_006_pos', 'cache_007_neg', 'cache_008_neg',
-    'cache_009_pos', 'cache_010_neg', 'cache_011_pos', 'cache_012_pos']
+    'cache_009_pos', 'cache_010_pos', 'cache_011_pos', 'cache_012_pos']
 tags = ['functional', 'cache']
 
 [tests/functional/cachefile]

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -191,7 +191,6 @@ elif sys.platform.startswith('linux'):
 maybe = {
     'alloc_class/alloc_class_012_pos': ['FAIL', '9142'],
     'alloc_class/alloc_class_013_pos': ['FAIL', '9142'],
-    'cache/cache_010_neg': ['FAIL', known_reason],
     'chattr/setup': ['SKIP', exec_reason],
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/cache/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cache/Makefile.am
@@ -11,7 +11,7 @@ dist_pkgdata_SCRIPTS = \
 	cache_007_neg.ksh \
 	cache_008_neg.ksh \
 	cache_009_pos.ksh \
-	cache_010_neg.ksh \
+	cache_010_pos.ksh \
 	cache_011_pos.ksh \
 	cache_012_pos.ksh
 

--- a/tests/zfs-tests/tests/functional/cache/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cache/setup.ksh
@@ -34,10 +34,6 @@
 
 verify_runnable "global"
 
-if ! is_physical_device $LDEV; then
-	log_unsupported "Only physical disk could be cache device"
-fi
-
 log_must rm -rf $VDIR $VDIR2
 log_must mkdir -p $VDIR $VDIR2
 log_must mkfile $SIZE $VDEV $VDEV2


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Commit 379ca9c removed the requirement on aux devices to be block
devices only but the test case cache_010_neg was not updated, making it
fail consistently.

WIP to get comments from maintainers and other contributors.

### Description
<!--- Describe your changes in detail -->


This change changes the test to check that cache devices _can_ be files
and character devices too. The testcase is renamed to cache_010_pos and
the exceptions for known failure removed from the test runner.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
