### PR TITLE
filesystem_limit/snapshot_limit is incorrectly enforced against root

### DIFF
--- a/include/os/freebsd/spl/sys/policy.h
+++ b/include/os/freebsd/spl/sys/policy.h
@@ -37,6 +37,7 @@ struct vattr;
 
 int	secpolicy_nfs(cred_t *cr);
 int	secpolicy_zfs(cred_t *crd);
+int	secpolicy_zfs_proc(cred_t *cr, proc_t *proc);
 int	secpolicy_sys_config(cred_t *cr, int checkonly);
 int	secpolicy_zinject(cred_t *cr);
 int	secpolicy_fs_unmount(cred_t *cr, struct mount *vfsp);

--- a/include/os/linux/zfs/sys/policy.h
+++ b/include/os/linux/zfs/sys/policy.h
@@ -48,6 +48,7 @@ int secpolicy_vnode_setid_retain(const cred_t *, boolean_t);
 int secpolicy_vnode_setids_setgids(const cred_t *, gid_t);
 int secpolicy_zinject(const cred_t *);
 int secpolicy_zfs(const cred_t *);
+int secpolicy_zfs_proc(const cred_t *, proc_t *);
 void secpolicy_setid_clear(vattr_t *, cred_t *);
 int secpolicy_setid_setsticky_clear(struct inode *, vattr_t *,
     const vattr_t *, cred_t *);

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -58,6 +58,7 @@ typedef struct dmu_recv_cookie {
 	uint64_t drc_ivset_guid;
 	void *drc_owner;
 	cred_t *drc_cred;
+	proc_t *drc_proc;
 	nvlist_t *drc_begin_nvl;
 
 	objset_t *drc_os;

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -284,6 +284,7 @@ typedef struct dsl_dataset_promote_arg {
 	uint64_t used, comp, uncomp, unique, cloneusedsnap, originusedsnap;
 	nvlist_t *err_ds;
 	cred_t *cr;
+	proc_t *proc;
 } dsl_dataset_promote_arg_t;
 
 typedef struct dsl_dataset_rollback_arg {
@@ -298,6 +299,7 @@ typedef struct dsl_dataset_snapshot_arg {
 	nvlist_t *ddsa_props;
 	nvlist_t *ddsa_errors;
 	cred_t *ddsa_cr;
+	proc_t *ddsa_proc;
 } dsl_dataset_snapshot_arg_t;
 
 /*
@@ -445,7 +447,7 @@ int dsl_dataset_clone_swap_check_impl(dsl_dataset_t *clone,
 void dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
     dsl_dataset_t *origin_head, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check_impl(dsl_dataset_t *ds, const char *snapname,
-    dmu_tx_t *tx, boolean_t recv, uint64_t cnt, cred_t *cr);
+    dmu_tx_t *tx, boolean_t recv, uint64_t cnt, cred_t *cr, proc_t *proc);
 void dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     dmu_tx_t *tx);
 

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -180,11 +180,11 @@ int dsl_dir_set_reservation(const char *ddname, zprop_source_t source,
     uint64_t reservation);
 int dsl_dir_activate_fs_ss_limit(const char *);
 int dsl_fs_ss_limit_check(dsl_dir_t *, uint64_t, zfs_prop_t, dsl_dir_t *,
-    cred_t *);
+    cred_t *, proc_t *);
 void dsl_fs_ss_count_adjust(dsl_dir_t *, int64_t, const char *, dmu_tx_t *);
 int dsl_dir_rename(const char *oldname, const char *newname);
 int dsl_dir_transfer_possible(dsl_dir_t *sdd, dsl_dir_t *tdd,
-    uint64_t fs_cnt, uint64_t ss_cnt, uint64_t space, cred_t *);
+    uint64_t fs_cnt, uint64_t ss_cnt, uint64_t space, cred_t *, proc_t *);
 boolean_t dsl_dir_is_clone(dsl_dir_t *dd);
 void dsl_dir_new_refreservation(dsl_dir_t *dd, struct dsl_dataset *ds,
     uint64_t reservation, cred_t *cr, dmu_tx_t *tx);

--- a/include/sys/zcp.h
+++ b/include/sys/zcp.h
@@ -75,6 +75,7 @@ typedef struct zcp_run_info {
 	 * rather than the 'current' thread's.
 	 */
 	cred_t		*zri_cred;
+	proc_t		*zri_proc;
 
 	/*
 	 * The tx in which this channel program is running.

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -709,6 +709,7 @@ extern int zfs_secpolicy_rename_perms(const char *from, const char *to,
     cred_t *cr);
 extern int zfs_secpolicy_destroy_perms(const char *name, cred_t *cr);
 extern int secpolicy_zfs(const cred_t *cr);
+extern int secpolicy_zfs_proc(const cred_t *cr, proc_t *proc);
 extern zoneid_t getzoneid(void);
 
 /* SID stuff */

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -909,6 +909,12 @@ secpolicy_zfs(const cred_t *cr)
 	return (0);
 }
 
+int
+secpolicy_zfs_proc(const cred_t *cr, proc_t *proc)
+{
+	return (0);
+}
+
 ksiddomain_t *
 ksid_lookupdomain(const char *dom)
 {

--- a/module/os/freebsd/spl/spl_policy.c
+++ b/module/os/freebsd/spl/spl_policy.c
@@ -53,6 +53,13 @@ secpolicy_zfs(cred_t *cr)
 }
 
 int
+secpolicy_zfs_proc(cred_t *cr, proc_t *proc)
+{
+
+	return (spl_priv_check_cred(cr, PRIV_VFS_MOUNT));
+}
+
+int
 secpolicy_sys_config(cred_t *cr, int checkonly __unused)
 {
 

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -245,6 +245,19 @@ secpolicy_zfs(const cred_t *cr)
 	return (priv_policy(cr, CAP_SYS_ADMIN, EACCES));
 }
 
+/*
+ * Equivalent to secpolicy_zfs(), but works even if the cred_t is not that of
+ * the current process.  Takes both cred_t and proc_t so that this can work
+ * easily on all platforms.
+ */
+int
+secpolicy_zfs_proc(const cred_t *cr, proc_t *proc)
+{
+	if (!has_capability(proc, CAP_SYS_ADMIN))
+		return (EACCES);
+	return (0);
+}
+
 void
 secpolicy_setid_clear(vattr_t *vap, cred_t *cr)
 {

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -42,11 +42,9 @@
  * all other cases this function must fail and return the passed err.
  */
 static int
-priv_policy_ns(const cred_t *cr, int capability, boolean_t all, int err,
+priv_policy_ns(const cred_t *cr, int capability, int err,
     struct user_namespace *ns)
 {
-	ASSERT3S(all, ==, B_FALSE);
-
 	if (cr != CRED() && (cr != kcred))
 		return (err);
 
@@ -61,13 +59,13 @@ priv_policy_ns(const cred_t *cr, int capability, boolean_t all, int err,
 }
 
 static int
-priv_policy(const cred_t *cr, int capability, boolean_t all, int err)
+priv_policy(const cred_t *cr, int capability, int err)
 {
-	return (priv_policy_ns(cr, capability, all, err, NULL));
+	return (priv_policy_ns(cr, capability, err, NULL));
 }
 
 static int
-priv_policy_user(const cred_t *cr, int capability, boolean_t all, int err)
+priv_policy_user(const cred_t *cr, int capability, int err)
 {
 	/*
 	 * All priv_policy_user checks are preceded by kuid/kgid_has_mapping()
@@ -76,9 +74,9 @@ priv_policy_user(const cred_t *cr, int capability, boolean_t all, int err)
 	 * namespace.
 	 */
 #if defined(CONFIG_USER_NS)
-	return (priv_policy_ns(cr, capability, all, err, cr->user_ns));
+	return (priv_policy_ns(cr, capability, err, cr->user_ns));
 #else
-	return (priv_policy_ns(cr, capability, all, err, NULL));
+	return (priv_policy_ns(cr, capability, err, NULL));
 #endif
 }
 
@@ -89,7 +87,7 @@ priv_policy_user(const cred_t *cr, int capability, boolean_t all, int err)
 int
 secpolicy_nfs(const cred_t *cr)
 {
-	return (priv_policy(cr, CAP_SYS_ADMIN, B_FALSE, EPERM));
+	return (priv_policy(cr, CAP_SYS_ADMIN, EPERM));
 }
 
 /*
@@ -98,7 +96,7 @@ secpolicy_nfs(const cred_t *cr)
 int
 secpolicy_sys_config(const cred_t *cr, boolean_t checkonly)
 {
-	return (priv_policy(cr, CAP_SYS_ADMIN, B_FALSE, EPERM));
+	return (priv_policy(cr, CAP_SYS_ADMIN, EPERM));
 }
 
 /*
@@ -134,10 +132,10 @@ secpolicy_vnode_any_access(const cred_t *cr, struct inode *ip, uid_t owner)
 		return (EPERM);
 #endif
 
-	if (priv_policy_user(cr, CAP_DAC_OVERRIDE, B_FALSE, EPERM) == 0)
+	if (priv_policy_user(cr, CAP_DAC_OVERRIDE, EPERM) == 0)
 		return (0);
 
-	if (priv_policy_user(cr, CAP_DAC_READ_SEARCH, B_FALSE, EPERM) == 0)
+	if (priv_policy_user(cr, CAP_DAC_READ_SEARCH, EPERM) == 0)
 		return (0);
 
 	return (EPERM);
@@ -157,7 +155,7 @@ secpolicy_vnode_chown(const cred_t *cr, uid_t owner)
 		return (EPERM);
 #endif
 
-	return (priv_policy_user(cr, CAP_FOWNER, B_FALSE, EPERM));
+	return (priv_policy_user(cr, CAP_FOWNER, EPERM));
 }
 
 /*
@@ -166,7 +164,7 @@ secpolicy_vnode_chown(const cred_t *cr, uid_t owner)
 int
 secpolicy_vnode_create_gid(const cred_t *cr)
 {
-	return (priv_policy(cr, CAP_SETGID, B_FALSE, EPERM));
+	return (priv_policy(cr, CAP_SETGID, EPERM));
 }
 
 /*
@@ -176,7 +174,7 @@ secpolicy_vnode_create_gid(const cred_t *cr)
 int
 secpolicy_vnode_remove(const cred_t *cr)
 {
-	return (priv_policy(cr, CAP_FOWNER, B_FALSE, EPERM));
+	return (priv_policy(cr, CAP_FOWNER, EPERM));
 }
 
 /*
@@ -194,7 +192,7 @@ secpolicy_vnode_setdac(const cred_t *cr, uid_t owner)
 		return (EPERM);
 #endif
 
-	return (priv_policy_user(cr, CAP_FOWNER, B_FALSE, EPERM));
+	return (priv_policy_user(cr, CAP_FOWNER, EPERM));
 }
 
 /*
@@ -208,7 +206,7 @@ secpolicy_vnode_setdac(const cred_t *cr, uid_t owner)
 int
 secpolicy_vnode_setid_retain(const cred_t *cr, boolean_t issuidroot)
 {
-	return (priv_policy_user(cr, CAP_FSETID, B_FALSE, EPERM));
+	return (priv_policy_user(cr, CAP_FSETID, EPERM));
 }
 
 /*
@@ -222,7 +220,7 @@ secpolicy_vnode_setids_setgids(const cred_t *cr, gid_t gid)
 		return (EPERM);
 #endif
 	if (crgetfsgid(cr) != gid && !groupmember(gid, cr))
-		return (priv_policy_user(cr, CAP_FSETID, B_FALSE, EPERM));
+		return (priv_policy_user(cr, CAP_FSETID, EPERM));
 
 	return (0);
 }
@@ -234,7 +232,7 @@ secpolicy_vnode_setids_setgids(const cred_t *cr, gid_t gid)
 int
 secpolicy_zinject(const cred_t *cr)
 {
-	return (priv_policy(cr, CAP_SYS_ADMIN, B_FALSE, EACCES));
+	return (priv_policy(cr, CAP_SYS_ADMIN, EACCES));
 }
 
 /*
@@ -244,7 +242,7 @@ secpolicy_zinject(const cred_t *cr)
 int
 secpolicy_zfs(const cred_t *cr)
 {
-	return (priv_policy(cr, CAP_SYS_ADMIN, B_FALSE, EACCES));
+	return (priv_policy(cr, CAP_SYS_ADMIN, EACCES));
 }
 
 void
@@ -273,7 +271,7 @@ secpolicy_vnode_setid_modify(const cred_t *cr, uid_t owner)
 		return (EPERM);
 #endif
 
-	return (priv_policy_user(cr, CAP_FSETID, B_FALSE, EPERM));
+	return (priv_policy_user(cr, CAP_FSETID, EPERM));
 }
 
 /*

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1096,6 +1096,7 @@ dmu_objset_create_impl(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 typedef struct dmu_objset_create_arg {
 	const char *doca_name;
 	cred_t *doca_cred;
+	proc_t *doca_proc;
 	void (*doca_userfunc)(objset_t *os, void *arg,
 	    cred_t *cr, dmu_tx_t *tx);
 	void *doca_userarg;
@@ -1140,7 +1141,7 @@ dmu_objset_create_check(void *arg, dmu_tx_t *tx)
 	}
 
 	error = dsl_fs_ss_limit_check(pdd, 1, ZFS_PROP_FILESYSTEM_LIMIT, NULL,
-	    doca->doca_cred);
+	    doca->doca_cred, doca->doca_proc);
 	if (error != 0) {
 		dsl_dir_rele(pdd, FTAG);
 		return (error);
@@ -1268,6 +1269,7 @@ dmu_objset_create(const char *name, dmu_objset_type_t type, uint64_t flags,
 
 	doca.doca_name = name;
 	doca.doca_cred = CRED();
+	doca.doca_proc = curproc;
 	doca.doca_flags = flags;
 	doca.doca_userfunc = func;
 	doca.doca_userarg = arg;
@@ -1296,6 +1298,7 @@ typedef struct dmu_objset_clone_arg {
 	const char *doca_clone;
 	const char *doca_origin;
 	cred_t *doca_cred;
+	proc_t *doca_proc;
 } dmu_objset_clone_arg_t;
 
 /*ARGSUSED*/
@@ -1324,7 +1327,7 @@ dmu_objset_clone_check(void *arg, dmu_tx_t *tx)
 	}
 
 	error = dsl_fs_ss_limit_check(pdd, 1, ZFS_PROP_FILESYSTEM_LIMIT, NULL,
-	    doca->doca_cred);
+	    doca->doca_cred, doca->doca_proc);
 	if (error != 0) {
 		dsl_dir_rele(pdd, FTAG);
 		return (SET_ERROR(EDQUOT));
@@ -1383,6 +1386,7 @@ dmu_objset_clone(const char *clone, const char *origin)
 	doca.doca_clone = clone;
 	doca.doca_origin = origin;
 	doca.doca_cred = CRED();
+	doca.doca_proc = curproc;
 
 	int rv = dsl_sync_task(clone,
 	    dmu_objset_clone_check, dmu_objset_clone_sync, &doca,

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -1150,6 +1150,7 @@ zcp_eval(const char *poolname, const char *program, boolean_t sync,
 	runinfo.zri_outnvl = outnvl;
 	runinfo.zri_result = 0;
 	runinfo.zri_cred = CRED();
+	runinfo.zri_proc = curproc;
 	runinfo.zri_timed_out = B_FALSE;
 	runinfo.zri_canceled = B_FALSE;
 	runinfo.zri_sync = sync;

--- a/module/zfs/zcp_synctask.c
+++ b/module/zfs/zcp_synctask.c
@@ -186,6 +186,7 @@ zcp_synctask_promote(lua_State *state, boolean_t sync, nvlist_t *err_details)
 	ddpa.ddpa_clonename = dsname;
 	ddpa.err_ds = err_details;
 	ddpa.cr = ri->zri_cred;
+	ddpa.proc = ri->zri_proc;
 
 	/*
 	 * If there was a snapshot name conflict, then err_ds will be filled
@@ -269,6 +270,7 @@ zcp_synctask_snapshot(lua_State *state, boolean_t sync, nvlist_t *err_details)
 	ddsa.ddsa_errors = NULL;
 	ddsa.ddsa_props = NULL;
 	ddsa.ddsa_cr = ri->zri_cred;
+	ddsa.ddsa_proc = ri->zri_proc;
 	ddsa.ddsa_snaps = fnvlist_alloc();
 	fnvlist_add_boolean(ddsa.ddsa_snaps, dsname);
 

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -171,8 +171,6 @@ elif sys.platform.startswith('linux'):
         'casenorm/mixed_formd_delete': ['FAIL', '7633'],
         'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],
         'casenorm/sensitive_formd_delete': ['FAIL', '7633'],
-        'limits/filesystem_limit': ['FAIL', '8226'],
-        'limits/snapshot_limit': ['FAIL', '8226'],
         'removal/removal_with_zdb': ['SKIP', known_reason],
     })
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The filesystem_limit and snapshot_limit properties limit the number of
filesystems or snapshots that can be created below this dataset.
According to the manpage, "The limit is not enforced if the user is
allowed to change the limit."  Two types of users are allowed to change
the limit:

1. Those that have been delegated the `filesystem_limit` or
`snapshot_limit` permission, e.g. with
`zfs allow USER filesystem_limit DATASET`.  This works properly.

2. A user with elevated system priviliges (e.g. root).  This does not
work - the root user will incorrectly get an error when trying to create
a snapshot/filesystem, if it exceeds the `_limit` property.

The problem is that `priv_policy_ns()` does not work if the `cred_t` is
not that of the current process.  This happens when
`dsl_enforce_ds_ss_limits()` is called in syncing context (as part of a
sync task's check func) to determine the permissions of the
corresponding user process.
### Description
<!--- Describe your changes in detail -->
This commit fixes the issue by passing the `task_struct` (typedef'ed as
a `proc_t`) to syncing context, and then using `has_capability()` to
determine if that process is privileged.  Note that we still need to
pass the `cred_t` to syncing context so that we can check if the user
was delegated this permission with `zfs allow`.

This problem only impacts Linux.  Wrappers are added to FreeBSD but it
continues to use `priv_check_cred()`, which works on arbitrary `cred_t`.

There's also some minor code cleanup in `policy.c`, removing the unused `all` parameter.  I kept that as a separate commit for ease of reviewing, but I'll squash them together if there are no objections.

Closes: #8226
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
manual testing of root and delegated user exceeding the `snapshot_limit`

ZTS including newly-activated tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
