### PR TITLE
config/kernel-inode-times: initialize timespec

### DIFF
--- a/config/kernel-inode-times.m4
+++ b/config/kernel-inode-times.m4
@@ -10,6 +10,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_TIMES], [
 		struct timespec64 ts;
 		struct inode ip;
 
+		memset(&ts, 0, sizeof(ts));
 		ts = timestamp_truncate(ts, &ip);
 	])
 


### PR DESCRIPTION
### Motivation and Context
Usage of the uninitalized `timespec64` triggers `-Werror,-Wuninitialized`
when compiled under clang for linux kernel 5.6, leading the build system
to believe that the function is not declared. This in turn breaks the build.

See #10279 

### Description
Initializes the said variable to suppress the warning.

### How Has This Been Tested?
Tested on my own system.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
