### PR TITLE
Revert "Let zfs mount all tolerate in-progress mounts"

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6734,25 +6734,8 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 			return (1);
 		}
 
-		if (zfs_mount(zhp, options, flags) != 0) {
-			/*
-			 * Check if a mount sneaked in after we checked
-			 */
-			if (!explicit &&
-			    libzfs_errno(g_zfs) == EZFS_MOUNTFAILED) {
-				usleep(10 * MILLISEC);
-				libzfs_mnttab_cache(g_zfs, B_FALSE);
-
-				if (zfs_is_mounted(zhp, NULL)) {
-					(void) fprintf(stderr, gettext(
-					    "Ignoring previous 'already "
-					    "mounted' error for '%s'\n"),
-					    zfs_get_name(zhp));
-					return (0);
-				}
-			}
+		if (zfs_mount(zhp, options, flags) != 0)
 			return (1);
-		}
 		break;
 	}
 


### PR DESCRIPTION
### Motivation and Context

Issue #9560.  Revert the change which introduced the segfault.

http://build.zfsonlinux.org/builders/Amazon%202%20x86_64%20Release%20%28TEST%29/builds/10170

### Description

This reverts commit a9cd8bf which introduced a segfault when running
`zfs mount -a` multiple times when there are mountpoints which are
not empty.  This segfault is now seen frequently by the CI after the
mount code was updated to directly call mount(2).

The original reason this logic was added is described in #8881.
Since then the systemd `zfs-share.target` has been updated to run
"After" the `zfs-mount.server` which should avoid this issue at boot.

### How Has This Been Tested?

Locally running the ZTS `zfs_mount` group.  Pending a full CI run
to assess if `zfs_mount_all_fail` test cases is still failing.  I was unable
to reproduce this issue locally with some initial testing but the CI
was hitting it frequently.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
