### PR TITLE
Linux 4.10 compat: has_capability()

### DIFF
--- a/config/kernel-userns-capabilities.m4
+++ b/config/kernel-userns-capabilities.m4
@@ -20,6 +20,33 @@ AC_DEFUN([ZFS_AC_KERNEL_NS_CAPABLE], [
 ])
 
 dnl #
+dnl # 4.10 API change
+dnl # has_capability() was exported.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_HAS_CAPABILITY], [
+	ZFS_LINUX_TEST_SRC([has_capability], [
+		#include <linux/capability.h>
+	],[
+		struct task_struct *task = NULL;
+		int cap = 0;
+		bool result __attribute__ ((unused));
+
+		result = has_capability(task, cap);
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_HAS_CAPABILITY], [
+	AC_MSG_CHECKING([whether has_capability() is available])
+	ZFS_LINUX_TEST_RESULT_SYMBOL([has_capability],
+	    [has_capability], [kernel/capability.c], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_HAS_CAPABILITY, 1, [has_capability() is available])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
 dnl # 2.6.39 API change
 dnl # struct user_namespace was added to struct cred_t as cred->user_ns member
 dnl #
@@ -66,12 +93,14 @@ AC_DEFUN([ZFS_AC_KERNEL_KUID_HAS_MAPPING], [
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_USERNS_CAPABILITIES], [
 	ZFS_AC_KERNEL_SRC_NS_CAPABLE
+	ZFS_AC_KERNEL_SRC_HAS_CAPABILITY
 	ZFS_AC_KERNEL_SRC_CRED_USER_NS
 	ZFS_AC_KERNEL_SRC_KUID_HAS_MAPPING
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_USERNS_CAPABILITIES], [
 	ZFS_AC_KERNEL_NS_CAPABLE
+	ZFS_AC_KERNEL_HAS_CAPABILITY
 	ZFS_AC_KERNEL_CRED_USER_NS
 	ZFS_AC_KERNEL_KUID_HAS_MAPPING
 ])

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -249,13 +249,22 @@ secpolicy_zfs(const cred_t *cr)
  * Equivalent to secpolicy_zfs(), but works even if the cred_t is not that of
  * the current process.  Takes both cred_t and proc_t so that this can work
  * easily on all platforms.
+ *
+ * The has_capability() function was first exported in the 4.10 Linux kernel
+ * then backported to some LTS kernels.  Prior to this change there was no
+ * mechanism to perform this check therefore EACCES is returned when the
+ * functionality is not present in the kernel.
  */
 int
 secpolicy_zfs_proc(const cred_t *cr, proc_t *proc)
 {
+#if defined(HAVE_HAS_CAPABILITY)
 	if (!has_capability(proc, CAP_SYS_ADMIN))
 		return (EACCES);
 	return (0);
+#else
+	return (EACCES);
+#endif
 }
 
 void

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -263,6 +263,8 @@ elif sys.platform.startswith('linux'):
         'cli_root/zpool_expand/zpool_expand_001_pos': ['FAIL', known_reason],
         'cli_root/zpool_expand/zpool_expand_005_pos': ['FAIL', known_reason],
         'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
+        'limits/filesystem_limit': ['SKIP', known_reason],
+        'limits/snapshot_limit': ['SKIP', known_reason],
         'refreserv/refreserv_raidz': ['FAIL', known_reason],
         'rsend/rsend_007_pos': ['FAIL', known_reason],
         'rsend/rsend_010_pos': ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
@@ -30,6 +30,18 @@
 
 verify_runnable "both"
 
+#
+# The has_capability() function was first exported in the 4.10 Linux kernel
+# then backported to some LTS kernels.  Prior to this change there was no
+# mechanism to perform the needed permission check.  Therefore, this test
+# is expected to fail on older kernels and is skipped.
+#
+if is_linux; then
+	if [[ $(linux_version) -lt $(linux_version "4.10") ]]; then
+		log_unsupported "Requires has_capability() kernel function"
+	fi
+fi
+
 function setup
 {
 	# We can't delegate 'mount' privs under Linux: to avoid issues with

--- a/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
@@ -31,6 +31,18 @@
 
 verify_runnable "both"
 
+#
+# The has_capability() function was first exported in the 4.10 Linux kernel
+# then backported to some LTS kernels.  Prior to this change there was no
+# mechanism to perform the needed permission check.  Therefore, this test
+# is expected to fail on older kernels and is skipped.
+#
+if is_linux; then
+	if [[ $(linux_version) -lt $(linux_version "4.10") ]]; then
+		log_unsupported "Requires has_capability() kernel function"
+	fi
+fi
+
 function setup
 {
 	# We can't delegate 'mount' privs under Linux: to avoid issues with


### PR DESCRIPTION
### Motivation and Context

Issue #10565

### Description

Stock kernels older than 4.10 do not export the has_capability()
function which is required by commit e59a377.  To avoid breaking
the build on older kernels revert to the safe legacy behavior and
return EACCES when privileges cannot be checked.

### How Has This Been Tested?

Compiled and verified correct configure result using both a kernel
which exports the symbol and one which does not.  The modules
were verified the load correctly and the relevant limits tests run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
