### PR TITLE
Update zts-report.py with additional tests

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -250,6 +250,20 @@ if sys.platform.startswith('freebsd'):
         'removal/removal_with_export': ['FAIL', known_reason],
         'resilver/resilver_restart_001': ['FAIL', known_reason],
     })
+elif sys.platform.startswith('linux'):
+    maybe.update({
+        'alloc_class/alloc_class_009_pos': ['FAIL', known_reason],
+        'alloc_class/alloc_class_010_pos': ['FAIL', known_reason],
+        'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
+        'cli_root/zpool_expand/zpool_expand_001_pos': ['FAIL', known_reason],
+        'cli_root/zpool_expand/zpool_expand_005_pos': ['FAIL', known_reason],
+        'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
+        'refreserv/refreserv_raidz': ['FAIL', known_reason],
+        'rsend/rsend_007_pos': ['FAIL', known_reason],
+        'rsend/rsend_010_pos': ['FAIL', known_reason],
+        'rsend/rsend_011_pos': ['FAIL', known_reason],
+        'snapshot/rollback_003_pos': ['FAIL', known_reason],
+    })
 
 
 def usage(s):


### PR DESCRIPTION
### Motivation and Context

Enable the Fedora 32 builder by default and reduce the number of
known false positives resulting in ZTS failures.  These tests should
be updated to be more reliable on all platforms and then removed
from the "maybe" list.

### Description

The following test cases may still occasionally fail and are being
added to the "maybe" list for Linux until they can be updated to be
entirely reliable.

    cli_root/zfs_rename/zfs_rename_002_pos.ksh
    cli_root/zpool_reopen/zpool_reopen_003_pos.ksh
    refreserv/refreserv_raidz

These 6 tests consistently fail only on Fedora 31+ are the failures
are related to the kernel rescanning the partition table on loopback
devices which is no longer reliable unless partprobe is used.  In
order to enable the Fedora bot by default they are also being added
to the list until the tests can be updated.

    cli_root/zpool_expand/zpool_expand_001_pos
    cli_root/zpool_expand/zpool_expand_005_pos
    rsend/rsend_007_pos
    rsend/rsend_010_pos
    rsend/rsend_011_pos
    snapshot/rollback_003_pos

http://build.zfsonlinux.org/builders/Fedora%2032%20x86_64%20%28TEST%29/builds/0/steps/shell_9/logs/summary

### How Has This Been Tested?

Manually inspected.  Pending verification from a full CI run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).