### PR TITLE
Change zfs_arc_meta_limit_percent default to 100

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -421,9 +421,9 @@ int zfs_compressed_arc_enabled = B_TRUE;
 
 /*
  * ARC will evict meta buffers that exceed arc_meta_limit. This
- * tunable make arc_meta_limit adjustable for different workloads.
+ * tunable makes arc_meta_limit adjustable for different workloads.
  */
-unsigned long zfs_arc_meta_limit_percent = 75;
+unsigned long zfs_arc_meta_limit_percent = 100;
 
 /*
  * Percentage that can be consumed by dnodes of ARC meta buffers.


### PR DESCRIPTION
As discussed on the mailing list: https://zfsonlinux.topicbox.com/groups/zfs-discuss/T2aca1048f5a31bb8/zfsarcmetalimitpercent-a-report-and-some-ideas-for-improvement-was-re-zfs-discuss-pmis-and-pm-in-arcstat-tuning

TL;DR: the idea is to avoid non-intuitivelly wasting up to 25% of ARC in workloads with less than 25% of "interesting" data (meaning data that would enhance performance to be kept in the ARC instead of getting evicted by more-recently-used / more-frequently-used metadata). This wastage is total when primarycache=metadata, but would also happen to any workload with less  than 25% (relative to the ARC size) of "interesting" data.

By changing the zfs_arc_meta_limit_percent default to 100%, these situations are avoided, and the decision about what to keep in the ARC is left to the MRU/MFU algorithms; people with special workloads that would benefit from such a "data reservation" (ie, metadata limit) are still free to tweak this parameter accordingly (or if they already do, their tweak will just keep working)  

Also, fixed a small English verb-conjugation mistake in the comment.

Signed-off-by: Durval Menezes <zfssign@durval.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
