### PR TITLE
ZTS: refreserv_005_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
@@ -45,9 +45,9 @@ verify_runnable "global"
 
 function cleanup
 {
-	log_must zfs destroy -rf $TESTPOOL/$TESTFS
-	log_must zfs create $TESTPOOL/$TESTFS
-	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+	destroy_dataset "$fs" "-rf"
+	log_must zfs create $fs
+	log_must zfs set mountpoint=$TESTDIR $fs
 }
 
 log_assert "Volume (ref)reservation is not limited by volsize"


### PR DESCRIPTION
### Motivation and Context

Frequent failures in the CI like this when testing refreserv_005_pos.ksh.

http://build.zfsonlinux.org/builders/Ubuntu%2016.04%20x86_64%20%28TEST%29/builds/11852

### Description

When recursively destroying the dataset it's possible for the
dataset volume to be open by an unrelated process, like blkid.
Use the destroy_dataset() which will retry when this occurs.

TEST_ZFSTESTS_ITERS="50"
TEST_ZFSTESTS_TAGS="refreserv"

### How Has This Been Tested?

Locally verified the test case passes.  However, since this has
been most frequently observed in the CI environment I've
request 50 runs of the test case to verify this change does
resolve the issue as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
