### PR TITLE
Fix unitialized variable in `zstream redup` command

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -308,7 +308,7 @@ zfs_redup_stream(int infd, int outfd, boolean_t verbose)
 			 * record with the found WRITE record, but with
 			 * drr_object,drr_offset,drr_toguid replaced with ours.
 			 */
-			uint64_t stream_offset;
+			uint64_t stream_offset = 0;
 			rdt_lookup(&rdt, drrwb.drr_refguid,
 			    drrwb.drr_refobject, drrwb.drr_refoffset,
 			    &stream_offset);


### PR DESCRIPTION
### Motivation and Context

Issue #10241 .

### Description

Fix uninitialized variable in `zstream redup` command.  The compiler
may determine the 'stream_offset' variable can be uninitialized
because not all rdt_lookup() exit paths set it.  This should never
happen in practice as documented by the assert, but initialize it
regardless to resolve the warning.

### How Has This Been Tested?

Locally compiled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
