### PR TITLE
Fix a lock order reversal in the FreeBSD getpages VOP

### DIFF
--- a/include/sys/zfs_rlock.h
+++ b/include/sys/zfs_rlock.h
@@ -71,6 +71,8 @@ void zfs_rangelock_fini(zfs_rangelock_t *);
 
 zfs_locked_range_t *zfs_rangelock_enter(zfs_rangelock_t *,
     uint64_t, uint64_t, zfs_rangelock_type_t);
+zfs_locked_range_t *zfs_rangelock_tryenter(zfs_rangelock_t *,
+    uint64_t, uint64_t, zfs_rangelock_type_t);
 void zfs_rangelock_exit(zfs_locked_range_t *);
 void zfs_rangelock_reduce(zfs_locked_range_t *, uint64_t, uint64_t);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Some recent changes to FreeBSD memory management system introduced a deadlock in zfs_getpages(). This was fixed by modifying zfs_getpages() to avoid blocking on a range lock: https://svnweb.freebsd.org/changeset/base/361287

Since FreeBSD is transitioning to OpenZFS as the upstream ZFS implementation, this bug fix should be included upstream.

### Description
zfs_getpages() is subject to a lock order reversal between the vm_page busy lock and ZFS' range lock. The latter is used to determine the extent of the read-ahead/behind range for the paging operation. To avoid deadlocking, the change modifies FreeBSD's zfs_getpages() to attempt a non-blocking acquisition of a ZFS range lock. The first commit introduces zfs_rangelock_tryenter(), and the second modifies zfs_getpages() to make use of the new interface.

Note that zfs_putpages() is not subject to the same problem because both it and zfs_write() acquire the page busy lock in shared mode.

### How Has This Been Tested?
The original fix was tested against a problem report submitted by a FreeBSD user. The bug cannot be deterministically reproduced, but the fix has been in FreeBSD-CURRENT for over a month.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
