### PR TITLE
Use online CPUs rather than max_ncpus for taskq thread count

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7348,8 +7348,8 @@ arc_init(void)
 	    offsetof(arc_prune_t, p_node));
 	mutex_init(&arc_prune_mtx, NULL, MUTEX_DEFAULT, NULL);
 
-	arc_prune_taskq = taskq_create("arc_prune", max_ncpus, defclsyspri,
-	    max_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
+	arc_prune_taskq = taskq_create("arc_prune", boot_ncpus, defclsyspri,
+	    boot_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 
 	arc_ksp = kstat_create("zfs", 0, "arcstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (arc_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -220,10 +220,10 @@ dsl_pool_open_impl(spa_t *spa, uint64_t txg)
 	mutex_init(&dp->dp_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&dp->dp_spaceavail_cv, NULL, CV_DEFAULT, NULL);
 
-	dp->dp_zrele_taskq = taskq_create("z_zrele", max_ncpus, defclsyspri,
-	    max_ncpus * 8, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
+	dp->dp_zrele_taskq = taskq_create("z_zrele", boot_ncpus, defclsyspri,
+	    boot_ncpus * 8, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	dp->dp_unlinked_drain_taskq = taskq_create("z_unlinked_drain",
-	    max_ncpus, defclsyspri, max_ncpus, INT_MAX,
+	    boot_ncpus, defclsyspri, boot_ncpus, INT_MAX,
 	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 
 	return (dp);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -453,7 +453,7 @@ txg_dispatch_callbacks(dsl_pool_t *dp, uint64_t txg)
 			 * Commit callback taskq hasn't been created yet.
 			 */
 			tx->tx_commit_cb_taskq = taskq_create("tx_commit_cb",
-			    max_ncpus, defclsyspri, max_ncpus, max_ncpus * 2,
+			    boot_ncpus, defclsyspri, boot_ncpus, boot_ncpus * 2,
 			    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 		}
 


### PR DESCRIPTION
Some systems have issues or allow CPU hotplugging that can make
max_cpus absurdly large. As these systems are rare and the
consequences of too many threads can be debilitating limit this
to a known good value.

Signed-off-by: DHE <git@dehacked.net>

### Motivation and Context
I have a machine where, for some reason, num_possible_cpus() returns 440. The correct number of CPUs/cores/threads in this system is 32. Don't know if that's a BIOS bug or something else, but having 440 instances of `arc_prune` "working" is a disaster.

I don't know if there's a better fix, but for now I'm drawing attention to what kills my system.

Alternative workaround: kernel commandline option `nr_cpus=32` for this system.

### Description
Change `max_cpus` to be the same as `boot_cpus`

### How Has This Been Tested?
Build tested as a trivial change

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
