### PR TITLE
FreeBSD: Fix includes to co-exist with dtrace's legacy opensolaris compat code 

### DIFF
--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -160,11 +160,13 @@ extern "C" {
 #define	KMALLOC_MAX_SIZE MAXPHYS
 
 #ifdef _KERNEL
+#if !defined(LOCORE) && !defined(_ASM)
 typedef unsigned long long	u_longlong_t;
 typedef long long		longlong_t;
 
-#include <linux/types.h>
+
 typedef	void zfs_kernel_param_t;
+#endif
 #define	param_set_charp(a, b) (0)
 #define	ATTR_UID AT_UID
 #define	ATTR_GID AT_GID
@@ -179,6 +181,9 @@ typedef	void zfs_kernel_param_t;
 #define	MUTEX_NOLOCKDEP 0
 #define	RW_NOLOCKDEP 0
 
+#if !defined(LOCORE) && !defined(_ASM)
+#include <sys/param.h>
+#include <linux/types.h>
 
 #if  __FreeBSD_version < 1300051
 #define	vm_page_valid(m) (m)->valid = VM_PAGE_BITS_ALL
@@ -207,7 +212,6 @@ typedef	void zfs_kernel_param_t;
 #else
 #define	getnewvnode_reserve_()	getnewvnode_reserve(1)
 #endif
-
 struct hlist_node {
 	struct hlist_node *next, **pprev;
 };
@@ -288,7 +292,7 @@ atomic_dec(atomic_t *v)
 {
 	return (atomic_fetchadd_int(&v->counter, -1) - 1);
 }
-
+#endif
 #else
 typedef long loff_t;
 typedef long rlim64_t;

--- a/include/os/freebsd/spl/sys/condvar.h
+++ b/include/os/freebsd/spl/sys/condvar.h
@@ -35,7 +35,6 @@
 #include <sys/spl_condvar.h>
 #include <sys/mutex.h>
 #include <sys/time.h>
-#include <sys/kmem.h>
 
 /*
  * cv_timedwait() is similar to cv_wait() except that it additionally expects

--- a/include/os/freebsd/spl/sys/file.h
+++ b/include/os/freebsd/spl/sys/file.h
@@ -29,6 +29,8 @@
 #ifndef _OPENSOLARIS_SYS_FILE_H_
 #define	_OPENSOLARIS_SYS_FILE_H_
 
+#include <sys/refcount.h>
+#include_next <sys/refcount.h>
 #include_next <sys/file.h>
 
 #define	FKIOCTL	0x80000000	/* ioctl addresses are from kernel */

--- a/include/os/freebsd/spl/sys/mount.h
+++ b/include/os/freebsd/spl/sys/mount.h
@@ -31,8 +31,9 @@
 
 #include <sys/param.h>
 #include_next <sys/mount.h>
+#ifdef BUILDING_ZFS
 #include <sys/vfs.h>
-
+#endif
 #define	MS_FORCE	MNT_FORCE
 #define	MS_REMOUNT	MNT_UPDATE
 

--- a/include/os/freebsd/spl/sys/sunddi.h
+++ b/include/os/freebsd/spl/sys/sunddi.h
@@ -29,7 +29,9 @@
 #include <sys/uio.h>
 #include <sys/mutex.h>
 #include <sys/u8_textprep.h>
+#ifdef BUILDING_ZFS
 #include <sys/vnode.h>
+#endif
 
 typedef int ddi_devid_t;
 

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -331,6 +331,7 @@ CFLAGS.fm.c= -Wno-cast-qual
 CFLAGS.lz4.c= -Wno-cast-qual
 CFLAGS.spa.c= -Wno-cast-qual
 CFLAGS.spa_misc.c= -Wno-cast-qual
+CFLAGS.sysctl_os.c= -include ../zfs_config.h
 CFLAGS.vdev_raidz.c= -Wno-cast-qual
 CFLAGS.vdev_raidz_math.c= -Wno-cast-qual
 CFLAGS.vdev_raidz_math_scalar.c= -Wno-cast-qual

--- a/module/os/freebsd/spl/spl_misc.c
+++ b/module/os/freebsd/spl/spl_misc.c
@@ -34,14 +34,23 @@ __FBSDID("$FreeBSD$");
 #include <sys/limits.h>
 #include <sys/misc.h>
 #include <sys/sysctl.h>
+#include <sys/vnode.h>
 
 #include <sys/zfs_context.h>
-
-char hw_serial[11] = "0";
 
 static struct opensolaris_utsname hw_utsname = {
 	.machine = MACHINE
 };
+
+#ifndef KERNEL_STATIC
+char hw_serial[11] = "0";
+
+utsname_t *
+utsname(void)
+{
+	return (&hw_utsname);
+}
+#endif
 
 static void
 opensolaris_utsname_init(void *arg)
@@ -98,10 +107,6 @@ spl_panic(const char *file, const char *func, int line, const char *fmt, ...)
 	va_end(ap);
 }
 
