### PR TITLE
arcstat: add 'avail', fix 'free'

### DIFF
--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -102,7 +102,7 @@ cols = {
     "grow":       [4, 1000, "ARC grow disabled"],
     "need":       [4, 1024, "ARC reclaim need"],
     "free":       [4, 1024, "ARC free memory"],
-    "avail":      [4, 1024, "ARC available memory"],
+    "avail":      [5, 1024, "ARC available memory"],
 }
 
 v = {}

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -81,6 +81,7 @@ cols = {
     "mh%":        [3, 100, "Metadata hit percentage"],
     "mm%":        [3, 100, "Metadata miss percentage"],
     "arcsz":      [5, 1024, "ARC size"],
+    "size":       [4, 1024, "ARC size"],
     "c":          [4, 1024, "ARC target size"],
     "mfu":        [4, 1000, "MFU list hits per second"],
     "mru":        [4, 1000, "MRU list hits per second"],
@@ -106,7 +107,7 @@ cols = {
 
 v = {}
 hdr = ["time", "read", "miss", "miss%", "dmis", "dm%", "pmis", "pm%", "mmis",
-       "mm%", "arcsz", "c"]
+       "mm%", "size", "c", "avail"]
 xhdr = ["time", "mfu", "mru", "mfug", "mrug", "eskip", "mtxmis", "dread",
         "pread", "read"]
 sint = 1               # Default interval is 1 second
@@ -429,6 +430,7 @@ def calculate():
     v["mm%"] = 100 - v["mh%"] if v["mread"] > 0 else 0
 
     v["arcsz"] = cur["size"]
+    v["size"] = cur["size"]
     v["c"] = cur["c"]
     v["mfu"] = d["mfu_hits"] / sint
     v["mru"] = d["mru_hits"] / sint

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -101,6 +101,7 @@ cols = {
     "grow":       [4, 1000, "ARC grow disabled"],
     "need":       [4, 1024, "ARC reclaim need"],
     "free":       [4, 1024, "ARC free memory"],
+    "avail":      [4, 1024, "ARC available memory"],
 }
 
 v = {}
@@ -225,7 +226,7 @@ def prettynum(sz, scale, num=0):
     elif 0 < num < 1:
         num = 0
 
-    while num > scale and index < 5:
+    while abs(num) > scale and index < 5:
         save = num
         num = num / scale
         index += 1
@@ -233,7 +234,7 @@ def prettynum(sz, scale, num=0):
     if index == 0:
         return "%*d" % (sz, num)
 
-    if (save / scale) < 10:
+    if abs(save / scale) < 10:
         return "%*.1f%s" % (sz - 1, num, suffix[index])
     else:
         return "%*d%s" % (sz - 1, num, suffix[index])
@@ -449,7 +450,8 @@ def calculate():
 
     v["grow"] = 0 if cur["arc_no_grow"] else 1
     v["need"] = cur["arc_need_free"]
-    v["free"] = cur["arc_sys_free"]
+    v["free"] = cur["memory_free_bytes"]
+    v["avail"] = cur["memory_available_bytes"]
 
 
 def main():

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -246,11 +246,9 @@ def print_values():
     global sep
     global v
 
-    for col in hdr:
-        sys.stdout.write("%s%s" % (
-            prettynum(cols[col][0], cols[col][1], v[col]),
-            sep
-        ))
+    sys.stdout.write(sep.join(
+      (prettynum(cols[col][0], cols[col][1], v[col]) for col in hdr)))
+
     sys.stdout.write("\n")
     sys.stdout.flush()
 

--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -247,7 +247,7 @@ def print_values():
     global v
 
     sys.stdout.write(sep.join(
-      (prettynum(cols[col][0], cols[col][1], v[col]) for col in hdr)))
+      prettynum(cols[col][0], cols[col][1], v[col]) for col in hdr))
 
     sys.stdout.write("\n")
     sys.stdout.flush()
@@ -257,8 +257,8 @@ def print_header():
     global hdr
     global sep
 
