### PR TITLE
Check zfs module is present and loaded before starting services

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -13,6 +13,7 @@ ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 
 [Install]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -12,6 +12,7 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 
 [Install]

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -11,6 +11,7 @@ Before=systemd-random-seed.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zfs mount -a
 
 [Install]


### PR DESCRIPTION
### Motivation and Context
Currently, systemd services can be enabled without zpools being present. This supports zpools being added and removed on an ad-hoc basis, e.g. when using external disks. However, the import and mount services will [Fail] when no zpools can be found.

### Description
This is a minor change to the systemd service templates that checks the zfs module is loaded by the kernel prior to attempting to import any zpool. This is particularly useful as the ZFS modules are automatically loaded when ZFS filesystems are detected, e.g. an external disk is added, so there are situations where it is not loaded on boot.

Setting an explicit ExecCondition means that the services will be [Skipped] rather than [Fail] if the zfs module is not loaded. The zfs module will only be absent if there are no devices with zpools currently attached.

### How Has This Been Tested?
This has been tested over the past week on a number of machines running Ubuntu 18.04 and Arch Linux. It is a minor change which doesn't affect the filesystem itself.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
