### PR TITLE
fix gcc 10.1 stringop-truncation error

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8898,9 +8898,9 @@ zpool_do_events_short(nvlist_t *nvl, ev_opts_t *opts)
 	verify(nvlist_lookup_int64_array(nvl, FM_EREPORT_TIME, &tv, &n) == 0);
 	memset(str, ' ', 32);
 	(void) ctime_r((const time_t *)&tv[0], ctime_str);
-	(void) strncpy(str, ctime_str+4,  6);		/* 'Jun 30' */
-	(void) strncpy(str+7, ctime_str+20, 4);		/* '1993' */
-	(void) strncpy(str+12, ctime_str+11, 8);	/* '21:49:08' */
+	(void) memcpy(str, ctime_str+4,  6);		/* 'Jun 30' */
+	(void) memcpy(str+7, ctime_str+20, 4);		/* '1993' */
+	(void) memcpy(str+12, ctime_str+11, 8);		/* '21:49:08' */
 	(void) sprintf(str+20, ".%09lld", (longlong_t)tv[1]); /* '.123456789' */
 	if (opts->scripted)
 		(void) printf(gettext("%s\t"), str);


### PR DESCRIPTION
Compiling with gcc 10.1 fails with:
```
zpool_main.c: In function ‘zpool_do_events_short’:
zpool_main.c:8901:9: error: ‘strncpy’ output may be truncated copying 6 bytes from a string of length 21 [-Werror=stringop-truncation]
 8901 |  (void) strncpy(str, ctime_str+4,  6);  /* 'Jun 30' */
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
zpool_main.c:8902:9: error: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 5 [-Werror=stringop-truncation]
 8902 |  (void) strncpy(str+7, ctime_str+20, 4);  /* '1993' */
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
zpool_main.c:8903:9: error: ‘strncpy’ output may be truncated copying 8 bytes from a string of length 14 [-Werror=stringop-truncation]
 8903 |  (void) strncpy(str+12, ctime_str+11, 8); /* '21:49:08' */
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
As we do not expect the destination of these `strncpy` calls to be NUL terminated, substitute them with `memcpy` per `https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation`

Signed-off-by: George Amanakis <gamanakis@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
