### PR TITLE
Upstream: Replace sprintf()->snprintf() strcpy()->strlcpy()

### DIFF
--- a/include/sys/zfs_fuid.h
+++ b/include/sys/zfs_fuid.h
@@ -117,7 +117,7 @@ extern int zfs_fuid_find_by_domain(zfsvfs_t *, const char *domain,
 extern const char *zfs_fuid_find_by_idx(zfsvfs_t *zfsvfs, uint32_t idx);
 extern void zfs_fuid_txhold(zfsvfs_t *zfsvfs, dmu_tx_t *tx);
 extern int zfs_id_to_fuidstr(zfsvfs_t *zfsvfs, const char *domain, uid_t rid,
-    char *buf, boolean_t addok);
+    char *buf, size_t len, boolean_t addok);
 #endif
 
 char *zfs_fuid_idx_domain(avl_tree_t *, uint32_t);

--- a/module/icp/algs/aes/aes_impl.c
+++ b/module/icp/algs/aes/aes_impl.c
@@ -330,7 +330,7 @@ aes_impl_init(void)
 	    sizeof (aes_fastest_impl));
 #endif
 
-	strcpy(aes_fastest_impl.name, "fastest");
+	strlcpy(aes_fastest_impl.name, "fastest", AES_IMPL_NAME_MAX);
 
 	/* Finish initialization */
 	atomic_swap_32(&icp_aes_impl, user_sel_impl);
@@ -405,7 +405,7 @@ aes_impl_set(const char *val)
 	return (err);
 }
 
-#if defined(_KERNEL)
+#if defined(_KERNEL) && defined(__linux__)
 
 static int
 icp_aes_impl_set(const char *val, zfs_kernel_param_t *kp)

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -843,7 +843,7 @@ gcm_impl_init(void)
 		    sizeof (gcm_fastest_impl));
 	}
 
