### PR TITLE
Fix dead links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,16 +56,17 @@ of these tools are discussed in detail on the [debugging ZFS wiki
 page](https://github.com/zfsonlinux/zfs/wiki/Debugging).
 
 ### Where can I ask for help?
-[The zfs-discuss mailing list or IRC](http://list.zfsonlinux.org)
-are the best places to ask for help. Please do not file support requests
-on the GitHub issue tracker.
+The [zfs-discuss mailing
+list](https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Mailing%20Lists.html)
+or IRC are the best places to ask for help. Please do not file
+support requests on the GitHub issue tracker.
 
 ## How Can I Contribute?
 
 ### Reporting Bugs
 *Please* contact us via the [zfs-discuss mailing
-list or IRC](http://list.zfsonlinux.org) if you aren't
-certain that you are experiencing a bug.
+list](https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Mailing%20Lists.html)
+or IRC if you aren't certain that you are experiencing a bug.
 
 If you run into an issue, please search our [issue
 tracker](https://github.com/zfsonlinux/zfs/issues) *first* to ensure the


### PR DESCRIPTION
Replace dead links to http://list.zfsonlinux.org.


### Motivation and Context

Fixes https://github.com/openzfs/zfs/issues/10367.


### Description

https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Mailing%20Lists.html would properly be a better direct replacement for http://list.zfsonlinux.org but as there text refers to a specific mailing list, why not use a more specific link as well?

~If even a change like this requires me signing off the commit, let me know.
I honestly just used the web interface with auto-fork to do this.
Could do a local clone and force-push a correction.~
*edit: Heck, I just did it. Writing this excuse above probably took me longer than doing it right.*

### How Has This Been Tested?

Just changed documentation. So no testing done.


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)


### Checklist:

- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).