### PR TITLE
Add bootfs.snapshot and bootfs.rollback kernel parameters

### DIFF
--- a/contrib/dracut/90zfs/.gitignore
+++ b/contrib/dracut/90zfs/.gitignore
@@ -7,3 +7,5 @@ zfs-lib.sh
 zfs-load-key.sh
 zfs-needshutdown.sh
 zfs-env-bootfs.service
+zfs-snapshot-bootfs.service
+zfs-rollback-bootfs.service

--- a/contrib/dracut/90zfs/Makefile.am
+++ b/contrib/dracut/90zfs/Makefile.am
@@ -10,7 +10,9 @@ pkgdracut_SCRIPTS = \
 	zfs-lib.sh
 
 pkgdracut_DATA = \
-	zfs-env-bootfs.service
+	zfs-env-bootfs.service \
+	zfs-snapshot-bootfs.service \
+	zfs-rollback-bootfs.service
 
 EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/export-zfs.sh.in \
@@ -21,7 +23,9 @@ EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-load-key.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-needshutdown.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-lib.sh.in \
-	$(top_srcdir)/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-env-bootfs.service.in \
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in \
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
 
 $(pkgdracut_SCRIPTS) $(pkgdracut_DATA) :%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -109,5 +109,12 @@ install() {
 			ln -s ../zfs-import.target "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target
 			type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import.target
 		fi
+		for _service in zfs-snapshot-bootfs.service zfs-rollback-bootfs.service ; do
+			inst "${moddir}"/$_service "${systemdsystemunitdir}"/$_service
+			if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/$_service ]; then
+				ln -s ../$_service "${initdir}/$systemdsystemunitdir/initrd.target.wants"/$_service
+				type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/$_service
+			fi
+		done
 	fi
 }

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -113,7 +113,6 @@ install() {
 			inst "${moddir}"/$_service "${systemdsystemunitdir}"/$_service
 			if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/$_service ]; then
 				ln -s ../$_service "${initdir}/$systemdsystemunitdir/initrd.target.wants"/$_service
-				type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/$_service
 			fi
 		done
 	fi

--- a/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Rollback bootfs just before it is mounted
+Requisite=zfs-import.target
+After=zfs-import.target zfs-snapshot-bootfs.service
+Before=dracut-mount.service
+DefaultDependencies=no
+ConditionKernelCommandLine=bootfs.rollback
+
+[Service]
+# ${BOOTFS} should have been set by zfs-env-bootfs.service
+Type=oneshot
+ExecStartPre=/bin/sh -c 'test -n "${BOOTFS}"'
+ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; /sbin/zfs rollback "${BOOTFS}@${SNAPNAME:-%v}"'
+RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
@@ -10,5 +10,5 @@ ConditionKernelCommandLine=bootfs.rollback
 # ${BOOTFS} should have been set by zfs-env-bootfs.service
 Type=oneshot
 ExecStartPre=/bin/sh -c 'test -n "${BOOTFS}"'
-ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; /sbin/zfs rollback "${BOOTFS}@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; /sbin/zfs rollback -Rf "${BOOTFS}@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Snapshot bootfs just before it is mounted
+Requisite=zfs-import.target
+After=zfs-import.target
+Before=dracut-mount.service
+DefaultDependencies=no
+ConditionKernelCommandLine=bootfs.snapshot
+
+[Service]
+# ${BOOTFS} should have been set by zfs-env-bootfs.service
+Type=oneshot
+ExecStartPre=/bin/sh -c 'test -n "${BOOTFS}"'
+ExecStart=-/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.snapshot)"; /sbin/zfs snapshot "${BOOTFS}@${SNAPNAME:-%v}"'
+RemainAfterExit=yes


### PR DESCRIPTION
Unlike other filesystems, snapshots and rollbacks of bootfs need to be
done from a rescue environment. This patch makes it possible to snap-
shot or rollback the bootfs simply by specifying bootfs.snapshot or
bootfs.rollback on the kernel command line. The operation will be
performed by dracut just before bootfs is mounted.

Signed-off-by: Gregory Bartholomew <gregory.lee.bartholomew@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a feature enhancement to make creating snapshots of the bootfs and rolling them back easier.

### Description
<!--- Describe your changes in detail -->
This patch adds two simple systemd services to be included in the user's initramfs if they are using systemd and dracut. The services are conditioned on the bootfs.snapshot and bootfs.rollback kernel parameters being present. So they will not do anything if neither options are set. If the bootfs.snapshot kernel parameter is present, a snapshot of the bootfs will be created just before it is mounted. If the bootfs.rollback parameter is present, an attempt will be made to rollback the bootfs just before it is mounted. The default name for the snapshot is the current kernel version string. A name can be specified by assigning the desired value to the kernel parameter (e.g. bootfs.snapshot=temp). One advantage of leaving the default value is that a new snapshot of your bootfs will be automatically created every time you upgrade your kernel if you leave the bootfs.snapshot parameter set in /etc/kernel/cmdline (or where ever your boot loader sets the kernel command line).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I have only done minimal testing of this patch on my personal computer (Fedora 31). The patch is pretty simple though, so I don't anticipate many problems.

I am submitting this as a draft pull request because it is my first (ever) attempt at submitting a pull request. I've probably missed many things/steps. Please let me know what I need to do to move this along if you are interested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
