### PR TITLE
[DRAFT] ARC dumping to L2ARC upon pool export

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -308,7 +308,7 @@ void arc_fini(void);
  */
 
 void l2arc_add_vdev(spa_t *spa, vdev_t *vd);
-void l2arc_remove_vdev(vdev_t *vd);
+void l2arc_remove_vdev(vdev_t *vd, boolean_t export);
 boolean_t l2arc_vdev_present(vdev_t *vd);
 void l2arc_rebuild_vdev(vdev_t *vd, boolean_t reopen);
 boolean_t l2arc_range_check_overlap(uint64_t bottom, uint64_t top,

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -407,6 +407,9 @@ typedef struct l2arc_dev {
 	 */
 	zfs_refcount_t		l2ad_lb_count;
 	boolean_t		l2ad_trim_all; /* TRIM whole device */
+	boolean_t		l2ad_dump_arc; /* ARC dumping */
+	/* Write size for ARC dumping */
+	uint64_t		l2ad_write_max;
 } l2arc_dev_t;
 
 /*


### PR DESCRIPTION
**[This is not stable yet, may lead to crashes]**

This commit enables dumping of all eligible ARC contents to L2ARC upon
exporing a pool by setting the zfs module l2arc_dump_arc to 1. This
could possibly enhance the efficiency of L2ARC. As the default
l2arc_write_max is small we define a dev->l2ad_write_max to be used
exclusively during dumping of ARC contents upon exporting the pool.

todo:
* implement zfs module
* add tests

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
