### PR TITLE
fix atomic_clear_long_excl wrong return

### DIFF
--- a/lib/libspl/asm-generic/atomic.c
+++ b/lib/libspl/asm-generic/atomic.c
@@ -415,7 +415,7 @@ atomic_clear_long_excl(volatile ulong_t *target, uint_t value)
 
 	VERIFY3S(pthread_mutex_lock(&atomic_lock), ==, 0);
 	bit = (1UL << value);
-	if ((*target & bit) != 1) {
+	if ((*target & bit) == 0) {
 		VERIFY3S(pthread_mutex_unlock(&atomic_lock), ==, 0);
 		return (-1);
 	}

--- a/lib/libspl/asm-generic/atomic.c
+++ b/lib/libspl/asm-generic/atomic.c
@@ -415,7 +415,7 @@ atomic_clear_long_excl(volatile ulong_t *target, uint_t value)
 
 	VERIFY3S(pthread_mutex_lock(&atomic_lock), ==, 0);
 	bit = (1UL << value);
-	if ((*target & bit) != 0) {
+	if ((*target & bit) != 1) {
 		VERIFY3S(pthread_mutex_unlock(&atomic_lock), ==, 0);
 		return (-1);
 	}


### PR DESCRIPTION
When clear a bit, we should check whether that bit is 1.
BTW atomic_clear_long_excl is not used.

Signed-off-by: Liu Qing <winglq@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
