### PR TITLE
Restore support for in-kernel ZFS ioctls.

### DIFF
--- a/include/sys/zfs_ioctl_impl.h
+++ b/include/sys/zfs_ioctl_impl.h
@@ -86,7 +86,7 @@ boolean_t zfs_vfs_held(zfsvfs_t *);
 int zfs_vfs_ref(zfsvfs_t **);
 void zfs_vfs_rele(zfsvfs_t *);
 
-long zfsdev_ioctl_common(uint_t, zfs_cmd_t *);
+long zfsdev_ioctl_common(uint_t, zfs_cmd_t *, int);
 int zfsdev_attach(void);
 void zfsdev_detach(void);
 int zfs_kmod_init(void);

--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -196,7 +196,7 @@ zfsdev_ioctl(struct cdev *dev, ulong_t zcmd, caddr_t arg, int flag,
 		error = SET_ERROR(EFAULT);
 		goto out;
 	}
-	error = zfsdev_ioctl_common(vecnum, zc);
+	error = zfsdev_ioctl_common(vecnum, zc, 0);
 	if (zcl) {
 		zfs_cmd_zof_to_bsd12(zc, zcl);
 		rc = copyout(zcl, uaddr, sizeof (*zcl));

--- a/module/os/linux/zfs/zfs_ioctl_os.c
+++ b/module/os/linux/zfs/zfs_ioctl_os.c
@@ -191,7 +191,7 @@ zfsdev_ioctl(struct file *filp, unsigned cmd, unsigned long arg)
 		error = -SET_ERROR(EFAULT);
 		goto out;
 	}
-	error = -zfsdev_ioctl_common(vecnum, zc);
+	error = -zfsdev_ioctl_common(vecnum, zc, 0);
 	rc = ddi_copyout(zc, (void *)(uintptr_t)arg, sizeof (zfs_cmd_t), 0);
 	if (error == 0 && rc != 0)
 		error = -SET_ERROR(EFAULT);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7374,9 +7374,9 @@ zfsdev_minor_alloc(void)
 }
 
 long
-zfsdev_ioctl_common(uint_t vecnum, zfs_cmd_t *zc)
+zfsdev_ioctl_common(uint_t vecnum, zfs_cmd_t *zc, int flag)
 {
-	int error, cmd, flag = 0;
+	int error, cmd;
 	const zfs_ioc_vec_t *vec;
 	char *saved_poolname = NULL;
 	nvlist_t *innvl = NULL;


### PR DESCRIPTION
### Motivation and Context
During code reading of ZFS ioctl handling I found some dead code: the zc_iflags field in the zfs_cmd structure is always 0 due to:

int flag = 0;
[...]
zc->zc_iflags = flag & FKIOCTL;

In Illumos it is possible to call ioctl functions from within the kernel by passing the FKIOCTL flag. Neither FreeBSD nor Linux support that, but it doesn't hurt to keep it around, as all the code is there.

### Description
Restore this functionality by allowing to pass a flag to the zfsdev_ioctl_common() function.

If we decide to entirely drop support for Illumos, we could remove the flag argument from zfsdev_ioctl_common(), remove zc_iflags field from the zfs_cmd structure, remove the iflag argument from the get_nvlist() function and remove the flags argument from the ddi_copyout() function.

### How Has This Been Tested?
The code was compiled on FreeBSD, module was loaded and few operations were performed to test that ioctls to /dev/zfs still work.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
