### PR TITLE
add async dmu support AND async dbuf_hold

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -311,7 +311,7 @@ dump_packed_nvlist(objset_t *os, uint64_t object, void *data, size_t size)
 	size_t nvsize = *(uint64_t *)data;
 	char *packed = umem_alloc(nvsize, UMEM_NOFAIL);
 
-	VERIFY(0 == dmu_read(os, object, 0, nvsize, packed, DMU_READ_PREFETCH));
+	VERIFY0(dmu_read(os, object, 0, nvsize, packed, DMU_CTX_FLAG_PREFETCH));
 
 	VERIFY(nvlist_unpack(packed, nvsize, &nv, 0) == 0);
 
@@ -923,7 +923,7 @@ dump_spacemap(objset_t *os, space_map_t *sm)
 	    offset += sizeof (word)) {
 
 		VERIFY0(dmu_read(os, space_map_object(sm), offset,
-		    sizeof (word), &word, DMU_READ_PREFETCH));
+		    sizeof (word), &word, DMU_CTX_FLAG_PREFETCH));
 
 		if (sm_entry_is_debug(word)) {
 			(void) printf("\t    [%6llu] %s: txg %llu pass %llu\n",
@@ -954,7 +954,7 @@ dump_spacemap(objset_t *os, space_map_t *sm)
 			offset += sizeof (extra_word);
 			VERIFY0(dmu_read(os, space_map_object(sm), offset,
 			    sizeof (extra_word), &extra_word,
-			    DMU_READ_PREFETCH));
+			    DMU_CTX_FLAG_PREFETCH));
 
 			ASSERT3U(offset, <=, space_map_length(sm));
 

--- a/include/os/freebsd/spl/sys/taskq.h
+++ b/include/os/freebsd/spl/sys/taskq.h
@@ -36,13 +36,14 @@ extern "C" {
 #endif
 
 #define	TASKQ_NAMELEN	31
+typedef void (*taskq_callback_fn)(void *);
 
-struct taskqueue;
-struct taskq {
+typedef struct taskq {
 	struct taskqueue	*tq_queue;
-};
+	taskq_callback_fn	tq_ctor;
+	taskq_callback_fn	tq_dtor;
+} taskq_t;
 
-typedef struct taskq taskq_t;
 typedef uintptr_t taskqid_t;
 typedef void (task_func_t)(void *);
 
@@ -54,8 +55,6 @@ typedef struct taskq_ent {
 	int tqent_type;
 	int tqent_gen;
 } taskq_ent_t;
-
-struct proc;
 
 /*
  * Public flags for taskq_create(): bit range 0-15
@@ -92,7 +91,7 @@ extern int taskq_empty_ent(taskq_ent_t *);
 taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
 taskq_t	*taskq_create_instance(const char *, int, int, pri_t, int, int, uint_t);
 taskq_t	*taskq_create_proc(const char *, int, pri_t, int, int,
-    struct proc *, uint_t);
+    struct proc *, uint_t,    taskq_callback_fn, taskq_callback_fn);
 taskq_t	*taskq_create_sysdc(const char *, int, int, int,
     struct proc *, uint_t, uint_t);
 void	nulltask(void *);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -352,6 +352,195 @@ typedef struct dmu_buf {
 } dmu_buf_t;
 
 /*
+ * These structures are for DMU consumers that want async callbacks.
+ */
+struct dmu_ctx;
+struct dmu_buf_set;
+struct zio;
+typedef void (*dmu_ctx_cb_t)(struct dmu_ctx *);
+typedef void (*dmu_buf_set_cb_t)(struct dmu_buf_set *);
+typedef uint64_t (*dmu_buf_transfer_cb_t)(struct dmu_buf_set *, dmu_buf_t *,
+    uint64_t, uint64_t);
+
+typedef enum {
+	DMU_CTX_FLAG_READ	= 1 << 1,
+	DMU_CTX_FLAG_UIO	= 1 << 2,
+	DMU_CTX_FLAG_PREFETCH	= 1 << 3,
+	DMU_CTX_FLAG_NO_HOLD	= 1 << 4,
+	DMU_CTX_FLAG_SUN_PAGES	= 1 << 5,
+	DMU_CTX_FLAG_NOFILL	= 1 << 6,
+	DMU_CTX_FLAG_ASYNC	= 1 << 7,
+	DMU_CTX_FLAG_NODECRYPT	= 1 << 8,
+	DMU_CTX_WRITER_FLAGS	= DMU_CTX_FLAG_SUN_PAGES,
+	DMU_CTX_READER_FLAGS	= DMU_CTX_FLAG_PREFETCH
+} dmu_ctx_flag_t;
+
+typedef struct dmu_ctx {
+	/*
+	 * Lock protecting parts of the DMU context where necessary;
+	 * currently only used for err.
+	 */
+	kmutex_t dc_mtx;
+
+	/* The primary data associated with this context. */
+	uint64_t dc_size;	/* Requested total I/O size. */
+	uint64_t dc_resid_init;	/* Initial remaining bytes to process. */
+	uint64_t dc_resid;	/* Remaining bytes to process. */
+	uint64_t dc_dn_start;	/* Starting block offset into the dnode. */
+	uint64_t dc_dn_offset;	/* Current block offset. */
+	dmu_tx_t *dc_tx;	/* Caller's transaction, if specified. */
+	void *dc_data_buf;	/* UIO or char pointer */
+
+	/* The dnode held in association with this context. */
+	struct dnode *dc_dn;
+	objset_t *dc_os;	/* Object set associated with the dnode. */
+	uint64_t dc_object;	/* Object ID associated with the dnode. */
+
+	/* Number of buffer sets left to complete. */
+	zfs_refcount_t dc_holds;
+
+	/* The tag used for this context. */
+	void *dc_tag;
+
+	/* The callback to call once an I/O completes entirely. */
+	dmu_ctx_cb_t dc_complete_cb;
+
+	/*
+	 * Method called when all members of a buf set are
+	 * ready transfer data.
+	 */
+	dmu_buf_set_cb_t dc_buf_set_transfer_cb;
+
+	/*
+	 * Method called to perform a transfer operation on a DMU
+	 * buffer.  For reads, this is set to dc_data_trasnfer_cb
+	 * (no additional setup or book keeping required for the
+	 * transfer).  For writes, this method wraps a call to
+	 * dc_data_transfer_cb with logic to manage the dirty state
+	 * of the DMU buffer.
+	 */
+	dmu_buf_transfer_cb_t dc_buf_transfer_cb;
+
+	/*
+	 * Method to copy a range of data into or out of a DMU buffer.
+	 * This is normally only set by dmu_ctx_init().
+	 */
+	dmu_buf_transfer_cb_t dc_data_transfer_cb;
+
+	/* Total number of bytes transferred. */
+	uint64_t dc_completed_size;
+
+	/* Flags for this DMU context. */
+	dmu_ctx_flag_t dc_flags;
+
+	/* The worst that occurred. */
+	int dc_err;
+} dmu_ctx_t;
+
+typedef struct dmu_buf_set {
+
+	/* The DMU context that this buffer set is associated with. */
+	dmu_ctx_t *dbs_dc;
+
+	/* Number of dmu_bufs associated with this context. */
+	int dbs_count;
+
+	/* Length of dbp; only used to free the correct size. */
+	int dbs_dbp_length;
+
+	/* Number of dmu_bufs left to complete. */
+	zfs_refcount_t dbs_holds;
+
+	/* The starting offset, relative to the associated dnode. */
+	uint64_t dbs_dn_start;
+	/* The size of the I/O. */
+	uint64_t dbs_size;
+	/* The amount of data remaining to process for this buffer set. */
+	uint64_t dbs_resid;
+
+	/* For writes only, if the context doesn't have a transaction. */
+	dmu_tx_t *dbs_tx;
+
+	/* The worst error that occurred. */
+	int dbs_err;
+
+	/* number of buffers held so far */
+	int dbs_async_holds;
+
+	/* The ZIO associated with this context. */
+	struct zio *dbs_zio;
+
+	/* The set of buffers themselves. */
+	struct dmu_buf *dbs_dbp[];
+} dmu_buf_set_t;
+
+int dmu_ctx_init(dmu_ctx_t *dc, struct dnode *dn, objset_t *os,
+    uint64_t object, uint64_t offset, uint64_t size, void *data_buf, void *tag,
+    dmu_ctx_flag_t flags);
+void dmu_ctx_seek(dmu_ctx_t *dc, uint64_t offset, uint64_t size,
+    void *data_buf);
+void dmu_ctx_rele(dmu_ctx_t *dc);
+void dmu_buf_set_rele(dmu_buf_set_t *dbs, int err);
+void dmu_buf_set_transfer(dmu_buf_set_t *dbs);
+void dmu_buf_set_transfer_write(dmu_buf_set_t *dbs);
+
+#ifndef __lint
+static inline boolean_t
+dmu_ctx_buf_is_char(dmu_ctx_t *dc)
+{
+	return ((dc->dc_flags & (DMU_CTX_FLAG_UIO|DMU_CTX_FLAG_SUN_PAGES)) ?
+	    B_FALSE : B_TRUE);
+}
+
+/* Optional context setters; use after calling dmu_ctx_init*(). */
+static inline void
+dmu_ctx_set_complete_cb(dmu_ctx_t *dc, dmu_ctx_cb_t cb)
+{
+	dc->dc_complete_cb = cb;
+}
+
+static inline void
+dmu_ctx_set_buf_set_transfer_cb(dmu_ctx_t *dc, dmu_buf_set_cb_t cb)
+{
+	dc->dc_buf_set_transfer_cb = cb;
+}
+
+static inline void
+dmu_ctx_set_buf_transfer_cb(dmu_ctx_t *dc, dmu_buf_transfer_cb_t cb)
+{
+	dc->dc_buf_transfer_cb = cb;
+}
+
+static inline void
+dmu_ctx_set_dmu_tx(dmu_ctx_t *dc, dmu_tx_t *tx)
+{
+	ASSERT(tx != NULL && ((dc->dc_flags & DMU_CTX_FLAG_READ) == 0));
+	dmu_ctx_set_buf_set_transfer_cb(dc, dmu_buf_set_transfer);
+	dc->dc_tx = tx;
+}
+
+static inline dmu_tx_t *
+dmu_buf_set_tx(dmu_buf_set_t *dbs)
+{
+	return (dbs->dbs_dc->dc_tx ? dbs->dbs_dc->dc_tx : dbs->dbs_tx);
+}
+#else
+extern boolean_t dmu_ctx_buf_is_char(dmu_ctx_t *dc);
+extern void dmu_ctx_set_complete_cb(dmu_ctx_t *dc, dmu_ctx_cb_t cb);
+extern void dmu_ctx_set_buf_set_transfer_cb(dmu_ctx_t *dc,
+    dmu_buf_set_cb_t cb);
+extern void dmu_ctx_set_buf_transfer_cb(dmu_ctx_t *dc,
+    dmu_buf_transfer_cb_t cb);
+extern void dmu_ctx_set_dmu_tx(dmu_ctx_t *dc, dmu_tx_t *tx);
+extern dmu_tx_t *dmu_buf_set_tx(dmu_buf_set_t *dbs);
+#endif
+
+/* DMU thread context handlers. */
+int dmu_thread_context_create(void);
+void dmu_thread_context_process(void);
+void dmu_thread_context_destroy(void *);
+
+/*
  * The names of zap entries in the DIRECTORY_OBJECT of the MOS.
  */
 #define	DMU_POOL_DIRECTORY_OBJECT	1
@@ -588,20 +777,8 @@ void dmu_buf_rele(dmu_buf_t *db, void *tag);
 uint64_t dmu_buf_refcount(dmu_buf_t *db);
 uint64_t dmu_buf_user_refcount(dmu_buf_t *db);
 
-/*
- * dmu_buf_hold_array holds the DMU buffers which contain all bytes in a
- * range of an object.  A pointer to an array of dmu_buf_t*'s is
- * returned (in *dbpp).
- *
- * dmu_buf_rele_array releases the hold on an array of dmu_buf_t*'s, and
- * frees the array.  The hold on the array of buffers MUST be released
- * with dmu_buf_rele_array.  You can NOT release the hold on each buffer
- * individually with dmu_buf_rele.
- */
-int dmu_buf_hold_array_by_bonus(dmu_buf_t *db, uint64_t offset,
-    uint64_t length, boolean_t read, void *tag,
-    int *numbufsp, dmu_buf_t ***dbpp);
-void dmu_buf_rele_array(dmu_buf_t **, int numbufs, void *tag);
+uint64_t dmu_buf_write_pages(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+	uint64_t sz);
 
 typedef void dmu_buf_evict_func_t(void *user_ptr);
 
@@ -745,6 +922,8 @@ struct blkptr *dmu_buf_get_blkptr(dmu_buf_t *db);
  * (ie. you've called dmu_tx_hold_object(tx, db->db_object)).
  */
 void dmu_buf_will_dirty(dmu_buf_t *db, dmu_tx_t *tx);
+void dmu_buf_will_dirty_range(dmu_buf_t *db, dmu_tx_t *tx, int offset,
+    int size);
 boolean_t dmu_buf_is_dirty(dmu_buf_t *db, dmu_tx_t *tx);
 void dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
     const uint8_t *salt, const uint8_t *iv, const uint8_t *mac, dmu_tx_t *tx);
@@ -833,9 +1012,8 @@ int dmu_free_long_object(objset_t *os, uint64_t object);
  * Canfail routines will return 0 on success, or an errno if there is a
  * nonrecoverable I/O error.
  */
-#define	DMU_READ_PREFETCH	0 /* prefetch */
-#define	DMU_READ_NO_PREFETCH	1 /* don't prefetch */
-#define	DMU_READ_NO_DECRYPT	2 /* don't decrypt */
+int dmu_issue(dmu_ctx_t *dc);
+void dmu_issue_restart(dmu_buf_set_t *dbs, int err);
 int dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	void *buf, uint32_t flags);
 int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
@@ -844,9 +1022,8 @@ void dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	const void *buf, dmu_tx_t *tx);
 void dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx);
-void dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
+int dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_tx_t *tx);
-#ifdef _KERNEL
 int dmu_read_uio(objset_t *os, uint64_t object, struct uio *uio, uint64_t size);
 int dmu_read_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size);
 int dmu_read_uio_dnode(dnode_t *dn, struct uio *uio, uint64_t size);
@@ -856,7 +1033,13 @@ int dmu_write_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size,
 	dmu_tx_t *tx);
 int dmu_write_uio_dnode(dnode_t *dn, struct uio *uio, uint64_t size,
 	dmu_tx_t *tx);
-#endif
+int dmu_read_async(dmu_ctx_t *dc, objset_t *os, uint64_t object,
+    uint64_t offset, uint64_t size, void *buf, uint32_t flags,
+    dmu_ctx_cb_t done_cb);
+int dmu_write_async(dmu_ctx_t *dc, objset_t *os, uint64_t object,
+    uint64_t offset, uint64_t size, void *buf, dmu_tx_t *tx,
+    dmu_ctx_cb_t done_cb);
+
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);
 int dmu_assign_arcbuf_by_dnode(dnode_t *dn, uint64_t offset,

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -452,6 +452,12 @@ void dnode_evict_dbufs(dnode_t *dn);
 void dnode_evict_bonus(dnode_t *dn);
 void dnode_free_interior_slots(dnode_t *dn);
 
+#if defined(ZFS_DEBUG) && defined(__linux__) && defined(_KERNEL)
+void dn_rlock(dnode_t *dn);
+#else
+#define	dn_rlock(dn) rw_enter(&(dn)->dn_struct_rwlock, RW_READER)
+#endif
+
 #define	DNODE_IS_DIRTY(_dn)						\
 	((_dn)->dn_dirty_txg >= spa_syncing_txg((_dn)->dn_objset->os_spa))
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -330,7 +330,7 @@ extern void cv_broadcast(kcondvar_t *cv);
 #define	tsd_get(k) pthread_getspecific(k)
 #define	tsd_set(k, v) pthread_setspecific(k, v)
 #define	tsd_create(kp, d) pthread_key_create((pthread_key_t *)kp, d)
-#define	tsd_destroy(kp) /* nothing */
+#define	tsd_destroy(kp) pthread_key_delete((pthread_key_t *)*kp)
 
 /*
  * kstat creation, installation and deletion
@@ -441,6 +441,8 @@ typedef struct taskq_ent {
 	uintptr_t		tqent_flags;
 } taskq_ent_t;
 
+typedef void (*taskq_callback_fn)(void *);
+
 typedef struct taskq {
 	char		tq_name[TASKQ_NAMELEN + 1];
 	kmutex_t	tq_lock;
@@ -458,6 +460,8 @@ typedef struct taskq {
 	int		tq_maxalloc_wait;
 	taskq_ent_t	*tq_freelist;
 	taskq_ent_t	tq_task;
+	taskq_callback_fn	tq_ctor;
+	taskq_callback_fn	tq_dtor;
 } taskq_t;
 
 #define	TQENT_FLAG_PREALLOC	0x1	/* taskq_dispatch_ent used */
@@ -477,10 +481,11 @@ typedef struct taskq {
 
 extern taskq_t *system_taskq;
 extern taskq_t *system_delay_taskq;
-
+extern taskq_t *taskq_create_with_callbacks(const char *, int, pri_t, int,
+    int, uint_t, taskq_callback_fn, taskq_callback_fn);
 extern taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
-#define	taskq_create_proc(a, b, c, d, e, p, f) \
-	    (taskq_create(a, b, c, d, e, f))
+#define	taskq_create_proc(a, b, c, d, e, p, f, ct, dt) \
+	(taskq_create_with_callbacks(a, b, c, d, e, f, ct, dt))
 #define	taskq_create_sysdc(a, b, d, e, p, dc, f) \
 	    (taskq_create(a, b, maxclsyspri, d, e, f))
 extern taskqid_t taskq_dispatch(taskq_t *, task_func_t, void *, uint_t);
@@ -738,7 +743,7 @@ extern fstrans_cookie_t spl_fstrans_mark(void);
 extern void spl_fstrans_unmark(fstrans_cookie_t);
 extern int __spl_pf_fstrans_check(void);
 extern int kmem_cache_reap_active(void);
-
+extern int uiomove(void *, size_t, enum uio_rw, uio_t *);
 #define	____cacheline_aligned
 
 #endif /* _KERNEL */

--- a/include/sys/zvol_impl.h
+++ b/include/sys/zvol_impl.h
@@ -58,6 +58,17 @@ typedef struct zvol_state {
 	struct zvol_state_os	*zv_zso;	/* private platform state */
 } zvol_state_t;
 
+typedef struct zvol_dmu_state {
+	/*
+	 * The DMU context associated with this DMU state.  Note that this
+	 * must be the first entry in order for the callback to be able to
+	 * discover the zvol_dmu_state_t.
+	 */
+	dmu_ctx_t zds_dc;
+	zvol_state_t *zds_zv;
+	boolean_t zds_sync;
+	struct zfs_locked_range *zds_lr;
+} zvol_dmu_state_t;
 
 extern list_t zvol_state_list;
 extern krwlock_t zvol_state_lock;
@@ -85,6 +96,10 @@ void zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
     uint64_t size, int sync);
 int zvol_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb,
     zio_t *zio);
