### PR TITLE
Add Makefile command to run checkbashisms on all /bin/sh scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,7 +114,7 @@ endif
 endif
 
 PHONY += codecheck
-codecheck: cstyle shellcheck flake8 mancheck testscheck vcscheck
+codecheck: cstyle shellcheck checkbashisms flake8 mancheck testscheck vcscheck
 
 PHONY += checkstyle
 checkstyle: codecheck commitcheck
@@ -144,6 +144,22 @@ shellcheck:
 			-type f ${filter_executable}); \
 	else \
 		echo "skipping shellcheck because shellcheck is not installed"; \
+	fi
+
+PHONY += checkbashisms
+checkbashisms:
+	@if type checkbashisms > /dev/null 2>&1; then \
+		checkbashisms -n -p -x \
+			$$(find ${top_srcdir} \
+				-name '.git' -prune \
+				-o -name 'build' -prune \
+				-o -name 'tests' -prune \
+				-o -name 'config' -prune \
+				-o -type f ! -name 'config*' \
+				! -name 'libtool' \
+			-exec bash -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \
+	else \
+		echo "skipping checkbashisms because checkbashisms is not installed"; \
 	fi
 
 PHONY += mancheck


### PR DESCRIPTION
Based on the shellcheck make target, add a target which checks
for violations of POSIX standards for shell scripts

Signed-off-by: Gabriel A. Devenyi <gdevenyi@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Motivation from #10510 which reports issues with POSIX shells

### Description
<!--- Describe your changes in detail -->

Created a modified version of the make shellcheck call to check for bashisms in scripts

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Tested locally on Ubuntu 18.04

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
