### PR TITLE
RPM: Fix regex so old versions of DKMS modules are removed on upgrade

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -93,7 +93,7 @@ fi
 CONFIG_H="/var/lib/dkms/%{module}/%{version}/*/*/%{module}_config.h"
 SPEC_META_ALIAS="@PACKAGE@-@VERSION@-@RELEASE@"
 DKMS_META_ALIAS=`cat $CONFIG_H 2>/dev/null |
-    awk -F'"' '/META_ALIAS/ { print $2; exit 0 }'`
+    awk -F'"' '/META_ALIAS\s+"/ { print $2; exit 0 }'`
 if [ "$SPEC_META_ALIAS" = "$DKMS_META_ALIAS" ]; then
     echo -e
     echo -e "Uninstall of %{module} module ($SPEC_META_ALIAS) beginning:"


### PR DESCRIPTION
Due to a mismatch between the text and a regex looking for that text,
the `%preuninstall` script would never run the `dkms remove` command
necessary to avoid corrupting the DKMS data configuration.  Increase
regex specificity to avoid this issue.

Closes: #9891


### Motivation and Context
Solves #9891 

### Description
Adds more specificity to regex, to ensure it matches against a line that has a double quote (`"`).  This keeps `awk` from printing no output.

### How Has This Been Tested?
1. Ran on a test Fedora system with ZFS 0.8.3 already installed on kernel 5.4.20
1. Updated system to latest version of packages with `dnf update -y -x zfs\* -x kernel\*`.
1. Downloaded zfs-dkms-0.8.3-1.fc31.src.rpm source RPM
1. Installed and modified .spec file to include changes seen in this commit
1. Built zfs-dkms-0.8.3-1.fc31.noarch.rpm locally, with this change in the script
1. Ran `rpm --reinstall --noscripts ./zfs-dkms-0.8.3-1.fc31.noarch.rpm` to install the new `%preuninstall` script
1. Ran `dkms status` to verify DKMS tool still works
1. Snapshot the VM
1. Ran `dnf update -y zfs-dkms` to install v0.8.4
1. Ran `dkms status` and verified DKMS tool still worked, with no mention of zfs 0.8.3, but with an install of zfs 0.8.4 available
1. Rebooted machine
1. Noticed zfs-import-cache.service failed -- fixed with `systemctl restart zfs-import-cache`
1. Reverted the VM
1. Ran `dnf update -y` to upgrade zfs-dkms to v0.8.4 and the kernel to 5.6.11
1. Ran `dkms status` and verified DKMS tool still worked, with no mention of zfs 0.8.3, but with an install of zfs 0.8.4 available (for both 5.4.20 and 5.6.11)
1. Rebooted machine
1. Noticed zfs-import-cache.service failed -- fixed with `systemctl restart zfs-import-cache`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