-	strcpy(gcm_fastest_impl.name, "fastest");
+	strlcpy(gcm_fastest_impl.name, "fastest", GCM_IMPL_NAME_MAX);
 
 #ifdef CAN_USE_GCM_ASM
 	/*
@@ -955,7 +955,7 @@ gcm_impl_set(const char *val)
 	return (err);
 }
 
-#if defined(_KERNEL)
+#if defined(_KERNEL) && defined(__linux__)
 
 static int
 icp_gcm_impl_set(const char *val, zfs_kernel_param_t *kp)

--- a/module/icp/os/modhash.c
+++ b/module/icp/os/modhash.c
@@ -453,17 +453,19 @@ mod_hash_create_extended(
     int sleep)				/* whether to sleep for mem */
 {
 	mod_hash_t *mod_hash;
+	size_t size;
 	ASSERT(hname && keycmp && hash_alg && vdtor && kdtor);
 
 	if ((mod_hash = kmem_zalloc(MH_SIZE(nchains), sleep)) == NULL)
 		return (NULL);
 
-	mod_hash->mh_name = kmem_alloc(strlen(hname) + 1, sleep);
+	size = strlen(hname) + 1;
+	mod_hash->mh_name = kmem_alloc(size, sleep);
 	if (mod_hash->mh_name == NULL) {
 		kmem_free(mod_hash, MH_SIZE(nchains));
 		return (NULL);
 	}
-	(void) strcpy(mod_hash->mh_name, hname);
+	(void) strlcpy(mod_hash->mh_name, hname, size);
 
 	rw_init(&mod_hash->mh_contents, NULL, RW_DEFAULT, NULL);
 	mod_hash->mh_sleep = sleep;

--- a/module/lua/lstrlib.c
+++ b/module/lua/lstrlib.c
@@ -853,9 +853,9 @@ static void addquoted (lua_State *L, luaL_Buffer *b, int arg) {
     else if (*s == '\0' || iscntrl(uchar(*s))) {
       char buff[10];
       if (!isdigit(uchar(*(s+1))))
-        sprintf(buff, "\\%d", (int)uchar(*s));
+        snprintf(buff, sizeof(buff), "\\%d", (int)uchar(*s));
       else
-        sprintf(buff, "\\%03d", (int)uchar(*s));
+        snprintf(buff, sizeof(buff), "\\%03d", (int)uchar(*s));
       luaL_addstring(b, buff);
     }
     else
@@ -890,11 +890,11 @@ static const char *scanformat (lua_State *L, const char *strfrmt, char *form) {
 /*
 ** add length modifier into formats
 */
-static void addlenmod (char *form, const char *lenmod) {
+static void addlenmod (char *form, const char *lenmod, size_t size) {
   size_t l = strlen(form);
   size_t lm = strlen(lenmod);
   char spec = form[l - 1];
-  strcpy(form + l - 1, lenmod);
+  strlcpy(form + l - 1, lenmod, size - (l - 1));
   form[l + lm - 1] = spec;
   form[l + lm] = '\0';
 }
@@ -931,7 +931,7 @@ static int str_format (lua_State *L) {
           lua_Number diff = n - (lua_Number)ni;
           luaL_argcheck(L, -1 < diff && diff < 1, arg,
                         "not a number in proper range");
-          addlenmod(form, LUA_INTFRMLEN);
+          addlenmod(form, LUA_INTFRMLEN, MAX_FORMAT);
           nb = str_sprintf(buff, form, ni);
           break;
         }
@@ -941,7 +941,7 @@ static int str_format (lua_State *L) {
           lua_Number diff = n - (lua_Number)ni;
           luaL_argcheck(L, -1 < diff && diff < 1, arg,
                         "not a non-negative number in proper range");
-          addlenmod(form, LUA_INTFRMLEN);
+          addlenmod(form, LUA_INTFRMLEN, MAX_FORMAT);
           nb = str_sprintf(buff, form, ni);
           break;
         }
@@ -951,7 +951,7 @@ static int str_format (lua_State *L) {
         case 'a': case 'A':
 #endif
         case 'g': case 'G': {
-          addlenmod(form, LUA_FLTFRMLEN);
+          addlenmod(form, LUA_FLTFRMLEN, MAX_FORMAT);
           nb = str_sprintf(buff, form, (LUA_FLTFRM_T)luaL_checknumber(L, arg));
           break;
         }

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1021,7 +1021,7 @@ zfs_statfs_project(zfsvfs_t *zfsvfs, znode_t *zp, struct kstatfs *statp,
 
 	strlcpy(buf, DMU_OBJACCT_PREFIX, DMU_OBJACCT_PREFIX_LEN + 1);
 	err = zfs_id_to_fuidstr(zfsvfs, NULL, zp->z_projid, buf + offset,
-	    B_FALSE);
+	    sizeof (buf) - offset, B_FALSE);
 	if (err)
 		return (err);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -253,7 +253,7 @@ void
 ddt_object_name(ddt_t *ddt, enum ddt_type type, enum ddt_class class,
     char *name)
 {
-	(void) sprintf(name, DMU_POOL_DDT,
+	(void) snprintf(name, DDT_NAMELEN, DMU_POOL_DDT,
 	    zio_checksum_table[ddt->ddt_checksum].ci_name,
 	    ddt_ops[type]->ddt_op_name, ddt_class_name[class]);
 }

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1870,14 +1870,15 @@ do_userquota_update(objset_t *os, userquota_cache_t *cache, uint64_t used,
 		if (subtract)
 			delta = -delta;
 
-		(void) sprintf(name, "%llx", (longlong_t)user);
+		(void) snprintf(name, sizeof (name), "%llx", (longlong_t)user);
 		userquota_update_cache(&cache->uqc_user_deltas, name, delta);
 
-		(void) sprintf(name, "%llx", (longlong_t)group);
+		(void) snprintf(name, sizeof (name), "%llx", (longlong_t)group);
 		userquota_update_cache(&cache->uqc_group_deltas, name, delta);
 
 		if (dmu_objset_projectquota_enabled(os)) {
-			(void) sprintf(name, "%llx", (longlong_t)project);
+			(void) snprintf(name, sizeof (name), "%llx",
+			    (longlong_t)project);
 			userquota_update_cache(&cache->uqc_project_deltas,
 			    name, delta);
 		}
@@ -2438,7 +2439,7 @@ dmu_snapshot_list_next(objset_t *os, int namelen, char *name,
 		return (SET_ERROR(ENAMETOOLONG));
 	}
 
-	(void) strcpy(name, attr.za_name);
+	(void) strlcpy(name, attr.za_name, namelen);
 	if (idp)
 		*idp = attr.za_first_integer;
 	if (case_conflict)
@@ -2483,7 +2484,7 @@ dmu_dir_list_next(objset_t *os, int namelen, char *name,
 		return (SET_ERROR(ENAMETOOLONG));
 	}
 
-	(void) strcpy(name, attr.za_name);
+	(void) strlcpy(name, attr.za_name, namelen);
 	if (idp)
 		*idp = attr.za_first_integer;
 	zap_cursor_advance(&cursor);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2001,7 +2001,8 @@ create_begin_record(struct dmu_send_params *dspp, objset_t *os,
 
 	if (dspp->savedok) {
 		drrb->drr_toguid = dspp->saved_guid;
-		strcpy(drrb->drr_toname, dspp->saved_toname);
+		strlcpy(drrb->drr_toname, dspp->saved_toname,
+		    sizeof (drrb->drr_toname));
 	} else {
 		dsl_dataset_name(to_ds, drrb->drr_toname);
 		if (!to_ds->ds_is_snapshot) {

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -245,7 +245,8 @@ dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
 			if (err != 0)
 				goto errout;
 		} else {
-			(void) strcpy(dd->dd_myname, spa_name(dp->dp_spa));
+			(void) strlcpy(dd->dd_myname, spa_name(dp->dp_spa),
+			    sizeof (dd->dd_myname));
 		}
 
 		if (dsl_dir_is_clone(dd)) {
@@ -423,7 +424,7 @@ getcomponent(const char *path, char *component, const char **nextp)
 			return (SET_ERROR(EINVAL));
 		if (strlen(path) >= ZFS_MAX_DATASET_NAME_LEN)
 			return (SET_ERROR(ENAMETOOLONG));
-		(void) strcpy(component, path);
+		(void) strlcpy(component, path, ZFS_MAX_DATASET_NAME_LEN);
 		p = NULL;
 	} else if (p[0] == '/') {
 		if (p - path >= ZFS_MAX_DATASET_NAME_LEN)

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -132,8 +132,9 @@ dsl_prop_get_dd(dsl_dir_t *dd, const char *propname,
 					if (inheriting) {
 						dsl_dir_name(dd, setpoint);
 					} else {
-						(void) strcpy(setpoint,
-						    ZPROP_SOURCE_VAL_RECVD);
+						(void) strlcpy(setpoint,
+						    ZPROP_SOURCE_VAL_RECVD,
+						    MAXNAMELEN);
 					}
 				}
 				break;
@@ -206,8 +207,9 @@ dsl_prop_get_ds(dsl_dataset_t *ds, const char *propname,
 			kmem_strfree(recvdstr);
 			if (err != ENOENT) {
 				if (setpoint != NULL && err == 0)
-					(void) strcpy(setpoint,
-					    ZPROP_SOURCE_VAL_RECVD);
+					(void) strlcpy(setpoint,
+					    ZPROP_SOURCE_VAL_RECVD,
+					    MAXNAMELEN);
 				return (err);
 			}
 		}

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -360,7 +360,7 @@ scan_init(void)
 	for (int i = 0; i < SPA_DVAS_PER_BP; i++) {
 		char name[36];
 
-		(void) sprintf(name, "sio_cache_%d", i);
+		(void) snprintf(name, sizeof (name), "sio_cache_%d", i);
 		sio_cache[i] = kmem_cache_create(name,
 		    (sizeof (scan_io_t) + ((i + 1) * sizeof (dva_t))),
 		    0, NULL, NULL, NULL, NULL, NULL, 0);

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -101,9 +101,9 @@ dsl_dataset_user_hold_check(void *arg, dmu_tx_t *tx)
 		size_t len = strlen(nvpair_name(pair)) +
 		    strlen(fnvpair_value_string(pair));
 		char *nameval = kmem_zalloc(len + 2, KM_SLEEP);
-		(void) strcpy(nameval, nvpair_name(pair));
-		(void) strcat(nameval, "@");
-		(void) strcat(nameval, fnvpair_value_string(pair));
+		(void) strlcpy(nameval, nvpair_name(pair), len + 2);
+		(void) strlcat(nameval, "@", len + 2);
+		(void) strlcat(nameval, fnvpair_value_string(pair), len + 2);
 		fnvlist_add_string(tmp_holds, nameval, "");
 		kmem_free(nameval, len + 2);
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6647,8 +6647,8 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 		spa_strfree(oldvd->vdev_path);
 		oldvd->vdev_path = kmem_alloc(strlen(newvd->vdev_path) + 5,
 		    KM_SLEEP);
-		(void) sprintf(oldvd->vdev_path, "%s/%s",
-		    newvd->vdev_path, "old");
+		(void) snprintf(oldvd->vdev_path, strlen(newvd->vdev_path) + 5,
+		    "%s/%s", newvd->vdev_path, "old");
 		if (oldvd->vdev_devid != NULL) {
 			spa_strfree(oldvd->vdev_devid);
 			oldvd->vdev_devid = NULL;

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1030,7 +1030,7 @@ zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
 	    (err = zap_cursor_retrieve(&zc, za)) == 0;
 	    zap_cursor_advance(&zc)) {
 		if ((za->za_first_integer & mask) == (value & mask)) {
-			(void) strcpy(name, za->za_name);
+			(void) strlcpy(name, za->za_name, MAXNAMELEN);
 			break;
 		}
 	}

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -1602,7 +1602,8 @@ zap_cursor_retrieve(zap_cursor_t *zc, zap_attribute_t *za)
 			za->za_integer_length = 8;
 			za->za_num_integers = 1;
 			za->za_first_integer = mzep->mze_value;
-			(void) strcpy(za->za_name, mzep->mze_name);
+			(void) strlcpy(za->za_name, mzep->mze_name,
+			    sizeof (za->za_name));
 			zc->zc_hash = mze->mze_hash;
 			zc->zc_cd = mze->mze_cd;
 			err = 0;

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -82,13 +82,13 @@ get_objset_type_name(dsl_dataset_t *ds, char *str)
 		return (error);
 	switch (type) {
 	case ZFS_TYPE_SNAPSHOT:
-		(void) strcpy(str, "snapshot");
+		(void) strlcpy(str, "snapshot", ZAP_MAXVALUELEN);
 		break;
 	case ZFS_TYPE_FILESYSTEM:
-		(void) strcpy(str, "filesystem");
+		(void) strlcpy(str, "filesystem", ZAP_MAXVALUELEN);
 		break;
 	case ZFS_TYPE_VOLUME:
-		(void) strcpy(str, "volume");
+		(void) strlcpy(str, "volume", ZAP_MAXVALUELEN);
 		break;
 	default:
 		return (EINVAL);
@@ -321,11 +321,11 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 		break;
 	case ZFS_PROP_FILESYSTEM_COUNT:
 		error = dsl_dir_get_filesystem_count(ds->ds_dir, &numval);
-		(void) strcpy(setpoint, "");
+		(void) strlcpy(setpoint, "", ZFS_MAX_DATASET_NAME_LEN);
 		break;
 	case ZFS_PROP_SNAPSHOT_COUNT:
 		error = dsl_dir_get_snapshot_count(ds->ds_dir, &numval);
-		(void) strcpy(setpoint, "");
+		(void) strlcpy(setpoint, "", ZFS_MAX_DATASET_NAME_LEN);
 		break;
 	case ZFS_PROP_NUMCLONES:
 		numval = dsl_get_numclones(ds);
@@ -367,7 +367,8 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 			    sizeof (numval), 1, &numval);
 		}
 		if (error == 0)
-			(void) strcpy(setpoint, dsname);
+			(void) strlcpy(setpoint, dsname,
+			    ZFS_MAX_DATASET_NAME_LEN);
 
 		break;
 	case ZFS_PROP_VOLBLOCKSIZE: {
@@ -693,9 +694,10 @@ parse_written_prop(const char *dataset_name, const char *prop_name,
 	ASSERT(zfs_prop_written(prop_name));
 	const char *name = prop_name + ZFS_WRITTEN_PROP_PREFIX_LEN;
 	if (strchr(name, '@') == NULL) {
-		(void) sprintf(snap_name, "%s@%s", dataset_name, name);
+		(void) snprintf(snap_name, ZFS_MAX_DATASET_NAME_LEN, "%s@%s",
+		    dataset_name, name);
 	} else {
-		(void) strcpy(snap_name, name);
+		(void) strlcpy(snap_name, name, ZFS_MAX_DATASET_NAME_LEN);
 	}
 }
 

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -778,7 +778,7 @@ zfs_fuid_txhold(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
  */
 int
 zfs_id_to_fuidstr(zfsvfs_t *zfsvfs, const char *domain, uid_t rid,
-    char *buf, boolean_t addok)
+    char *buf, size_t len, boolean_t addok)
 {
 	uint64_t fuid;
 	int domainid = 0;
@@ -789,7 +789,7 @@ zfs_id_to_fuidstr(zfsvfs_t *zfsvfs, const char *domain, uid_t rid,
 			return (SET_ERROR(ENOENT));
 	}
 	fuid = FUID_ENCODE(domainid, rid);
-	(void) sprintf(buf, "%llx", (longlong_t)fuid);
+	(void) snprintf(buf, len, "%llx", (longlong_t)fuid);
 	return (0);
 }
 #endif

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2504,7 +2504,8 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 			zfs_cmd_t *zc;
 
 			zc = kmem_zalloc(sizeof (zfs_cmd_t), KM_SLEEP);
-			(void) strcpy(zc->zc_name, dsname);
+			(void) strlcpy(zc->zc_name, dsname,
+			    sizeof (zc->zc_name));
 			(void) zfs_ioc_userspace_upgrade(zc);
 			(void) zfs_ioc_id_quota_upgrade(zc);
 			kmem_free(zc, sizeof (zfs_cmd_t));
@@ -5271,7 +5272,7 @@ zfs_ioc_recv_new(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 	    strchr(snapname, '%'))
 		return (SET_ERROR(EINVAL));
 
-	(void) strcpy(tofs, snapname);
+	(void) strlcpy(tofs, snapname, sizeof (tofs));
 	tosnap = strchr(tofs, '@');
 	*tosnap++ = '\0';
 

--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -269,7 +269,8 @@ zfs_userspace_one(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 		offset = DMU_OBJACCT_PREFIX_LEN;
 	}
 
-	err = zfs_id_to_fuidstr(zfsvfs, domain, rid, buf + offset, B_FALSE);
+	err = zfs_id_to_fuidstr(zfsvfs, domain, rid, buf + offset,
+	    sizeof (buf) - offset, B_FALSE);
 	if (err)
 		return (err);
 
@@ -325,7 +326,7 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 		return (SET_ERROR(EINVAL));
 	}
 
-	err = zfs_id_to_fuidstr(zfsvfs, domain, rid, buf, B_TRUE);
+	err = zfs_id_to_fuidstr(zfsvfs, domain, rid, buf, sizeof (buf), B_TRUE);
 	if (err)
 		return (err);
 	fuid_dirtied = zfsvfs->z_fuid_dirty;
@@ -407,12 +408,13 @@ zfs_id_overobjquota(zfsvfs_t *zfsvfs, uint64_t usedobj, uint64_t id)
 	if (quotaobj == 0 || zfsvfs->z_replay)
 		return (B_FALSE);
 
-	(void) sprintf(buf, "%llx", (longlong_t)id);
+	(void) snprintf(buf, sizeof (buf), "%llx", (longlong_t)id);
 	err = zap_lookup(zfsvfs->z_os, quotaobj, buf, 8, 1, &quota);
 	if (err != 0)
 		return (B_FALSE);
 
-	(void) sprintf(buf, DMU_OBJACCT_PREFIX "%llx", (longlong_t)id);
+	(void) snprintf(buf, sizeof (buf), DMU_OBJACCT_PREFIX "%llx",
+	    (longlong_t)id);
 	err = zap_lookup(zfsvfs->z_os, usedobj, buf, 8, 1, &used);
 	if (err != 0)
 		return (B_FALSE);
@@ -448,7 +450,7 @@ zfs_id_overblockquota(zfsvfs_t *zfsvfs, uint64_t usedobj, uint64_t id)
 	if (quotaobj == 0 || zfsvfs->z_replay)
 		return (B_FALSE);
 
-	(void) sprintf(buf, "%llx", (longlong_t)id);
+	(void) snprintf(buf, sizeof (buf), "%llx", (longlong_t)id);
 	err = zap_lookup(zfsvfs->z_os, quotaobj, buf, 8, 1, &quota);
 	if (err != 0)
 		return (B_FALSE);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -203,11 +203,13 @@ zio_init(void)
 
 		if (align != 0) {
 			char name[36];
-			(void) sprintf(name, "zio_buf_%lu", (ulong_t)size);
+			(void) snprintf(name, sizeof (name), "zio_buf_%lu",
+			    (ulong_t)size);
 			zio_buf_cache[c] = kmem_cache_create(name, size,
 			    align, NULL, NULL, NULL, NULL, NULL, cflags);
 
-			(void) sprintf(name, "zio_data_buf_%lu", (ulong_t)size);
+			(void) snprintf(name, sizeof (name), "zio_data_buf_%lu",
+			    (ulong_t)size);
 			zio_data_buf_cache[c] = kmem_cache_create(name, size,
 			    align, NULL, NULL, NULL, NULL,
 			    data_alloc_arena, data_cflags);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

strcpy() and sprintf() are deprecated on some platforms.

Care is needed to ensure correct size is used.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unfortunately, compiling stops with error when attempting to use deprecated
functions on macOS.

### Description
<!--- Describe your changes in detail -->
If other platforms miss snprintf, we should add a #define to
sprintf, likewise strlcpy().

Biggest change is adding another size parameter to zfs_id_to_fuidstr().

The various *_impl_get() functions have been taken out for macOS, using 
#ifdefs as the string is passed to ZFS from the Linux kernel. I am unsure of its size. If someone with Linux background knows the size, I can update the PR. (It will not even compile using strcpy).

Did git just eat part of the commit message? Oh heh, '#' is comment.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Extensive testing of zfs-test on macOS. Other platforms unknown.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
