### PR TITLE
Add more sanity testing for zdb input args

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -103,8 +103,8 @@ tests = [ 'clean_mirror_001_pos', 'clean_mirror_002_pos',
 tags = ['functional', 'clean_mirror']
 
 [tests/functional/cli_root/zdb]
-tests = ['zdb_001_neg', 'zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos',
-    'zdb_005_pos', 'zdb_006_pos', 'zdb_checksum', 'zdb_decompress',
+tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
+    'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos', 'zdb_checksum', 'zdb_decompress',
     'zdb_object_range_neg', 'zdb_object_range_pos', 'zdb_display_block',
     'zdb_objset_id']
 pre =

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -1,11 +1,12 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zdb
 dist_pkgdata_SCRIPTS = \
-	zdb_001_neg.ksh \
 	zdb_002_pos.ksh \
 	zdb_003_pos.ksh \
 	zdb_004_pos.ksh \
 	zdb_005_pos.ksh \
 	zdb_006_pos.ksh \
+	zdb_args_neg.ksh \
+	zdb_args_pos.ksh \
 	zdb_checksum.ksh \
 	zdb_decompress.ksh \
 	zdb_object_range_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
@@ -56,18 +56,28 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "add mirror fakepool" "add raidz fakepool" \
     "add raidz1 fakepool" "add raidz2 fakepool" \
     "setvprop" "blah blah" "-%" "--?" "-*" "-=" \
-    "-a" "-f" "-g" "-h" "-j" "-m" "-n" "-o" "-p" \
-    "-p /tmp" "-r" "-t" "-w" "-x" "-y" "-z" \
-    "-D" "-E" "-G" "-H" "-I" "-J" "-K" "-M" \
-    "-N" "-Q" "-R" "-S" "-T" "-W" "-Z"
+    "-a" "-f" "-g" "-j" "-n" "-o" "-p" "-p /tmp" "-r" \
+    "-t" "-w" "-y" "-z" "-E" "-H" "-I" "-J" "-K" \
+    "-N" "-Q" "-R" "-T" "-W" "-Z"
 
 log_assert "Execute zdb using invalid parameters."
 
-typeset -i i=0
-while [[ $i -lt ${#args[*]} ]]; do
-	log_mustnot zdb ${args[i]}
+log_onexit cleanup
 
-	((i = i + 1))
-done
+function cleanup
+{
+	default_cleanup_noexit
+}
+
+function test_imported_pool
+{
+	for i in ${args[@]}; do
+		log_mustnot zdb $i $TESTPOOL
+	done
+}
+
+default_mirror_setup_noexit $DISKS
+
+test_imported_pool
 
 log_pass "Badly formed zdb parameters fail as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_pos.ksh
@@ -1,0 +1,104 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2012, 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZDB allows a large number of possible inputs
+# and combinations of those inputs. Test for non-zero
+# exit values. These input options are based on the zdb
+# man page
+#
+# STRATEGY:
+# 1. Create an array containing value zdb parameters.
+# 2. For each element, execute the sub-command.
+# 3. Verify it does not return a error.
+#
+
+verify_runnable "global"
+
+log_assert "Execute zdb using valid parameters."
+
+log_onexit cleanup
+
+function cleanup
+{
+	default_cleanup_noexit
+}
+
+function test_imported_pool
+{
+	typeset -a args=("-A" "-b" "-C" "-c" "-d" "-D" "-G" "-h" "-i" "-L" \
+            "-M" "-P" "-s" "-v" "-Y")
+        for i in ${args[@]}; do
+		log_must eval "zdb $i $TESTPOOL >/dev/null"
+	done
+}
+
+function test_exported_pool
+{
+	log_must zpool export $TESTPOOL
+	typeset -a args=("-A" "-b" "-C" "-c" "-d" "-D" "-F" "-G" "-h" "-i" "-L" "-M" \
+            "-P" "-s" "-v" "-X" "-Y")
+        for i in ${args[@]}; do
+		log_must eval "zdb -e $i $TESTPOOL >/dev/null"
+	done
+	log_must zpool import $TESTPOOL
+}
+
+function test_vdev
+{
+	typeset -a args=("-A" "-q" "-u" "-Aqu")
+	VDEVS=$(get_pool_devices ${TESTPOOL} ${DEV_RDSKDIR})
+	log_note $VDEVS
+	set -A VDEV_ARRAY $VDEVS
+        for i in ${args[@]}; do
+		log_must eval "zdb -l $i ${VDEV_ARRAY[0]} >/dev/null"
+	done
+}
+
+function test_metaslab
+{
+	typeset -a args=("-A" "-L" "-P" "-Y")
+        for i in ${args[@]}; do
+		log_must eval "zdb -m $i $TESTPOOL >/dev/null"
+	done
+}
+
+default_mirror_setup_noexit $DISKS
+
+test_imported_pool
+test_exported_pool
+test_vdev
+test_metaslab
+
+log_pass "Valid zdb parameters pass as expected."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There's a lot going on in ZDB, in the past as I've expanded it's features I've accidentally introduced regressions. I decided to take a stab at extending some of our testing. 
### Description
<!--- Describe your changes in detail -->
Add positive argument testing to confirm that flags that we expect to be available don't result in failures or crashes. 

Modify the existing negative arg test to have a more explicit name and correct the test by adding a `pool` argument to the zdb invocation (some tests with valid flags were erroneously passing because they were missing the pool arg).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
