### PR TITLE
flake8 E741 variable name warning

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -272,8 +272,8 @@ def process_results(pathname):
     pattern_log = r'^\s*Log directory:\s*(\S*)'
 
     d = {}
-    for l in f.readlines():
-        m = re.match(pattern, l)
+    for line in f.readlines():
+        m = re.match(pattern, line)
         if m and len(m.groups()) == 4:
             summary['total'] += 1
             if m.group(4) == "PASS":
@@ -281,7 +281,7 @@ def process_results(pathname):
             d[m.group(1)] = m.group(4)
             continue
 
-        m = re.match(pattern_log, l)
+        m = re.match(pattern_log, line)
         if m:
             summary['logfile'] = m.group(1)
 


### PR DESCRIPTION
### Motivation and Context

Resolve new flake8 warning observed in the CI with updated version:

http://build.zfsonlinux.org/builders/Ubuntu%2018.04%20x86_64%20%28STYLE%29/builds/2257/steps/shell_2/logs/stdio

### Description

Update the zts-report.py script to conform to the flake8 E741 rule.

    "Variables named I, O, and l can be very hard to read. This is
    because the letter I and the letter l are easily confused, and
    the letter O and the number 0 can be easily confused."

- https://www.flake8rules.com/rules/E741.html

### How Has This Been Tested?

Locally running `make checkstyle`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).