### PR TITLE
ztest: Fix ztest_run_zdb() failure

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -6457,11 +6457,11 @@ ztest_run_zdb(char *pool)
 	ztest_get_zdb_bin(bin, len);
 
 	(void) sprintf(zdb,
-	    "%s -bcc%s%s -G -d -Y -U %s %s",
+	    "%s -bcc%s%s -G -d -Y -e -p %s %s",
 	    bin,
 	    ztest_opts.zo_verbose >= 3 ? "s" : "",
 	    ztest_opts.zo_verbose >= 4 ? "v" : "",
-	    spa_config_path,
+	    ztest_opts.zo_dir,
 	    pool);
 
 	if (ztest_opts.zo_verbose >= 5)


### PR DESCRIPTION
### Motivation and Context

Resolve a failure case occasionally reported by `ztest`.

### Description

It's possible for ztest to be killed while the pool is exported
which results in an empty cache file.  This is a valid state to
test, but the validation check performed by ztest_run_zdb()
depends on the pool being in the cache file.  If it's not the
following error is printed.

    zdb -bccsv -G -d -Y -U /tmp/zloop-run/zpool.cache ztest
    zdb: can't open '/tmp/zloop-run': No such file or directory

Resolve these failures by removing the dependency on the cache
file.  Functionally, we only care that the pool can be imported
and that the zdb verification passes.

### How Has This Been Tested?

Manually verified the updated zdb command works as expected
using the saved vdevs from a previous zloop.sh failure.  Locally the
updated version of ztest has been running for an hour without issue.
Longer ztest runs for the CI have been requested in this PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
