### PR TITLE
Finish refactoring for ZFS_MODULE_PARAM_CALL

### DIFF
--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -134,11 +134,13 @@ enum scope_prefix_types {
  *   spa_slop_shift
  */
 /* BEGIN CSTYLED */
-#define ZFS_MODULE_PARAM_CALL(scope_prefix, name_prefix, name, setfunc, getfunc, perm, desc) \
+#define	ZFS_MODULE_PARAM_CALL(scope_prefix, name_prefix, name, setfunc, getfunc, perm, desc) \
 	CTASSERT_GLOBAL((sizeof (scope_prefix) == sizeof (enum scope_prefix_types))); \
 	module_param_call(name_prefix ## name, setfunc, getfunc, &name_prefix ## name, perm); \
 	MODULE_PARM_DESC(name_prefix ## name, desc)
 /* END CSTYLED */
+
+#define	ZFS_MODULE_PARAM_ARGS	const char *buf, zfs_kernel_param_t *kp
 
 #define	ZFS_MODULE_DESCRIPTION(s) MODULE_DESCRIPTION(s)
 #define	ZFS_MODULE_AUTHOR(s) MODULE_AUTHOR(s)

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -614,8 +614,8 @@ extern uint64_t arc_free_memory(void);
 extern int64_t arc_available_memory(void);
 extern void arc_tuning_update(void);
 
-extern int param_set_arc_long(const char *buf, zfs_kernel_param_t *kp);
-extern int param_set_arc_int(const char *buf, zfs_kernel_param_t *kp);
+extern int param_set_arc_long(ZFS_MODULE_PARAM_ARGS);
+extern int param_set_arc_int(ZFS_MODULE_PARAM_ARGS);
 
 #ifdef __cplusplus
 }

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1179,10 +1179,10 @@ extern void spa_notify_waiters(spa_t *spa);
 extern void spa_wake_waiters(spa_t *spa);
 
 /* module param call functions */
-int param_set_deadman_ziotime(const char *val, zfs_kernel_param_t *kp);
-int param_set_deadman_synctime(const char *val, zfs_kernel_param_t *kp);
-int param_set_slop_shift(const char *buf, zfs_kernel_param_t *kp);
-int param_set_deadman_failmode(const char *val, zfs_kernel_param_t *kp);
+int param_set_deadman_ziotime(ZFS_MODULE_PARAM_ARGS);
+int param_set_deadman_synctime(ZFS_MODULE_PARAM_ARGS);
+int param_set_slop_shift(ZFS_MODULE_PARAM_ARGS);
+int param_set_deadman_failmode(ZFS_MODULE_PARAM_ARGS);
 
 #ifdef ZFS_DEBUG
 #define	dprintf_bp(bp, fmt, ...) do {				\

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -198,6 +198,7 @@ typedef struct zfs_kernel_param {
 } zfs_kernel_param_t;
 
 #define	ZFS_MODULE_PARAM(scope_prefix, name_prefix, name, type, perm, desc)
+#define	ZFS_MODULE_PARAM_ARGS void
 #define	ZFS_MODULE_PARAM_CALL(scope_prefix, name_prefix, name, setfunc, \
 	getfunc, perm, desc)
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2891,5 +2891,5 @@ ZFS_MODULE_PARAM(zfs, zfs_, special_class_metadata_reserve_pct, INT, ZMOD_RW,
 	"free space available");
 /* END CSTYLED */
 
-ZFS_MODULE_PARAM_CALL(spa, spa_, slop_shift, param_set_slop_shift,
+ZFS_MODULE_PARAM_CALL(zfs_spa, spa_, slop_shift, param_set_slop_shift,
 	param_get_int, ZMOD_RW, "Reserved free space in pool");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Linux and FreeBSD have different parameters for tunable proc handler.
This has prevented FreeBSD from implementing the ZFS_MODULE_PARAM_CALL
macro.

### Description
<!--- Describe your changes in detail -->
To complete the sharing of ZFS_MODULE_PARAM_CALL declarations, create
per-platform definitions of the parameter list, ZFS_MODULE_PARAM_ARGS.

With the declarations wired up we discovered an incorrect scope prefix
for spa_slop_shift, so this is now fixed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
