### PR TITLE
bash_completion: add missing attributes

### DIFF
--- a/contrib/bash_completion.d/zfs
+++ b/contrib/bash_completion.d/zfs
@@ -209,10 +209,10 @@ __zfs_complete()
                     COMPREPLY=($(compgen -W "" -- "$cur"))
                     ;;
                 -t)
-                    __zfs_complete_multiple_options "filesystem volume snapshot all" "$cur"
+                    __zfs_complete_multiple_options "filesystem volume snapshot bookmark all" "$cur"
                     ;;
                 -s)
-                    __zfs_complete_multiple_options "local default inherited temporary none" "$cur"
+                    __zfs_complete_multiple_options "local default inherited temporary received none" "$cur"
                     ;;
                 -o)
                     __zfs_complete_multiple_options "name property value source received all" "$cur"
@@ -242,7 +242,7 @@ __zfs_complete()
                     COMPREPLY=($(compgen -W "" -- "$cur"))
                     ;;
                 -t)
-                    __zfs_complete_multiple_options "filesystem volume snapshot all" "$cur"
+                    __zfs_complete_multiple_options "filesystem volume snapshot bookmark all" "$cur"
                     ;;
                 -o)
                     __zfs_complete_multiple_options "$(__zfs_get_properties)" "$cur"


### PR DESCRIPTION
### Motivation and Context
Bash completion is not complete.

### Description

There a some attributes missing which are shown in man pages.

zfs list -t type
           A comma-separated list of types to display, where type is one of filesystem, snapshot, volume, `bookmark`, or all.  For example, specifying -t snapshot displays only snapshots.

zfs get -s source
           A comma-separated list of sources to display.  Those properties coming from a source other than those in this list are ignored.  Each source must be one of the following: local, default, inherited, temporary, `received`, and none.  The default value is all sources.

zfs get -t type
           A comma-separated list of types to display, where type is one of filesystem, snapshot, volume, `bookmark`, or all.


### How Has This Been Tested?

I changed this file accordingly.  

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

