### PR TITLE
Fixed LDADD library links in Makefiles for cross compilation builds.

### DIFF
--- a/cmd/mount_zfs/Makefile.am
+++ b/cmd/mount_zfs/Makefile.am
@@ -14,4 +14,5 @@ mount_zfs_SOURCES = \
 
 mount_zfs_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/raidz_test/Makefile.am
+++ b/cmd/raidz_test/Makefile.am
@@ -14,6 +14,7 @@ raidz_test_SOURCES = \
 	raidz_bench.c
 
 raidz_test_LDADD = \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libzpool/libzpool.la
 
 raidz_test_LDADD += -lm -ldl

--- a/cmd/zed/Makefile.am
+++ b/cmd/zed/Makefile.am
@@ -38,6 +38,7 @@ zed_SOURCES = $(ZED_SRC) $(FMA_SRC)
 zed_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la
 
 zed_LDADD += -lrt

--- a/cmd/zinject/Makefile.am
+++ b/cmd/zinject/Makefile.am
@@ -9,4 +9,5 @@ zinject_SOURCES = \
 
 zinject_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -22,6 +22,7 @@ endif
 zpool_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la
 
 if BUILD_FREEBSD

--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -10,4 +10,5 @@ zstream_SOURCES = \
 
 zstream_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la

--- a/tests/zfs-tests/cmd/btree_test/Makefile.am
+++ b/tests/zfs-tests/cmd/btree_test/Makefile.am
@@ -29,4 +29,5 @@ btree_test_SOURCES = btree_test.c
 
 btree_test_LDADD = \
 	$(top_builddir)/lib/libavl/libavl.la \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libzpool/libzpool.la

--- a/tests/zfs-tests/tests/functional/hkdf/Makefile.am
+++ b/tests/zfs-tests/tests/functional/hkdf/Makefile.am
@@ -1,6 +1,8 @@
 include $(top_srcdir)/config/Rules.am
 
-LDADD = $(top_builddir)/lib/libzpool/libzpool.la
+LDADD = \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzpool/libzpool.la
 
 AUTOMAKE_OPTIONS = subdir-objects
 

--- a/tests/zfs-tests/tests/functional/libzfs/Makefile.am
+++ b/tests/zfs-tests/tests/functional/libzfs/Makefile.am
@@ -10,6 +10,8 @@ dist_pkgdata_SCRIPTS = \
 	libzfs_input.ksh
 
 many_fds_LDADD = \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la \
 	$(top_builddir)/lib/libzfs/libzfs.la
 
 pkgexec_PROGRAMS = many_fds


### PR DESCRIPTION
### Motivation and Context

When building on native dev system, there are no issues but when cross-compiling for a target system (even after running `./autogen.sh && ./configure`), some linker errors are observed. See example error below:

```
make[5]: Entering directory '/home/petros/devel/hyve-os/packages/zfs/tests/zfs-tests/cmd/btree_test'
  CC       btree_test.o
  CCLD     btree_test
../../../../lib/libzpool/.libs/libzpool.so: undefined reference to `fnvlist_pack_xdr'
collect2: error: ld returned 1 exit status
Makefile:723: recipe for target 'btree_test' failed
make[5]: *** [btree_test] Error 1
```

### Description

The only way to avoid these errors is by adjusting the `Makefile.am` of those various components to add the library dependencies.

### How Has This Been Tested?

This has been built and the affected utilities have been functional tested in both the native dev environment (running Ubuntu Server 18.04 LTS) and again in the cross-compiled target environment (running a custom minimal LFS distribution using the 5.4.37 kernel, GCC 7.5 and glibc 2.30).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).