+int zvol_dmu_ctx_init(zvol_dmu_state_t *zds, void *data, uint64_t off,
+    uint64_t io_size, uint32_t dmu_flags, dmu_ctx_cb_t done_cb);
+void zvol_dmu_issue(zvol_dmu_state_t *zds);
+void zvol_dmu_done(dmu_ctx_t *dmu_ctx);
 int zvol_init_impl(void);
 void zvol_fini_impl(void);
 

--- a/module/os/freebsd/spl/spl_taskq.c
+++ b/module/os/freebsd/spl/spl_taskq.c
@@ -106,16 +106,29 @@ SYSUNINIT(system_taskq_fini, SI_SUB_CONFIGURE, SI_ORDER_ANY, system_taskq_fini,
     NULL);
 
 static void
-taskq_tsd_set(void *context)
+taskq_ctor(void *context)
 {
 	taskq_t *tq = context;
 
 	tsd_set(taskq_tsd, tq);
+	if (tq->tq_ctor)
+		tq->tq_ctor(tq);
+}
+
+static void
+taskq_dtor(void *context)
+{
+	taskq_t *tq = context;
+
+	tsd_set(taskq_tsd, NULL);
+	if (tq->tq_dtor)
+		tq->tq_dtor(tq);
 }
 
 static taskq_t *
 taskq_create_with_init(const char *name, int nthreads, pri_t pri,
-    int minalloc __unused, int maxalloc __unused, uint_t flags)
+    int minalloc __unused, int maxalloc __unused, uint_t flags,
+    taskq_callback_fn ctor, taskq_callback_fn dtor)
 {
 	taskq_t *tq;
 
@@ -125,10 +138,12 @@ taskq_create_with_init(const char *name, int nthreads, pri_t pri,
 	tq = kmem_alloc(sizeof (*tq), KM_SLEEP);
 	tq->tq_queue = taskqueue_create(name, M_WAITOK,
 	    taskqueue_thread_enqueue, &tq->tq_queue);
+	tq->tq_ctor = ctor;
+	tq->tq_dtor = dtor;
 	taskqueue_set_callback(tq->tq_queue, TASKQUEUE_CALLBACK_TYPE_INIT,
-	    taskq_tsd_set, tq);
+	    taskq_ctor, tq);
 	taskqueue_set_callback(tq->tq_queue, TASKQUEUE_CALLBACK_TYPE_SHUTDOWN,
-	    taskq_tsd_set, NULL);
+	    taskq_dtor, tq);
 	(void) taskqueue_start_threads(&tq->tq_queue, nthreads, pri,
 	    "%s", name);
 
@@ -141,16 +156,17 @@ taskq_create(const char *name, int nthreads, pri_t pri, int minalloc __unused,
 {
 
 	return (taskq_create_with_init(name, nthreads, pri, minalloc, maxalloc,
-	    flags));
+	    flags, NULL, NULL));
 }
 
 taskq_t *
 taskq_create_proc(const char *name, int nthreads, pri_t pri, int minalloc,
-    int maxalloc, proc_t *proc __unused, uint_t flags)
+    int maxalloc, proc_t *proc __unused, uint_t flags,
+    taskq_callback_fn ctor, taskq_callback_fn dtor)
 {
 
 	return (taskq_create_with_init(name, nthreads, pri, minalloc, maxalloc,
-	    flags));
+	    flags, ctor, dtor));
 }
 
 void

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -75,107 +75,85 @@ __FBSDID("$FreeBSD$");
 #define	dmu_page_unlock(m)
 #endif
 
-static int
-dmu_buf_hold_array(objset_t *os, uint64_t object, uint64_t offset,
-    uint64_t length, int read, void *tag, int *numbufsp, dmu_buf_t ***dbpp)
+uint64_t
+dmu_buf_write_pages(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
 {
-	dnode_t *dn;
-	int err;
+	vm_page_t *pp = dbs->dbs_dc->dc_data_buf;
+	struct sf_buf *sf;
+	int copied;
 
-	err = dnode_hold(os, object, FTAG, &dn);
-	if (err)
-		return (err);
+	/*
+	 * Seek to the page that starts this transfer.
+	 */
+	pp += (db->db_offset	+ off - dbs->dbs_dc->dc_dn_start) / PAGESIZE;
+	for (copied = 0; copied < sz; copied += PAGESIZE) {
+		caddr_t va;
+		int thiscpy;
 
-	err = dmu_buf_hold_array_by_dnode(dn, offset, length, read, tag,
-	    numbufsp, dbpp, DMU_READ_PREFETCH);
-
-	dnode_rele(dn, FTAG);
-
-	return (err);
+		ASSERT3U(ptoa((*pp)->pindex), ==, db->db_offset + off);
+		thiscpy = MIN(PAGESIZE, sz - copied);
+		va = zfs_map_page(*pp, &sf);
+		bcopy(va, (char *)db->db_data + off, thiscpy);
+		zfs_unmap_page(sf);
+		pp += 1;
+		off += PAGESIZE;
+	}
+	return (sz);
 }
+
+typedef struct dmu_read_pages_ctx {
+	dmu_ctx_t dc;
+	int *rahead;
+	int *rbehind;
+	int count;
+} dmu_read_pages_ctx_t;
 
 int
 dmu_write_pages(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     vm_page_t *ma, dmu_tx_t *tx)
 {
-	dmu_buf_t **dbp;
-	struct sf_buf *sf;
-	int numbufs, i;
+	dmu_ctx_t dc;
 	int err;
 
 	if (size == 0)
 		return (0);
 
-	err = dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp);
+	err = dmu_ctx_init(&dc, /* dnode */ NULL, os, object, offset,
+	    size, ma, FTAG, DMU_CTX_FLAG_SUN_PAGES);
 	if (err)
 		return (err);
 
-	for (i = 0; i < numbufs; i++) {
-		int tocpy, copied, thiscpy;
-		int bufoff;
-		dmu_buf_t *db = dbp[i];
-		caddr_t va;
-
-		ASSERT(size > 0);
-		ASSERT3U(db->db_size, >=, PAGESIZE);
-
-		bufoff = offset - db->db_offset;
-		tocpy = (int)MIN(db->db_size - bufoff, size);
-
-		ASSERT(i == 0 || i == numbufs-1 || tocpy == db->db_size);
-
-		if (tocpy == db->db_size)
-			dmu_buf_will_fill(db, tx);
-		else
-			dmu_buf_will_dirty(db, tx);
-
-		for (copied = 0; copied < tocpy; copied += PAGESIZE) {
-			ASSERT3U(ptoa((*ma)->pindex), ==,
-			    db->db_offset + bufoff);
-			thiscpy = MIN(PAGESIZE, tocpy - copied);
-			va = zfs_map_page(*ma, &sf);
-			bcopy(va, (char *)db->db_data + bufoff, thiscpy);
-			zfs_unmap_page(sf);
-			ma += 1;
-			bufoff += PAGESIZE;
-		}
-
-		if (tocpy == db->db_size)
-			dmu_buf_fill_done(db, tx);
-
-		offset += tocpy;
-		size -= tocpy;
-	}
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	dmu_ctx_set_dmu_tx(&dc, tx);
+	err = dmu_issue(&dc);
+	dmu_ctx_rele(&dc);
 	return (err);
 }
 
-int
-dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
-    int *rbehind, int *rahead, int last_size)
+static void
+dmu_read_pages_buf_set_transfer(dmu_buf_set_t *dbs)
 {
 	struct sf_buf *sf;
 	vm_object_t vmobj;
-	vm_page_t m;
+	vm_page_t m, *ma;
 	dmu_buf_t **dbp;
 	dmu_buf_t *db;
 	caddr_t va;
 	int numbufs, i;
 	int bufoff, pgoff, tocpy;
-	int mi, di;
-	int err;
+	int mi, di, count;
+	int *rahead, *rbehind;
+	dmu_read_pages_ctx_t *drpc;
 
-	ASSERT3U(ma[0]->pindex + count - 1, ==, ma[count - 1]->pindex);
-	ASSERT(last_size <= PAGE_SIZE);
-
-	err = dmu_buf_hold_array(os, object, IDX_TO_OFF(ma[0]->pindex),
-	    IDX_TO_OFF(count - 1) + last_size, TRUE, FTAG, &numbufs, &dbp);
-	if (err != 0)
-		return (err);
+	ma = (vm_page_t *)dbs->dbs_dc->dc_data_buf;
+	drpc = (dmu_read_pages_ctx_t *)dbs->dbs_dc;
+	rahead = drpc->rahead;
+	rbehind = drpc->rbehind;
+	count = drpc->count;
+	numbufs = dbs->dbs_count;
+	dbp = dbs->dbs_dbp;
 
 #ifdef DEBUG
-	IMPLY(last_size < PAGE_SIZE, *rahead == 0);
 	if (dbp[0]->db_offset != 0 || numbufs > 1) {
 		for (i = 0; i < numbufs; i++) {
 			ASSERT(ISP2(dbp[i]->db_size));
@@ -340,7 +318,32 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 	}
 	*rahead = i;
 	zfs_vmobject_wunlock_12(vmobj);
+}
 
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (0);
+int
+dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
+    int *rbehind, int *rahead, int last_size)
+{
+	dmu_read_pages_ctx_t drpc;
+	uint32_t dmu_flags = DMU_CTX_FLAG_READ;
+	int err;
+
+	ASSERT3U(ma[0]->pindex + count - 1, ==, ma[count - 1]->pindex);
+	ASSERT(last_size <= PAGE_SIZE);
+#ifdef DEBUG
+	IMPLY(last_size < PAGE_SIZE, *rahead == 0);
+#endif
+	drpc.rbehind = rbehind;
+	drpc.rahead = rahead;
+	drpc.count = count;
+	err = dmu_ctx_init(&drpc.dc, /* dnode */ NULL, os,
+	    object, IDX_TO_OFF(ma[0]->pindex), IDX_TO_OFF(count -1) + last_size,
+	    ma, FTAG, dmu_flags);
+	if (err != 0)
+		return (err);
+	dmu_ctx_set_buf_set_transfer_cb(&drpc.dc,
+	    dmu_read_pages_buf_set_transfer);
+	dmu_issue(&drpc.dc);
+	dmu_ctx_rele(&drpc.dc);
+	return (drpc.dc.dc_err);
 }

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1090,7 +1090,7 @@ zfs_acl_node_read(znode_t *zp, boolean_t have_lock, zfs_acl_t **aclpp,
 		if (znode_acl.z_acl_extern_obj) {
 			error = dmu_read(zp->z_zfsvfs->z_os,
 			    znode_acl.z_acl_extern_obj, 0, aclnode->z_size,
-			    aclnode->z_acldata, DMU_READ_PREFETCH);
+			    aclnode->z_acldata, DMU_CTX_FLAG_PREFETCH);
 		} else {
 			bcopy(znode_acl.z_ace_data, aclnode->z_acldata,
 			    aclnode->z_size);

--- a/module/os/freebsd/zfs/zfs_vnops.c
+++ b/module/os/freebsd/zfs/zfs_vnops.c
@@ -554,7 +554,7 @@ update_pages(vnode_t *vp, int64_t start, int len, objset_t *os, uint64_t oid,
 
 			va = zfs_map_page(pp, &sf);
 			(void) dmu_read(os, oid, start+off, nbytes,
-			    va+off, DMU_READ_PREFETCH);
+			    va+off, DMU_CTX_FLAG_PREFETCH);
 			zfs_unmap_page(sf);
 
 			zfs_vmobject_wlock_12(obj);
@@ -609,7 +609,7 @@ mappedread_sf(vnode_t *vp, int nbytes, uio_t *uio)
 			zfs_vmobject_wunlock_12(obj);
 			va = zfs_map_page(pp, &sf);
 			error = dmu_read(os, zp->z_id, start, bytes, va,
-			    DMU_READ_PREFETCH);
+			    DMU_CTX_FLAG_PREFETCH);
 			if (bytes != PAGESIZE && error == 0)
 				bzero(va + bytes, PAGESIZE - bytes);
 			zfs_unmap_page(sf);
