### PR TITLE
Increase default arc_c_min to accomodate dbuf cache

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1017,7 +1017,7 @@ Default value: \fB1\fR.
 .ad
 .RS 12n
 Min size of ARC in bytes. If set to 0 then arc_c_min will default to
-consuming the larger of 32M or 1/32 of total system memory.
+consuming the larger of 32M or 1/8 of total system memory.
 .sp
 Default value: \fB0\fR.
 .RE

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7305,8 +7305,14 @@ arc_init(void)
 	arc_lowmem_init();
 #endif
 
-	/* Set min cache to 1/32 of all memory, or 32MB, whichever is more. */
-	arc_c_min = MAX(allmem / 32, 2ULL << SPA_MAXBLOCKSHIFT);
+	/*
+	 * Set min cache to 1/8 of all memory, or 32MB, whichever is more.
+	 * Note that this needs to be large enough to contain the entire dbuf
+	 * cache, plus the ARC's copy of this data.  By default the dbuf
+	 * cache is 3/64ths of memory (see dbuf_cache_shift), so this should
+	 * be at least 6/64ths of memory.
+	 */
+	arc_c_min = MAX(allmem / 8, 2ULL << SPA_MAXBLOCKSHIFT);
 
 	/* How to set default max varies by platform. */
 	arc_c_max = arc_default_max(arc_c_min, allmem);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The arc target size `arc_c` needs to be at least large enough to contain
the entire dbuf cache, plus the ARC's copy of this data.  Otherwise we
could be in a situation where `arc_is_overflowing()` is `TRUE` for a
long time, because the ARC can not evict data to get down to the target
size, because the data is pinned by the dbuf cache.  This can cause ZFS
operations to pause while `arc_get_data_impl()` waits for the ARC to no
longer be "overflowing".

The dbuf cache is 3/64ths of memory (see `dbuf_cache_shift` and
`dbuf_metadata_cache_shift`), so the ARC needs to be at least 6/64ths of
memory, to include both the dbuf cache and the additional copy in the
ARC.

### Description
<!--- Describe your changes in detail -->
This commit changes the minimum arc size `arc_c_min` to be 1/8th (8/64ths) of all
memory.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Just boot & check arc_c_min so far.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
