### PR TITLE
lib/libzfs, rpm: Install pkgconfig files in the correct directory

### DIFF
--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -8,7 +8,7 @@ VPATH = \
 # Suppress unused but set variable warnings often due to ASSERTs
 AM_CFLAGS += $(NO_UNUSED_BUT_SET_VARIABLE)
 
-libzfs_pcdir = $(datarootdir)/pkgconfig
+libzfs_pcdir = $(libdir)/pkgconfig
 libzfs_pc_DATA = libzfs.pc libzfs_core.pc
 
 DEFAULT_INCLUDES += \

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -471,8 +471,8 @@ systemctl --system daemon-reload >/dev/null || true
 %{_libdir}/libzfs*.so.*
 
 %files -n libzfs2-devel
-%{_datarootdir}/pkgconfig/libzfs.pc
-%{_datarootdir}/pkgconfig/libzfs_core.pc
+%{_libdir}/pkgconfig/libzfs.pc
+%{_libdir}/pkgconfig/libzfs_core.pc
 %{_libdir}/*.so
 %{_includedir}/*
 %doc AUTHORS COPYRIGHT LICENSE NOTICE README.md


### PR DESCRIPTION
### Motivation and Context
`libzfs` is an architecture-specific library, thus its pkgconfig files should also be installed into the architecture-specific path for pkgconfig files so that systems that support multilib or multiarch installation will be able to work properly.

### Description
* Change the install path for pkgconfig files from `%{_datarootdir}/pkgconfig` to `%{_libdir}/pkgconfig`

### How Has This Been Tested?
Did local package builds for CentOS 8, Fedora 32, Ubuntu 16.04, and Ubuntu 20.04 with success. The `pkg-config` tool still is able to look up the pkgconfig content installed by the `libzfs2-devel` package.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