@@ -1312,7 +1312,7 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb, zio_t *zio)
 			error = SET_ERROR(ENOENT);
 		} else {
 			error = dmu_read(os, object, offset, size, buf,
-			    DMU_READ_NO_PREFETCH);
+			    /* flags */ 0);
 		}
 		ASSERT(error == 0 || error == ENOENT);
 	} else { /* indirect write */
@@ -1345,7 +1345,7 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb, zio_t *zio)
 #endif
 		if (error == 0)
 			error = dmu_buf_hold(os, object, offset, zgd, &db,
-			    DMU_READ_NO_PREFETCH);
+			    0);
 
 		if (error == 0) {
 			blkptr_t *bp = &lr->lr_blkptr;

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -869,6 +869,9 @@ taskq_thread(void *args)
 	flush_signals(current);
 
 	tsd_set(taskq_tsd, tq);
+	if (tq->tq_ctor != NULL)
+		tq->tq_ctor(tq);
+
 	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
 	/*
 	 * If we are dynamically spawned, decrease spawning count. Note that
@@ -988,7 +991,8 @@ error:
 	spin_unlock_irqrestore(&tq->tq_lock, flags);
 
 	tsd_set(taskq_tsd, NULL);
-
+	if (tq->tq_dtor != NULL)
+		tq->tq_dtor(tq);
 	return (0);
 }
 
@@ -1025,8 +1029,9 @@ taskq_thread_create(taskq_t *tq)
 }
 
 taskq_t *
-taskq_create(const char *name, int nthreads, pri_t pri,
-    int minalloc, int maxalloc, uint_t flags)
+taskq_create_with_callbacks(const char *name, int nthreads, pri_t pri,
+    int minalloc, int maxalloc, uint_t flags, taskq_callback_fn ctor,
+    taskq_callback_fn dtor)
 {
 	taskq_t *tq;
 	taskq_thread_t *tqt;
@@ -1066,6 +1071,8 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	tq->tq_flags = (flags | TASKQ_ACTIVE);
 	tq->tq_next_id = TASKQID_INITIAL;
 	tq->tq_lowest_id = TASKQID_INITIAL;
+	tq->tq_ctor = ctor;
+	tq->tq_dtor = dtor;
 	INIT_LIST_HEAD(&tq->tq_free_list);
 	INIT_LIST_HEAD(&tq->tq_pend_list);
 	INIT_LIST_HEAD(&tq->tq_prio_list);
@@ -1117,6 +1124,16 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 
 	return (tq);
 }
+EXPORT_SYMBOL(taskq_create_with_callbacks);
+
+taskq_t *
+taskq_create(const char *name, int nthreads, pri_t pri,
+    int minalloc, int maxalloc, uint_t flags)
+{
+	return (taskq_create_with_callbacks(name, nthreads, pri, minalloc,
+	    maxalloc, flags, NULL, NULL));
+}
+
 EXPORT_SYMBOL(taskq_create);
 
 void

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -1100,7 +1100,7 @@ zfs_acl_node_read(struct znode *zp, boolean_t have_lock, zfs_acl_t **aclpp,
 		if (znode_acl.z_acl_extern_obj) {
 			error = dmu_read(ZTOZSB(zp)->z_os,
 			    znode_acl.z_acl_extern_obj, 0, aclnode->z_size,
-			    aclnode->z_acldata, DMU_READ_PREFETCH);
+			    aclnode->z_acldata, DMU_CTX_FLAG_PREFETCH);
 		} else {
 			bcopy(znode_acl.z_ace_data, aclnode->z_acldata,
 			    aclnode->z_size);

--- a/module/os/linux/zfs/zfs_vnops.c
+++ b/module/os/linux/zfs/zfs_vnops.c
@@ -341,7 +341,7 @@ update_pages(struct inode *ip, int64_t start, int len,
 
 			pb = kmap(pp);
 			(void) dmu_read(os, oid, start+off, nbytes, pb+off,
-			    DMU_READ_PREFETCH);
+			    DMU_CTX_FLAG_PREFETCH);
 			kunmap(pp);
 
 			if (mapping_writably_mapped(mp))
@@ -1117,7 +1117,7 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb, zio_t *zio)
 			error = SET_ERROR(ENOENT);
 		} else {
 			error = dmu_read(os, object, offset, size, buf,
-			    DMU_READ_NO_PREFETCH);
+			    /* flags */ 0);
 		}
 		ASSERT(error == 0 || error == ENOENT);
 	} else { /* indirect write */
@@ -1150,7 +1150,7 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb, zio_t *zio)
 #endif
 		if (error == 0)
 			error = dmu_buf_hold(os, object, offset, zgd, &db,
-			    DMU_READ_NO_PREFETCH);
+			    /* flags */ 0);
 
 		if (error == 0) {
 			blkptr_t *bp = &lr->lr_blkptr;
@@ -4615,7 +4615,7 @@ zfs_fillpage(struct inode *ip, struct page *pl[], int nr_pages)
 		cur_pp = pl[page_idx++];
 		va = kmap(cur_pp);
 		err = dmu_read(os, zp->z_id, io_off, PAGESIZE, va,
-		    DMU_READ_PREFETCH);
+		    DMU_CTX_FLAG_PREFETCH);
 		kunmap(cur_pp);
 		if (err) {
 			/* convert checksum errors into IO errors */

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -469,7 +469,7 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 			uint64_t obj_from_sublist;
 			err = dmu_read(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
 			    offset, sizeof (uint64_t), &obj_from_sublist,
-			    DMU_READ_PREFETCH);
+			    DMU_CTX_FLAG_PREFETCH);
 			if (err)
 				break;
 			bpobj_t *sublist = kmem_alloc(sizeof (bpobj_t),

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -217,7 +217,7 @@ bptree_iterate(objset_t *os, uint64_t obj, boolean_t free, bptree_itor_t func,
 		    TRAVERSE_NO_DECRYPT;
 
 		err = dmu_read(os, obj, i * sizeof (bte), sizeof (bte),
-		    &bte, DMU_READ_NO_PREFETCH);
+		    &bte, /* flags */ 0);
 		if (err != 0)
 			break;
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -148,11 +148,20 @@ dbuf_stats_t dbuf_stats = {
 		continue;						\
 }
 
+typedef struct dbuf_hold_async_ctx {
+	dmu_buf_set_t *dbs;
+	zio_t *zio;
+	uint64_t dn_off;
+	uint64_t resid;
+} dbuf_hold_async_ctx_t;
+
 static boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 static void dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx);
 static void dbuf_sync_leaf_verify_bonus_dnode(dbuf_dirty_record_t *dr);
 static int dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, uint32_t flags);
-
+static int dbuf_hold_impl_(dnode_t *dn, uint8_t level, uint64_t blkid,
+    boolean_t fail_sparse, boolean_t fail_uncached, void *tag,
+    dmu_buf_impl_t **dbp, dbuf_hold_async_ctx_t *ctx);
 extern inline void dmu_buf_init_user(dmu_buf_user_t *dbu,
     dmu_buf_evict_func_t *evict_func_sync,
     dmu_buf_evict_func_t *evict_func_async,
@@ -762,6 +771,35 @@ dbuf_kstat_update(kstat_t *ksp, int rw)
 	return (0);
 }
 
+static dmu_buf_set_t *
+dbuf_process_buf_sets_(dmu_buf_impl_t *db, int err, const char *function)
+{
+	dmu_buf_set_node_t *dbsn, *next;
+	dmu_buf_set_t *dbs = NULL;
+	int count = 0;
+
+	ASSERT(db->db_buf != NULL || err);
+	for (dbsn = list_head(&db->db_buf_sets); dbsn != NULL; dbsn = next) {
+		next = list_next(&db->db_buf_sets, dbsn);
+		if (dbsn->dbsn_dmu_restart) {
+			ASSERT(dbs == NULL);
+			dbs = dbsn->dbsn_dbs;
+		} else
+			dmu_buf_set_rele(dbsn->dbsn_dbs, err);
+		dmu_buf_set_node_remove(&db->db_buf_sets, dbsn);
+		count++;
+	}
+#if 0
+	if (count)
+		printf("processed %d buf_sets for %p in %s\n",
+		    count, db, function);
+#endif
+	return (dbs);
+}
+
+#define	dbuf_process_buf_sets(a, b)				\
+	dbuf_process_buf_sets_((a), (b), __func__)
+
 void
 dbuf_init(void)
 {
@@ -1244,6 +1282,8 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
     arc_buf_t *buf, void *vdb)
 {
 	dmu_buf_impl_t *db = vdb;
+	dmu_buf_set_t *dbs;
+	int err = 0;
 
 	mutex_enter(&db->db_mtx);
 	ASSERT3U(db->db_state, ==, DB_READ);
@@ -1260,6 +1300,7 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 		ASSERT3P(db->db_buf, ==, NULL);
 		db->db_state = DB_UNCACHED;
 		DTRACE_SET_STATE(db, "i/o error");
+		err = EIO;
 	} else if (db->db_level == 0 && db->db_freed_in_flight) {
 		/* freed in flight */
 		ASSERT(zio == NULL || zio->io_error == 0);
@@ -1277,8 +1318,11 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 		db->db_state = DB_CACHED;
 		DTRACE_SET_STATE(db, "successful read");
 	}
+	dbs = dbuf_process_buf_sets(db, err);
 	cv_broadcast(&db->db_changed);
 	dbuf_rele_and_unlock(db, NULL, B_FALSE);
+	if (dbs != NULL)
+		dmu_issue_restart(dbs, err);
 }
 
 /*
@@ -1294,7 +1338,6 @@ dbuf_read_bonus(dmu_buf_impl_t *db, dnode_t *dn, uint32_t flags)
 	err = dbuf_read_verify_dnode_crypt(db, flags);
 	if (err)
 		return (err);
-
 	bonuslen = MIN(dn->dn_bonuslen, dn->dn_phys->dn_bonuslen);
 	max_bonuslen = DN_SLOTS_TO_BONUSLEN(dn->dn_num_slots);
 	ASSERT(MUTEX_HELD(&db->db_mtx));
@@ -1307,6 +1350,7 @@ dbuf_read_bonus(dmu_buf_impl_t *db, dnode_t *dn, uint32_t flags)
 	if (bonuslen)
 		bcopy(DN_BONUS(dn->dn_phys), db->db.db_data, bonuslen);
 	db->db_state = DB_CACHED;
+	/* XXX does this belong here ? */
 	DTRACE_SET_STATE(db, "bonus buffer filled");
 	return (0);
 }
@@ -1437,6 +1481,7 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 	uint32_t aflags = ARC_FLAG_NOWAIT;
 	int err, zio_flags;
 	boolean_t bonus_read;
+	dmu_buf_set_t *dbs = NULL;
 
 	err = zio_flags = 0;
 	bonus_read = B_FALSE;
@@ -1521,8 +1566,13 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 	return (err);
 early_unlock:
 	DB_DNODE_EXIT(db);
+	if (err || db->db_buf != NULL)
+		dbs = dbuf_process_buf_sets(db, err);
 	mutex_exit(&db->db_mtx);
 	dmu_buf_unlock_parent(db, dblt, tag);
+	if (dbs != NULL)
+		dmu_issue_restart(dbs, err);
+
 	return (err);
 }
 
@@ -1578,8 +1628,9 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 	}
 }
 
-int
-dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
+static int
+dbuf_read_(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
+    dmu_buf_set_t *dbs)
 {
 	int err = 0;
 	boolean_t prefetch;
@@ -1641,13 +1692,21 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 	} else if (db->db_state == DB_UNCACHED) {
 		spa_t *spa = dn->dn_objset->os_spa;
 		boolean_t need_wait = B_FALSE;
+		boolean_t do_ewouldblock = B_FALSE;
 
 		db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
+
+		do_ewouldblock  = (dbs != NULL &&
+		    db->db_blkptr != NULL && !BP_IS_HOLE(db->db_blkptr));
 
 		if (zio == NULL &&
 		    db->db_blkptr != NULL && !BP_IS_HOLE(db->db_blkptr)) {
 			zio = zio_root(spa, NULL, NULL, ZIO_FLAG_CANFAIL);
 			need_wait = B_TRUE;
+		}
+		if (do_ewouldblock) {
+			ASSERT(zio != NULL);
+			dmu_buf_set_node_add(&db->db_buf_sets, dbs, B_TRUE);
 		}
 		err = dbuf_read_impl(db, zio, flags, dblt, FTAG);
 		/*
@@ -1661,6 +1720,8 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 
 		DB_DNODE_EXIT(db);
 		DBUF_STAT_BUMP(hash_misses);
+		if (do_ewouldblock)
+			return (EWOULDBLOCK);
 
 		/*
 		 * If we created a zio_root we must execute it to avoid
@@ -1708,6 +1769,12 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 	}
 
 	return (err);
+}
+
+int
+dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
+{
+	return (dbuf_read_(db, zio, flags, NULL));
 }
 
 static void
@@ -1787,6 +1854,7 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 	uint64_t txg = tx->tx_txg;
 	avl_index_t where;
 	dbuf_dirty_record_t *dr;
+	dmu_buf_set_t *dbs = NULL;
 
 	if (end_blkid > dn->dn_maxblkid &&
 	    !(start_blkid == DMU_SPILL_BLKID || end_blkid == DMU_SPILL_BLKID))
@@ -1871,10 +1939,11 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 			rw_exit(&db->db_rwlock);
 			arc_buf_freeze(db->db_buf);
 		}
-
+		if (db->db_buf != NULL)
+			dbs = dbuf_process_buf_sets(db, /* err */ 0);
 		mutex_exit(&db->db_mtx);
 	}
-
+	ASSERT(dbs == NULL);
 	kmem_free(db_search, sizeof (dmu_buf_impl_t));
 	mutex_exit(&dn->dn_dbufs_mtx);
 }
@@ -2497,6 +2566,8 @@ dmu_buf_fill_done(dmu_buf_t *dbuf, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbuf;
 	dbuf_states_t old_state;
+	dmu_buf_set_t *dbs;
+
 	mutex_enter(&db->db_mtx);
 	DBUF_VERIFY(db);
 
@@ -2514,9 +2585,12 @@ dmu_buf_fill_done(dmu_buf_t *dbuf, dmu_tx_t *tx)
 		} else {
 			DTRACE_SET_STATE(db, "fill done");
 		}
+		dbs = dbuf_process_buf_sets(db, /* err */ 0);
 		cv_broadcast(&db->db_changed);
-	}
+	} else
+		dbs = dbuf_process_buf_sets(db, /* err */ 0);
 	mutex_exit(&db->db_mtx);
+	ASSERT(dbs == NULL);
 }
 
 void
