### PR TITLE
Remove unnecessary references to slavery

### DIFF
--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -36,6 +36,7 @@ zpoolexecdir = $(zfsexecdir)/zpool.d
 EXTRA_DIST = zpool.d/README
 
 dist_zpoolexec_SCRIPTS = \
+	zpool.d/dm-deps \
 	zpool.d/enc \
 	zpool.d/encdev \
 	zpool.d/fault_led \
@@ -50,7 +51,6 @@ dist_zpoolexec_SCRIPTS = \
 	zpool.d/serial \
 	zpool.d/ses \
 	zpool.d/size \
-	zpool.d/slaves \
 	zpool.d/slot \
 	zpool.d/smart \
 	zpool.d/smartx \
@@ -80,6 +80,7 @@ dist_zpoolexec_SCRIPTS = \
 	zpool.d/test_ended
 
 zpoolconfdefaults = \
+	dm-deps \
 	enc \
 	encdev \
 	fault_led \
@@ -94,7 +95,6 @@ zpoolconfdefaults = \
 	serial \
 	ses \
 	size \
-	slaves \
 	slot \
 	smart \
 	smartx \

--- a/cmd/zpool/zpool.d/dm-deps
+++ b/cmd/zpool/zpool.d/dm-deps
@@ -1,14 +1,11 @@
 #!/bin/sh
 #
-# Show device mapper slave devices.  This is useful for looking up the
-# /dev/sd* devices associated with a dm or multipath device.  For example:
-#
-# $ ls /sys/block/dm-113/slaves/
-# sddt  sdjw
+# Show device mapper dependent / underlying devices.  This is useful for
+# looking up the /dev/sd* devices associated with a dm or multipath device. 
 #
 
 if [ "$1" = "-h" ] ; then
-	echo "Show device mapper slave devices."
+	echo "Show device mapper dependent (underlying) devices."
 	exit
 fi
 
@@ -29,4 +26,4 @@ if [ -d "/sys/class/block/$dev/slaves" ] ; then
 	val=$(echo "$val" | sed -r 's/[[:blank:]]+/ /g')
 fi
 
-echo "slaves=$val"
+echo "dm-deps=$val"

--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -74,10 +74,10 @@ check() {
     local blockdevs
     local fstype
     local majmin
-    local _slavedev
-    local _slavedevname
-    local _slavedevtype
-    local _slavemajmin
+    local _depdev
+    local _depdevname
+    local _depdevtype
+    local _depmajmin
     local _dev
 
 if [[ $hostonly ]]; then
@@ -108,15 +108,15 @@ if [[ $hostonly ]]; then
             host_fs_types["$dev"]="$fstype"
             majmin=$(get_maj_min "$dev")
             if [[ -d /sys/dev/block/$majmin/slaves ]] ; then
-                for _slavedev in /sys/dev/block/$majmin/slaves/*; do
-                    [[ -f $_slavedev/dev ]] || continue
-                    _slavedev=/dev/$(basename "$_slavedev")
-                    _slavedevname=$(udevadm info --query=property --name="$_slavedev" | grep "^DEVNAME=" | sed 's|^DEVNAME=||')
-                    _slavedevtype=$(get_devtype "$_slavedevname")
-                    _slavemajmin=$(get_maj_min "$_slavedevname")
-                    dinfo "zfsexpandknowledge: slave block device backing ZFS dataset $mp: $_slavedevname"
-                    array_contains "$_slavedevname" "${host_devs[@]}" || host_devs+=("$_slavedevname")
-                    host_fs_types["$_slavedevname"]="$_slavedevtype"
+                for _depdev in /sys/dev/block/$majmin/slaves/*; do
+                    [[ -f $_depdev/dev ]] || continue
+                    _depdev=/dev/$(basename "$_depdev")
+                    _depdevname=$(udevadm info --query=property --name="$_depdev" | grep "^DEVNAME=" | sed 's|^DEVNAME=||')
+                    _depdevtype=$(get_devtype "$_depdevname")
+                    _depmajmin=$(get_maj_min "$_depdevname")
+                    dinfo "zfsexpandknowledge: underlying block device backing ZFS dataset $mp: $_depdevname"
+                    array_contains "$_depdevname" "${host_devs[@]}" || host_devs+=("$_depdevname")
+                    host_fs_types["$_depdevname"]="$_depdevtype"
                 done
             fi
         done

--- a/include/os/freebsd/spl/sys/dkio.h
+++ b/include/os/freebsd/spl/sys/dkio.h
@@ -69,7 +69,6 @@ struct dk_cinfo {
 	uint_t	dki_vec;		/* interrupt vector */
 	char	dki_dname[DK_DEVLEN];	/* drive name (no unit #) */
 	uint_t	dki_unit;		/* unit number */
-	uint_t	dki_slave;		/* slave number */
 	ushort_t dki_partition;		/* partition number */
 	ushort_t dki_maxtransfer;	/* max. transfer size in DEV_BSIZE */
 };

