### PR TITLE
man.8: Add bookmark to list of types.

### DIFF
--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -282,8 +282,9 @@ has been set somewhere in the tree under which the dataset resides.
 The type of dataset:
 .Sy filesystem ,
 .Sy volume ,
+.Sy snapshot ,
 or
-.Sy snapshot .
+.Sy bookmark .
 .It Sy used
 The amount of space consumed by this dataset and all its descendents.
 This is the value that is checked against this dataset's quota and reservation.


### PR DESCRIPTION
### Motivation and Context
While checking bash_completion I missed bookmark as type in man-pages.

```
# zfs get type zpool2#b
NAME      PROPERTY  VALUE     SOURCE
zpool2#b  type      bookmark  -
```

### Description
Add missing attribute to man page.

### How Has This Been Tested?
-

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
