### PR TITLE
Fix a dependency loop

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -38,8 +38,6 @@ do_fail() {
 is_known() {
   query="$1"
   IFS=' '
-  # protect against special characters
-  set -f
   for element in $2 ; do
     if [ "$query" = "$element" ] ; then
       return 0
@@ -54,8 +52,7 @@ is_known() {
 create_dependencies() {
   unitfile="$1"
   suffix="$2"
-  # protect against special characters
-  set -f
+  IFS=' '
   for target in $3 ; do
     target_dir="${dest_norm}/${target}.${suffix}/"
     mkdir -p "${target_dir}"
@@ -72,6 +69,7 @@ else
   do_fail "zero or three arguments required"
 fi
 
+pools=$(zpool list -H -o name || true)
 
 # All needed information about each ZFS is available from
 # zfs list -H -t filesystem -o <properties>
@@ -83,11 +81,11 @@ process_line() {
   # zfs list -H -o name,...
   # fields are tab separated
   IFS="$(printf '\t')"
-  # protect against special characters in, e.g., mountpoints
-  set -f
   # shellcheck disable=SC2086
   set -- $1
+
   dataset="${1}"
+  pool="${dataset%%/*}"
   p_mountpoint="${2}"
   p_canmount="${3}"
   p_atime="${4}"
@@ -119,6 +117,25 @@ process_line() {
   wantedby=""
   requiredby=""
   noauto="off"
+
+  # If the pool is already imported, zfs-import.target is not needed.  This
+  # avoids a dependency loop on root-on-ZFS systems:
+  # systemd-random-seed.service After (via RequiresMountsFor) var-lib.mount
+  # After zfs-import.target After zfs-import-{cache,scan}.service After
+  # cryptsetup.service After systemd-random-seed.service.
+  #
+  # Pools are newline-separated and may contain spaces in their names.
+  # There is no better portable way to set IFS to just a newline.  Using
+  # $(printf '\n') doesn't work because $(...) strips trailing newlines.
+  IFS="
+"
+  for p in $pools ; do
+    if [ "$p" = "$pool" ] ; then
+      after=""
+      wants=""
+      break
+    fi
+  done
 
   if [ -n "${p_systemd_after}" ] && \
       [ "${p_systemd_after}" != "-" ] ; then
@@ -438,6 +455,8 @@ Options=defaults${opts},zfsutil" > "${dest_norm}/${mountfile}"
 }
 
 for cachefile in "${FSLIST}/"* ; do
+  # Disable glob expansion to protect against special characters when parsing.
+  set -f
   # Sort cachefile's lines by canmount, "on" before "noauto"
   # and feed each line into process_line
   sort -t "$(printf '\t')" -k 3 -r "${cachefile}" | \

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -221,6 +221,10 @@ ${keymountdep}
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# This avoids a dependency loop involving systemd-journald.socket if this
+# dataset is a parent of the root filesystem.
+StandardOutput=null
+StandardError=null
 ExecStart=${keyloadcmd}
 ExecStop=${keyunloadcmd}"   > "${dest_norm}/${keyloadunit}"
     fi

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -6,7 +6,6 @@ After=systemd-udev-settle.service
 After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target
-Before=systemd-random-seed.service
 ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]


### PR DESCRIPTION
### Motivation and Context

When generating units with zfs-mount-generator, if the pool is already
imported, zfs-import.target is not needed.  This avoids a dependency
loop on root-on-ZFS systems:
  * systemd-random-seed.service After (via RequiresMountsFor)
  * var-lib.mount After
  * zfs-import.target After
  * zfs-import-{cache,scan}.service After
  * cryptsetup.service After
  * systemd-random-seed.service

### Description
This changes zfs-mount-generator to omit the dependency and ordering on zfs-import.target if the pool is already imported (which is the case for the root pool, as it is imported by the initrd).

This fixes the issue reported to Ubuntu here:
https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1875577

This change reverts 8ae8b2a1445bcccee1bb8ee7d4886f30050f6f53 from #9360. The author of that (didrocks) is aware of this. See my comment: https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1875577/comments/5 and his reply: https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1875577/comments/9

### How Has This Been Tested?
I have tested this (as adjusted for ZFS 0.8.3 in 20.04) on test VMs as part of the Root on ZFS HOWTO updates. Prior to that, it was tested by the original reporter here:
https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1875577/comments/13

This could use a little testing in master.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
