### PR TITLE
Removing ZERO_PAGE abd_alloc_zero_scatter

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -42,7 +42,6 @@ typedef int abd_iter_func_t(void *buf, size_t len, void *priv);
 typedef int abd_iter_func2_t(void *bufa, void *bufb, size_t len, void *priv);
 
 extern int zfs_abd_scatter_enabled;
-extern abd_t *abd_zero_scatter;
 
 /*
  * Allocations and deallocations

--- a/include/sys/abd_impl.h
+++ b/include/sys/abd_impl.h
@@ -92,6 +92,8 @@ struct abd_iter {
 	struct scatterlist *iter_sg;	/* current sg */
 };
 
+extern abd_t *abd_zero_scatter;
+
 abd_t *abd_gang_get_offset(abd_t *, size_t *);
 
 /*

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -167,6 +167,13 @@ int zfs_abd_scatter_min_size = 512 * 3;
  */
 abd_t *abd_zero_scatter = NULL;
 
+struct page;
+/*
+ * abd_zero_page we will be an allocated zero'd PAGESIZE buffer, which is
+ * assigned to set each of the pages of abd_zero_scatter.
+ */
+static struct page *abd_zero_page = NULL;
+
 static kmem_cache_t *abd_cache = NULL;
 static kstat_t *abd_ksp;
 
@@ -439,8 +446,7 @@ abd_free_chunks(abd_t *abd)
 
 /*
  * Allocate scatter ABD of size SPA_MAXBLOCKSIZE, where each page in
- * the scatterlist will be set to ZERO_PAGE(0). ZERO_PAGE(0) returns
- * a global shared page that is always zero'd out.
+ * the scatterlist will be set to the zero'd out buffer abd_zero_page.
  */
 static void
 abd_alloc_zero_scatter(void)
@@ -448,8 +454,15 @@ abd_alloc_zero_scatter(void)
 	struct scatterlist *sg = NULL;
 	struct sg_table table;
 	gfp_t gfp = __GFP_NOWARN | GFP_NOIO;
+	gfp_t gfp_zero_page = gfp | __GFP_ZERO;
 	int nr_pages = abd_chunkcnt_for_bytes(SPA_MAXBLOCKSIZE);
 	int i = 0;
+
+	while ((abd_zero_page = __page_cache_alloc(gfp_zero_page)) == NULL) {
+		ABDSTAT_BUMP(abdstat_scatter_page_alloc_retry);
+		schedule_timeout_interruptible(1);
+	}
+	abd_mark_zfs_page(abd_zero_page);
 
 	while (sg_alloc_table(&table, nr_pages, gfp)) {
 		ABDSTAT_BUMP(abdstat_scatter_sg_table_retry);
@@ -468,7 +481,7 @@ abd_alloc_zero_scatter(void)
 	zfs_refcount_create(&abd_zero_scatter->abd_children);
 
 	abd_for_each_sg(abd_zero_scatter, sg, nr_pages, i) {
-		sg_set_page(sg, ZERO_PAGE(0), PAGESIZE, 0);
+		sg_set_page(sg, abd_zero_page, PAGESIZE, 0);
 	}
 
 	ABDSTAT_BUMP(abdstat_scatter_cnt);
@@ -477,14 +490,6 @@ abd_alloc_zero_scatter(void)
 }
 
 #else /* _KERNEL */
-
-struct page;
-
-/*
- * In user space abd_zero_page we will be an allocated zero'd PAGESIZE
- * buffer, which is assigned to set each of the pages of abd_zero_scatter.
- */
-static struct page *abd_zero_page = NULL;
 
 #ifndef PAGE_SHIFT
 #define	PAGE_SHIFT (highbit64(PAGESIZE)-1)
@@ -680,7 +685,11 @@ abd_free_zero_scatter(void)
 	abd_free_sg_table(abd_zero_scatter);
 	abd_free_struct(abd_zero_scatter);
 	abd_zero_scatter = NULL;
-#if !defined(_KERNEL)
+	ASSERT3P(abd_zero_page, !=, NULL);
+#if defined(_KERNEL)
+	abd_unmark_zfs_page(abd_zero_page);
+	__free_page(abd_zero_page);
+#else
 	umem_free(abd_zero_page, PAGESIZE);
 #endif /* _KERNEL */
 }


### PR DESCRIPTION
For MIPS architectures on Linux the ZERO_PAGE macro references
empty_zero_page, which is exported as a GPL symbol. The call to
ZERO_PAGE in abd_alloc_zero_scatter has been removed and a single
zero'd page is now allocated for each of the pages in abd_zero_scatter
in the kernel ABD code path.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
For MIPS architectures in Linux the ZERO_PAGE macro references empty_zero_page. This is a GPL only symbol.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes a dependency on a GPL symbol for MIPS architectures.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
In order to fix this, I have removed the call to ZERO_PAGE in the Linux abd_os.c for allocating the abd_zero_scatter ABD. Instead I just allocate a single page and pass the __GP_ZERO flag to zero out the page.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested with zloop.sh (ran for 30 mins) and ZTS test.
<!--- Include details of your testing environment, and the tests you ran to -->
Test on CentOS Linux kernel 4.18.5.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