@@ -2782,7 +2856,8 @@ dbuf_destroy(dmu_buf_impl_t *db)
 __attribute__((always_inline))
 static inline int
 dbuf_findbp(dnode_t *dn, int level, uint64_t blkid, int fail_sparse,
-    dmu_buf_impl_t **parentp, blkptr_t **bpp)
+    dmu_buf_impl_t **parentp, blkptr_t **bpp,
+    dbuf_hold_async_ctx_t *ctx)
 {
 	*parentp = NULL;
 	*bpp = NULL;
@@ -2835,15 +2910,20 @@ dbuf_findbp(dnode_t *dn, int level, uint64_t blkid, int fail_sparse,
 		return (SET_ERROR(ENOENT));
 	} else if (level < nlevels-1) {
 		/* this block is referenced from an indirect block */
-		int err;
+		int err, flags;
+		dmu_buf_set_t *dbs = NULL;
+		zio_t *zio = NULL;
 
-		err = dbuf_hold_impl(dn, level + 1,
-		    blkid >> epbs, fail_sparse, FALSE, NULL, parentp);
-
+		err = dbuf_hold_impl_(dn, level + 1,
+		    blkid >> epbs, fail_sparse, FALSE, NULL, parentp, ctx);
 		if (err)
 			return (err);
-		err = dbuf_read(*parentp, NULL,
-		    (DB_RF_HAVESTRUCT | DB_RF_NOPREFETCH | DB_RF_CANFAIL));
+		flags = DB_RF_HAVESTRUCT | DB_RF_NOPREFETCH | DB_RF_CANFAIL;
+		if (ctx != NULL && ctx->zio != NULL) {
+			zio = ctx->zio;
+			dbs = ctx->dbs;
+		}
+		err = dbuf_read_(*parentp, zio, flags, dbs);
 		if (err) {
 			dbuf_rele(*parentp, NULL);
 			*parentp = NULL;
@@ -2884,6 +2964,8 @@ dbuf_create(dnode_t *dn, uint8_t level, uint64_t blkid,
 
 	list_create(&db->db_dirty_records, sizeof (dbuf_dirty_record_t),
 	    offsetof(dbuf_dirty_record_t, dr_dbuf_node));
+	list_create(&db->db_buf_sets, sizeof (dmu_buf_set_node_t),
+	    offsetof(dmu_buf_set_node_t, dbsn_link));
 
 	db->db_objset = os;
 	db->db.db_object = dn->dn_object;
@@ -2974,7 +3056,7 @@ dbuf_dnode_findbp(dnode_t *dn, uint64_t level, uint64_t blkid,
 	int err = 0;
 	ASSERT(RW_LOCK_HELD(&dn->dn_struct_rwlock));
 
-	err = dbuf_findbp(dn, level, blkid, B_FALSE, &dbp, &bp2);
+	err = dbuf_findbp(dn, level, blkid, B_FALSE, &dbp, &bp2, NULL);
 	if (err == 0) {
 		*bp = *bp2;
 		if (dbp != NULL)
@@ -3283,14 +3365,52 @@ dbuf_hold_copy(dnode_t *dn, dmu_buf_impl_t *db)
 	rw_exit(&db->db_rwlock);
 }
 
+static void
+dbuf_hold_update_buf_set(dbuf_hold_async_ctx_t *ctx, dmu_buf_impl_t *db)
+{
+	dmu_ctx_t *dc;
+	uint64_t bufoff, tocpy;
+	dmu_buf_set_t *dbs;
+	uint64_t resid, dn_off;
+
+	if (ctx == NULL)
+		return;
+
+	resid = ctx->resid;
+	dn_off = ctx->dn_off;
+	dbs = ctx->dbs;
+	dc = dbs->dbs_dc;
+	ASSERT(dn_off >= db->db.db_offset);
+
+	/* If a reading buffer set is associated, add the callback now. */
+	if (dc->dc_flags & DMU_CTX_FLAG_READ) {
+		if (db->db_state == DB_CACHED) {
+			/* Dbuf is already at the desired state. */
+			dmu_buf_set_rele(dbs, /* err */ 0);
+		} else {
+			dmu_buf_set_node_add(&db->db_buf_sets, dbs, B_FALSE);
+		}
+	} else if (dc->dc_flags & DMU_CTX_FLAG_ASYNC) {
+		/* Calculate the amount of data this buffer contributes. */
+		bufoff = dn_off - db->db.db_offset;
+		tocpy = (int)MIN(db->db.db_size - bufoff, resid);
+		if (db->db_state == DB_CACHED || tocpy == db->db.db_size) {
+			/* Dbuf is resident or will be overwritten. */
+			dmu_buf_set_rele(dbs, /* err */ 0);
+		} else {
+			dmu_buf_set_node_add(&db->db_buf_sets, dbs, B_FALSE);
+		}
+	}
+}
+
 /*
  * Returns with db_holds incremented, and db_mtx not held.
  * Note: dn_struct_rwlock must be held.
  */
-int
-dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
+static int
+dbuf_hold_impl_(dnode_t *dn, uint8_t level, uint64_t blkid,
     boolean_t fail_sparse, boolean_t fail_uncached,
-    void *tag, dmu_buf_impl_t **dbp)
+    void *tag, dmu_buf_impl_t **dbp, dbuf_hold_async_ctx_t *ctx)
 {
 	dmu_buf_impl_t *db, *parent = NULL;
 
@@ -3318,7 +3438,8 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 			return (SET_ERROR(ENOENT));
 
 		ASSERT3P(parent, ==, NULL);
-		err = dbuf_findbp(dn, level, blkid, fail_sparse, &parent, &bp);
+		err = dbuf_findbp(dn, level, blkid, fail_sparse, &parent,
+		    &bp, ctx);
 		if (fail_sparse) {
 			if (err == 0 && bp && BP_IS_HOLE(bp))
 				err = SET_ERROR(ENOENT);
@@ -3380,6 +3501,8 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 	}
 	(void) zfs_refcount_add(&db->db_holds, tag);
 	DBUF_VERIFY(db);
+	if (level == 0)
+		dbuf_hold_update_buf_set(ctx, db);
 	mutex_exit(&db->db_mtx);
 
 	/* NOTE: we can't rele the parent until after we drop the db_mtx */
@@ -3394,6 +3517,16 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 	return (0);
 }
 
+int
+dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
+    boolean_t fail_sparse, boolean_t fail_uncached,
+    void *tag, dmu_buf_impl_t **dbp)
+{
+
+	return (dbuf_hold_impl_(dn, level, blkid, fail_sparse, fail_uncached,
+	    tag, dbp, NULL));
+}
+
 dmu_buf_impl_t *
 dbuf_hold(dnode_t *dn, uint64_t blkid, void *tag)
 {
@@ -3404,8 +3537,24 @@ dmu_buf_impl_t *
 dbuf_hold_level(dnode_t *dn, int level, uint64_t blkid, void *tag)
 {
 	dmu_buf_impl_t *db;
-	int err = dbuf_hold_impl(dn, level, blkid, FALSE, FALSE, tag, &db);
+	int err = dbuf_hold_impl(dn, level, blkid, FALSE, FALSE,
+	    tag, &db);
 	return (err ? NULL : db);
+}
+
+int
+dbuf_hold_level_async(struct dnode *dn, int level, uint64_t blkid,
+    void *tag, dmu_buf_impl_t **dbp, uint64_t dn_off, dmu_buf_set_t *dbs,
+    uint64_t resid, zio_t *zio)
+{
+	dbuf_hold_async_ctx_t ctx;
+
+	ctx.dn_off = dn_off;
+	ctx.dbs = dbs;
+	ctx.resid = resid;
+	ctx.zio = zio;
+	return (dbuf_hold_impl_(dn, level, blkid, FALSE, FALSE,
+	    tag, dbp, &ctx));
 }
 
 void

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -23,9 +23,11 @@
  * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright (c) 2016, Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2015 by Chunwei Chen. All rights reserved.
  * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2020 iXsystems Inc.
  */
 
 #include <sys/dmu.h>
@@ -151,6 +153,1035 @@ const dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS] = {
 	{	zfs_acl_byteswap,	"acl"		}
 };
 
+#ifdef _KERNEL
+#define	DPRINTF(...)
+#else
+#define	DPRINTF printf
+#endif
+
+#ifdef ZFS_DEBUG
+#define	DEBUG_REFCOUNT(a, b, c) uint32_t b
+#define	DEBUG_COUNTER_U(a, b, c) uint64_t b
+#define	DEBUG_REFCOUNT_ADD(b) atomic_inc_32(&(b))
+#define	DEBUG_REFCOUNT_DEC(b) atomic_dec_32(&(b))
+#else
+#define	DEBUG_REFCOUNT(a, b, c)
+#define	DEBUG_COUNTER_U(a, b, c)
+#define	DEBUG_REFCOUNT_ADD(b)
+#define	DEBUG_REFCOUNT_DEC(b)
+#endif
+
+
+DEBUG_REFCOUNT(_vfs_zfs_dmu, dbsn_in_flight, "DMU buf set nodes in flight");
+DEBUG_COUNTER_U(_vfs_zfs_dmu, dmu_ctx_total, "Total DMU contexts");
+DEBUG_COUNTER_U(_vfs_zfs_dmu, buf_set_total, "Total buffer sets");
+DEBUG_REFCOUNT(_vfs_zfs_dmu, dmu_ctx_in_flight, "DMU contexts in flight");
+DEBUG_REFCOUNT(_vfs_zfs_dmu, buf_set_in_flight, "Buffer sets in flight");
+
+#if defined(_KERNEL) && defined(__FreeBSD__)
+#define	dmu_uiomove(data, sz, dir, uio)			\
+	vn_io_fault_uiomove((data), (sz), (uio))
+#else
+#define	dmu_uiomove(data, sz, dir, uio)			\
+	uiomove((data), (sz), (dir), (uio))
+#endif
+
+/*
+ * DMU Context based functions.
+ */
+
+/* Used for TSD for processing completed asynchronous I/Os. */
+uint_t zfs_async_io_key;
+
+void
+dmu_buf_set_node_add(list_t *list, dmu_buf_set_t *dbs, boolean_t restart)
+{
+	dmu_buf_set_node_t *dbsn = kmem_zalloc(sizeof (dmu_buf_set_node_t),
+	    KM_SLEEP);
+	list_link_init(&dbsn->dbsn_link);
+	dbsn->dbsn_dbs = dbs;
+	dbsn->dbsn_dmu_restart = restart;
+	list_insert_tail(list, dbsn);
+	DEBUG_REFCOUNT_ADD(dbsn_in_flight);
+}
+
+void
+dmu_buf_set_node_remove(list_t *list, dmu_buf_set_node_t *dbsn)
+{
+	list_remove(list, dbsn);
+	kmem_free(dbsn, sizeof (dmu_buf_set_node_t));
+	ASSERT(dbsn_in_flight > 0);
+	DEBUG_REFCOUNT_DEC(dbsn_in_flight);
+}
+
+
+/*
+ * Error reporting for dmu_buf_set and dmu_context objects.  These share a
+ * mutex because they are not expected to happen frequently, so they should
+ * only be called if an error occurs.
+ */
+static void
+dmu_buf_set_set_error(dmu_buf_set_t *dbs, int err)
+{
+	mutex_enter(&dbs->dbs_dc->dc_mtx);
+	dbs->dbs_err = zio_worst_error(dbs->dbs_err, err);
+	mutex_exit(&dbs->dbs_dc->dc_mtx);
+}
+
+static void
+dmu_ctx_set_error(dmu_ctx_t *dc, int err)
+{
+	if (err != 0) {
+		mutex_enter(&dc->dc_mtx);
+		dc->dc_err = zio_worst_error(dc->dc_err, err);
+		mutex_exit(&dc->dc_mtx);
+	}
+}
+#ifdef UIO_XUIO
+static void
+dmu_buf_read_xuio(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+#ifdef _KERNEL
+	uio_t *uio = (uio_t *)dbs->dbs_dc->dc_data_buf;
+	xuio_t *xuio = (xuio_t *)uio;
+	dmu_buf_impl_t *dbi = (dmu_buf_impl_t *)db;
+	arc_buf_t *dbuf_abuf = dbi->db_buf;
+	arc_buf_t *abuf = dbuf_loan_arcbuf(dbi);
+
+	if (dmu_xuio_add(xuio, abuf, off, sz) == 0) {
+		uio->uio_resid -= sz;
+		uio->uio_loffset += sz;
+	}
+
+	if (abuf == dbuf_abuf)
+		XUIOSTAT_BUMP(xuiostat_rbuf_nocopy);
+	else
+		XUIOSTAT_BUMP(xuiostat_rbuf_copied);
+#endif
+}
+#endif
+
+static uint64_t
+dmu_buf_do_uio(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz, enum uio_rw dir)
+{
+	int err;
+	uio_t *uio = (uio_t *)dbs->dbs_dc->dc_data_buf;
+	uint64_t adv = uio->uio_resid;
+
+	err = dmu_uiomove((char *)db->db_data + off, sz, dir, uio);
+	if (err)
+		dmu_buf_set_set_error(dbs, err);
+	adv -= uio->uio_resid;
+
+	return (adv);
+}
+
+static uint64_t
+dmu_buf_read_uio(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	return (dmu_buf_do_uio(dbs, db, off, sz, UIO_READ));
+}
+
+static uint64_t
+dmu_buf_write_uio(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	return (dmu_buf_do_uio(dbs, db, off, sz, UIO_WRITE));
+}
+
+static uint64_t
+dmu_buf_read_char(dmu_buf_set_t *buf_set, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	char *data = (char *)buf_set->dbs_dc->dc_data_buf + db->db_offset -
+	    buf_set->dbs_dc->dc_dn_start + off;
+	bcopy((char *)db->db_data + off, data, sz);
+	return (sz);
+}
+
+static uint64_t
+dmu_buf_write_char(dmu_buf_set_t *buf_set, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	char *data = (char *)buf_set->dbs_dc->dc_data_buf + db->db_offset -
+	    buf_set->dbs_dc->dc_dn_start + off;
+	bcopy(data, (char *)db->db_data + off, sz);
+	return (sz);
+}
+
+static uint64_t
+dmu_buf_transfer_nofill(dmu_buf_set_t *buf_set, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	dmu_tx_t *tx = dmu_buf_set_tx(buf_set);
+	dmu_buf_will_not_fill(db, tx);
+	/* No need to do any more here. */
+	return (sz);
+}
+
+static uint64_t
+dmu_buf_transfer_write(dmu_buf_set_t *dbs, dmu_buf_t *db, uint64_t off,
+    uint64_t sz)
+{
+	dmu_tx_t *tx = dmu_buf_set_tx(dbs);
+	uint64_t adv;
+
+	if (sz == db->db_size)
+		dmu_buf_will_fill(db, tx);
+	else
+		dmu_buf_will_dirty(db, tx);
+	// dmu_buf_will_dirty_range(db, tx, off, sz);
+	adv = dbs->dbs_dc->dc_data_transfer_cb(dbs, db, off, sz);
+	/* XXX -- need to handle error condition */
+	dmu_buf_fill_done(db, tx);
+	return (adv);
+}
+
+void
+dmu_buf_set_transfer(dmu_buf_set_t *buf_set)
+{
+	uint64_t offset, size;
+	dmu_ctx_t *dmu_ctx = buf_set->dbs_dc;
+
+	/* Initialize the current state. */
+	size = buf_set->dbs_size;
+	offset = buf_set->dbs_dn_start;
+
+	/* Perform the I/O copy, one buffer at a time. */
+	for (int i = 0; i < buf_set->dbs_count; i++) {
+		dmu_buf_t *db = buf_set->dbs_dbp[i];
+		uint64_t off = offset - db->db_offset;
+		uint64_t sz = MIN(db->db_size - off, size);
+		uint64_t adv;
+
+		ASSERT(size > 0);
+		adv = dmu_ctx->dc_buf_transfer_cb(buf_set, db, off, sz);
+		if (buf_set->dbs_err)
+			break;
+		offset += adv;
+		size -= adv;
+	}
+}
+
+void
+dmu_buf_set_transfer_write(dmu_buf_set_t *dbs)
+{
+
+	dmu_buf_set_transfer(dbs);
+	ASSERT(dbs->dbs_dc->dc_dn != NULL);
+	/* Release the dnode immediately before committing the tx. */
+	dnode_rele(dbs->dbs_dc->dc_dn, dbs->dbs_dc->dc_tag);
+	dbs->dbs_dc->dc_dn = NULL;
+}
+
+static void
+dmu_buf_set_transfer_write_tx(dmu_buf_set_t *dbs)
+{
+
+	dmu_buf_set_transfer_write(dbs);
+	dmu_tx_commit(dbs->dbs_tx);
+}
+
+/*
+ * Release a DMU context hold, cleaning up if no holds remain.
+ *
+ * - dmu_ctx	DMU context to release.
+ */
+void
+dmu_ctx_rele(dmu_ctx_t *dmu_ctx)
+{
+	if (zfs_refcount_remove(&dmu_ctx->dc_holds, NULL) != 0)
+		return;
+
+	mutex_destroy(&dmu_ctx->dc_mtx);
+	zfs_refcount_destroy(&dmu_ctx->dc_holds);
+	ASSERT(dmu_ctx_in_flight > 0);
+	DEBUG_REFCOUNT_DEC(dmu_ctx_in_flight);
+
+	if ((dmu_ctx->dc_flags & DMU_CTX_FLAG_NO_HOLD) == 0 &&
+	    (dmu_ctx->dc_dn != NULL))
+		dnode_rele(dmu_ctx->dc_dn, dmu_ctx->dc_tag);
+
+	/* At this point, there are no buffer sets left.  Call back. */
+	if (dmu_ctx->dc_complete_cb != NULL)
+		dmu_ctx->dc_complete_cb(dmu_ctx);
+}
+
+/*
+ * Process a buffer set that is ready for transfer into/out of the
+ * user's buffers.
+ *
+ * NOTE: This can only be called once per dmu_buf_set, so access to the
+ *       dmu_buf_set's elements doesn't need a lock.
+ */
+static void
+dmu_buf_set_ready(dmu_buf_set_t *dbs)
+{
+	dmu_ctx_t *dc = dbs->dbs_dc;
+
+	/* Only perform I/O if no errors occurred for the buffer set. */
+	if (dbs->dbs_err == 0) {
+		dc->dc_buf_set_transfer_cb(dbs);
+		if (dbs->dbs_err == 0)
+			atomic_add_64(&dc->dc_completed_size, dbs->dbs_size);
+	}
+	dmu_ctx_set_error(dc, dbs->dbs_err);
+
+	for (int i = 0; i < dbs->dbs_count; i++) {
+		dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbs->dbs_dbp[i];
+		ASSERT(db != NULL);
+		dbuf_rele(db, dc->dc_tag);
+	}
+
+	DEBUG_REFCOUNT_DEC(buf_set_in_flight);
+	kmem_free(dbs, sizeof (dmu_buf_set_t) +
+	    dbs->dbs_dbp_length * sizeof (dmu_buf_t *));
+	dmu_ctx_rele(dc);
+}
+
+int
+dmu_thread_context_create(void)
+{
+	int ret = 0;
+	dmu_cb_state_t *dcs;
+
+	/* This function should never be called more than once in a thread. */
+	ASSERT3P(tsd_get(zfs_async_io_key), ==, NULL);
+	/* Called with taskqueue mutex held. */
+	dcs = kmem_zalloc(sizeof (dmu_cb_state_t), KM_SLEEP);
+	list_create(&dcs->dcs_io_list, sizeof (dmu_buf_set_node_t),
+	    offsetof(dmu_buf_set_node_t, dbsn_link));
+
+	ret = tsd_set(zfs_async_io_key, dcs);
+#ifdef ZFS_DEBUG
+	{
+		dmu_cb_state_t *check = tsd_get(zfs_async_io_key);
+		ASSERT(check == dcs);
+	}
+#endif
+	return (ret);
+}
+
+void
+dmu_thread_context_destroy(void *context __maybe_unused)
+{
+	dmu_cb_state_t *dcs;
+
+	dcs = tsd_get(zfs_async_io_key);
+	/* This function may be called on a thread that didn't call create. */
+	if (dcs == NULL)
+		return;
+
+	/*
+	 * This function should only get called after a thread has finished
+	 * processing its queue.
+	 */
+	ASSERT(list_is_empty(&dcs->dcs_io_list));
+
+	kmem_free(dcs, sizeof (dmu_cb_state_t));
+	VERIFY(tsd_set(zfs_async_io_key, NULL) == 0);
+}
+
+void
+dmu_thread_context_process(void)
+{
+	dmu_cb_state_t *dcs = tsd_get(zfs_async_io_key);
+	dmu_buf_set_node_t *dbsn, *next;
+
+	/*
+	 * If the current thread didn't register, it doesn't handle queued
+	 * async I/O's.  It is probably not a zio thread.  This is needed
+	 * because zio_execute() can be called from non-zio threads.
+	 */
+	if (dcs == NULL)
+		return;
+
+	for (dbsn = list_head(&dcs->dcs_io_list); dbsn != NULL; dbsn = next) {
+		next = list_next(&dcs->dcs_io_list, dbsn);
+		dmu_buf_set_ready(dbsn->dbsn_dbs);
+		dmu_buf_set_node_remove(&dcs->dcs_io_list, dbsn);
+	}
+}
+
+/*
+ * Release a buffer set for a given dbuf.
+ *
+ * - buf_set	Buffer set to release.
+ * - err		Whether an error occurred.
+ *
+ * invariant:		If specified, the dbuf's mutex must be held.
+ */
+void
+dmu_buf_set_rele(dmu_buf_set_t *dbs, int err)
+{
+	dmu_ctx_t *dmu_ctx = dbs->dbs_dc;
+	dmu_cb_state_t *dcs;
+
+	if (dbs == NULL)
+		return;
+	/* Report an error, if any. */
+	if (err)
+		dmu_buf_set_set_error(dbs, err);
+
+	/* If we are finished, schedule this buffer set for delivery. */
+	ASSERT(!zfs_refcount_is_zero(&dbs->dbs_holds));
+	if (zfs_refcount_remove(&dbs->dbs_holds, NULL) != 0)
+		return;
+
+	dcs = tsd_get(zfs_async_io_key);
+	if (dcs != NULL && (dmu_ctx->dc_flags & DMU_CTX_FLAG_ASYNC)) {
+		dmu_buf_set_node_add(&dcs->dcs_io_list, dbs, B_FALSE);
+	} else {
+			/*
+			 * The current thread doesn't have anything
+			 * registered in its TSD, so it must not handle
+			 * queued delivery.  Dispatch this set now.
+			 */
+			dmu_buf_set_ready(dbs);
+	}
+}
+
+/*
+ * Set up the buffers for a given set.
+ *
+ * - buf_set	Buffer set to set up buffers for.
+ *
+ * returns: errno	If any buffer could not be held for this buffer set.
+ *          0		Success.
+ */
+static int
+dmu_buf_set_setup_buffers(dmu_buf_set_t *dbs, boolean_t restarted)
+{
+	dmu_ctx_t *dc = dbs->dbs_dc;
+	dnode_t *dn = dc->dc_dn;
+	zio_t *async_zio = NULL;
+	dmu_buf_impl_t *db;
+	uint64_t blkid;
+	uint64_t bufoff, bufsiz;
+	int i, dbuf_flags;
+	boolean_t read, prefetch;
+
+	read = dc->dc_flags & DMU_CTX_FLAG_READ;
+	prefetch = dc->dc_flags & DMU_CTX_FLAG_PREFETCH;
+	dbuf_flags = DB_RF_CANFAIL | DB_RF_NEVERWAIT | DB_RF_HAVESTRUCT;
+	if (!prefetch || dbs->dbs_size > zfetch_array_rd_sz)
+		dbuf_flags |= DB_RF_NOPREFETCH;
+
+	if (!restarted) {
+		dmu_prefetch(dn->dn_objset, dc->dc_object, 1, dc->dc_dn_offset,
+		    dbs->dbs_resid, ZIO_PRIORITY_SYNC_READ);
+		dbs->dbs_zio = zio_root(dn->dn_objset->os_spa, NULL, NULL,
+		    ZIO_FLAG_CANFAIL);
+	}
+	blkid = dbuf_whichblock(dn, 0, dbs->dbs_dn_start);
+
+	if (dc->dc_flags & DMU_CTX_FLAG_ASYNC)
+		async_zio = dbs->dbs_zio;
+
+	/*
+	 * Note that while this loop is running, any zio's set up for async
+	 * reads are not executing, therefore access to this dbs is
+	 * serialized within this function; i.e. atomics are not needed here.
+	 */
+	for (i = dbs->dbs_async_holds; i < dbs->dbs_count; i++) {
+		db = NULL;
+
+		int err = dbuf_hold_level_async(dn, /* level */ 0, blkid + i,
+		    dc->dc_tag, &db, dc->dc_dn_offset, dbs, dbs->dbs_resid,
+		    async_zio);
+
+		if (err == EWOULDBLOCK) {
+			ASSERT(dc->dc_flags & DMU_CTX_FLAG_ASYNC);
+			return (err);
+		}
+		VERIFY(err == 0);
+		if (db == NULL) {
+			VERIFY(err);
+			/* Only include counts for the processed buffers. */
+			dbs->dbs_count = i;
+			/* initiator */
+			zfs_refcount_destroy(&dbs->dbs_holds);
+			zfs_refcount_create_untracked(&dbs->dbs_holds);
+			zfs_refcount_add_many(&dbs->dbs_holds, i + 1, NULL);
+			zio_nowait(dbs->dbs_zio);
+			return (err);
+		}
+		dbs->dbs_async_holds++;
+		/* Calculate the amount of data this buffer contributes. */
+		bufoff = dc->dc_dn_offset - db->db.db_offset;
+		bufsiz = (int)MIN(db->db.db_size - bufoff, dbs->dbs_resid);
+		dbs->dbs_resid -= bufsiz;
+
+		/* initiate async i/o */
+		if ((dc->dc_flags & DMU_CTX_FLAG_READ) ||
+		    (bufsiz != db->db.db_size &&
+		    db->db_state != DB_CACHED))
+			(void) dbuf_read(db, dbs->dbs_zio, dbuf_flags);
+
+		/* Update the caller's data to let them know what's next. */
+		dc->dc_dn_offset += bufsiz;
+		dc->dc_resid -= bufsiz;
+		/* Put this dbuf in the buffer set's list. */
+		dbs->dbs_dbp[i] = &db->db;
+	}
+
+	if (prefetch && DNODE_META_IS_CACHEABLE(dn) &&
+	    dbs->dbs_size <= zfetch_array_rd_sz) {
+		dmu_zfetch(&dn->dn_zfetch, blkid, dbs->dbs_count,
+		    read && DNODE_IS_CACHEABLE(dn), B_TRUE);
+	}
+	return (0);
+}
+
+/*
+ * Set up a new transaction for the DMU context.
+ *
+ * - dmu_ctx	DMU context to set up new transaction for.
+ * - txp		Address to store dmu_tx_t pointer.
+ * - dnp		Address to store dnode_t pointer for new dnode.
+ */
+static int
+dmu_ctx_setup_tx(dmu_ctx_t *dmu_ctx, dmu_tx_t **txp, dnode_t **dnp,
+    uint64_t size)
+{
+	int err;
+
+	/* Readers and writers with a context transaction do not apply. */
+	if ((dmu_ctx->dc_flags & DMU_CTX_FLAG_READ) || dmu_ctx->dc_tx != NULL)
+		return (0);
+
+	*txp = dmu_tx_create(dmu_ctx->dc_os);
+	dmu_tx_hold_write(*txp, dmu_ctx->dc_object,
+	    dmu_ctx->dc_dn_offset, size);
+	err = dmu_tx_assign(*txp, TXG_WAIT);
+	if (err)
+		goto out;
+
+	/*
+	 * Writer without caller TX: dnode hold is done here rather
+	 * than in dmu_ctx_init().
+	 */
+	err = dnode_hold(dmu_ctx->dc_os, dmu_ctx->dc_object,
+	    dmu_ctx->dc_tag, dnp);
+	if (err)
+		goto out;
+	dmu_ctx->dc_dn = *dnp;
+
+out:
+	if (err && *txp != NULL) {
+		dmu_tx_abort(*txp);
+		*txp = NULL;
+	}
+	return (err);
+}
+
+/*
+ * Allocate and initialize a dmu_buf_set_t *
+ *
+ */
+static int
+dmu_buf_set_allocate(dmu_ctx_t *dmu_ctx, dmu_buf_set_t **buf_set_p,
+    uint64_t size, dnode_t **dnp)
+{
+	dmu_tx_t *tx = NULL;
+	dmu_buf_set_t *dbs;
+	int err, nblks;
+	size_t set_size;
+	dnode_t *dn;
+
+	/*
+	 * Create a transaction for writes, if needed.  This must be done
+	 * first in order to hold the correct struct_rwlock, use the
+	 * correct values for dn_datablksz, etc.
+	 */
+	err = dmu_ctx_setup_tx(dmu_ctx, &tx, dnp, size);
+	*buf_set_p = NULL;
+	if (err)
+		return (err);
+	dn = *dnp;
+	dn_rlock(dn);
+
+	/* Figure out how many blocks are needed for the requested size. */
+	if (dn->dn_datablkshift) {
+		nblks = P2ROUNDUP(dmu_ctx->dc_dn_offset + size,
+		    dn->dn_datablksz);
+		nblks -= P2ALIGN(dmu_ctx->dc_dn_offset, dn->dn_datablksz);
+		nblks >>= dn->dn_datablkshift;
+	} else {
+		if ((dmu_ctx->dc_dn_offset + size) > dn->dn_datablksz) {
+			zfs_panic_recover("zfs: accessing past end of object "
+			    "%llx/%llx (size=%u access=%llu+%llu)",
+			    (longlong_t)dn->dn_objset->
+			    os_dsl_dataset->ds_object,
+			    (longlong_t)dn->dn_object, dn->dn_datablksz,
+			    (longlong_t)dmu_ctx->dc_dn_offset,
+			    (longlong_t)size);
+			rw_exit(&dn->dn_struct_rwlock);
+			return (SET_ERROR(EIO));
+		}
+		nblks = 1;
+	}
+
+	/* Create the new buffer set. */
+	set_size = sizeof (dmu_buf_set_t) + nblks * sizeof (dmu_buf_t *);
+	dbs = kmem_zalloc(set_size, KM_SLEEP);
+
+	/* Initialize a new buffer set. */
+	DEBUG_REFCOUNT_ADD(buf_set_in_flight);
+#ifdef ZFS_DEBUG
+	atomic_add_64(&buf_set_total, 1);
+#endif
+	dbs->dbs_size = size;
+	dbs->dbs_resid = size;
+	dbs->dbs_dn_start = dmu_ctx->dc_dn_offset;
+	dbs->dbs_count = nblks;
+	dbs->dbs_dbp_length = nblks;
+	dbs->dbs_tx = tx;
+	zfs_refcount_create_untracked(&dbs->dbs_holds);
+
+	/* Include a refcount for the initiator. */
+	if (dmu_ctx->dc_flags & (DMU_CTX_FLAG_READ|DMU_CTX_FLAG_ASYNC))
+		zfs_refcount_add_many(&dbs->dbs_holds, nblks + 1, NULL);
+	else
+		/* For synchronous writes, dbufs never need to call us back. */
+		zfs_refcount_add(&dbs->dbs_holds, NULL);
+	dbs->dbs_dc = dmu_ctx;
+	zfs_refcount_add(&dmu_ctx->dc_holds, NULL);
+	/* Either we're a reader or we have a transaction somewhere. */
+	ASSERT((dmu_ctx->dc_flags & DMU_CTX_FLAG_READ) || dmu_buf_set_tx(dbs));
+	*buf_set_p = dbs;
+	return (0);
+}
+/*
+ * Initialize a buffer set of a certain size.
+ *
+ * - dmu_ctx	DMU context to associate the buffer set with.
+ * - buf_set_p	Pointer to set to the new buffer set's address.
+ * - size		Requested size of the buffer set.
+ *
+ * returns: 0		Success.
+ *          EIO		I/O error: tried to access past the end of the dnode,
+ * 			or dmu_buf_set_setup_buffers() failed.
+ */
+static int
+dmu_buf_set_init(dmu_ctx_t *dmu_ctx, dmu_buf_set_t **buf_set_p,
+    uint64_t size)
+{
+	dmu_buf_set_t *dbs;
+	dmu_tx_t *tx;
+	size_t set_size;
+	int err, nblks;
+	dnode_t *dn = dmu_ctx->dc_dn;
+	boolean_t restarted;
+
+	ASSERT(dmu_ctx != NULL);
+	ASSERT(!zfs_refcount_is_zero(&dmu_ctx->dc_holds));
+	dbs = *buf_set_p;
+
+	if (dbs == NULL) {
+		restarted = B_FALSE;
+		if ((err = dmu_buf_set_allocate(dmu_ctx, &dbs, size, &dn)))
+			return (err);
+	} else {
+		restarted = B_TRUE;
+		dn_rlock(dn);
+	}
+	tx = dbs->dbs_tx;
+	err = dmu_buf_set_setup_buffers(dbs, restarted);
+	if (err  == 0) {
+		*buf_set_p = dbs;
+	} else  if (err == EWOULDBLOCK) {
+		rw_exit(&dn->dn_struct_rwlock);
+		return (err);
+	} else {
+		/* XXX this whole error path needs revisiting */
+		nblks = dbs->dbs_count;
+		set_size = sizeof (dmu_buf_set_t) +
+		    nblks * sizeof (dmu_buf_t *);
+
+		if (dmu_ctx->dc_flags & (DMU_CTX_FLAG_READ|DMU_CTX_FLAG_ASYNC))
+			zfs_refcount_destroy_many(&dbs->dbs_holds, nblks + 1);
+		else
+			/* For writes, dbufs never need to call us back. */
+			zfs_refcount_destroy_many(&dbs->dbs_holds, 1);
+		zfs_refcount_remove(&dmu_ctx->dc_holds, NULL);
+		zio_nowait(dbs->dbs_zio);
+		kmem_free(dbs, set_size);
+		/* Initialize a new buffer set. */
+		DEBUG_REFCOUNT_ADD(buf_set_in_flight);
+#ifdef ZFS_DEBUG
+		atomic_add_64(&buf_set_total, -1);
+#endif
+	}
+	if (err && tx != NULL)
+		dmu_tx_abort(tx);
+	rw_exit(&dn->dn_struct_rwlock);
+	return (err);
+}
+
+/*
+ * Process the I/Os queued for a given buffer set.
+ *
+ * - buf_set	Buffer set to process I/Os for.
+ *
+ * returns: errno	Errors from zio_wait or a buffer went UNCACHED.
+ *          0		Success.
+ */
+static int
+dmu_buf_set_process_io(dmu_buf_set_t *dbs)
+{
+	int err, i;
+	dmu_ctx_t *dmu_ctx = dbs->dbs_dc;
+
+	/*
+	 * If the I/O is asynchronous, issue the I/O's without waiting.
+	 * Writes do not need to wait for any ZIOs.
+	 */
+	if ((dmu_ctx->dc_flags & DMU_CTX_FLAG_ASYNC) ||
+	    (dmu_ctx->dc_flags & DMU_CTX_FLAG_READ) == 0) {
+		zio_nowait(dbs->dbs_zio);
+		return (0);
+	}
+
+	/* Wait for async i/o. */
+	err = zio_wait(dbs->dbs_zio);
+	if (err)
+		return (err);
+	/* wait for other io to complete */
+	for (i = 0; i < dbs->dbs_count; i++) {
+		dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbs->dbs_dbp[i];
+		mutex_enter(&db->db_mtx);
+		while (db->db_state == DB_READ ||
+		    db->db_state == DB_FILL)
+			cv_wait(&db->db_changed, &db->db_mtx);
+		if (db->db_state == DB_UNCACHED)
+			err = SET_ERROR(EIO);
+		mutex_exit(&db->db_mtx);
+		if (err)
+			return (err);
+	}
+	return (0);
+}
+
+/*
+ * Issue the I/O specified in the given DMU context.
+ *
+ * - dmu_ctx	The DMU context.
+ *
+ * returns: errno	Errors executing I/O chunks.
+ *          0		If a DMU callback is specified; the callback
+ *			receives any errors.
+ *          0		If no DMU callback is specified: Success.
+ */
+int
+dmu_issue(dmu_ctx_t *dc)
+{
+	int err = 0;
+	uint64_t io_size;
+	dmu_buf_set_t *dbs;
+
+	/* If this context is async, it must have a context callback. */
+	ASSERT((dc->dc_flags & DMU_CTX_FLAG_ASYNC) == 0 ||
+	    dc->dc_complete_cb != NULL);
+
+	/*
+	 * For writers, if a tx was specified but a dnode wasn't, hold here.
+	 * This could be done in dmu_ctx_set_dmu_tx(), but that would
+	 * require dmu.h to include a dnode_hold() prototype.
+	 */
+	if (dc->dc_tx != NULL && dc->dc_dn == NULL) {
+		err = dnode_hold(dc->dc_os, dc->dc_object, dc->dc_tag,
+		    &dc->dc_dn);
+		if (err)
+			return (err);
+	}
+	/* While there is work left to do, execute the next chunk. */
+	dprintf("%s(%p) -> buf %p off %lu sz %lu\n", __func__, dc,
+	    dc->dc_data_buf, dc->dc_dn_offset, dc->dc_resid);
+	while (dc->dc_resid > 0 && err == 0) {
+		io_size = MIN(dc->dc_resid, DMU_MAX_ACCESS/2);
+		dbs = NULL;
+
+		dprintf("%s(%p@%lu+%lu) chunk %lu\n", __func__, dc,
+		    dc->dc_dn_offset, dc->dc_resid, io_size);
+		err = dmu_buf_set_init(dc, &dbs, io_size);
+		if (err == EWOULDBLOCK)
+			return (0);
+		/* Process the I/O requests, if the initialization passed. */
+		if (err == 0) {
+			err = dmu_buf_set_process_io(dbs);
+			dmu_buf_set_rele(dbs, err);
+		}
+	}
+	/*
+	 * At this point, either this I/O is async, or all buffer sets
+	 * have finished processing.
+	 */
+	VERIFY((dc->dc_flags & DMU_CTX_FLAG_ASYNC) ||
+	    zfs_refcount_count(&dc->dc_holds) == 1);
+
+	/*
+	 * If an error occurs while actually performing I/O, propagate to
+	 * the caller.  If an error occurs in this context, ensure that
+	 * async callers also receive it via the context, if appropriate.
+	 */
+	dmu_ctx_set_error(dc, err);
+
+	return (dc->dc_err);
+}
+
+void
+dmu_issue_restart(dmu_buf_set_t *dbs, int err)
+{
+	uint64_t io_size;
+	dmu_ctx_t *dc;
+
+	dc = dbs->dbs_dc;
+	if (err) {
+		/*
+		 * We skipped a hold + rele || hold + read
+		 */
+		VERIFY(zfs_refcount_remove(&dbs->dbs_holds, NULL) != 0);
+		dmu_buf_set_rele(dbs, err);
+	}
+	/* This context must be async */
+	ASSERT(dc->dc_flags & DMU_CTX_FLAG_ASYNC);
+
+	/* While there is work left to do, execute the next chunk. */
+	dprintf("%s(%p) -> buf %p off %lu sz %lu\n", __func__, dc,
+	    dc->dc_data_buf, dc->dc_dn_offset, dc->dc_resid);
+	while (dc->dc_resid > 0 && err == 0) {
+		io_size = MIN(dc->dc_resid, DMU_MAX_ACCESS/2);
+
+		dprintf("%s(%p@%lu+%lu) chunk %lu\n", __func__, dc,
+		    dc->dc_dn_offset, dc->dc_resid, io_size);
+		err = dmu_buf_set_init(dc, &dbs, io_size);
+		if (err == EWOULDBLOCK)
+			return;
+		/* Process the I/O requests, if the initialization passed. */
+		if (err == 0)
+			err = dmu_buf_set_process_io(dbs);
+		if (dbs != NULL)
+			dmu_buf_set_rele(dbs, err);
+		dbs = NULL;
+	}
+
+	/*
+	 * If an error occurs while actually performing I/O, propagate to
+	 * the caller.  If an error occurs in this context, ensure that
+	 * async callers also receive it via the context, if appropriate.
+	 */
+	dmu_ctx_set_error(dc, err);
+}
+
+
+/*
+ * Set up a DMU context.
+ *
+ * - dmu_ctx	The DMU context.
+ * - dn		A held dnode to associate with the context, or NULL.
+ * - os		The object set associated with the context.
+ * - object	The object ID associated with the context.
+ * - size		Size of the I/O to be performed.
+ * - offset	Offset into the dnode to perform the I/O.
+ * - data_buf	Data buffer to perform I/O transfers with.
+ * - tag		Hold tag to use.
+ * - flags		DMU context flags.
+ *
+ * \note	The dnode must not be NULL, unless this is a writer.
+ * \note	The dnode, if specified, must be held, unless the
+ *		DMU_CTX_FLAG_NO_HOLD flag is specified.
+ */
+int
+dmu_ctx_init(dmu_ctx_t *dmu_ctx, struct dnode *dn, objset_t *os,
+    uint64_t object, uint64_t offset, uint64_t size, void *data_buf, void *tag,
+    dmu_ctx_flag_t flags)
+{
+	boolean_t reader = (flags & DMU_CTX_FLAG_READ) != 0;
+	int err;
+
+	DEBUG_REFCOUNT_ADD(dmu_ctx_in_flight);
+#ifdef ZFS_DEBUG
+	atomic_add_64(&dmu_ctx_total, 1);
+	/* Make sure the dnode is passed in appropriately. */
+	if (dn == NULL)
+		ASSERT(os != NULL);
+	else
+		ASSERT(!zfs_refcount_is_zero(&dn->dn_holds) ||
+		    (flags & DMU_CTX_FLAG_NO_HOLD));
+#endif
+
+	/* Make sure the flags are compatible with the I/O type. */
+	ASSERT(reader || ((flags & DMU_CTX_READER_FLAGS) == 0));
+	ASSERT(!reader || ((flags & DMU_CTX_WRITER_FLAGS) == 0));
+	/* The NOFILL flag and a NULL data_buf go hand in hand. */
+	ASSERT(((flags & DMU_CTX_FLAG_NOFILL) != 0) ^ (data_buf != NULL));
+
+	/*
+	 * If the caller is a reader and didn't pass in a dnode, hold it.
+	 * Writers (re-)hold a dnode in dmu_ctx_setup_tx(), or if a tx
+	 * is specified, in dmu_issue().
+	 */
+	if (dn == NULL && (flags & DMU_CTX_FLAG_READ)) {
+		err = dnode_hold(os, object, tag, &dn);
+		if (err)
+			return (err);
+	}
+
+	/* All set, actually initialize the context! */
+	bzero(dmu_ctx, sizeof (dmu_ctx_t));
+	mutex_init(&dmu_ctx->dc_mtx, "context lock", MUTEX_DEFAULT, NULL);
+	dmu_ctx->dc_dn = dn;
+	dmu_ctx->dc_os = os;
+	dmu_ctx->dc_object = object;
+	dmu_ctx->dc_size = size;
+	dmu_ctx->dc_flags = flags;
+	dmu_ctx_seek(dmu_ctx, offset, size, data_buf);
+	dmu_ctx->dc_tag = tag;
+
+	/* Initialize default I/O callbacks. */
+	if (dmu_ctx->dc_flags & DMU_CTX_FLAG_UIO) {
+#ifdef UIO_XUIO
+		uio_t *uio = (uio_t *)dmu_ctx->dc_data_buf;
+		if (uio->uio_extflg == UIO_XUIO) {
+			ASSERT(reader);
+			dmu_ctx->dc_data_transfer_cb = dmu_buf_read_xuio;
+		} else
+#endif
+		{
+			dmu_ctx->dc_data_transfer_cb = reader ?
+			    dmu_buf_read_uio : dmu_buf_write_uio;
+		}
+#if defined(_KERNEL) && !defined(__linux__)
+	} else if (dmu_ctx->dc_flags & DMU_CTX_FLAG_SUN_PAGES) {
+		/* implies writer */
+		dmu_ctx->dc_data_transfer_cb = dmu_buf_write_pages;
+#endif
+	} else {
+		dmu_ctx->dc_data_transfer_cb = reader ? dmu_buf_read_char :
+		    dmu_buf_write_char;
+	}
+	dmu_ctx->dc_buf_set_transfer_cb = reader ? dmu_buf_set_transfer :
+	    dmu_buf_set_transfer_write_tx;
+	if ((dmu_ctx->dc_flags & DMU_CTX_FLAG_NOFILL) == 0) {
+		dmu_ctx->dc_buf_transfer_cb = reader ?
+		    dmu_ctx->dc_data_transfer_cb :
+		    dmu_buf_transfer_write;
+	} else
+		dmu_ctx->dc_buf_transfer_cb = dmu_buf_transfer_nofill;
+
+	/* Initialize including a refcount for the initiator. */
+	zfs_refcount_create(&dmu_ctx->dc_holds);
+	zfs_refcount_add(&dmu_ctx->dc_holds, NULL);
+	return (0);
+}
+
+/*
+ * Update a DMU context for the next call.
+ *
+ * - dmu_ctx	The DMU context.
+ * - data_buf	The updated destination data buffer.
+ * - offset	The offset into the dnode.
+ * - size		The size of the next call.
+ */
+void
+dmu_ctx_seek(dmu_ctx_t *dmu_ctx, uint64_t offset, uint64_t size,
+    void *data_buf)
+{
+	dnode_t *dn = dmu_ctx->dc_dn;
+
+#ifdef ZFS_DEBUG
+	if (dmu_ctx->dc_flags & DMU_CTX_FLAG_UIO) {
+		uio_t *uio = (uio_t *)data_buf;
+		/* Make sure UIO callers pass in the correct offset. */
+		ASSERT(uio->uio_loffset == offset);
+	}
+	/* Make sure non-char * pointers stay the same. */
+	if (!dmu_ctx_buf_is_char(dmu_ctx))
+		ASSERT(dmu_ctx->dc_data_buf == NULL ||
+		    dmu_ctx->dc_data_buf == data_buf);
+#endif /* ZFS_DEBUG */
+
+	/*
+	 * Deal with odd block sizes, where there can't be data past
+	 * the first block.  If we ever do the tail block optimization,
+	 * we will need to handle that here as well.
+	 */
+	if ((dmu_ctx->dc_flags & DMU_CTX_FLAG_READ) && dn->dn_maxblkid == 0 &&
+	    dmu_ctx_buf_is_char(dmu_ctx)) {
+		int newsz = offset > dn->dn_datablksz ? 0 :
+		    MIN(size, dn->dn_datablksz - offset);
+		bzero((char *)data_buf + newsz, size - newsz);
+		size = newsz;
+	}
+	dmu_ctx->dc_dn_offset = offset;
+	dmu_ctx->dc_dn_start = offset;
+	dmu_ctx->dc_resid = size;
+	dmu_ctx->dc_resid_init = size;
+	dmu_ctx->dc_data_buf = data_buf;
+}
+
+static int
+dmu_async_impl(dmu_ctx_t *dc, dnode_t *dn, objset_t *os, uint64_t object,
+    uint64_t offset, uint64_t size, void *buf, uint32_t flags, dmu_tx_t *tx,
+    dmu_ctx_cb_t done_cb)
+{
+	int err;
+
+	err = dmu_ctx_init(dc, dn, os, object, offset,
+	    size, buf, FTAG, flags|DMU_CTX_FLAG_ASYNC);
+	if (err)
+		return (err);
+	dmu_ctx_set_complete_cb(dc, done_cb);
+
+	if ((flags & DMU_CTX_FLAG_READ) == 0)
+		dmu_ctx_set_dmu_tx(dc, tx);
+	err = dmu_issue(dc);
+	dmu_ctx_rele(dc);
+
+	return (err);
+}
+
+static int
+dmu_write_impl(dnode_t *dn, objset_t *os, uint64_t object, uint64_t offset,
+    uint64_t size, const void *buf, dmu_tx_t *tx, uint32_t flags)
+{
+	void *bufp = (void *)(uintptr_t)buf;
+	dmu_ctx_t dmu_ctx;
+	int err;
+
+	err = dmu_ctx_init(&dmu_ctx, dn, os, object, offset,
+	    size, bufp, FTAG, flags);
+	if (err == 0) {
+		dmu_ctx_set_dmu_tx(&dmu_ctx, tx);
+
+		err = dmu_issue(&dmu_ctx);
+		dmu_ctx_rele(&dmu_ctx);
+	}
+	return (err);
+}
+
+int
+dmu_read_async(dmu_ctx_t *dc, objset_t *os, uint64_t object, uint64_t offset,
+    uint64_t size, void *buf, uint32_t flags, dmu_ctx_cb_t done_cb)
+{
+
+	return (dmu_async_impl(dc, /* dnode */NULL, os, object, offset, size,
+	    buf, flags|DMU_CTX_FLAG_READ, NULL, done_cb));
+}
+
+int
+dmu_write_async(dmu_ctx_t *dc, objset_t *os, uint64_t object, uint64_t offset,
+    uint64_t size, void *buf, dmu_tx_t *tx, dmu_ctx_cb_t done_cb)
+{
+
+	return (dmu_async_impl(dc, /* dnode */NULL, os, object, offset, size,
+	    buf, /* flags */ 0, tx, done_cb));
+}
+
 int
 dmu_buf_hold_noread_by_dnode(dnode_t *dn, uint64_t offset,
     void *tag, dmu_buf_t **dbp)
@@ -158,7 +1189,7 @@ dmu_buf_hold_noread_by_dnode(dnode_t *dn, uint64_t offset,
 	uint64_t blkid;
 	dmu_buf_impl_t *db;
 
-	rw_enter(&dn->dn_struct_rwlock, RW_READER);
+	dn_rlock(dn);
 	blkid = dbuf_whichblock(dn, 0, offset);
 	db = dbuf_hold(dn, blkid, tag);
 	rw_exit(&dn->dn_struct_rwlock);
@@ -183,6 +1214,7 @@ dmu_buf_hold_noread(objset_t *os, uint64_t object, uint64_t offset,
 	err = dnode_hold(os, object, FTAG, &dn);
 	if (err)
 		return (err);
+
 	rw_enter(&dn->dn_struct_rwlock, RW_READER);
 	blkid = dbuf_whichblock(dn, 0, offset);
 	db = dbuf_hold(dn, blkid, tag);
@@ -205,9 +1237,9 @@ dmu_buf_hold_by_dnode(dnode_t *dn, uint64_t offset,
 	int err;
 	int db_flags = DB_RF_CANFAIL;
 
-	if (flags & DMU_READ_NO_PREFETCH)
+	if ((flags & DMU_CTX_FLAG_PREFETCH) == 0)
 		db_flags |= DB_RF_NOPREFETCH;
-	if (flags & DMU_READ_NO_DECRYPT)
+	if (flags & DMU_CTX_FLAG_NODECRYPT)
 		db_flags |= DB_RF_NO_DECRYPT;
 
 	err = dmu_buf_hold_noread_by_dnode(dn, offset, tag, dbp);
@@ -230,9 +1262,9 @@ dmu_buf_hold(objset_t *os, uint64_t object, uint64_t offset,
 	int err;
 	int db_flags = DB_RF_CANFAIL;
 
-	if (flags & DMU_READ_NO_PREFETCH)
+	if ((flags & DMU_CTX_FLAG_PREFETCH) == 0)
 		db_flags |= DB_RF_NOPREFETCH;
-	if (flags & DMU_READ_NO_DECRYPT)
+	if (flags & DMU_CTX_FLAG_NODECRYPT)
 		db_flags |= DB_RF_NO_DECRYPT;
 
 	err = dmu_buf_hold_noread(os, object, offset, tag, dbp);
@@ -342,9 +1374,9 @@ int dmu_bonus_hold_by_dnode(dnode_t *dn, void *tag, dmu_buf_t **dbp,
 	int error;
 	uint32_t db_flags = DB_RF_MUST_SUCCEED;
 
-	if (flags & DMU_READ_NO_PREFETCH)
+	if ((flags & DMU_CTX_FLAG_PREFETCH) == 0)
 		db_flags |= DB_RF_NOPREFETCH;
-	if (flags & DMU_READ_NO_DECRYPT)
+	if (flags & DMU_CTX_FLAG_NODECRYPT)
 		db_flags |= DB_RF_NO_DECRYPT;
 
 	rw_enter(&dn->dn_struct_rwlock, RW_READER);
@@ -391,7 +1423,7 @@ dmu_bonus_hold(objset_t *os, uint64_t object, void *tag, dmu_buf_t **dbp)
 	if (error)
 		return (error);
 
-	error = dmu_bonus_hold_by_dnode(dn, tag, dbp, DMU_READ_NO_PREFETCH);
+	error = dmu_bonus_hold_by_dnode(dn, tag, dbp, 0);
 	dnode_rele(dn, FTAG);
 
 	return (error);
@@ -472,7 +1504,7 @@ dmu_spill_hold_by_bonus(dmu_buf_t *bonus, uint32_t flags, void *tag,
 	int err;
 	uint32_t db_flags = DB_RF_CANFAIL;
 
-	if (flags & DMU_READ_NO_DECRYPT)
+	if (flags & DMU_CTX_FLAG_NODECRYPT)
 		db_flags |= DB_RF_NO_DECRYPT;
 
 	DB_DNODE_ENTER(db);
@@ -481,160 +1513,6 @@ dmu_spill_hold_by_bonus(dmu_buf_t *bonus, uint32_t flags, void *tag,
 	DB_DNODE_EXIT(db);
 
 	return (err);
-}
-
-/*
- * Note: longer-term, we should modify all of the dmu_buf_*() interfaces
- * to take a held dnode rather than <os, object> -- the lookup is wasteful,
- * and can induce severe lock contention when writing to several files
- * whose dnodes are in the same block.
- */
-int
-dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
-    boolean_t read, void *tag, int *numbufsp, dmu_buf_t ***dbpp, uint32_t flags)
-{
-	dmu_buf_t **dbp;
-	uint64_t blkid, nblks, i;
-	uint32_t dbuf_flags;
-	int err;
-	zio_t *zio;
-
-	ASSERT(length <= DMU_MAX_ACCESS);
-
-	/*
-	 * Note: We directly notify the prefetch code of this read, so that
-	 * we can tell it about the multi-block read.  dbuf_read() only knows
-	 * about the one block it is accessing.
-	 */
-	dbuf_flags = DB_RF_CANFAIL | DB_RF_NEVERWAIT | DB_RF_HAVESTRUCT |
-	    DB_RF_NOPREFETCH;
-
-	rw_enter(&dn->dn_struct_rwlock, RW_READER);
-	if (dn->dn_datablkshift) {
-		int blkshift = dn->dn_datablkshift;
-		nblks = (P2ROUNDUP(offset + length, 1ULL << blkshift) -
-		    P2ALIGN(offset, 1ULL << blkshift)) >> blkshift;
-	} else {
-		if (offset + length > dn->dn_datablksz) {
-			zfs_panic_recover("zfs: accessing past end of object "
-			    "%llx/%llx (size=%u access=%llu+%llu)",
-			    (longlong_t)dn->dn_objset->
-			    os_dsl_dataset->ds_object,
-			    (longlong_t)dn->dn_object, dn->dn_datablksz,
-			    (longlong_t)offset, (longlong_t)length);
-			rw_exit(&dn->dn_struct_rwlock);
-			return (SET_ERROR(EIO));
-		}
-		nblks = 1;
-	}
-	dbp = kmem_zalloc(sizeof (dmu_buf_t *) * nblks, KM_SLEEP);
-
-	zio = zio_root(dn->dn_objset->os_spa, NULL, NULL, ZIO_FLAG_CANFAIL);
-	blkid = dbuf_whichblock(dn, 0, offset);
-	for (i = 0; i < nblks; i++) {
-		dmu_buf_impl_t *db = dbuf_hold(dn, blkid + i, tag);
-		if (db == NULL) {
-			rw_exit(&dn->dn_struct_rwlock);
-			dmu_buf_rele_array(dbp, nblks, tag);
-			zio_nowait(zio);
-			return (SET_ERROR(EIO));
-		}
-
-		/* initiate async i/o */
-		if (read)
-			(void) dbuf_read(db, zio, dbuf_flags);
-		dbp[i] = &db->db;
-	}
-
-	if ((flags & DMU_READ_NO_PREFETCH) == 0 &&
-	    DNODE_META_IS_CACHEABLE(dn) && length <= zfetch_array_rd_sz) {
-		dmu_zfetch(&dn->dn_zfetch, blkid, nblks,
-		    read && DNODE_IS_CACHEABLE(dn), B_TRUE);
-	}
-	rw_exit(&dn->dn_struct_rwlock);
-
-	/* wait for async i/o */
-	err = zio_wait(zio);
-	if (err) {
-		dmu_buf_rele_array(dbp, nblks, tag);
-		return (err);
-	}
-
-	/* wait for other io to complete */
-	if (read) {
-		for (i = 0; i < nblks; i++) {
-			dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbp[i];
-			mutex_enter(&db->db_mtx);
-			while (db->db_state == DB_READ ||
-			    db->db_state == DB_FILL)
-				cv_wait(&db->db_changed, &db->db_mtx);
-			if (db->db_state == DB_UNCACHED)
-				err = SET_ERROR(EIO);
-			mutex_exit(&db->db_mtx);
-			if (err) {
-				dmu_buf_rele_array(dbp, nblks, tag);
-				return (err);
-			}
-		}
-	}
-
-	*numbufsp = nblks;
-	*dbpp = dbp;
-	return (0);
-}
-
-static int
-dmu_buf_hold_array(objset_t *os, uint64_t object, uint64_t offset,
-    uint64_t length, int read, void *tag, int *numbufsp, dmu_buf_t ***dbpp)
-{
-	dnode_t *dn;
-	int err;
-
-	err = dnode_hold(os, object, FTAG, &dn);
-	if (err)
-		return (err);
-
-	err = dmu_buf_hold_array_by_dnode(dn, offset, length, read, tag,
-	    numbufsp, dbpp, DMU_READ_PREFETCH);
-
-	dnode_rele(dn, FTAG);
-
-	return (err);
-}
-
-int
-dmu_buf_hold_array_by_bonus(dmu_buf_t *db_fake, uint64_t offset,
-    uint64_t length, boolean_t read, void *tag, int *numbufsp,
-    dmu_buf_t ***dbpp)
-{
-	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
-	dnode_t *dn;
-	int err;
-
-	DB_DNODE_ENTER(db);
-	dn = DB_DNODE(db);
-	err = dmu_buf_hold_array_by_dnode(dn, offset, length, read, tag,
-	    numbufsp, dbpp, DMU_READ_PREFETCH);
-	DB_DNODE_EXIT(db);
-
-	return (err);
-}
-
-void
-dmu_buf_rele_array(dmu_buf_t **dbp_fake, int numbufs, void *tag)
-{
-	int i;
-	dmu_buf_impl_t **dbp = (dmu_buf_impl_t **)dbp_fake;
-
-	if (numbufs == 0)
-		return;
-
-	for (i = 0; i < numbufs; i++) {
-		if (dbp[i])
-			dbuf_rele(dbp[i], tag);
-	}
-
-	kmem_free(dbp, sizeof (dmu_buf_t *) * numbufs);
 }
 
 /*
@@ -659,7 +1537,7 @@ dmu_prefetch(objset_t *os, uint64_t object, int64_t level, uint64_t offset,
 		if (object == 0 || object >= DN_MAX_OBJECT)
 			return;
 
-		rw_enter(&dn->dn_struct_rwlock, RW_READER);
+		dn_rlock(dn);
 		blkid = dbuf_whichblock(dn, level,
 		    object * sizeof (dnode_phys_t));
 		dbuf_prefetch(dn, level, blkid, pri, 0);
@@ -688,7 +1566,7 @@ dmu_prefetch(objset_t *os, uint64_t object, int64_t level, uint64_t offset,
 	 * offset)  is the first.  Then the number we need to prefetch is the
 	 * last - first + 1.
 	 */
-	rw_enter(&dn->dn_struct_rwlock, RW_READER);
+	dn_rlock(dn);
 	if (level > 0 || dn->dn_datablkshift != 0) {
 		nblks = dbuf_whichblock(dn, level, offset + len - 1) -
 		    dbuf_whichblock(dn, level, offset) + 1;
@@ -965,55 +1843,20 @@ dmu_free_range(objset_t *os, uint64_t object, uint64_t offset,
 }
 
 static int
-dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
-    void *buf, uint32_t flags)
+dmu_read_impl(dnode_t *dn, objset_t *os, uint64_t object, uint64_t offset,
+    uint64_t size, void *buf, uint32_t flags)
 {
-	dmu_buf_t **dbp;
-	int numbufs, err = 0;
+	int err;
+	dmu_ctx_t dmu_ctx;
 
-	/*
-	 * Deal with odd block sizes, where there can't be data past the first
-	 * block.  If we ever do the tail block optimization, we will need to
-	 * handle that here as well.
-	 */
-	if (dn->dn_maxblkid == 0) {
-		uint64_t newsz = offset > dn->dn_datablksz ? 0 :
-		    MIN(size, dn->dn_datablksz - offset);
-		bzero((char *)buf + newsz, size - newsz);
-		size = newsz;
-	}
+	err = dmu_ctx_init(&dmu_ctx, dn, os, object, offset,
+	    size, buf, FTAG, flags|DMU_CTX_FLAG_READ);
+	if (err)
+		return (err);
 
-	while (size > 0) {
-		uint64_t mylen = MIN(size, DMU_MAX_ACCESS / 2);
-		int i;
+	err = dmu_issue(&dmu_ctx);
+	dmu_ctx_rele(&dmu_ctx);
 
-		/*
-		 * NB: we could do this block-at-a-time, but it's nice
-		 * to be reading in parallel.
-		 */
-		err = dmu_buf_hold_array_by_dnode(dn, offset, mylen,
-		    TRUE, FTAG, &numbufs, &dbp, flags);
-		if (err)
-			break;
-
-		for (i = 0; i < numbufs; i++) {
-			uint64_t tocpy;
-			int64_t bufoff;
-			dmu_buf_t *db = dbp[i];
-
-			ASSERT(size > 0);
-
-			bufoff = offset - db->db_offset;
-			tocpy = MIN(db->db_size - bufoff, size);
-
-			(void) memcpy(buf, (char *)db->db_data + bufoff, tocpy);
-
-			offset += tocpy;
-			size -= tocpy;
-			buf = (char *)buf + tocpy;
-		}
-		dmu_buf_rele_array(dbp, numbufs, FTAG);
-	}
 	return (err);
 }
 
@@ -1021,113 +1864,55 @@ int
 dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     void *buf, uint32_t flags)
 {
-	dnode_t *dn;
-	int err;
 
-	err = dnode_hold(os, object, FTAG, &dn);
-	if (err != 0)
-		return (err);
-
-	err = dmu_read_impl(dn, offset, size, buf, flags);
-	dnode_rele(dn, FTAG);
-	return (err);
+	return (dmu_read_impl(/* dnode */NULL, os, object, offset, size,
+	    buf, flags));
 }
 
 int
 dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
     uint32_t flags)
 {
-	return (dmu_read_impl(dn, offset, size, buf, flags));
-}
 
-static void
-dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
-    const void *buf, dmu_tx_t *tx)
-{
-	int i;
-
-	for (i = 0; i < numbufs; i++) {
-		uint64_t tocpy;
-		int64_t bufoff;
-		dmu_buf_t *db = dbp[i];
-
-		ASSERT(size > 0);
-
-		bufoff = offset - db->db_offset;
-		tocpy = MIN(db->db_size - bufoff, size);
-
-		ASSERT(i == 0 || i == numbufs-1 || tocpy == db->db_size);
-
-		if (tocpy == db->db_size)
-			dmu_buf_will_fill(db, tx);
-		else
-			dmu_buf_will_dirty(db, tx);
-
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
-
-		if (tocpy == db->db_size)
-			dmu_buf_fill_done(db, tx);
-
-		offset += tocpy;
-		size -= tocpy;
-		buf = (char *)buf + tocpy;
-	}
+	return (dmu_read_impl(dn, dn->dn_objset, dn->dn_object, offset, size,
+	    buf, flags|DMU_CTX_FLAG_NO_HOLD));
 }
 
 void
 dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx)
 {
-	dmu_buf_t **dbp;
-	int numbufs;
-
-	if (size == 0)
-		return;
-
-	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp));
-	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	dmu_write_impl(/* dnode */ NULL, os, object, offset, size, buf, tx, 0);
 }
 
-/*
- * Note: Lustre is an external consumer of this interface.
- */
 void
 dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx)
 {
-	dmu_buf_t **dbp;
-	int numbufs;
 
-	if (size == 0)
-		return;
-
-	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
-	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	dmu_write_impl(dn, dn->dn_objset, dn->dn_object, offset, size, buf,
+	    tx, 0);
 }
 
-void
+int
 dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     dmu_tx_t *tx)
 {
-	dmu_buf_t **dbp;
-	int numbufs, i;
+	dmu_ctx_t dc;
+	int err;
 
 	if (size == 0)
-		return;
+		return (0);
 
-	VERIFY(0 == dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp));
+	err = dmu_ctx_init(&dc, /* dnode */ NULL, os, object, offset, size,
+	    /* data_buf */ NULL, FTAG, DMU_CTX_FLAG_NOFILL);
+	if (err)
+		return (err);
 
