### PR TITLE
Minor `zstream redup` command fixes

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -218,6 +218,7 @@ zfs_redup_stream(int infd, int outfd, boolean_t verbose)
 	rdt.ddecache = umem_cache_create("rde", sizeof (redup_entry_t), 0,
 	    NULL, NULL, NULL, NULL, NULL, 0);
 	rdt.numhashbits = highbit64(numbuckets) - 1;
+	rdt.ddt_count = 0;
 
 	char *buf = safe_calloc(bufsz);
 	FILE *ofp = fdopen(infd, "r");

--- a/cmd/zstreamdump/.gitignore
+++ b/cmd/zstreamdump/.gitignore
@@ -1,1 +1,0 @@
-zstreamdump


### PR DESCRIPTION
### Motivation and Context

Resolve build warning introduced by #10156.

### Description

* Fix uninitialized variable in `zstream redup` command.  The
  'rdt.ddt_count' variable is uninitialized because it was
  allocated from the stack and not globally.  Initialize it.
  This was reported by gcc when compiling with debugging enabled.
    
    zstream_redup.c:157:16: error: 'rdt.ddt_count' may be used
    uninitialized in this function [-Werror=maybe-uninitialized]
    
* Remove the cmd/zstreamdump/.gitignore file.  It's no longer
  needed now that the zstreamdump command is a script.

### How Has This Been Tested?

Locally compiled with the fix applied to verify the warning was resolved.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
