### PR TITLE
Make zstreamdump output the size of the nvlist before decoding it

### DIFF
--- a/cmd/zstream/zstream_dump.c
+++ b/cmd/zstream/zstream_dump.c
@@ -378,6 +378,8 @@ zstream_do_dump(int argc, char *argv[])
 			(void) printf("\tfromguid = %llx\n",
 			    (u_longlong_t)drrb->drr_fromguid);
 			(void) printf("\ttoname = %s\n", drrb->drr_toname);
+			(void) printf("\tpayloadlen = %u\n",
+			    drr->drr_payloadlen);
 			if (verbose)
 				(void) printf("\n");
 


### PR DESCRIPTION
### Motivation and Context
This is helpful in debugging #9616 and is just generally useful

### Description
zstreamdump now outputs the size of the nvlist in the BEGIN record

```
# zfs send -RvecL media/zfs@copy | zstreamdump
BEGIN record
        hdrtype = 2
        features = 4
        magic = 2f5bacbac
        creation_time = 0
        type = 0
        flags = 0x0
        toguid = 0
        fromguid = 0
        toname = media/zfs@copy
        nvlist_size = 4864
nvlist version: 0
        tosnap = copy
        fss = (embedded nvlist)
        nvlist version: 0
                0x47c2e4291e6d3b3e = (embedded nvlist)
                nvlist version: 0
                        name = media/zfs
                        parentfromsnap = 0x0
                        props = (embedded nvlist)
                        nvlist version: 0
                                mountpoint = /zfs
                                jailed = 0x1
                        (end props)

                        snaps = (embedded nvlist)
                        nvlist version: 0
                                copy = 0x50906582baa89107
                        (end snaps)

                        snapprops = (embedded nvlist)
                        nvlist version: 0
                                copy = (embedded nvlist)
                                nvlist version: 0
                                (end copy)

                        (end snapprops)

                (end 0x47c2e4291e6d3b3e)
```

### How Has This Been Tested?
Piping a stream into zstreamdump

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
