### PR TITLE
FreeBSD: Don't require zeroing new locks before init

### DIFF
--- a/include/os/freebsd/spl/sys/mutex.h
+++ b/include/os/freebsd/spl/sys/mutex.h
@@ -39,7 +39,7 @@ typedef struct sx	kmutex_t;
 #include <sys/sx.h>
 
 typedef enum {
-	MUTEX_DEFAULT = 6	/* kernel default mutex */
+	MUTEX_DEFAULT = 0	/* kernel default mutex */
 } kmutex_type_t;
 
 #define	MUTEX_HELD(x)		(mutex_owned(x))
@@ -53,9 +53,7 @@ typedef enum {
 
 #define	mutex_init(lock, desc, type, arg)	do {			\
 	const char *_name;						\
-	ASSERT((type) == 0 || (type) == MUTEX_DEFAULT);			\
-	KASSERT(((lock)->lock_object.lo_flags & LO_ALLMASK) !=		\
-	    LO_EXPECTED, ("lock %s already initialized", #lock));	\
+	ASSERT((type) == MUTEX_DEFAULT);				\
 	for (_name = #lock; *_name != '\0'; _name++) {			\
 		if (*_name >= 'a' && *_name <= 'z')			\
 			break;						\


### PR DESCRIPTION


Signed-off-by: Ryan Moeller <ryan@iXsystems.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has not shown to be of use enough to justify the inconvenience.

### Description
<!--- Describe your changes in detail -->
Remove the KASSERT in FreeBSD's mutex_init. While here, change the confusing and meaningless value of MUTEX_DEFAULT to 0 instead of 6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Built on FreeBSD, did some basic testing by creating a pool, checking out ZFS sources onto the pool, and building ZFS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