-    for col in hdr:
-        sys.stdout.write("%*s%s" % (cols[col][0], col, sep))
+    sys.stdout.write(sep.join("%*s" % (cols[col][0], col) for col in hdr))
+
     sys.stdout.write("\n")
 
 

--- a/man/man1/arcstat.1
+++ b/man/man1/arcstat.1
@@ -392,7 +392,18 @@ ARC reclaim needed
 \fBfree \fR
 .ad
 .RS 14n
-ARC free memory
+The ARC's idea of how much free memory there is, which includes evictable memory in the page cache.
+Since the ARC tries to keep \fBavail\fR above zero, \fBavail\fR is usually more instructive to observe than \fBfree\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBavail \fR
+.ad
+.RS 14n
+The ARC's idea of how much free memory is available to it, which is a bit less than \fBfree\fR.
+May temporarily be negative, in which case the ARC will reduce the target size \fBc\fR.
 .RE
 .\"
 

--- a/man/man1/arcstat.1
+++ b/man/man1/arcstat.1
@@ -236,10 +236,19 @@ Time
 .sp
 .ne 2
 .na
-\fBarcsz \fR
+\fBsize \fR
 .ad
 .RS 14n
 ARC size
+.RE
+
+.sp
+.ne 2
+.na
+\fBarcsz \fR
+.ad
+.RS 14n
+Alias for \fBsize\fR
 .RE
 
 .sp


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The meaning of the `free` field is currently `zfs_arc_sys_free`, which
is the target amount of memory to leave free for the system, and is
constant after booting.

### Description
<!--- Describe your changes in detail -->
This commit changes the meaning of `free` to arc_free_memory(), the
amount of memory that the ARC considers to be free.

It also adds a new arcstat field `avail`, which tracks
`arc_available_memory()`.  This field is printed with the default output.

Since `avail` can be negative, it also updates the arcstat script to
pretty-print negative values.

Add a field `size`, which is the same as `arcsz`.  This matches the implementation (and `arc` is redundant since everything in `arcstat` relates to the ARC).  `size` is displayed by default, rather than `arcsz`, but for backwards compatibility, `arcsz` can still be specified with `-f`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
example output:
```
  $ arcstat -f time,miss,arcsz,c,grow,need,free,avail 1
      time  miss  arcsz     c  grow  need  free  avail
  15:03:02   39K   114G  114G     0     0  2.4G  407M
  15:03:03   42K   114G  114G     0     0  2.1G  120M
  15:03:04   40K   114G  114G     0     0  1.8G  -177M
  15:03:05   24K   113G  112G     0     0  1.7G  -269M
  15:03:06   29K   111G  110G     0     0  1.6G  -385M
  15:03:07   27K   110G  108G     0     0  1.4G  -535M
  15:03:08   13K   108G  108G     0     0  2.2G  239M
  15:03:09   33K   107G  107G     0     0  1.3G  -639M
  15:03:10   16K   105G  102G     0     0  2.6G  704M
  15:03:11  7.2K   102G  102G     0     0  5.1G  3.1G
  15:03:12   42K   103G  102G     0     0  4.8G  2.8G
```

default output is 79 columns wide.  `arcsz` is changed to `size`, and `avail` is added:
```
$ arcstat 1
    time  read  miss  miss%  dmis  dm%  pmis  pm%  mmis  mm%  size     c  avail
15:12:30   965   241     24     0    0   241  100     1    0  115G  115G   2.0G
15:12:31  137K   34K     24     1    0   34K  100    34    0  115G  115G   2.2G
15:12:32  157K   39K     24     7    0   39K  100    43    0  115G  115G   1.9G
15:12:33  154K   38K     24     0    0   38K  100    37    0  115G  115G   2.1G
15:12:34  160K   39K     24     4    0   39K  100    42    0  115G  115G   2.3G
15:12:35  165K   41K     24     0    0   41K  100    41    0  115G  115G   2.0G
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
