### PR TITLE
Fix abd_enter/exit_critical wrappers

### DIFF
--- a/include/sys/abd_impl.h
+++ b/include/sys/abd_impl.h
@@ -98,8 +98,6 @@ void abd_update_scatter_stats(abd_t *, abd_stats_op_t);
 void abd_update_linear_stats(abd_t *, abd_stats_op_t);
 void abd_verify_scatter(abd_t *);
 void abd_free_linear_page(abd_t *);
-void abd_enter_critical(unsigned long);
-void abd_exit_critical(unsigned long);
 /* OS specific abd_iter functions */
 void abd_iter_init(struct abd_iter  *, abd_t *);
 boolean_t abd_iter_at_end(struct abd_iter *);
@@ -118,6 +116,19 @@ void abd_iter_unmap(struct abd_iter *);
 
 #define	ABD_SCATTER(abd)	(abd->abd_u.abd_scatter)
 #define	ABD_LINEAR_BUF(abd)	(abd->abd_u.abd_linear.abd_buf)
+
+#if defined(_KERNEL)
+#if defined(__FreeBSD__)
+#define	abd_enter_critical(flags)	critical_enter()
+#define	abd_exit_critical(flags)	critical_exit()
+#else
+#define	abd_enter_critical(flags)	local_irq_save(flags)
+#define	abd_exit_critical(flags)	local_irq_restore(flags)
+#endif
+#else /* !_KERNEL */
+#define	abd_enter_critical(flags)	((void)0)
+#define	abd_exit_critical(flags)	((void)0)
+#endif
 
 #ifdef __cplusplus
 }

--- a/module/os/freebsd/zfs/abd_os.c
+++ b/module/os/freebsd/zfs/abd_os.c
@@ -419,15 +419,3 @@ abd_iter_unmap(struct abd_iter *aiter)
 	aiter->iter_mapaddr = NULL;
 	aiter->iter_mapsize = 0;
 }
-
-void
-abd_enter_critical(unsigned long flags)
-{
-	critical_enter();
-}
-
-void
-abd_exit_critical(unsigned long flags)
-{
-	critical_exit();
-}

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -803,18 +803,6 @@ abd_iter_unmap(struct abd_iter *aiter)
 	aiter->iter_mapsize = 0;
 }
 
-void
-abd_enter_critical(unsigned long flags)
-{
-	local_irq_save(flags);
-}
-
-void
-abd_exit_critical(unsigned long flags)
-{
-	local_irq_restore(flags);
-}
-
 #if defined(_KERNEL)
 /*
  * bio_nr_pages for ABD.

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -703,7 +703,7 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd,
 	struct abd_iter caiters[3];
 	struct abd_iter daiter = {0};
 	void *caddrs[3];
-	unsigned long flags = 0;
+	unsigned long flags __maybe_unused = 0;
 
 	ASSERT3U(parity, <=, 3);
 
@@ -800,7 +800,7 @@ abd_raidz_rec_iterate(abd_t **cabds, abd_t **tabds,
 	struct abd_iter citers[3];
 	struct abd_iter xiters[3];
 	void *caddrs[3], *xaddrs[3];
-	unsigned long flags = 0;
+	unsigned long flags __maybe_unused = 0;
 
 	ASSERT3U(parity, <=, 3);
 


### PR DESCRIPTION
### Motivation and Context

When loading the kernel modules the follow warning is printed if the
`CONFIG_DEBUG_ATOMIC_SLEEP` kernel debug option is enabled.

```
BUG: sleeping function call from invalid context at kernel/mutex:104
in_atomic(): 0, irqs_disabled(): 1, pid: 19780, name: insmod
```

### Description

Commit fc551d7 introduced the wrappers `abd_enter_critical()` and
`abd_exit_critical()` to mark critical sections.  On Linux these are
implemented with the `local_irq_save()` and `local_irq_restore()` macros
which set the 'flags' argument when saving.  By wrapping them with
a function the local variable is no longer set by the macro and is
no longer properly restored.

Convert `abd_enter_critical()` and `abd_exit_critical()` to macros to
resolve this issue and ensure the flags are properly restored.

### How Has This Been Tested?

The warning is no longer printed to the console on module load
when this change is applied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