-	for (i = 0; i < numbufs; i++) {
-		dmu_buf_t *db = dbp[i];
-
-		dmu_buf_will_not_fill(db, tx);
-	}
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	dmu_ctx_set_dmu_tx(&dc, tx);
+	err = dmu_issue(&dc);
+	dmu_ctx_rele(&dc);
+	return (err);
 }
 
 void
@@ -1149,18 +1934,39 @@ dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
 	dmu_buf_rele(db, FTAG);
 }
 
+typedef struct dmu_redact_cb_ctx {
+	dmu_ctx_t dc;
+	dmu_tx_t *tx;
+} dmu_redact_cb_ctx_t;
+
+static void
+dmu_redact_cb(dmu_buf_set_t *dbs)
+{
+	dmu_buf_t **dbp;
+	int numbufs, i;
+	dmu_redact_cb_ctx_t *ctx;
+
+	dbp = dbs->dbs_dbp;
+	numbufs = dbs->dbs_count;
+	ctx = (dmu_redact_cb_ctx_t *)dbs->dbs_dc;
+
+	for (i = 0; i < numbufs; i++)
+		dmu_buf_redact(dbp[i], ctx->tx);
+}
+
 void
 dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     dmu_tx_t *tx)
 {
-	int numbufs, i;
-	dmu_buf_t **dbp;
+	dmu_redact_cb_ctx_t ctx;
+	uint32_t dmu_flags = DMU_CTX_FLAG_READ | DMU_CTX_FLAG_NOFILL;
 
-	VERIFY0(dmu_buf_hold_array(os, object, offset, size, FALSE, FTAG,
-	    &numbufs, &dbp));
-	for (i = 0; i < numbufs; i++)
-		dmu_buf_redact(dbp[i], tx);
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	ctx.tx = tx;
+	VERIFY0(dmu_ctx_init(&ctx.dc, /* dnode */ NULL, os,
+	    object, offset, size, /* data_buf */ NULL, FTAG, dmu_flags));
+	dmu_ctx_set_buf_set_transfer_cb(&ctx.dc, dmu_redact_cb);
+	dmu_issue(&ctx.dc);
+	dmu_ctx_rele(&ctx.dc);
 }
 
 /*
@@ -1312,68 +2118,12 @@ xuio_stat_wbuf_nocopy(void)
 {
 	XUIOSTAT_BUMP(xuiostat_wbuf_nocopy);
 }
-
-#ifdef _KERNEL
 int
 dmu_read_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size)
 {
-	dmu_buf_t **dbp;
-	int numbufs, i, err;
-#ifdef HAVE_UIO_ZEROCOPY
-	xuio_t *xuio = NULL;
-#endif
 
-	/*
-	 * NB: we could do this block-at-a-time, but it's nice
-	 * to be reading in parallel.
-	 */
-	err = dmu_buf_hold_array_by_dnode(dn, uio->uio_loffset, size,
-	    TRUE, FTAG, &numbufs, &dbp, 0);
-	if (err)
-		return (err);
-
-	for (i = 0; i < numbufs; i++) {
-		uint64_t tocpy;
-		int64_t bufoff;
-		dmu_buf_t *db = dbp[i];
-
-		ASSERT(size > 0);
-
-		bufoff = uio->uio_loffset - db->db_offset;
-		tocpy = MIN(db->db_size - bufoff, size);
-
-#ifdef HAVE_UIO_ZEROCOPY
-		if (xuio) {
-			dmu_buf_impl_t *dbi = (dmu_buf_impl_t *)db;
-			arc_buf_t *dbuf_abuf = dbi->db_buf;
-			arc_buf_t *abuf = dbuf_loan_arcbuf(dbi);
-			err = dmu_xuio_add(xuio, abuf, bufoff, tocpy);
-			if (!err) {
-				uio->uio_resid -= tocpy;
-				uio->uio_loffset += tocpy;
-			}
-
-			if (abuf == dbuf_abuf)
-				XUIOSTAT_BUMP(xuiostat_rbuf_nocopy);
-			else
-				XUIOSTAT_BUMP(xuiostat_rbuf_copied);
-		} else
-#endif
-#ifdef __FreeBSD__
-			err = vn_io_fault_uiomove((char *)db->db_data + bufoff,
-			    tocpy, uio);
-#else
-			err = uiomove((char *)db->db_data + bufoff, tocpy,
-			    UIO_READ, uio);
-#endif
-		if (err)
-			break;
-
-		size -= tocpy;
-	}
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-
-	return (err);
+	return (dmu_read_impl(dn, NULL, 0, uio->uio_loffset, size, uio,
+	    DMU_CTX_FLAG_UIO|DMU_CTX_FLAG_NO_HOLD));
 }
 
 /*
@@ -1411,79 +2161,24 @@ dmu_read_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size)
 int
 dmu_read_uio(objset_t *os, uint64_t object, uio_t *uio, uint64_t size)
 {
-	dnode_t *dn;
-	int err;
 
 	if (size == 0)
 		return (0);
 
-	err = dnode_hold(os, object, FTAG, &dn);
-	if (err)
-		return (err);
-
-	err = dmu_read_uio_dnode(dn, uio, size);
-
-	dnode_rele(dn, FTAG);
-
-	return (err);
+	return (dmu_read_impl(NULL, os, object, uio->uio_loffset, size, uio,
+	    DMU_CTX_FLAG_UIO));
 }
 
 int
 dmu_write_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size, dmu_tx_t *tx)
 {
-	dmu_buf_t **dbp;
-	int numbufs;
-	int err = 0;
-	int i;
 
-	err = dmu_buf_hold_array_by_dnode(dn, uio->uio_loffset, size,
-	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
-	if (err)
-		return (err);
+	if (size == 0)
+		return (0);
 
-	for (i = 0; i < numbufs; i++) {
-		uint64_t tocpy;
-		int64_t bufoff;
-		dmu_buf_t *db = dbp[i];
-
-		ASSERT(size > 0);
-
-		bufoff = uio->uio_loffset - db->db_offset;
-		tocpy = MIN(db->db_size - bufoff, size);
-
-		ASSERT(i == 0 || i == numbufs-1 || tocpy == db->db_size);
-
-		if (tocpy == db->db_size)
-			dmu_buf_will_fill(db, tx);
-		else
-			dmu_buf_will_dirty(db, tx);
-
-		/*
-		 * XXX uiomove could block forever (eg.nfs-backed
-		 * pages).  There needs to be a uiolockdown() function
-		 * to lock the pages in memory, so that uiomove won't
-		 * block.
-		 */
-#ifdef __FreeBSD__
-		err = vn_io_fault_uiomove((char *)db->db_data + bufoff,
-		    tocpy, uio);
-#else
-		err = uiomove((char *)db->db_data + bufoff, tocpy,
-		    UIO_WRITE, uio);
-#endif
-		if (tocpy == db->db_size)
-			dmu_buf_fill_done(db, tx);
-
-		if (err)
-			break;
-
-		size -= tocpy;
-	}
-
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (err);
+	return (dmu_write_impl(dn, NULL, 0, uio->uio_loffset, size, uio, tx,
+	    DMU_CTX_FLAG_UIO|DMU_CTX_FLAG_NO_HOLD));
 }
