### PR TITLE
x32 builds

### DIFF
--- a/include/os/linux/spl/sys/isa_defs.h
+++ b/include/os/linux/spl/sys/isa_defs.h
@@ -40,8 +40,12 @@
 #define	__x86
 #endif
 
+#if defined(_ILP32)
+/* x32-specific defines; careful to *not* define _LP64 here */
+#else
 #if !defined(_LP64)
 #define	_LP64
+#endif
 #endif
 
 #define	_ALIGNMENT_REQUIRED	1
@@ -216,7 +220,7 @@
 #else
 /*
  * Currently supported:
- * x86_64, i386, arm, powerpc, s390, sparc, mips, and RV64G
+ * x86_64, x32, i386, arm, powerpc, s390, sparc, mips, and RV64G
  */
 #error "Unsupported ISA type"
 #endif

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -46,8 +46,12 @@ extern "C" {
 #define	__x86
 #endif
 
+#if defined(_ILP32)
+/* x32-specific defines; careful to *not* define _LP64 here */
+#else
 #if !defined(_LP64)
 #define	_LP64
+#endif
 #endif
 
 #if !defined(_LITTLE_ENDIAN)
@@ -214,7 +218,7 @@ extern "C" {
 #else
 /*
  * Currently supported:
- * x86_64, i386, arm, powerpc, s390, sparc, mips, and RV64G
+ * x86_64, x32, i386, arm, powerpc, s390, sparc, mips, and RV64G
  */
 #error "Unsupported ISA type"
 #endif

--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -51,7 +51,7 @@ print_timestamp(uint_t timestamp_fmt)
 		fmt = nl_langinfo(_DATE_FMT);
 
 	if (timestamp_fmt == UDATE) {
-		(void) printf("%ld\n", t);
+		(void) printf("%lld\n", (longlong_t)t);
 	} else if (timestamp_fmt == DDATE) {
 		char dstr[64];
 		int len;

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -4888,8 +4888,8 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		zfs_nicebytes(bytes, buf1, sizeof (buf1));
 		zfs_nicebytes(bytes/delta, buf2, sizeof (buf1));
 
-		(void) printf("received %s stream in %lu seconds (%s/sec)\n",
-		    buf1, delta, buf2);
+		(void) printf("received %s stream in %lld seconds (%s/sec)\n",
+		    buf1, (longlong_t)delta, buf2);
 	}
 
 	err = 0;


### PR DESCRIPTION
### Motivation and Context
I use the debian x32 port on one of my machines, but #844 prevented building the userspace tools: no longer.

### Description
Patch 1 adds proper x32 handling to the SPL ISA (well, ABI) detection header – if both `__x86_64__` *and* `_ILP32` are defined, `_LP64` is *not*, whereas previously it *was*, which yielded [an error](https://github.com/openzfs/zfs/issues/844#issuecomment-260155030) later in the header (and, if that error was circumvented, segfaults in libuutil as it picked the wrong pointer/long types for its bit-twiddling magic).

Patch 2 adds a new `ZFS_TIME_T_FORMAT` config entry, which evaluates to `"l"` when `sizeof(time_t) == sizeof(long)` and `"ll"` otherwise and uses it in the two places using just `"l"` yielded warnings on x32.

This approach is heavy-handed and could be replaced by casting it to `[unsigned] long long` and formatting with `"ll"` in both of those places. Thoughts?

### How Has This Been Tested?
I've used the userspace tools for the better part of a week now, with all the usual create/destroy/send/receive/scrub operations working. `zfs-tests.sh` passes as well.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly – AFAICT no documentation needs updating?
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes – none needed.
- [x] I have run the ZFS Test Suite with this change applied.