### PR TITLE
Change zfsunlock for better busybox compatibility

### DIFF
--- a/contrib/initramfs/zfsunlock
+++ b/contrib/initramfs/zfsunlock
@@ -25,7 +25,7 @@ while [ ! -e /run/zfs_unlock_complete ]; do
 		/sbin/zfs load-key "$zfs_fs_name" || true
 	if [ "$(/sbin/zfs get -H -ovalue keystatus "$zfs_fs_name" 2> /dev/null)" = "available" ]; then
 		echo "Password for $zfs_fs_name accepted."
-		zfs_console_askpwd_pid=$(ps a -o pid= -o args | grep -v grep | grep "$zfs_console_askpwd_cmd" | cut -d ' ' -f3 | sort -n | head -n1)
+		zfs_console_askpwd_pid=$(ps | awk '!'"/awk/ && /$zfs_console_askpwd_cmd/ { print \$1; exit }")
 		if [ -n "$zfs_console_askpwd_pid" ]; then
 			kill "$zfs_console_askpwd_pid"
 		fi


### PR DESCRIPTION
### Motivation and Context
This addresses an issue with #10027 found by @tcaputi after it was merged. See the discussion starting here: https://github.com/openzfs/zfs/pull/10027#issuecomment-625640255

### Description
It turns out that there are two versions of Busybox, at least on Ubuntu
18.04.  If you have the busybox-static package installed, you get a
busybox that supports `ps a` and `head`.  If you only have
busybox-initramfs, you don't.  Either way, you have `awk`.

This change should also make this compatible with GNU ps, if you somehow
end up with that in the initramfs environment.

### How Has This Been Tested?
I have tested this using busybox on a running system. ~It needs testing by someone in the initramfs before this can be considered for merging.~

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