-
 /*
  * Write 'size' bytes from the uio buffer.
  * To object zdb->db_object.
@@ -1506,9 +2201,9 @@ dmu_write_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size,
 
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
-	err = dmu_write_uio_dnode(dn, uio, size, tx);
+	err = dmu_write_impl(dn, NULL, 0, uio->uio_loffset, size, uio, tx,
+	    DMU_CTX_FLAG_UIO|DMU_CTX_FLAG_NO_HOLD);
 	DB_DNODE_EXIT(db);
-
 	return (err);
 }
 
@@ -1521,23 +2216,12 @@ int
 dmu_write_uio(objset_t *os, uint64_t object, uio_t *uio, uint64_t size,
     dmu_tx_t *tx)
 {
-	dnode_t *dn;
-	int err;
 
 	if (size == 0)
 		return (0);
-
-	err = dnode_hold(os, object, FTAG, &dn);
-	if (err)
-		return (err);
-
-	err = dmu_write_uio_dnode(dn, uio, size, tx);
-
-	dnode_rele(dn, FTAG);
-
-	return (err);
+	return (dmu_write_impl(NULL, os, object, uio->uio_loffset, size,
+	    uio, tx, DMU_CTX_FLAG_UIO));
 }
-#endif /* _KERNEL */
 
 /*
  * Allocate a loaned anonymous arc buffer.
@@ -2433,8 +3117,6 @@ dmu_fini(void)
 
 EXPORT_SYMBOL(dmu_bonus_hold);
 EXPORT_SYMBOL(dmu_bonus_hold_by_dnode);
-EXPORT_SYMBOL(dmu_buf_hold_array_by_bonus);
-EXPORT_SYMBOL(dmu_buf_rele_array);
 EXPORT_SYMBOL(dmu_prefetch);
 EXPORT_SYMBOL(dmu_free_range);
 EXPORT_SYMBOL(dmu_free_long_range);

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1550,7 +1550,8 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 		uint64_t offset = rwa->or_firstobj * DNODE_MIN_SIZE;
 
 		err = dmu_buf_hold_by_dnode(DMU_META_DNODE(rwa->os),
-		    offset, FTAG, &db, DMU_READ_PREFETCH | DMU_READ_NO_DECRYPT);
+		    offset, FTAG, &db, DMU_CTX_FLAG_PREFETCH |
+		    DMU_CTX_FLAG_NODECRYPT);
 		if (err != 0) {
 			dmu_tx_commit(tx);
 			return (SET_ERROR(EINVAL));
@@ -1594,10 +1595,10 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 	if (data != NULL) {
 		dmu_buf_t *db;
 		dnode_t *dn;
-		uint32_t flags = DMU_READ_NO_PREFETCH;
+		uint32_t flags = 0;
 
 		if (rwa->raw)
-			flags |= DMU_READ_NO_DECRYPT;
+			flags |= DMU_CTX_FLAG_NODECRYPT;
 
 		VERIFY0(dnode_hold(rwa->os, drro->drr_object, FTAG, &dn));
 		VERIFY0(dmu_bonus_hold_by_dnode(dn, FTAG, &db, flags));
@@ -1883,7 +1884,7 @@ receive_spill(struct receive_writer_arg *rwa, struct drr_spill *drrs,
 		rwa->max_object = drrs->drr_object;
 
 	VERIFY0(dmu_bonus_hold(rwa->os, drrs->drr_object, FTAG, &db));
-	if ((err = dmu_spill_hold_by_bonus(db, DMU_READ_NO_DECRYPT, FTAG,
+	if ((err = dmu_spill_hold_by_bonus(db, DMU_CTX_FLAG_NODECRYPT, FTAG,
 	    &db_spill)) != 0) {
 		dmu_buf_rele(db, FTAG);
 		return (err);

--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -859,7 +859,7 @@ hold_next_object(objset_t *os, struct redact_record *rec, void *tag,
 {
 	int err = 0;
 	if (*dn != NULL)
-		dnode_rele(*dn, FTAG);
+		dnode_rele(*dn, tag);
 	*dn = NULL;
 	if (*object < rec->start_object) {
 		*object = rec->start_object - 1;

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -208,7 +208,7 @@ dmu_tx_check_ioerr(zio_t *zio, dnode_t *dn, int level, uint64_t blkid)
 	int err;
 	dmu_buf_impl_t *db;
 
-	rw_enter(&dn->dn_struct_rwlock, RW_READER);
+	dn_rlock(dn);
 	db = dbuf_hold_level(dn, level, blkid, FTAG);
 	rw_exit(&dn->dn_struct_rwlock);
 	if (db == NULL)

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1662,7 +1662,7 @@ dsl_redaction_list_traverse(redaction_list_t *rl, zbookmark_phys_t *resume,
 		ASSERT3U(maxbufid, >, minbufid);
 		uint64_t midbufid = minbufid + ((maxbufid - minbufid) / 2);
 		err = dmu_read(mos, rl->rl_object, midbufid * bufsize, bufsize,
-		    buf, DMU_READ_NO_PREFETCH);
+		    buf, /* flags */ 0);
 		if (err != 0)
 			break;
 
