### PR TITLE
Racist code refactoring

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -616,7 +616,7 @@ for_each_vdev_run_cb(zpool_handle_t *zhp, nvlist_t *nv, void *cb_vcdl)
 		}
 	}
 
-	/* Check for whitelisted vdevs here, if any */
+	/* Check for allowlisted vdevs here, if any */
 	for (i = 0; i < vcdl->vdev_names_count; i++) {
 		vname = zpool_vdev_name(g_zfs, zhp, nv, vcdl->cb_name_flags);
 		if (strcmp(vcdl->vdev_names[i], vname) == 0) {
@@ -627,7 +627,7 @@ for_each_vdev_run_cb(zpool_handle_t *zhp, nvlist_t *nv, void *cb_vcdl)
 		free(vname);
 	}
 
-	/* If we whitelisted vdevs, and this isn't one of them, then bail out */
+	/* If we allowlisted vdevs, and this isn't one of them, then bail out */
 	if (!match && vcdl->vdev_names_count)
 		return (0);
 

--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -103,7 +103,7 @@ typedef struct vdev_cmd_data_list
 	char *cmd;		/* Command to run */
 	unsigned int count;	/* Number of vdev_cmd_data items (vdevs) */
 
-	/* vars to whitelist only certain vdevs, if requested */
+	/* vars to allowlist only certain vdevs, if requested */
 	libzfs_handle_t *g_zfs;
 	char **vdev_names;
 	int vdev_names_count;

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -88,13 +88,13 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 /*
  * Do not even look at these devices.
  */
-static const char * const blacklist_devs[] = {
+static const char * const blocklist_devs[] = {
 	"nfslock",
 	"sequencer",
 	"zfs",
 };
-#define	BLACKLIST_DIR		"/dev/"
-#define	BLACKLIST_DIR_LEN	5
+#define	BLOCKLIST_DIR		"/dev/"
+#define	BLOCKLIST_DIR_LEN	5
 
 void
 zpool_open_func(void *arg)
@@ -108,12 +108,12 @@ zpool_open_func(void *arg)
 	off_t mediasize = 0;
 
 	/*
-	 * Do not even look at blacklisted devices.
+	 * Do not even look at blocklisted devices.
 	 */
-	if (strncmp(rn->rn_name, BLACKLIST_DIR, BLACKLIST_DIR_LEN) == 0) {
-		char *name = rn->rn_name + BLACKLIST_DIR_LEN;
-		for (i = 0; i < nitems(blacklist_devs); ++i) {
-			const char *badname = blacklist_devs[i];
+	if (strncmp(rn->rn_name, BLOCKLIST_DIR, BLOCKLIST_DIR_LEN) == 0) {
+		char *name = rn->rn_name + BLOCKLIST_DIR_LEN;
+		for (i = 0; i < nitems(blocklist_devs); ++i) {
+			const char *badname = blocklist_devs[i];
 			size_t len = strlen(badname);
 			if (strncmp(name, badname, len) == 0) {
 				return;


### PR DESCRIPTION
Words such as "wh\*telist" or "b\*acklist" are racist. We cannot have those absolutely disgusting  derogatory words in our codebase. Therefore, we need to change them to race-neutral words.

There are more references to racial supremacy throughout the code. These should be discussed.

Should this macro be renamed to `skip_blankspace`?
https://github.com/openzfs/zfs/blob/master/module/nvpair/nvpair.c#L46

Also, in the Lua module, we mark objects as "wh\*te" or "b\*ack". I suggest changing the colors to some non-offensive ones. I propose indigo (`#4B0082`) and forest green (`#228B22`).
https://github.com/openzfs/zfs/blob/master/module/lua/lgc.c

### Motivation and Context
Following other open-source projects, we should strive to keep the ZFS code base clean of any vulgar, racist or other unnecessary remarks and to allow for friendly and welcoming environment for people of all kinds.

### How Has This Been Tested?
It compiles - it's just basic refactoring.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
