### PR TITLE
remove refences to blacklist/whitelist

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -616,7 +616,7 @@ for_each_vdev_run_cb(zpool_handle_t *zhp, nvlist_t *nv, void *cb_vcdl)
 		}
 	}
 
-	/* Check for whitelisted vdevs here, if any */
+	/* Check for selected vdevs here, if any */
 	for (i = 0; i < vcdl->vdev_names_count; i++) {
 		vname = zpool_vdev_name(g_zfs, zhp, nv, vcdl->cb_name_flags);
 		if (strcmp(vcdl->vdev_names[i], vname) == 0) {
@@ -627,7 +627,7 @@ for_each_vdev_run_cb(zpool_handle_t *zhp, nvlist_t *nv, void *cb_vcdl)
 		free(vname);
 	}
 
-	/* If we whitelisted vdevs, and this isn't one of them, then bail out */
+	/* If we selected vdevs, and this isn't one of them, then bail out */
 	if (!match && vcdl->vdev_names_count)
 		return (0);
 

--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -103,7 +103,7 @@ typedef struct vdev_cmd_data_list
 	char *cmd;		/* Command to run */
 	unsigned int count;	/* Number of vdev_cmd_data items (vdevs) */
 
-	/* vars to whitelist only certain vdevs, if requested */
+	/* fields used to select only certain vdevs, if requested */
 	libzfs_handle_t *g_zfs;
 	char **vdev_names;
 	int vdev_names_count;

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -88,13 +88,13 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 /*
  * Do not even look at these devices.
  */
-static const char * const blacklist_devs[] = {
+static const char * const excluded_devs[] = {
 	"nfslock",
 	"sequencer",
 	"zfs",
 };
-#define	BLACKLIST_DIR		"/dev/"
-#define	BLACKLIST_DIR_LEN	5
+#define	EXCLUDED_DIR		"/dev/"
+#define	EXCLUDED_DIR_LEN	5
 
 void
 zpool_open_func(void *arg)
@@ -108,14 +108,14 @@ zpool_open_func(void *arg)
 	off_t mediasize = 0;
 
 	/*
-	 * Do not even look at blacklisted devices.
+	 * Do not even look at excluded devices.
 	 */
-	if (strncmp(rn->rn_name, BLACKLIST_DIR, BLACKLIST_DIR_LEN) == 0) {
-		char *name = rn->rn_name + BLACKLIST_DIR_LEN;
-		for (i = 0; i < nitems(blacklist_devs); ++i) {
-			const char *badname = blacklist_devs[i];
-			size_t len = strlen(badname);
-			if (strncmp(name, badname, len) == 0) {
+	if (strncmp(rn->rn_name, EXCLUDED_DIR, EXCLUDED_DIR_LEN) == 0) {
+		char *name = rn->rn_name + EXCLUDED_DIR_LEN;
+		for (i = 0; i < nitems(excluded_devs); ++i) {
+			const char *excluded_name = excluded_devs[i];
+			size_t len = strlen(excluded_name);
+			if (strncmp(name, excluded_name, len) == 0) {
 				return;
 			}
 		}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These terms reinforce the incorrect notion that black is bad and white
is good.

### Description
<!--- Describe your changes in detail -->
Replace this language with more specific terms which are also more clear
and don't rely on metaphor.  Specifically:

* When vdevs are specified on the command line, they are the "selected"
vdevs.

* Entries in /dev/ which should not be considered as possible disks are
"excluded" devices.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
compiles

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
