### PR TITLE
Allow sys/vdev_disk.h to have OS fields

### DIFF
--- a/include/sys/vdev_disk.h
+++ b/include/sys/vdev_disk.h
@@ -42,13 +42,5 @@
 
 #ifdef _KERNEL
 #include <sys/vdev.h>
-
-typedef struct vdev_disk {
-	ddi_devid_t		vd_devid;
-	char			*vd_minor;
-	struct block_device	*vd_bdev;
-	krwlock_t		vd_lock;
-} vdev_disk_t;
-
 #endif /* _KERNEL */
 #endif /* _SYS_VDEV_DISK_H */

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -37,6 +37,11 @@
 #include <linux/msdos_fs.h>
 #include <linux/vfs_compat.h>
 
+typedef struct vdev_disk {
+	struct block_device		*vd_bdev;
+	krwlock_t			vd_lock;
+} vdev_disk_t;
+
 /*
  * Unique identifier for the exclusive vdev holder.
  */


### PR DESCRIPTION

Move OS specific fields from vdev_disk.h into (new) platform header.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

macOS and FreeBSD doesn't need to know what a `struct block_device` is, and I guarantee Linux and FreeBSD do not want to know about `class iokit::storage::ioblockdevice`.

### Description
<!--- Describe your changes in detail -->

Based on the same style as zfs_znode_os.h.
Create an os/$platform/sys/vdev_disk_os.h for each platform, move
Linux specific fields into it. Currently it leaves FreeBSD's empty.

macOS header file will come in a future PR. If you are curious, it will look something like:
https://github.com/openzfsonosx/openzfs/blob/sorted2/include/os/macos/zfs/sys/vdev_disk_os.h#L26


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
- [x] Code porting (possibly-breaking change which makes code more universal)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
