### PR TITLE
Add gang ABD child to parent gang ABD

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -378,6 +378,32 @@ abd_alloc_gang_abd(void)
 }
 
 /*
+ * If we are adding a gang ABD to another gang ABD we will iterate
+ * though the child gang's individual ABD and add them individually
+ * to the parent.
+ */
+static void
+abd_gang_add_gang(abd_t *pabd, abd_t *cabd)
+{
+	abd_t *child = NULL;
+
+	ASSERT(abd_is_gang(pabd));
+	ASSERT(abd_is_gang(cabd));
+
+	for (child = list_head(&ABD_GANG(cabd).abd_gang_chain);
+	    child != NULL;
+	    child = list_next(&ABD_GANG(cabd).abd_gang_chain, child)) {
+		/*
+		 * We always pass B_FALSE for free_on_free as it is the
+		 * original child gang ABDs responsibilty to determine
+		 * if any of its child ABDs should be free'd on the call
+		 * to abd_free().
+		 */
+		abd_gang_add(pabd, child, B_FALSE);
+	}
+}
+
+/*
  * Add a child ABD to a gang ABD's chained list.
  */
 void
@@ -386,6 +412,24 @@ abd_gang_add(abd_t *pabd, abd_t *cabd, boolean_t free_on_free)
 	ASSERT(abd_is_gang(pabd));
 	ASSERT(!abd_is_gang(cabd));
 	abd_t *child_abd = NULL;
+
+	/*
+	 * If the child being added is a gang ABD, we will add each
+	 * of its child ABDs separately to the parent gang ABD. This
+	 * allows us to account for the offset correctly in the parent
+	 * gang ABD. We do allow gang ABDs to have gang ABD children.
+	 */
+	if (abd_is_gang(cabd)) {
+		/*
+		 * The parent ABD can not be responsible for freeing the
+		 * child gang ABD because we will just be adding the
+		 * child's ABDs to the parent individually.
+		 */
+		ASSERT(!list_link_active(&cabd->abd_gang_link));
+		ASSERT3B(free_on_free, ==, B_FALSE);
+		return (abd_gang_add_gang(pabd, cabd));
+	}
+	ASSERT(!abd_is_gang(cabd));
 
 	/*
 	 * In order to verify that an ABD is not already part of


### PR DESCRIPTION
By design a gang ABD can not have another gang ABD as a child. This is
to make sure the logical offset in a gang ABD is consistent with the
individual ABDS it contains as children. If a gang ABD is added as a
child of a gang ABD we will add the individual children of the gang ABD
to the parent gang ABD. Ths allows for a consistent view of offsets
within the parent gang ABD.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Added functionality for a gang ABD to take another gang ABD to be added as child.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will help solve aggregating IO's in vdev_queue_aggregate() for the dRAID PR #10102.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
In order for a gang ABD to add another gang ABD as child, the child gang ABD underlying ABD's must be iterated through and added to the parent individually. This allows for the offset/size logic inside of the parent gang ABD to be consistent. It is still the child gang ABD's responsibility to mark any of it's own ABD's as free_on_free.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Test on FreeBSD and Linux with both zpool (30 mins) and ZTS tests.
<!--- Include details of your testing environment, and the tests you ran to -->
Linux: CentOS Kernel 4.18.5
FreeBSD 12.1 STABLE
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
