### PR TITLE
mount: use the mount syscall directly

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7319,9 +7319,6 @@ unshare_unmount(int op, int argc, char **argv)
 			const char *mntarg = NULL;
 
 			uu_avl_remove(tree, node);
-#ifndef __FreeBSD__
-			mntarg = node->un_zhp->zfs_name;
-#endif
 			switch (op) {
 			case OP_SHARE:
 				if (zfs_unshareall_bytype(node->un_zhp,

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -801,6 +801,13 @@ extern int zfs_mount_at(zfs_handle_t *, const char *, int, const char *);
 extern int zfs_unmount(zfs_handle_t *, const char *, int);
 extern int zfs_unmountall(zfs_handle_t *, int);
 
+#if defined(__linux__)
+extern int zfs_parse_mount_options(char *mntopts, unsigned long *mntflags,
+    unsigned long *zfsflags, int sloppy, char *badopt, char *mtabopt);
+extern void zfs_adjust_mount_options(zfs_handle_t *zhp, const char *mntpoint,
+    char *mntopts, char *mtabopt);
+#endif
+
 /*
  * Share support functions.
  */

--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -246,7 +246,8 @@ typedef struct differ_info {
 
 extern proto_table_t proto_table[PROTO_END];
 
-extern int do_mount(const char *src, const char *mntpt, char *opts, int flags);
+extern int do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts,
+    int flags);
 extern int do_unmount(const char *mntpt, int flags);
 extern int zfs_mount_delegation_check(void);
 extern int zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto);

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -500,7 +500,7 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 	}
 
 	/* perform the mount */
-	rc = do_mount(zfs_get_name(zhp), mountpoint, mntopts, flags);
+	rc = do_mount(zhp, mountpoint, mntopts, flags);
 	if (rc) {
 		/*
 		 * Generic errors are nasty, but there are just way too many

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -41,6 +41,7 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <sys/mnttab.h>
 #include <sys/errno.h>
+#include <libzfs.h>
 
 static void
 build_iovec(struct iovec **iov, int *iovlen, const char *name, void *val,
@@ -115,11 +116,11 @@ do_mount_(const char *spec, const char *dir, int mflag, char *fstype,
 }
 
 int
-do_mount(const char *src, const char *mntpt, char *opts, int flags)
+do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts, int flags)
 {
 
-	return (do_mount_(src, mntpt, flags, MNTTYPE_ZFS, NULL, 0, opts,
-	    sizeof (mntpt)));
+	return (do_mount_(zfs_get_name(zhp), mntpt, flags, MNTTYPE_ZFS, NULL, 0,
+	    opts, sizeof (mntpt)));
 }
 
 int

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -282,7 +282,268 @@ is_shared_impl(libzfs_handle_t *hdl, const char *mountpoint,
 	return (SHARED_NOT_SHARED);
 }
 
+
+#define	ZS_COMMENT	0x00000000	/* comment */
+#define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */
+
+typedef struct option_map {
+	const char *name;
+	unsigned long mntmask;
+	unsigned long zfsmask;
+} option_map_t;
+
+static const option_map_t option_map[] = {
+	/* Canonicalized filesystem independent options from mount(8) */
+	{ MNTOPT_NOAUTO,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_DEFAULTS,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_NODEVICES,	MS_NODEV,	ZS_COMMENT	},
+	{ MNTOPT_DEVICES,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_DIRSYNC,	MS_DIRSYNC,	ZS_COMMENT	},
+	{ MNTOPT_NOEXEC,	MS_NOEXEC,	ZS_COMMENT	},
+	{ MNTOPT_EXEC,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_GROUP,		MS_GROUP,	ZS_COMMENT	},
+	{ MNTOPT_NETDEV,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_NOFAIL,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_NOSUID,	MS_NOSUID,	ZS_COMMENT	},
+	{ MNTOPT_SUID,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_OWNER,		MS_OWNER,	ZS_COMMENT	},
+	{ MNTOPT_REMOUNT,	MS_REMOUNT,	ZS_COMMENT	},
+	{ MNTOPT_RO,		MS_RDONLY,	ZS_COMMENT	},
+	{ MNTOPT_RW,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_SYNC,		MS_SYNCHRONOUS,	ZS_COMMENT	},
+	{ MNTOPT_USER,		MS_USERS,	ZS_COMMENT	},
+	{ MNTOPT_USERS,		MS_USERS,	ZS_COMMENT	},
+	/* acl flags passed with util-linux-2.24 mount command */
+	{ MNTOPT_ACL,		MS_POSIXACL,	ZS_COMMENT	},
+	{ MNTOPT_NOACL,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_POSIXACL,	MS_POSIXACL,	ZS_COMMENT	},
+#ifdef MS_NOATIME
+	{ MNTOPT_NOATIME,	MS_NOATIME,	ZS_COMMENT	},
+	{ MNTOPT_ATIME,		MS_COMMENT,	ZS_COMMENT	},
+#endif
+#ifdef MS_NODIRATIME
+	{ MNTOPT_NODIRATIME,	MS_NODIRATIME,	ZS_COMMENT	},
+	{ MNTOPT_DIRATIME,	MS_COMMENT,	ZS_COMMENT	},
+#endif
+#ifdef MS_RELATIME
+	{ MNTOPT_RELATIME,	MS_RELATIME,	ZS_COMMENT	},
+	{ MNTOPT_NORELATIME,	MS_COMMENT,	ZS_COMMENT	},
+#endif
+#ifdef MS_STRICTATIME
+	{ MNTOPT_STRICTATIME,	MS_STRICTATIME,	ZS_COMMENT	},
+	{ MNTOPT_NOSTRICTATIME,	MS_COMMENT,	ZS_COMMENT	},
+#endif
+#ifdef MS_LAZYTIME
+	{ MNTOPT_LAZYTIME,	MS_LAZYTIME,	ZS_COMMENT	},
+#endif
+	{ MNTOPT_CONTEXT,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_FSCONTEXT,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_DEFCONTEXT,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_ROOTCONTEXT,	MS_COMMENT,	ZS_COMMENT	},
+#ifdef MS_I_VERSION
+	{ MNTOPT_IVERSION,	MS_I_VERSION,	ZS_COMMENT	},
+#endif
+#ifdef MS_MANDLOCK
+	{ MNTOPT_NBMAND,	MS_MANDLOCK,	ZS_COMMENT	},
+	{ MNTOPT_NONBMAND,	MS_COMMENT,	ZS_COMMENT	},
+#endif
+	/* Valid options not found in mount(8) */
+	{ MNTOPT_BIND,		MS_BIND,	ZS_COMMENT	},
+#ifdef MS_REC
+	{ MNTOPT_RBIND,		MS_BIND|MS_REC,	ZS_COMMENT	},
+#endif
+	{ MNTOPT_COMMENT,	MS_COMMENT,	ZS_COMMENT	},
+#ifdef MS_NOSUB
+	{ MNTOPT_NOSUB,		MS_NOSUB,	ZS_COMMENT	},
+#endif
+#ifdef MS_SILENT
+	{ MNTOPT_QUIET,		MS_SILENT,	ZS_COMMENT	},
+#endif
+	/* Custom zfs options */
+	{ MNTOPT_XATTR,		MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_NOXATTR,	MS_COMMENT,	ZS_COMMENT	},
+	{ MNTOPT_ZFSUTIL,	MS_COMMENT,	ZS_ZFSUTIL	},
+	{ NULL,			0,		0		} };
+
 /*
+ * Break the mount option in to a name/value pair.  The name is
+ * validated against the option map and mount flags set accordingly.
+ */
+static int
+parse_option(char *mntopt, unsigned long *mntflags,
+    unsigned long *zfsflags, int sloppy)
+{
+	const option_map_t *opt;
+	char *ptr, *name, *value = NULL;
+	int error = 0;
+
+	name = strdup(mntopt);
+	if (name == NULL)
+		return (ENOMEM);
+
+	for (ptr = name; ptr && *ptr; ptr++) {
+		if (*ptr == '=') {
+			*ptr = '\0';
+			value = ptr+1;
+			VERIFY3P(value, !=, NULL);
+			break;
+		}
+	}
+
+	for (opt = option_map; opt->name != NULL; opt++) {
+		if (strncmp(name, opt->name, strlen(name)) == 0) {
+			*mntflags |= opt->mntmask;
+			*zfsflags |= opt->zfsmask;
+			error = 0;
+			goto out;
+		}
+	}
+
+	if (!sloppy)
+		error = ENOENT;
+out:
+	/* If required further process on the value may be done here */
+	free(name);
+	return (error);
+}
+
+/*
+ * Translate the mount option string in to MS_* mount flags for the
+ * kernel vfs.  When sloppy is non-zero unknown options will be ignored
+ * otherwise they are considered fatal are copied in to badopt.
+ */
+int
+zfs_parse_mount_options(char *mntopts, unsigned long *mntflags,
+    unsigned long *zfsflags, int sloppy, char *badopt, char *mtabopt)
+{
+	int error = 0, quote = 0, flag = 0, count = 0;
+	char *ptr, *opt, *opts;
+
+	opts = strdup(mntopts);
+	if (opts == NULL)
+		return (ENOMEM);
+
+	*mntflags = 0;
+	opt = NULL;
+
+	/*
+	 * Scan through all mount options which must be comma delimited.
+	 * We must be careful to notice regions which are double quoted
+	 * and skip commas in these regions.  Each option is then checked
+	 * to determine if it is a known option.
+	 */
+	for (ptr = opts; ptr && !flag; ptr++) {
+		if (opt == NULL)
+			opt = ptr;
+
+		if (*ptr == '"')
+			quote = !quote;
+
+		if (quote)
+			continue;
+
+		if (*ptr == '\0')
+			flag = 1;
+
+		if ((*ptr == ',') || (*ptr == '\0')) {
+			*ptr = '\0';
+
+			error = parse_option(opt, mntflags, zfsflags, sloppy);
+			if (error) {
+				strcpy(badopt, opt);
+				goto out;
+
+			}
+
+			if (!(*mntflags & MS_REMOUNT) &&
+			    !(*zfsflags & ZS_ZFSUTIL) &&
+			    mtabopt != NULL) {
+				if (count > 0)
+					strlcat(mtabopt, ",", MNT_LINE_MAX);
+
+				strlcat(mtabopt, opt, MNT_LINE_MAX);
+				count++;
+			}
+
+			opt = NULL;
+		}
+	}
+
+out:
+	free(opts);
+	return (error);
+}
+
+static void
+append_mntopt(const char *name, const char *val, char *mntopts,
+    char *mtabopt, boolean_t quote)
+{
+	char tmp[MNT_LINE_MAX];
+
+	snprintf(tmp, MNT_LINE_MAX, quote ? ",%s=\"%s\"" : ",%s=%s", name, val);
+
+	if (mntopts)
+		strlcat(mntopts, tmp, MNT_LINE_MAX);
+
+	if (mtabopt)
+		strlcat(mtabopt, tmp, MNT_LINE_MAX);
+}
+
+static void
+zfs_selinux_setcontext(zfs_handle_t *zhp, zfs_prop_t zpt, const char *name,
+    char *mntopts, char *mtabopt)
+{
+	char context[ZFS_MAXPROPLEN];
+
+	if (zfs_prop_get(zhp, zpt, context, sizeof (context),
+	    NULL, NULL, 0, B_FALSE) == 0) {
+		if (strcmp(context, "none") != 0)
+			append_mntopt(name, context, mntopts, mtabopt, B_TRUE);
+	}
+}
+
+void
+zfs_adjust_mount_options(zfs_handle_t *zhp, const char *mntpoint,
+    char *mntopts, char *mtabopt)
+{
+	char prop[ZFS_MAXPROPLEN];
+
+	/*
+	 * Checks to see if the ZFS_PROP_SELINUX_CONTEXT exists
+	 * if it does, create a tmp variable in case it's needed
+	 * checks to see if the selinux context is set to the default
+	 * if it is, allow the setting of the other context properties
+	 * this is needed because the 'context' property overrides others
+	 * if it is not the default, set the 'context' property
+	 */
+	if (zfs_prop_get(zhp, ZFS_PROP_SELINUX_CONTEXT, prop, sizeof (prop),
+	    NULL, NULL, 0, B_FALSE) == 0) {
+		if (strcmp(prop, "none") == 0) {
+			zfs_selinux_setcontext(zhp, ZFS_PROP_SELINUX_FSCONTEXT,
+			    MNTOPT_FSCONTEXT, mntopts, mtabopt);
+			zfs_selinux_setcontext(zhp, ZFS_PROP_SELINUX_DEFCONTEXT,
+			    MNTOPT_DEFCONTEXT, mntopts, mtabopt);
+			zfs_selinux_setcontext(zhp,
+			    ZFS_PROP_SELINUX_ROOTCONTEXT, MNTOPT_ROOTCONTEXT,
+			    mntopts, mtabopt);
+		} else {
+			append_mntopt(MNTOPT_CONTEXT, prop,
+			    mntopts, mtabopt, B_TRUE);
+		}
+	}
+
+	/* A hint used to determine an auto-mounted snapshot mount point */
+	append_mntopt(MNTOPT_MNTPOINT, mntpoint, mntopts, NULL, B_FALSE);
+}
+
+/*
+ * By default the filesystem by preparing the mount options (i.e. parsing
+ * some flags from the "opts" parameter into the "flags" parameter) and then
+ * directly calling the system call mount(2). We don't need the mount utility
+ * or update /etc/mtab, because this is a symlink on all modern systems.
+ *
+ * If the environment variable ZFS_MOUNT_HELPER is set, we fall back to the
+ * previous behavior:
  * The filesystem is mounted by invoking the system mount utility rather
  * than by the system call mount(2).  This ensures that the /etc/mtab
  * file is correctly locked for the update.  Performing our own locking
@@ -290,52 +551,66 @@ is_shared_impl(libzfs_handle_t *hdl, const char *mountpoint,
  * the mount utility performs its locking.  Unfortunately, this also means
  * in the case of a mount failure we do not have the exact errno.  We must
  * make due with return value from the mount process.
- *
- * In the long term a shared library called libmount is under development
- * which provides a common API to address the locking and errno issues.
- * Once the standard mount utility has been updated to use this library
- * we can add an autoconf check to conditionally use it.
- *
- * http://www.kernel.org/pub/linux/utils/util-linux/libmount-docs/index.html
  */
 int
-do_mount(const char *src, const char *mntpt, char *opts, int flags)
+do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts, int flags)
 {
-	char *argv[9] = {
-	    "/bin/mount",
-	    "--no-canonicalize",
-	    "-t", MNTTYPE_ZFS,
-	    "-o", opts,
-	    (char *)src,
-	    (char *)mntpt,
-	    (char *)NULL };
-	int rc;
+	const char *src = zfs_get_name(zhp);
+	int error = 0;
 
-	/* Return only the most critical mount error */
-	rc = libzfs_run_process(argv[0], argv, STDOUT_VERBOSE|STDERR_VERBOSE);
-	if (rc) {
-		if (rc & MOUNT_FILEIO)
-			return (EIO);
-		if (rc & MOUNT_USER)
-			return (EINTR);
-		if (rc & MOUNT_SOFTWARE)
-			return (EPIPE);
-		if (rc & MOUNT_BUSY)
-			return (EBUSY);
-		if (rc & MOUNT_SYSERR)
-			return (EAGAIN);
-		if (rc & MOUNT_USAGE)
+	if (!libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
+		char badopt[MNT_LINE_MAX] = {0};
+		unsigned long mntflags = flags, zfsflags;
+		char myopts[MNT_LINE_MAX] = {0};
+
+		if (zfs_parse_mount_options(opts, &mntflags,
+		    &zfsflags, 0, badopt, NULL)) {
 			return (EINVAL);
+		}
+		strlcat(myopts, opts, MNT_LINE_MAX);
+		zfs_adjust_mount_options(zhp, mntpt, myopts, NULL);
+		error = mount(src, mntpt, MNTTYPE_ZFS, mntflags, myopts);
+	} else {
+		char *argv[9] = {
+		    "/bin/mount",
+		    "--no-canonicalize",
+		    "-t", MNTTYPE_ZFS,
+		    "-o", opts,
+		    (char *)src,
+		    (char *)mntpt,
+		    (char *)NULL };
 
-		return (ENXIO); /* Generic error */
+		/* Return only the most critical mount error */
+		error = libzfs_run_process(argv[0], argv,
+		    STDOUT_VERBOSE|STDERR_VERBOSE);
+		if (error) {
+			if (error & MOUNT_FILEIO) {
+				error = EIO;
+			} else if (error & MOUNT_USER) {
+				error = EINTR;
+			} else if (error & MOUNT_SOFTWARE) {
+				error = EPIPE;
+			} else if (error & MOUNT_BUSY) {
+				error = EBUSY;
+			} else if (error & MOUNT_SYSERR) {
+				error = EAGAIN;
+			} else if (error & MOUNT_USAGE) {
+				error = EINVAL;
+			} else
+				error = ENXIO; /* Generic error */
+		}
 	}
 
-	return (0);
+	return (error);
 }
 
 int
 do_unmount(const char *mntpt, int flags)
 {
+	if (!libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
+		return (umount2(mntpt, flags));
+	}
+
 	char force_opt[] = "-f";
 	char lazy_opt[] = "-l";
 	char *argv[7] = {

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -710,6 +710,15 @@ Do note that any changes done with the
 .Xr net 8
 command will be undone if the share is ever unshared (such as at a reboot etc).
 .El
+.Sh ENVIRONMENT VARIABLES
+.Bl -tag -width "ZFS_MOUNT_HELPER"
+.It Ev ZFS_MOUNT_HELPER
+Cause
+.Nm zfs mount
+to use
+.Em /bin/mount
+to mount zfs datasets. This option is provided for backwards compatibility with older zfs versions.
+.El
 .Sh INTERFACE STABILITY
 .Sy Committed .
 .Sh SEE ALSO

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -675,7 +675,7 @@ function test_fs_setup
 	datasetexists $recvfs && log_must_busy zfs destroy -r $recvpool
 	datasetexists $streamfs && log_must_busy zfs destroy -r $streamfs
 
-	if $(datasetexists $sendfs || zfs create -o compress=lz4 $sendfs); then
+	if datasetexists $sendfs || zfs create -o compress=lz4 $sendfs; then
 		mk_files 1000 256 0 $sendfs &
 		mk_files 1000 131072 0 $sendfs &
 		mk_files 100 1048576 0 $sendfs &


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This is just a draft change to understand if/how using mount directly breaks any test cases.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation behind this PR is to be able to mount zfs datasets without the invocation of external processes. This allows the mounting to be used from inside a pam module. Spawning processes from within a pam module is highly discouraged as the application might be confused by the additional child processes.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
For now some mount-related unit tests have been executed locally and they passed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

I am not sure, how I would classify this PR. It can be seen both as a new feature but also as a cleanup/bugfix kind of change.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
