### PR TITLE
pam: fix test usage in configure script.

### DIFF
--- a/config/user-pam.m4
+++ b/config/user-pam.m4
@@ -19,7 +19,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_PAM], [
 		AC_CHECK_HEADERS([security/pam_modules.h], [
 			enable_pam=yes
 		], [
-			AS_IF([test "x$enable_pam" == "xyes"], [
+			AS_IF([test "x$enable_pam" = "xyes"], [
 				AC_MSG_FAILURE([
 	*** security/pam_modules.h missing, libpam0g-dev package required
 				])
@@ -28,7 +28,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_PAM], [
 			])
 		])
 	])
-	AS_IF([test "x$enable_pam" == "xyes"], [
+	AS_IF([test "x$enable_pam" = "xyes"], [
 		DEFINE_PAM='--with "pam" --define "_pamconfigsdir $(pamconfigsdir)"'
 	])
 	AC_SUBST(DEFINE_PAM)


### PR DESCRIPTION
The standard test command does not support the == operator. Certain
shells, including bash, do support it, but in those shells it does
exactly the same thing as the standard = operator. Use that instead.

Signed-off-by: Harald van Dijk <harald@gigawatt.nl>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes the following configure error:

```
checking security/pam_modules.h usability... yes
checking security/pam_modules.h presence... yes
checking for security/pam_modules.h... yes
./configure: 50545: test: xyes: unexpected operator
```

Note: other non-portable scripting remains in configure:

```
checking whether rpm is available... yes (4.15.1)
checking whether rpmbuild is available... yes (4.15.1)
./configure: 13450: RPM_DEFINE_COMMON+= --define "$(DEBUG_KMEM_ZFS) 1": not found
./configure: 13451: RPM_DEFINE_COMMON+= --define "$(DEBUG_KMEM_TRACKING_ZFS) 1": not found
./configure: 13452: RPM_DEFINE_COMMON+= --define "$(DEBUGINFO_ZFS) 1": not found
./configure: 13453: RPM_DEFINE_COMMON+= --define "$(ASAN_ZFS) 1": not found
./configure: 13472: RPM_DEFINE_UTIL+= $(DEFINE_INITRAMFS): not found
./configure: 13473: RPM_DEFINE_UTIL+= $(DEFINE_SYSTEMD): not found
./configure: 13474: RPM_DEFINE_UTIL+= $(DEFINE_PYZFS): not found
./configure: 13475: RPM_DEFINE_UTIL+= $(DEFINE_PAM): not found
./configure: 13476: RPM_DEFINE_UTIL+= $(DEFINE_PYTHON_VERSION): not found
./configure: 13477: RPM_DEFINE_UTIL+= $(DEFINE_PYTHON_PKG_VERSION): not found
./configure: 13488: RPM_DEFINE_KMOD+= --define "ksrc $(LINUX)": not found
./configure: 13489: RPM_DEFINE_KMOD+= --define "kobj $(LINUX_OBJ)": not found
./configure: 13490: RPM_DEFINE_KMOD+= --define "_wrong_version_format_terminate_build 0": not found
```

I am ignoring this as I do not use rpm and it does not and will not cause problems for me. If there is a preference to fix this at the same time, I can do so.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