--- a/lib/libspl/include/sys/dkio.h
+++ b/lib/libspl/include/sys/dkio.h
@@ -59,7 +59,6 @@ struct dk_cinfo {
 	uint_t	dki_vec;		/* interrupt vector */
 	char	dki_dname[DK_DEVLEN];	/* drive name (no unit #) */
 	uint_t	dki_unit;		/* unit number */
-	uint_t	dki_slave;		/* slave number */
 	ushort_t dki_partition;		/* partition number */
 	ushort_t dki_maxtransfer;	/* max. transfer size in DEV_BSIZE */
 };

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -203,7 +203,11 @@ dm_get_underlying_path(const char *dm_name)
 	if (dp == NULL)
 		goto end;
 
-	/* Return first sd* entry in /sys/block/dm-N/slaves/ */
+	/*
+	 * Return first entry (that isn't itself a directory) in the
+	 * directory containing device-mapper dependent (underlying)
+	 * devices.
+	 */
 	while ((ep = readdir(dp))) {
 		if (ep->d_type != DT_DIR) {	/* skip "." and ".." dirs */
 			size = asprintf(&path, "/dev/%s", ep->d_name);

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -431,18 +431,13 @@ option.
    U13      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
    U14      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
 
-# zpool iostat -vc slaves
-   capacity operations bandwidth
-   pool       alloc free  read  write read  write slaves
-   ---------- ----- ----- ----- ----- ----- ----- ---------
-   tank       20.4G 7.23T 26    152   20.7M 21.6M
-   mirror     20.4G 7.23T 26    152   20.7M 21.6M
-   U1         -     -     0     31    1.46K 20.6M sdb sdff
-   U10        -     -     0     1     3.77K 13.3K sdas sdgw
-   U11        -     -     0     1     288K  13.3K sdat sdgx
-   U12        -     -     0     1     78.4K 13.3K sdau sdgy
-   U13        -     -     0     1     128K  13.3K sdav sdgz
-   U14        -     -     0     1     63.2K 13.3K sdfk sdg
+# zpool iostat -vc size
+              capacity     operations     bandwidth
+pool        alloc   free   read  write   read  write  size
+----------  -----  -----  -----  -----  -----  -----  ----
+rpool       14.6G  54.9G      4     55   250K  2.69M
+  sda1      14.6G  54.9G      4     55   250K  2.69M   70G
+----------  -----  -----  -----  -----  -----  -----  ----
 .Ed
 .El
 .Sh ENVIRONMENT VARIABLES

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -336,25 +336,25 @@ function on_off_disk # disk state{online,offline} host
 		if [[ $state == "offline" ]] && ( is_mpath_device $disk ); then
 			dm_name="$(readlink $DEV_DSKDIR/$disk \
 			    | nawk -F / '{print $2}')"
-			slave="$(ls /sys/block/${dm_name}/slaves \
+			dep="$(ls /sys/block/${dm_name}/slaves \
 			    | nawk '{print $1}')"
-			while [[ -n $slave ]]; do
+			while [[ -n $dep ]]; do
 				#check if disk is online
-				lsscsi | egrep $slave > /dev/null
+				lsscsi | egrep $dep > /dev/null
 				if (($? == 0)); then
-					slave_dir="/sys/block/${dm_name}"
-					slave_dir+="/slaves/${slave}/device"
-					ss="${slave_dir}/state"
-					sd="${slave_dir}/delete"
+					dep_dir="/sys/block/${dm_name}"
+					dep_dir+="/slaves/${dep}/device"
+					ss="${dep_dir}/state"
+					sd="${dep_dir}/delete"
 					log_must eval "echo 'offline' > ${ss}"
 					log_must eval "echo '1' > ${sd}"
-					lsscsi | egrep $slave > /dev/null
+					lsscsi | egrep $dep > /dev/null
 						if (($? == 0)); then
 							log_fail "Offlining" \
 							    "$disk failed"
 						fi
 				fi
-				slave="$(ls /sys/block/$dm_name/slaves \
+				dep="$(ls /sys/block/$dm_name/slaves \
 				    2>/dev/null | nawk '{print $1}')"
 			done
 		elif [[ $state == "offline" ]] && ( is_real_device $disk ); then
@@ -380,9 +380,9 @@ function on_off_disk # disk state{online,offline} host
 			if is_mpath_device $disk; then
 				dm_name="$(readlink $DEV_DSKDIR/$disk \
 				    | nawk -F / '{print $2}')"
-				slave="$(ls /sys/block/$dm_name/slaves \
+				dep="$(ls /sys/block/$dm_name/slaves \
 				    | nawk '{print $1}')"
-				lsscsi | egrep $slave > /dev/null
+				lsscsi | egrep $dep > /dev/null
 				if (($? != 0)); then
 					log_fail "Onlining $disk failed"
 				fi


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The horrible effects of human slavery continue to impact society.  The
casual use of the term "slave" in computer software is an unnecessary
reference to a painful human experience.

### Description
<!--- Describe your changes in detail -->
This commit removes all possible references to the term "slave".

Implementation notes:

The zpool.d/slaves script is renamed to dm-deps, which uses the same
terminology as `dmsetup deps`.

References to the `/sys/class/block/$dev/slaves` directory remain.  This
directory name is determined by the Linux kernel.  Although
`dmsetup deps` provides the same information, it unfortunately requires
elevated privileges, whereas the `/sys/...` directory is world-readable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Manual testing of `dm-deps` script and manpage.
Ran the test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
