### PR TITLE
zed additional features

### DIFF
--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -263,18 +263,43 @@ main(int argc, char *argv[])
 	if (zed_conf_read_state(zcp, &saved_eid, saved_etime) < 0)
 		exit(EXIT_FAILURE);
 
-	zed_event_init(zcp);
+idle:
+	/*
+	 * If -I is specified, attempt to open /dev/zfs repeatedly until
+	 * successful.
+	 */
+	do {
+		if (!zed_event_init(zcp))
+			break;
+		/* Wait for some time and try again. tunable? */
+		sleep(30);
+	} while (!_got_exit && zcp->do_idle);
+
+	if (_got_exit)
+		goto out;
+
 	zed_event_seek(zcp, saved_eid, saved_etime);
 
 	while (!_got_exit) {
+		int rv;
 		if (_got_hup) {
 			_got_hup = 0;
 			(void) zed_conf_scan_dir(zcp);
 		}
-		zed_event_service(zcp);
+		rv = zed_event_service(zcp);
+
+		/* ENODEV: When kernel module is unloaded (osx) */
+		if (rv == ENODEV)
+			break;
 	}
+
 	zed_log_msg(LOG_NOTICE, "Exiting");
 	zed_event_fini(zcp);
+
+	if (zcp->do_idle && !_got_exit)
+		goto idle;
+
+out:
 	zed_conf_destroy(zcp);
 	zed_log_fini();
 	exit(EXIT_SUCCESS);

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -153,6 +153,8 @@ _zed_conf_display_help(const char *prog, int got_err)
 	    "Force daemon to run.");
 	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-F",
 	    "Run daemon in the foreground.");
+	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-I",
+	    "Idle daemon until kernel module is (re)loaded.");
 	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-M",
 	    "Lock all pages in memory.");
 	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-P",