@@ -1699,7 +1699,7 @@ dsl_redaction_list_traverse(redaction_list_t *rl, zbookmark_phys_t *resume,
 		if (curidx % redact_block_buf_num_entries(bufsize) == 0) {
 			err = dmu_read(mos, rl->rl_object, curidx *
 			    sizeof (*buf), bufsize, buf,
-			    DMU_READ_PREFETCH);
+			    DMU_CTX_FLAG_PREFETCH);
 			if (err != 0)
 				break;
 		}

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -132,12 +132,12 @@ spa_history_advance_bof(spa_t *spa, spa_history_phys_t *shpp)
 	firstread = MIN(sizeof (reclen), shpp->sh_phys_max_off - phys_bof);
 
 	if ((err = dmu_read(mos, spa->spa_history, phys_bof, firstread,
-	    buf, DMU_READ_PREFETCH)) != 0)
+	    buf, DMU_CTX_FLAG_PREFETCH)) != 0)
 		return (err);
 	if (firstread != sizeof (reclen)) {
 		if ((err = dmu_read(mos, spa->spa_history,
 		    shpp->sh_pool_create_len, sizeof (reclen) - firstread,
-		    buf + firstread, DMU_READ_PREFETCH)) != 0)
+		    buf + firstread, DMU_CTX_FLAG_PREFETCH)) != 0)
 			return (err);
 	}
 