-utsname_t *
-utsname(void)
-{
-	return (&hw_utsname);
-}
+
 SYSINIT(opensolaris_utsname_init, SI_SUB_TUNABLES, SI_ORDER_ANY,
     opensolaris_utsname_init, NULL);

--- a/module/os/freebsd/spl/spl_sysevent.c
+++ b/module/os/freebsd/spl/spl_sysevent.c
@@ -33,6 +33,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/systm.h>
 #include <sys/malloc.h>
 #include <sys/kmem.h>
+#include <sys/list.h>
 #include <sys/sbuf.h>
 #include <sys/nvpair.h>
 #include <sys/sunddi.h>

--- a/module/os/freebsd/zfs/arc_os.c
+++ b/module/os/freebsd/zfs/arc_os.c
@@ -44,6 +44,7 @@
 #include <sys/arc_impl.h>
 #include <sys/sdt.h>
 #include <sys/aggsum.h>
+#include <sys/vnode.h>
 #include <cityhash.h>
 
 extern struct vfsops zfs_vfsops;

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -90,7 +90,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/arc_impl.h>
 #include <sys/dsl_pool.h>
 
-#include <../zfs_config.h>
 
 /* BEGIN CSTYLED */
 SYSCTL_DECL(_vfs_zfs);
@@ -124,10 +123,11 @@ SYSCTL_NODE(_vfs_zfs_vdev, OID_AUTO, cache, CTLFLAG_RW, 0, "ZFS VDEV Cache");
 SYSCTL_NODE(_vfs_zfs_vdev, OID_AUTO, mirror, CTLFLAG_RD, 0,
     "ZFS VDEV mirror");
 
+#ifdef ZFS_META_VERSION
 SYSCTL_DECL(_vfs_zfs_version);
 SYSCTL_CONST_STRING(_vfs_zfs_version, OID_AUTO, module, CTLFLAG_RD,
     (ZFS_META_VERSION "-" ZFS_META_RELEASE), "OpenZFS module version");
-
+#endif
 extern arc_state_t ARC_anon;
 extern arc_state_t ARC_mru;
 extern arc_state_t ARC_mru_ghost;

--- a/module/os/freebsd/zfs/vdev_file.c
+++ b/module/os/freebsd/zfs/vdev_file.c
@@ -25,6 +25,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
+#include <sys/file.h>
 #include <sys/vdev_file.h>
 #include <sys/vdev_impl.h>
 #include <sys/zio.h>

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -29,6 +29,7 @@
 #include <sys/param.h>
 #include <sys/kernel.h>
 #include <sys/bio.h>
+#include <sys/file.h>
 #include <sys/spa.h>
 #include <sys/spa_impl.h>
 #include <sys/vdev_impl.h>

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -27,6 +27,7 @@
  */
 
 #include <sys/spa.h>
+#include <sys/file.h>
 #include <sys/fm/fs/zfs.h>
 #include <sys/spa_impl.h>
 #include <sys/nvpair.h>


### PR DESCRIPTION
Fix header conflicts when building zfs with openzfs as a vendor import.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