@@ -249,7 +251,7 @@ _zed_conf_parse_path(char **resultp, const char *path)
 void
 zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 {
-	const char * const opts = ":hLVc:d:p:P:s:vfFMZ";
+	const char * const opts = ":hLVc:d:p:P:s:vfFMZI";
 	int opt;
 
 	if (!zcp || !argv || !argv[0])
@@ -273,6 +275,9 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 			break;
 		case 'd':
 			_zed_conf_parse_path(&zcp->zedlet_dir, optarg);
+			break;
+		case 'I':
+			zcp->do_idle = 1;
 			break;
 		case 'p':
 			_zed_conf_parse_path(&zcp->pid_file, optarg);

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -25,6 +25,7 @@ struct zed_conf {
 	unsigned	do_memlock:1;		/* true if locking memory */
 	unsigned	do_verbose:1;		/* true if verbosity enabled */
 	unsigned	do_zero:1;		/* true if zeroing state */
+	unsigned	do_idle:1;		/* true if idle enabled */
 	int		syslog_facility;	/* syslog facility value */
 	int		min_events;		/* RESERVED FOR FUTURE USE */
 	int		max_events;		/* RESERVED FOR FUTURE USE */

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -40,25 +40,36 @@
 /*
  * Open the libzfs interface.
  */
-void
+int
 zed_event_init(struct zed_conf *zcp)
 {
 	if (!zcp)
 		zed_log_die("Failed zed_event_init: %s", strerror(EINVAL));
 
 	zcp->zfs_hdl = libzfs_init();
-	if (!zcp->zfs_hdl)
+	if (!zcp->zfs_hdl) {
+		if (zcp->do_idle)
+			return (-1);
 		zed_log_die("Failed to initialize libzfs");
+	}
 
 	zcp->zevent_fd = open(ZFS_DEV, O_RDWR);
-	if (zcp->zevent_fd < 0)
+	if (zcp->zevent_fd < 0) {
+		if (zcp->do_idle)
+			return (-1);
 		zed_log_die("Failed to open \"%s\": %s",
 		    ZFS_DEV, strerror(errno));
+	}
 
 	zfs_agent_init(zcp->zfs_hdl);
 
-	if (zed_disk_event_init() != 0)
+	if (zed_disk_event_init() != 0) {
+		if (zcp->do_idle)
+			return (-1);
 		zed_log_die("Failed to initialize disk events");
+	}
+
+	return (0);
 }
 
 /*
@@ -872,7 +883,7 @@ _zed_event_add_time_strings(uint64_t eid, zed_strings_t *zsp, int64_t etime[])
 /*
  * Service the next zevent, blocking until one is available.
  */
-void
+int
 zed_event_service(struct zed_conf *zcp)
 {
 	nvlist_t *nvl;
@@ -890,13 +901,13 @@ zed_event_service(struct zed_conf *zcp)
 		errno = EINVAL;
 		zed_log_msg(LOG_ERR, "Failed to service zevent: %s",
 		    strerror(errno));
-		return;
+		return (EINVAL);
 	}
 	rv = zpool_events_next(zcp->zfs_hdl, &nvl, &n_dropped, ZEVENT_NONE,
 	    zcp->zevent_fd);
 
 	if ((rv != 0) || !nvl)
-		return;
+		return (errno);
 
 	if (n_dropped > 0) {
 		zed_log_msg(LOG_WARNING, "Missed %d events", n_dropped);
@@ -949,4 +960,5 @@ zed_event_service(struct zed_conf *zcp)
 		zed_strings_destroy(zsp);
 	}
 	nvlist_free(nvl);
+	return (0);
 }

--- a/cmd/zed/zed_event.h
+++ b/cmd/zed/zed_event.h
@@ -17,13 +17,13 @@
 
 #include <stdint.h>
 
-void zed_event_init(struct zed_conf *zcp);
+int zed_event_init(struct zed_conf *zcp);
 
 void zed_event_fini(struct zed_conf *zcp);
 
 int zed_event_seek(struct zed_conf *zcp, uint64_t saved_eid,
     int64_t saved_etime[]);
 
-void zed_event_service(struct zed_conf *zcp);
+int zed_event_service(struct zed_conf *zcp);
 
 #endif	/* !ZED_EVENT_H */

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -24,6 +24,7 @@ ZED \- ZFS Event Daemon
 [\fB\-f\fR]
 [\fB\-F\fR]
 [\fB\-h\fR]
+[\fB\-I\fR]
 [\fB\-L\fR]
 [\fB\-M\fR]
 [\fB\-p\fR \fIpidfile\fR]
@@ -65,6 +66,12 @@ Run the daemon in the foreground.
 Lock all current and future pages in the virtual memory address space.
 This may help the daemon remain responsive when the system is under heavy
 memory pressure.
+.TP
+.BI \-I
+Request that the daemon idle rather than exit when the kernel modules are
+not loaded. Processing of events will start, or resume, when the kernel
+modules are (re)loaded. Under Linux the kernel modules cannot be unloaded
+while the daemon is running.
 .TP
 .BI \-Z
 Zero the daemon's state, thereby allowing zevents still within the kernel


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Add two features to zed, exit clean on unload, and a new command flag to stick around.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To run better from launchctl on macOS, to avoid cpubusy loops.

### Description
<!--- Describe your changes in detail -->
This commit adds two features to zed, that macOS desires. The first
is that when you unload the kernel module, zed would enter into a
cpubusy loop calling zfs_events_next() repeatedly. We now look for
ENODEV, returned by kernel, so zed can exit gracefully.

Second feature is -I (idle) (alas -P persist was taken) is for the
deamon to;

1; if started without ZFS kernel module, stick around waiting for it.
2; if kernel module is unloaded, go back to 1.

This is due to daemons in macOS is started by launchctl, and is
expected to stick around.

Currently, the busy loop only exists when errno is ENODEV. This is
to ensure that functionality that upstream expects is not changed.
It did not care about errors before, and it still does not. (with the
exception of ENODEV).

However, it is probably better that all errors (ERESTART notwithstanding)
exits the loop, and the issues complaining about zed taking all CPU
will go away.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
