### PR TITLE
Silence used-uninitialized warning

### DIFF
--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1371,8 +1371,8 @@ metaslab_rt_create(range_tree_t *rt, void *arg)
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
 
-	size_t size;
-	int (*compare) (const void *, const void *);
+	size_t size = 0;
+	int (*compare) (const void *, const void *) = NULL;
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
 		size = sizeof (range_seg32_t);

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -195,8 +195,8 @@ range_tree_create_impl(range_tree_ops_t *ops, range_seg_type_t type, void *arg,
 
 	ASSERT3U(shift, <, 64);
 	ASSERT3U(type, <=, RANGE_SEG_NUM_TYPES);
-	size_t size;
-	int (*compare) (const void *, const void *);
+	size_t size = 0;
+	int (*compare) (const void *, const void *) = NULL;
 	switch (type) {
 	case RANGE_SEG32:
 		size = sizeof (range_seg32_t);
@@ -731,7 +731,7 @@ rt_btree_create(range_tree_t *rt, void *arg)
 {
 	zfs_btree_t *size_tree = arg;
 
-	size_t size;
+	size_t size = 0;
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
 		size = sizeof (range_seg32_t);


### PR DESCRIPTION
In the default: case.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

clang compilation stop due to warning.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes a warning.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
