### PR TITLE
Gitrev

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,16 +54,7 @@ CLEANFILES = $(GITREV)
 
 PHONY = gitrev
 gitrev:
-	$(AM_V_GEN)ZFS_GITREV=$$(cd $(top_srcdir) && \
-		git describe --always --long --dirty 2>/dev/null); \
-	ZFS_GITREV=$${ZFS_GITREV:-unknown}; \
-	printf '#define\tZFS_META_GITREV "%s"\n' \
-			"$${ZFS_GITREV}" >$(GITREV)~; \
-	if cmp -s $(GITREV) $(GITREV)~; then \
-		$(RM) $(GITREV)~; \
-	else \
-		mv -f $(GITREV)~ $(GITREV); \
-	fi
+	$(AM_V_GEN)$(top_srcdir)/scripts/make_gitrev.sh $(GITREV)
 
 all: gitrev
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,6 @@ EXTRA_DIST += module/zfs/THIRDPARTYLICENSE.cityhash.descrip
 @CODE_COVERAGE_RULES@
 
 GITREV = include/zfs_gitrev.h
-CLEANFILES = $(GITREV)
 
 PHONY = gitrev
 gitrev:
@@ -59,6 +58,9 @@ gitrev:
 all: gitrev
 
 # Double-colon rules are allowed; there are multiple independent definitions.
+maintainer-clean-local::
+	-$(RM) $(GITREV)
+
 distclean-local::
 	-$(RM) -R autom4te*.cache build
 	-find . \( -name SCCS -o -name BitKeeper -o -name .svn -o -name CVS \
@@ -76,6 +78,7 @@ all-local:
 	    ${top_builddir}/scripts/zfs-tests.sh -c
 
 dist-hook:
+	$(AM_V_GEN)$(top_srcdir)/scripts/make_gitrev.sh -D $(distdir) $(GITREV)
 	$(SED) ${ac_inplace} -e 's/Release:[[:print:]]*/Release:      $(RELEASE)/' \
 		$(distdir)/META
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -15,6 +15,7 @@ EXTRA_DIST = \
 	dkms.postbuild \
 	enum-extract.pl \
 	kmodtool \
+	make_gitrev.sh \
 	man-dates.sh \
 	paxcheck.sh \
 	zfs2zol-patch.sed \

--- a/scripts/make_gitrev.sh
+++ b/scripts/make_gitrev.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2018 by Delphix. All rights reserved.
+# Copyright (c) 2018 by Matthew Thode. All rights reserved.
+
+#
+# Generate zfs_gitrev.h.  Note that we need to do this for every
+# invocation of `make`, including for incremental builds.  Therefore we
+# can't use a zfs_gitrev.h.in file which would be processed only when
+# `configure` is run.
+#
+
+set -e -u
+
+top_srcdir="$(dirname "$0")/.."
+GITREV="${1:-include/zfs_gitrev.h}"
+
+# GITREV should be a relative path (relative to top_builddir)
+case "${GITREV}" in
+	/*) echo "Error: ${GITREV} should be a relative path" >&2
+	    exit 1;;
+esac
+
+ZFS_GITREV=$({ cd "${top_srcdir}" &&
+	git describe --always --long --dirty 2>/dev/null; } || :)
+ZFS_GITREV=${ZFS_GITREV:-unknown}
+
+GITREVTMP="${GITREV}~"
+printf '#define\tZFS_META_GITREV "%s"\n' "${ZFS_GITREV}" >"${GITREVTMP}"
+if cmp -s "${GITREV}" "${GITREVTMP}"
+then
+	rm -f "${GITREVTMP}"
+else
+	mv -f "${GITREVTMP}" "${GITREV}"
+fi


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Move zfs_gitrev.h generation back into the shell script, and change gitrev generation to allow distributed sources generated from a git repository to keep the original gitrev.

https://github.com/openzfs/zfs/pull/10493#issuecomment-660261465
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the gitrev (proc/sys/kernel/spl/gitrev) will only show "unknown" unless ZFS was compiled from git. This change will keep the git tag if sources were prepared using make dist from a git repository.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
