### PR TITLE
ARC shrinking blocks reads/writes

### DIFF
--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -894,6 +894,7 @@ extern int arc_lotsfree_percent;
 extern void arc_reduce_target_size(int64_t to_free);
 extern boolean_t arc_reclaim_needed(void);
 extern void arc_kmem_reap_soon(void);
+extern boolean_t arc_is_overflowing(void);
 
 extern void arc_lowmem_init(void);
 extern void arc_lowmem_fini(void);

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -268,6 +268,24 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	 */
 	if (pages > 0) {
 		arc_reduce_target_size(ptob(sc->nr_to_scan));
+
+		/*
+		 * Repeated calls to the arc shrinker can reduce arc_c
+		 * drastically, potentially all the way to arc_c_min.  While
+		 * arc_c is below arc_size, ZFS can't process read/write
+		 * requests, because arc_get_data_impl() will block.  To
+		 * ensure that arc_c doesn't shrink faster than the adjust
+		 * thread can keep up, we wait for eviction here.
+		 */
+		mutex_enter(&arc_adjust_lock);
+		if (arc_is_overflowing()) {
+			arc_adjust_needed = B_TRUE;
+			zthr_wakeup(arc_adjust_zthr);
+			(void) cv_wait(&arc_adjust_waiters_cv,
+			    &arc_adjust_lock);
+		}
+		mutex_exit(&arc_adjust_lock);
+
 		if (current_is_kswapd())
 			arc_kmem_reap_soon();
 #ifdef HAVE_SPLIT_SHRINKER_CALLBACK


### PR DESCRIPTION





<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ZFS registers a memory hook, `__arc_shrinker_func`, which is supposed to
allow the ARC to shrink when the kernel experiences memory pressure.
The ARC shrinker changes `arc_c` via a call to `arc_reduce_target_size()`.
Before commit 3ec34e55271d433e3c, the ARC shrinker would also evict data
from the ARC to bring `arc_size` down to the new `arc_c`.  However, that
commit (seemingly inadvertently) made it so that the ARC shrinker no
longer evicts any data or waits for eviction to complete.

Repeated calls to the ARC shrinker can reduce `arc_c` drastically, often
all the way to `arc_c_min`.  Since it doesn't wait for the actual
eviction of data from the ARC, this creates a situation where `arc_size`
is more than `arc_c` for the several seconds/minutes it takes for
`arc_adjust_zthr` to evict data from the ARC.  During this time,
arc_get_data_impl() will block, so ZFS can't process read/write requests
(e.g. from iSCSI, NFS, or read/write syscalls).

Note: commit 3ec34e55271d433e3c is `OpenZFS 9284 - arc_reclaim_thread has 2 jobs`
and was integrated in December 2018, and is part of ZoL 0.8.x but not 0.7.x.

### Description
<!--- Describe your changes in detail -->
To ensure that `arc_c` doesn't shrink faster than the adjust thread can
keep up, this commit makes the ARC shrinker wait for the eviction to
complete, resulting in similar behavior to what we had before commit
3ec34e55271d433e3c.

Additionally, when the ARC size is reduced drastically, the
`arc_adjust_zthr` can be on-CPU for many seconds without blocking.  Any
threads that are bound to the same CPU that arc_adjust_zthr is running
on will not able to run for a long time.

To ensure that CPU-bound threads can make progress, this commit changes
`arc_evict_state_impl()` make a voluntary preemption call,
`cond_resched()`.

Note, there are many other problems in this space, including the fact that there's no need for the ARC to shrink down to arc_c_min in response to small amounts of memory pressure, problems with how the ARC decides how large it should be, including other interactions with the kernel shrinker code, and the ARC's monitoring of memory pressure in arc_reap_zthr.  I'm also working on those problems and will open a separate PR for those more complicated changes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

The problem can be reproduced by creating memory pressure while the ARC is full.  E.g. one thread reading a file that's larger than RAM in a loop, to fill up the ARC.  Then create memory pressure, e.g. by writing to tmpfs.  `arcstat` shows that `arc_c` immediately drops to the minimum, but `arcsz` takes ~3 minutes to reach the minimum, during which time there are no reads from disk (`miss`):

```
    time  read  miss  miss%  dmis  dm%  pmis  pm%  mmis  mm%  arcsz     c
05:18:25     1     0      0     0    0     0    0     0    0   248G  179G
05:18:35    71     3      5     0    0     3  100     0    0   238G   81G
05:18:45     2     0      0     0    0     0    0     0    0   230G   35G
05:18:55    11     0      0     0    0     0    0     0    0   211G   14G
05:19:05     0     0      0     0    0     0    0     0    0   191G   14G
05:19:15     8     0      0     0    0     0    0     0    0   172G   14G
...
05:21:55     1     0      0     0    0     0    0     0    0    28G   14G
05:22:05     0     0      0     0    0     0    0     0    0    26G   14G
05:22:15     0     0      0     0    0     0    0     0    0    23G   14G
05:22:25     4     0      0     0    0     0    0     0    0    16G   14G
05:22:35  163K   81K     49    50    0   81K   99   150   11    14G   14G
05:22:45  233K  116K     50     0    0  116K  100   172   45    15G   15G
05:22:55  239K  119K     49     0    0  119K   99   102   30    18G   18G
05:23:05  244K  122K     49     0    0  122K   99   102   28    21G   21G
```

With the proposed changes we see that `arc_c` drops more slowly, in lockstep with `arcsz`.  While they are decreasing, we stilll process ~25% of the reads (`miss`) that we do normally.  (This system is configured differently than the one in the example above, so it "only" takes 30 seconds to evict the whole ARC, but this change doesn't significantly impact how long the eviction takes.)

```
    time  miss  arcsz     c
19:02:59   38K   114G  114G
19:03:00   38K   114G  114G
19:03:01   38K   115G  114G
19:03:02   38K   114G  114G
19:03:03   37K   115G  114G
19:03:04   35K   115G  114G
19:03:05   21K   113G  112G
19:03:06  7.5K   110G  110G
19:03:07 10.0K   107G  107G
19:03:08   11K   104G  104G
19:03:09   10K   101G  101G
19:03:10   11K    98G   98G
19:03:11   10K    95G   95G
19:03:12  9.2K    92G   91G
19:03:13  9.4K    89G   88G
19:03:14  8.9K    86G   85G
19:03:15  8.2K    82G   82G
19:03:16  8.2K    79G   79G
...
19:03:32  6.3K    27G   25G
19:03:33  5.8K    24G   22G
19:03:34  5.8K    20G   19G
19:03:35  5.8K    18G   15G
19:03:36  6.3K    14G   12G
19:03:37  6.5K    10G  8.8G
19:03:38  7.5K   8.0G  5.4G
19:03:39   10K   4.7G  3.9G
19:03:40   36K   3.9G  3.9G
19:03:41   45K   3.9G  3.9G
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
