### PR TITLE
ZTS: Fix zfs_mount.kshlib cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
@@ -110,7 +110,7 @@ function cleanup_filesystem #pool #fs
 
 	if datasetexists "$pool/$fs" ; then
 		mtpt=$(get_prop mountpoint "$pool/$fs")
-		log_must zfs destroy -r $pool/$fs
+		destroy_dataset "$pool/$fs" "-r"
 
 		[[ -d $mtpt ]] && \
 			log_must rm -rf $mtpt


### PR DESCRIPTION
### Motivation and Context

Resolve occasional failures observed when running the ZTS `zfs_mount` group.

### Description

Update cleanup_filesystem to use destroy_dataset when performing cleanup.  This ensures the destroy is retried if the pool is busy preventing occasional failures.

### How Has This Been Tested?

Locally running 20 iterations of the `zfs_mount` group resulted in a handful of failures caused by a zvol being busy at cleanup time.  After applying this patch 100 iterations were run and no failures were observed.  The logs showed that the retry code was invoked on several occasions preventing what otherwise would have been a test failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
