### PR TITLE
Fixing gang ABD child removal race condition

### DIFF
--- a/include/os/linux/spl/sys/list.h
+++ b/include/os/linux/spl/sys/list.h
@@ -26,6 +26,7 @@
 #define	_SPL_LIST_H
 
 #include <sys/types.h>
+#include <sys/debug.h>
 #include <linux/list.h>
 
 /*
@@ -184,7 +185,8 @@ list_prev(list_t *list, void *object)
 static inline int
 list_link_active(list_node_t *node)
 {
-	return (node->next != LIST_POISON1) && (node->prev != LIST_POISON2);
+	EQUIV(node->next == LIST_POISON1, node->prev == LIST_POISON2);
+	return (node->next != LIST_POISON1);
 }
 
 static inline void

--- a/lib/libspl/list.c
+++ b/lib/libspl/list.c
@@ -232,6 +232,7 @@ list_link_init(list_node_t *ln)
 int
 list_link_active(list_node_t *ln)
 {
+	EQUIV(ln->next == NULL, ln->prev == NULL);
 	return (ln->next != NULL);
 }
 

--- a/module/os/freebsd/spl/list.c
+++ b/module/os/freebsd/spl/list.c
@@ -235,6 +235,7 @@ list_link_init(list_node_t *link)
 int
 list_link_active(list_node_t *link)
 {
+	EQUIV(link->list_next == NULL, link->list_prev == NULL);
 	return (link->list_next != NULL);
 }
 


### PR DESCRIPTION

On linux the list debug code has been setting off a failure when
checking that the node->next->prev value is pointing back at the node.
At times this check evaluates to 0xdead. When removing a child from a
gang ABD we must acquire the child's abd_mtx to make sure that the
same ABD is not being added to another gang ABD while it is being
removed from a gang ABD. This fixes a race condition when checking
if an ABDs link is already active and part of another gang ABD before
adding it to a gang.

Added additional debug code for the gang ABD in abd_verify() to make
sure each child ABD has active links. Also check to make sure another
gang ABD is not added to a gang ABD.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Currently when an ABD struct that was part of a gang ABD is removed with list_remove_head() in abd_free_gang_abd() we will get a failure in the linux kernel list debug code were the next->prev is pointing at LIST_POISON2 instead of the node address. There was a race condition that existed when removing a child from a gang ABD and the child's abd_mtx need to be acquired to make sure it was not being removed and added to gang ABD at the same time.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes race condition in gang ABD between abd_gang_add() and abd_free_gang_abd().
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openzfs/zfs/issues/10401

### Description
<!--- Describe your changes in detail -->
I have added an additional function, list_link_not_actve(), to avoid a short circuit in the && statement so both next and prev are verified to point at LIST_POISON(1/2) values. In abd_verify() I have added an additional ASSERT for verifying that a each child in a gang ABD has an active link.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have ran using zloop.sh on Centos 8
<!--- Include details of your testing environment, and the tests you ran to -->
CentOS 8: Kernel 4.18.0-193
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
