### PR TITLE
make_gitrev.sh: do not escape repository

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,12 @@ all-local:
 	    ${top_builddir}/scripts/zfs-tests.sh -c
 
 dist-hook: gitrev
-	cp ${top_srcdir}/include/zfs_gitrev.h $(distdir)/include; \
+	cp ${top_srcdir}/include/zfs_gitrev.h $(distdir)/include
+	sed	-e '/^\.PHONY: gitrev$$/,/^$$/d' \
+		-e '/^BUILT_SOURCES = gitrev$$/d' \
+		-e 's/^dist-hook: gitrev$$/dist-hook:/' \
+		-i $(distdir)/Makefile.am $(distdir)/Makefile.in
+	rm $(distdir)/scripts/make_gitrev.sh
 	sed ${ac_inplace} -e 's/Release:[[:print:]]*/Release:      $(RELEASE)/' \
 		$(distdir)/META
 


### PR DESCRIPTION
### Motivation and Context

When building from sources using an archive inside another
repository, `git describe` actually read the commit from the super
repository, not zfs'.

### Description

Fixing it by reading from the expected git dir.

### How Has This Been Tested?

Gentoo git build using my patch, checking that the generated `include/zfs_gitrev.h` is "unknown" when not in zfs' git and the name-version-commit hash when in the repo.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
