### PR TITLE
Mount generator fixes

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -191,7 +191,6 @@ Documentation=man:zfs-mount-generator(8)
 DefaultDependencies=no
 Wants=${wants}
 After=${after}
-Before=${before}
 ${requires}
 ${keymountdep}
 

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -173,6 +173,12 @@ set -eu;\
 keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";\
 [ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;\
 ${keyloadscript}'"
+      keyunloadcmd="\
+/bin/sh -c '\
+set -eu;\
+keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";\
+[ \"\$\$keystatus\" = \"available\" ] || exit 0;\
+@sbindir@/zfs unload-key \"${dataset}\"'"
 
 
 
@@ -199,7 +205,7 @@ ${keymountdep}
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=${keyloadcmd}
-ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}"
+ExecStop=${keyunloadcmd}"   > "${dest_norm}/${keyloadunit}"
     fi
     # Update the dependencies for the mount file to want the
     # key-loading unit.

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -115,6 +115,7 @@ process_line() {
   wants="zfs-import.target"
   requires=""
   requiredmounts=""
+  bindsto=""
   wantedby=""
   requiredby=""
   noauto="off"
@@ -202,7 +203,8 @@ ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}
     fi
     # Update the dependencies for the mount file to want the
     # key-loading unit.
-    wants="${wants} ${keyloadunit}"
+    wants="${wants}"
+    bindsto="BindsTo=${keyloadunit}"
     after="${after} ${keyloadunit}"
   fi
 
@@ -413,6 +415,7 @@ Documentation=man:zfs-mount-generator(8)
 Before=${before}
 After=${after}
 Wants=${wants}
+${bindsto}
 ${requires}
 ${requiredmounts}
 


### PR DESCRIPTION
This set of changes makes the zfs mount generated units more effective and tight in case of encryption selected.

### Motivation and Context
The goal of this PR is to make the systemd zfs generator a little bit more robust against failure, especially when encryption is involved.

Those are done in multiple ways (each in separate commits):
* Make unload-key logic similar to load-key as unloading an unloaded key via zfs command will fail.
* Make tighter the dependency between the mount unit and its load-key unit, so that stopping or failure load-key unit will impact directly its .mount service
* Allow the mount unit to be imported at any time (like via systemd automount for on demand mount or via a service dependency request) instead of forcing it before zfs-mount.service (which will just skip this dataset silently as the key is not loaded)

### Description

Taking by each point in the commit message:

* Make unloading the key more robust

  The unit was failing instead of stopping if someone manually unloaded the key before stopping the unit (zfs unload-key is failing on an  unavailable key). Follow a similar logic than for loading the key, checking for the key status before unloading it.

* BindsTo dataset keyload unit to mount associate unit

  We need a stronger dependency between the mount unit and its keyload unit when we know that the dataset is encrypted.
If the keyload unit fails, Wants= will still try to mount the dataset, which will then fail.
It’s better to show that the failure is due to a dependency failing, the keyload unit, by tighting up the dependency. We can do this as we know that we generate both units in the generator and so, it’s not an optional dependency. BindsTo enable as well that if the keyload unit fails at any point, the associated mountpoint will be then unmounted.
Note: **Requires** could be enough as this is a simple **oneshot** service, but if it will evolve in a real service, the relationship is better addressed that way.

* Ensure mount unit pilots when its ZFS key is loaded

  Drop Before=zfs.mount dependency explicity on generated load-key .service unit.
Indeed, the associated mount unit is After=<dataset-load-key>.service.
This is thus the mount point which controls at what point it wants to be mounted (Before=zfs-mount.service in stock generator), but this can be an automount point, or triggered by another service.
This additional dependency from the key load service is not needed thus.


### How Has This Been Tested?
We checked after a `systemctl daemon-reload` that:
* Stopping load-key unit twice or stopping after a manual zfs unload-key doesn’t fail anymore.
* Stopping the key-load unit will try to stop the mount service.
* If the load-key unit is failing, the .mount unit will not try to start with "Dependency failed for". Without the fix, it was starting and failing with "Failed to mount ..."
* Stopping the load-key service state will depend on the .mount unit state. if the dataset can be unmounted (busy for instance), the key-load unit was simply failing with "Key unload error: '...' is busy". Now, if the mount unit can’t be unmounted successfully, then the key-load service will be in failure referring that it can’t stop the mount unit.
* We can now start the .mount units at any time on boot, by a systemd service or via zfs-mount.service if the system administrators adds a `.conf.d/` file for wanting it.
* Stopping the .mount unit still keep the load-key service active, and thus the key loaded. This is a no-change compared to current behavior (note that in ubuntu: for user home datasets only, this is not true as we will link load-key and mount units lifecycle, to have per-user home encryption and decryption on demand with a separate automount unit. We are happy to upstream such a feature with a dedicated user property if interested).
* Regular mount unit (not encrypted datasets) are not impacted.

Those changes of course only impacts systemd systems with some encrypted datasets, when the user enabled the zfs mount generator via the list cache zed hook.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Note: they are indeed multiple commits, but those are small and impacts the same areas of code. We separated them for better articulations of the changes.service
The generator doesn’t have any automated tests, hence this box not checked. However, as previously explained, a lot of manual tests have been processed.
No documentation is impacted AFAIK.
