### PR TITLE
Update zfs-functions.in

### DIFF
--- a/etc/zfs/zfs-functions.in
+++ b/etc/zfs/zfs-functions.in
@@ -96,8 +96,8 @@ ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 # Sensible defaults
 ZFS_MOUNT='yes'
 ZFS_UNMOUNT='yes'
-
-export ZFS ZED ZPOOL ZPOOL_CACHE ZFS_MOUNT ZFS_UNMOUNT
+ZFS_SHARE='yes'
+ZFS_UNSHARE='yes'
 
 # Source zfs configuration, overriding the defaults
 if [ -f @initconfdir@/zfs ]; then
@@ -105,6 +105,8 @@ if [ -f @initconfdir@/zfs ]; then
 fi
 
 # ----------------------------------------------------
+
+export ZFS ZED ZPOOL ZPOOL_CACHE ZFS_MOUNT ZFS_UNMOUNT ZFS_SHARE ZFS_UNSHARE
 
 zfs_action()
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Closes #10341 
Related to bug #10341 and #10376 
The init.d zfs-share script does not perform the intended action without having a variable set for ZFS_SHARE and ZFS_UNSHARE

### Description
Assign default values to ZFS_SHARE and ZFS_UNSHARE. Export the environment variables after sourcing the configuration file. 

### How Has This Been Tested?
Tested on gentoo with kernel version 5.6.14

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
