### PR TITLE
sys/mnttab.h: include sys/stat.h for stat64

### DIFF
--- a/lib/libspl/include/os/linux/sys/mnttab.h
+++ b/lib/libspl/include/os/linux/sys/mnttab.h
@@ -32,6 +32,7 @@
 
 #include <stdio.h>
 #include <mntent.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 
 #ifdef MNTTAB
@@ -67,7 +68,6 @@ struct extmnttab {
 	uint_t mnt_minor;
 };
 
-struct stat64;
 struct statfs;
 
 extern int getmntany(FILE *fp, struct mnttab *mp, struct mnttab *mpref);


### PR DESCRIPTION
### Motivation and Context
Currently building ZFS on a musl-libc based system yield this error:

```
os/linux/getmntany.c:106:1: error: conflicting types for 'getextmntent'
getextmntent(const char *path, struct extmnttab *entry, struct stat64 *statbuf)
^
../../lib/libspl/include/os/linux/sys/mnttab.h:75:12: note: previous declaration is here
extern int getextmntent(const char *path, struct extmnttab *mp,
           ^
1 error generated.
```

This is due to musl `<sys/stat.h>` defines `stat64` as a macro.

### Description
Includes `<sys/stat.h>` directly from `linux/sys/mnttab.h` to get the correct `struct stat64`.

### How Has This Been Tested?
Successfully built and run on my system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