@@ -491,10 +491,10 @@ spa_history_get(spa_t *spa, uint64_t *offp, uint64_t *len, char *buf)
 	}
 
 	err = dmu_read(mos, spa->spa_history, phys_read_off, read_len, buf,
-	    DMU_READ_PREFETCH);
+	    DMU_CTX_FLAG_PREFETCH);
 	if (leftover && err == 0) {
 		err = dmu_read(mos, spa->spa_history, shpp->sh_pool_create_len,
-		    leftover, buf + read_len, DMU_READ_PREFETCH);
+		    leftover, buf + read_len, DMU_CTX_FLAG_PREFETCH);
 	}
 	mutex_exit(&spa->spa_history_lock);
 

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -100,7 +100,7 @@ space_map_iterate(space_map_t *sm, uint64_t end, sm_cb_t callback, void *arg)
 	    block_base += blksz) {
 		dmu_buf_t *db;
 		error = dmu_buf_hold(sm->sm_os, space_map_object(sm),
-		    block_base, FTAG, &db, DMU_READ_PREFETCH);
+		    block_base, FTAG, &db, DMU_CTX_FLAG_PREFETCH);
 		if (error != 0)
 			return (error);
 
@@ -190,7 +190,7 @@ space_map_reversed_last_block_entries(space_map_t *sm, uint64_t *buf,
 	uint64_t last_word_offset =
 	    sm->sm_phys->smp_length - sizeof (uint64_t);
 	error = dmu_buf_hold(sm->sm_os, space_map_object(sm), last_word_offset,
-	    FTAG, &db, DMU_READ_NO_PREFETCH);
+	    FTAG, &db, /* flags */ 0);
 	if (error != 0)
 		return (error);
 
@@ -571,7 +571,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			uint64_t next_word_offset = sm->sm_phys->smp_length;
 			VERIFY0(dmu_buf_hold(sm->sm_os,
 			    space_map_object(sm), next_word_offset,
-			    tag, &db, DMU_READ_PREFETCH));
+			    tag, &db, DMU_CTX_FLAG_PREFETCH));
 			dmu_buf_will_dirty(db, tx);
 
 			/* update caller's dbuf */
@@ -669,7 +669,7 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	 */
 	uint64_t next_word_offset = sm->sm_phys->smp_length;
 	VERIFY0(dmu_buf_hold(sm->sm_os, space_map_object(sm),
-	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH));
+	    next_word_offset, FTAG, &db, DMU_CTX_FLAG_PREFETCH));
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
 	dmu_buf_will_dirty(db, tx);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1314,7 +1314,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 		if (txg == 0 && vd->vdev_ms_array != 0) {
 			error = dmu_read(mos, vd->vdev_ms_array,
 			    m * sizeof (uint64_t), sizeof (uint64_t), &object,
-			    DMU_READ_PREFETCH);
+			    DMU_CTX_FLAG_PREFETCH);
 			if (error != 0) {
 				vdev_dbgmsg(vd, "unable to read the metaslab "
 				    "array [error=%d]", error);

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -110,7 +110,7 @@ vdev_indirect_births_open(objset_t *os, uint64_t births_object)
 		uint64_t births_size = vdev_indirect_births_size_impl(vib);
 		vib->vib_entries = vmem_alloc(births_size, KM_SLEEP);
 		VERIFY0(dmu_read(vib->vib_objset, vib->vib_object, 0,
-		    births_size, vib->vib_entries, DMU_READ_PREFETCH));
+		    births_size, vib->vib_entries, DMU_CTX_FLAG_PREFETCH));
 	}
 
 	ASSERT(vdev_indirect_births_verify(vib));

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -359,7 +359,7 @@ vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
 		uint64_t map_size = vdev_indirect_mapping_size(vim);
 		vim->vim_entries = vmem_alloc(map_size, KM_SLEEP);
 		VERIFY0(dmu_read(os, vim->vim_object, 0, map_size,
-		    vim->vim_entries, DMU_READ_PREFETCH));
+		    vim->vim_entries, DMU_CTX_FLAG_PREFETCH));
 	}
 
 	ASSERT(vdev_indirect_mapping_verify(vim));
@@ -485,7 +485,7 @@ vdev_indirect_mapping_add_entries(vdev_indirect_mapping_t *vim,
 	}
 	VERIFY0(dmu_read(vim->vim_objset, vim->vim_object, old_size,
 	    new_size - old_size, &vim->vim_entries[old_count],
-	    DMU_READ_PREFETCH));
+	    DMU_CTX_FLAG_PREFETCH));
 
 	zfs_dbgmsg("txg %llu: wrote %llu entries to "
 	    "indirect mapping obj %llu; max offset=0x%llx",
@@ -580,7 +580,7 @@ vdev_indirect_mapping_load_obsolete_counts(vdev_indirect_mapping_t *vim)
 		VERIFY0(dmu_read(vim->vim_objset,
 		    vim->vim_phys->vimp_counts_object,
 		    0, counts_size,
-		    counts, DMU_READ_PREFETCH));
+		    counts, DMU_CTX_FLAG_PREFETCH));
 	} else {
 		bzero(counts, counts_size);
 	}

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -586,7 +586,7 @@ zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 {
 	dmu_buf_t *db;
 
-	int err = dmu_buf_hold_by_dnode(dn, 0, tag, &db, DMU_READ_NO_PREFETCH);
+	int err = dmu_buf_hold_by_dnode(dn, 0, tag, &db, /* flags */ 0);
 	if (err != 0) {
 		return (err);
 	}
@@ -611,7 +611,7 @@ zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
 {
 	dmu_buf_t *db;
 
-	int err = dmu_buf_hold(os, obj, 0, tag, &db, DMU_READ_NO_PREFETCH);
+	int err = dmu_buf_hold(os, obj, 0, tag, &db, /* flags */ 0);
 	if (err != 0)
 		return (err);
 #ifdef ZFS_DEBUG
@@ -703,7 +703,7 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
 
-	VERIFY0(dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH));
+	VERIFY0(dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, /* flags */ 0));
 
 	dmu_buf_will_dirty(db, tx);
 	mzap_phys_t *zp = db->db_data;

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -126,7 +126,7 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 
 		packed = kmem_alloc(fuid_size, KM_SLEEP);
 		VERIFY(dmu_read(os, fuid_obj, 0,
-		    fuid_size, packed, DMU_READ_PREFETCH) == 0);
+		    fuid_size, packed, DMU_CTX_FLAG_PREFETCH) == 0);
 		VERIFY(nvlist_unpack(packed, fuid_size,
 		    &nvp, 0) == 0);
 		VERIFY(nvlist_lookup_nvlist_array(nvp, FUID_NVP_ARRAY,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -196,6 +196,7 @@
 #include <sys/rrwlock.h>
 #include <sys/zfs_file.h>
 
+#include <sys/dbuf.h>
 #include <sys/dmu_recv.h>
 #include <sys/dmu_send.h>
 #include <sys/dmu_recv.h>
@@ -7592,6 +7593,7 @@ zfs_kmod_init(void)
 	tsd_create(&zfs_fsyncer_key, NULL);
 	tsd_create(&rrw_tsd_key, rrw_tsd_destroy);
 	tsd_create(&zfs_allow_log_key, zfs_allow_log_destroy);
+	tsd_create(&zfs_async_io_key, dmu_thread_context_destroy);
 
 	return (0);
 out:
@@ -7626,4 +7628,5 @@ zfs_kmod_fini(void)
 	tsd_destroy(&zfs_fsyncer_key);
 	tsd_destroy(&rrw_tsd_key);
 	tsd_destroy(&zfs_allow_log_key);
+	tsd_destroy(&zfs_async_io_key);
 }

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -588,7 +588,7 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 
 		DB_DNODE_ENTER(db);
 		if (wr_state == WR_COPIED && dmu_read_by_dnode(DB_DNODE(db),
-		    off, len, lr + 1, DMU_READ_NO_PREFETCH) != 0) {
+		    off, len, lr + 1, /* flags */ 0) != 0) {
 			zil_itx_destroy(itx);
 			itx = zil_itx_create(txtype, sizeof (*lr));
 			lr = (lr_write_t *)&itx->itx_lr;

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -85,7 +85,7 @@ zfs_sa_readlink(znode_t *zp, uio_t *uio)
 	} else {
 		dmu_buf_t *dbp;
 		if ((error = dmu_buf_hold(ZTOZSB(zp)->z_os, zp->z_id,
-		    0, FTAG, &dbp, DMU_READ_NO_PREFETCH)) == 0) {
+		    0, FTAG, &dbp, /* flags */ 0)) == 0) {
 			error = uiomove(dbp->db_data,
 			    MIN((size_t)bufsz, uio->uio_resid), UIO_READ, uio);
 			dmu_buf_rele(dbp, FTAG);
@@ -110,7 +110,7 @@ zfs_sa_symlink(znode_t *zp, char *link, int len, dmu_tx_t *tx)
 
 		zfs_grow_blocksize(zp, len, tx);
 		VERIFY0(dmu_buf_hold(ZTOZSB(zp)->z_os, zp->z_id, 0, FTAG, &dbp,
-		    DMU_READ_NO_PREFETCH));
+		    /* flags */ 0));
 
 		dmu_buf_will_dirty(dbp, tx);
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2137,7 +2137,7 @@ __zio_execute(zio_t *zio)
 			boolean_t cut = (stage == ZIO_STAGE_VDEV_IO_START) ?
 			    zio_requeue_io_start_cut_in_line : B_FALSE;
 			zio_taskq_dispatch(zio, ZIO_TASKQ_ISSUE, cut);
-			return;
+			goto done;
 		}
 
 		/*
@@ -2148,7 +2148,7 @@ __zio_execute(zio_t *zio)
 			boolean_t cut = (stage == ZIO_STAGE_VDEV_IO_START) ?
 			    zio_requeue_io_start_cut_in_line : B_FALSE;
 			zio_taskq_dispatch(zio, ZIO_TASKQ_ISSUE, cut);
-			return;
+			goto done;
 		}
 
 		zio->io_stage = stage;
@@ -2162,8 +2162,12 @@ __zio_execute(zio_t *zio)
 		zio = zio_pipeline[highbit64(stage) - 1](zio);
 
 		if (zio == NULL)
-			return;
+			goto done;
 	}
+
+done:
+	/* Process any deferred events placed on this thread's list. */
+	dmu_thread_context_process();
 }
 
 


### PR DESCRIPTION
An extension to #10303 that eliminates synchronous reads from `dbuf_hold_level` in `dmu_issue`, thereby making indirect block reads asynchronous as well. The net result of this is that async reads are truly asynchronous. Async writes require further work to restart the context rather than blocking in synchronous reads or on the write throttle.

This further extends the SpectraLogic work so submitting as a separate PR

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
