### PR TITLE
Add support to decode a resume token.

### DIFF
--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -6,7 +6,8 @@ zstream_SOURCES = \
 	zstream.c \
 	zstream.h \
 	zstream_dump.c \
-	zstream_redup.c
+	zstream_redup.c \
+	zstream_token.c
 
 zstream_LDADD = \
 	$(abs_top_builddir)/lib/libzfs/libzfs.la \

--- a/cmd/zstream/zstream.c
+++ b/cmd/zstream/zstream.c
@@ -15,6 +15,7 @@
 
 /*
  * Copyright (c) 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2020 by Datto Inc. All rights reserved.
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -39,6 +40,8 @@ zstream_usage(void)
 	    "\tzstream dump [-vCd] FILE\n"
 	    "\t... | zstream dump [-vCd]\n"
 	    "\n"
+	    "\tzstream token resume_token\n"
+	    "\n"
 	    "\tzstream redup [-v] FILE | ...\n");
 	exit(1);
 }
@@ -53,6 +56,8 @@ main(int argc, char *argv[])
 
 	if (strcmp(subcommand, "dump") == 0) {
 		return (zstream_do_dump(argc - 1, argv + 1));
+	} else if (strcmp(subcommand, "token") == 0) {
+		return (zstream_do_token(argc - 1, argv + 1));
 	} else if (strcmp(subcommand, "redup") == 0) {
 		return (zstream_do_redup(argc - 1, argv + 1));
 	} else {

--- a/cmd/zstream/zstream.h
+++ b/cmd/zstream/zstream.h
@@ -26,6 +26,7 @@ extern "C" {
 
 extern int zstream_do_redup(int, char *[]);
 extern int zstream_do_dump(int, char *[]);
+extern int zstream_do_token(int, char *[]);
 extern void zstream_usage(void);
 
 #ifdef	__cplusplus

--- a/cmd/zstream/zstream_token.c
+++ b/cmd/zstream/zstream_token.c
@@ -1,0 +1,78 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ *
+ * Portions Copyright 2012 Martin Matuska <martin@matuska.org>
+ */
+
+/*
+ * Copyright (c) 2020 by Datto Inc. All rights reserved.
+ */
+
+#include <ctype.h>
+#include <libnvpair.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <unistd.h>
+#include <stddef.h>
+
+#include <libzfs.h>
+#include <libzfs_core.h>
+
+#include <sys/dmu.h>
+#include <sys/zfs_ioctl.h>
+#include "zstream.h"
+
+int
+zstream_do_token(int argc, char *argv[])
+{
+	char *resume_token = NULL;
+
+	if (argc < 2) {
+		(void) fprintf(stderr, "Need to pass the resume token\n");
+		zstream_usage();
+	}
+
+	resume_token = argv[1];
+
+	libzfs_handle_t *hdl = libzfs_init();
+
+	nvlist_t *resume_nvl =
+	    zfs_send_resume_token_to_nvlist(hdl, resume_token);
+
+	if (resume_nvl == NULL) {
+		(void) fprintf(stderr,
+		    "Unable to parse resume token: %s\n",
+		    libzfs_error_description(hdl));
+		libzfs_fini(hdl);
+		return (1);
+	}
+
+	dump_nvlist(resume_nvl, 5);
+	nvlist_free(resume_nvl);
+
+	libzfs_fini(hdl);
+	return (0);
+}

--- a/man/man8/zstream.8
+++ b/man/man8/zstream.8
@@ -35,6 +35,9 @@
 .Cm redup
 .Op Fl v
 .Ar file
+.Nm
+.Cm token
+.Ar resume_token
 .Sh DESCRIPTION
 .sp
 .LP
@@ -65,6 +68,12 @@ Print metadata for each record.
 Dump data contained in each record.
 Implies verbose.
 .El
+.It Xo
+.Nm
+.Cm token
+.Ar resume_token
+.Xc
+Dumps zfs resume token information
 .It Xo
 .Nm
 .Cm redup

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -26,6 +26,7 @@
 
 #
 # Copyright (c) 2013, 2018 by Delphix. All rights reserved.
+# Copyright (c) 2020 by Datto Inc. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -655,6 +656,21 @@ function resume_test
 		    log_fail "NO FILE /$streamfs/$stream_num"
 	done
 	log_must zfs recv -suv $recvfs </$streamfs/$stream_num
+}
+
+function get_resume_token
+{
+	sendcmd=$1
+	streamfs=$2
+	recvfs=$3
+
+	log_must eval "$sendcmd > /$streamfs/1"
+	mess_send_file /$streamfs/1
+	log_mustnot zfs recv -suv $recvfs < /$streamfs/1 2>&1
+	token=$(zfs get -Hp -o value receive_resume_token $recvfs)
+	echo "$token" > /$streamfs/resume_token
+
+	return 0
 }
 
 #


### PR DESCRIPTION
Adding a new option -t resume_token within zstream dump. This
now allows users to decode a resume token to retrieve the toname
field. This can be useful for tools that need this information.

Signed-off-by: Tony Perkins <tperkins@datto.com>

This provides a way to extract more information from a resume token.

### Motivation and Context
This provides a way for us to generically identify a failed zfs send/recv by 
inspecting the resume token.

### Description
This uses libzfs to parse the resume token, and display the contents from 
the nvlist.

### How Has This Been Tested?
A new functional test has been created under rsend to help test the new option.
This was tested under Ubuntu / ZoL, and our system build test infrastructure.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ X] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X ] I have run the ZFS Test Suite with this change applied.
- [X ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
