### PR TITLE
Introduce names for ZTHRs.

### DIFF
--- a/include/os/freebsd/spl/sys/proc.h
+++ b/include/os/freebsd/spl/sys/proc.h
@@ -65,7 +65,7 @@ extern struct proc *zfsproc;
 
 static __inline kthread_t *
 do_thread_create(caddr_t stk, size_t stksize, void (*proc)(void *), void *arg,
-    size_t len, proc_t *pp, int state, pri_t pri)
+    size_t len, proc_t *pp, int state, pri_t pri, const char *name)
 {
 	kthread_t *td = NULL;
 	int error;
@@ -78,7 +78,7 @@ do_thread_create(caddr_t stk, size_t stksize, void (*proc)(void *), void *arg,
 	ASSERT(state == TS_RUN);
 
 	error = kproc_kthread_add(proc, arg, &zfsproc, &td,
-	    RFSTOPPED, stksize / PAGE_SIZE, "zfskern", "solthread %p", proc);
+	    RFSTOPPED, stksize / PAGE_SIZE, "zfskern", "%s", name);
 	if (error == 0) {
 		thread_lock(td);
 		sched_prio(td, pri);
@@ -90,8 +90,11 @@ do_thread_create(caddr_t stk, size_t stksize, void (*proc)(void *), void *arg,
 	return (td);
 }
 
+#define	thread_create_named(name, stk, stksize, proc, arg, len,	\
+    pp, state, pri) \
+	do_thread_create(stk, stksize, proc, arg, len, pp, state, pri, name)
 #define	thread_create(stk, stksize, proc, arg, len, pp, state, pri) \
-	do_thread_create(stk, stksize, proc, arg, len, pp, state, pri)
+	do_thread_create(stk, stksize, proc, arg, len, pp, state, pri, #proc)
 #define	thread_exit()	kthread_exit()
 
 int	uread(proc_t *, void *, size_t, uintptr_t);

--- a/include/os/linux/spl/sys/thread.h
+++ b/include/os/linux/spl/sys/thread.h
@@ -45,6 +45,11 @@
 
 typedef void (*thread_func_t)(void *);
 
+#define	thread_create_named(name, stk, stksize, func, arg, len,	\
+    pp, state, pri)	\
+	__thread_create(stk, stksize, (thread_func_t)func,		\
+	name, arg, len, pp, state, pri)
+
 /* BEGIN CSTYLED */
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
 	__thread_create(stk, stksize, (thread_func_t)func,		\

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -218,6 +218,9 @@ typedef pthread_t	kthread_t;
 #define	kpreempt(x)	yield()
 #define	getcomm()	"unknown"
 
+#define	thread_create_named(name, stk, stksize, func, arg, len, \
+    pp, state, pri)	\
+	zk_thread_create(func, arg, stksize, state)
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
 	zk_thread_create(func, arg, stksize, state)
 #define	thread_exit()	pthread_exit(NULL)

--- a/include/sys/zthr.h
+++ b/include/sys/zthr.h
@@ -24,10 +24,11 @@ typedef struct zthr zthr_t;
 typedef void (zthr_func_t)(void *, zthr_t *);
 typedef boolean_t (zthr_checkfunc_t)(void *, zthr_t *);
 
-extern zthr_t *zthr_create(zthr_checkfunc_t checkfunc,
-    zthr_func_t *func, void *arg);
-extern zthr_t *zthr_create_timer(zthr_checkfunc_t *checkfunc,
-    zthr_func_t *func, void *arg, hrtime_t nano_wait);
+extern zthr_t *zthr_create(const char *zthr_name,
+    zthr_checkfunc_t checkfunc, zthr_func_t *func, void *arg);
+extern zthr_t *zthr_create_timer(const char *zthr_name,
+    zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg,
+	hrtime_t nano_wait);
 extern void zthr_destroy(zthr_t *t);
 
 extern void zthr_wakeup(zthr_t *t);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7339,10 +7339,10 @@ arc_init(void)
 		kstat_install(arc_ksp);
 	}
 
-	arc_evict_zthr = zthr_create_timer(arc_evict_cb_check,
-	    arc_evict_cb, NULL, SEC2NSEC(1));
-	arc_reap_zthr = zthr_create_timer(arc_reap_cb_check,
-	    arc_reap_cb, NULL, SEC2NSEC(1));
+	arc_evict_zthr = zthr_create_timer("arc_evict",
+	    arc_evict_cb_check, arc_evict_cb, NULL, SEC2NSEC(1));
+	arc_reap_zthr = zthr_create_timer("arc_reap",
+	    arc_reap_cb_check, arc_reap_cb, NULL, SEC2NSEC(1));
 
 	arc_warm = B_FALSE;
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2548,7 +2548,8 @@ static void
 spa_start_livelist_destroy_thread(spa_t *spa)
 {
 	ASSERT3P(spa->spa_livelist_delete_zthr, ==, NULL);
-	spa->spa_livelist_delete_zthr = zthr_create(
+	spa->spa_livelist_delete_zthr =
+	    zthr_create("z_livelist_destroy",
 	    spa_livelist_delete_cb_check, spa_livelist_delete_cb, spa);
 }
 
@@ -2755,8 +2756,10 @@ spa_start_livelist_condensing_thread(spa_t *spa)
 	spa->spa_to_condense.cancelled = B_FALSE;
 
 	ASSERT3P(spa->spa_livelist_condense_zthr, ==, NULL);
-	spa->spa_livelist_condense_zthr = zthr_create(
-	    spa_livelist_condense_cb_check, spa_livelist_condense_cb, spa);
+	spa->spa_livelist_condense_zthr =
+	    zthr_create("z_livelist_condense",
+	    spa_livelist_condense_cb_check,
+	    spa_livelist_condense_cb, spa);
 }
 
 static void
@@ -2772,7 +2775,8 @@ spa_spawn_aux_threads(spa_t *spa)
 
 	ASSERT3P(spa->spa_checkpoint_discard_zthr, ==, NULL);
 	spa->spa_checkpoint_discard_zthr =
-	    zthr_create(spa_checkpoint_discard_thread_check,
+	    zthr_create("z_checkpoint_discard",
+	    spa_checkpoint_discard_thread_check,
 	    spa_checkpoint_discard_thread, spa);
 }
 

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -884,7 +884,8 @@ void
 spa_start_indirect_condensing_thread(spa_t *spa)
 {
 	ASSERT3P(spa->spa_condense_zthr, ==, NULL);
-	spa->spa_condense_zthr = zthr_create(spa_condense_indirect_thread_check,
+	spa->spa_condense_zthr = zthr_create("z_indirect_condense",
+	    spa_condense_indirect_thread_check,
 	    spa_condense_indirect_thread, spa);
 }
 

--- a/module/zfs/zthr.c
+++ b/module/zfs/zthr.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2020 by Delphix. All rights reserved.
  */
 
 /*
@@ -269,9 +269,11 @@ zthr_procedure(void *arg)
 }
 
 zthr_t *
-zthr_create(zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg)
+zthr_create(const char *zthr_name, zthr_checkfunc_t *checkfunc,
+    zthr_func_t *func, void *arg)
 {
-	return (zthr_create_timer(checkfunc, func, arg, (hrtime_t)0));
+	return (zthr_create_timer(zthr_name, checkfunc,
+	    func, arg, (hrtime_t)0));
 }
 
 /*
@@ -280,8 +282,8 @@ zthr_create(zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg)
  * start working if required) will be triggered.
  */
 zthr_t *
-zthr_create_timer(zthr_checkfunc_t *checkfunc, zthr_func_t *func,
-    void *arg, hrtime_t max_sleep)
+zthr_create_timer(const char *zthr_name, zthr_checkfunc_t *checkfunc,
+    zthr_func_t *func, void *arg, hrtime_t max_sleep)
 {
 	zthr_t *t = kmem_zalloc(sizeof (*t), KM_SLEEP);
 	mutex_init(&t->zthr_state_lock, NULL, MUTEX_DEFAULT, NULL);
@@ -295,8 +297,9 @@ zthr_create_timer(zthr_checkfunc_t *checkfunc, zthr_func_t *func,
 	t->zthr_arg = arg;
 	t->zthr_sleep_timeout = max_sleep;
 
-	t->zthr_thread = thread_create(NULL, 0, zthr_procedure, t,
-	    0, &p0, TS_RUN, minclsyspri);
+	t->zthr_thread = thread_create_named(zthr_name, NULL, 0,
+	    zthr_procedure, t, 0, &p0, TS_RUN, minclsyspri);
+
 	mutex_exit(&t->zthr_state_lock);
 
 	return (t);


### PR DESCRIPTION
When debugging issues or generally analyzing the runtime of
a system it would be nice to be able to tell the different
ZTHRs running by name rather than having to analyze their
stack.

Co-authored-by: Ryan Moeller <ryan@iXsystems.com>
Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### How Has This Been Tested?

Manually through `sdb` and `top` in Linux:
```
$ sudo sdb -e 'threads ! grep arc'
0xffff8bb9d9060000 INTERRUPTIBLE 415   139  arc_reap
0xffff8bb9d9062e80 INTERRUPTIBLE 414   139  arc_evict
0xffff8bb9da64dd00 INTERRUPTIBLE 422   120  l2arc_feed
0xffff8bb9daf65d00 INTERRUPTIBLE 413   120  arc_prune

$ top -b -n 1 | grep arc
  413 root      20   0       0      0      0 S   0.0  0.0   0:00.00 arc_prune
  414 root      39  19       0      0      0 S   0.0  0.0   0:00.02 arc_evict
  415 root      39  19       0      0      0 S   0.0  0.0   0:00.02 arc_reap
  422 root      20   0       0      0      0 S   0.0  0.0   0:00.01 l2arc_feed

$ sudo sdb -e 'threads ! grep z_'
0xffff8bb9d6800000 INTERRUPTIBLE 518   100  z_cl_int
...<cropped>...
0xffff8bb9d6ff1740 INTERRUPTIBLE 523   120  z_zvol
0xffff8bb9d6ff2e80 INTERRUPTIBLE 522   100  z_trim_int
0xffff8bb9d6ff45c0 INTERRUPTIBLE 521   100  z_trim_iss
0xffff8bb9d6ff5d00 INTERRUPTIBLE 520   100  z_ioctl_int
0xffff8bb9da510000 INTERRUPTIBLE 589   139  z_livelist_dest
0xffff8bb9da511740 INTERRUPTIBLE 588   139  z_indirect_cond
0xffff8bb9da648000 INTERRUPTIBLE 421   139  z_vdev_file
0xffff8bb9daef5d00 INTERRUPTIBLE 531   120  z_unlinked_drai
0xffff8bb9daf61740 INTERRUPTIBLE 530   120  z_zrele
0xffff8bb9dafa2e80 INTERRUPTIBLE 591   139  z_checkpoint_di
0xffff8bb9dafa45c0 INTERRUPTIBLE 590   139  z_livelist_cond

$ top -b -n 1 | grep z_
  421 root      39  19       0      0      0 S   0.0  0.0   0:00.00 z_vdev_file
...<cropped>...
  531 root      20   0       0      0      0 S   0.0  0.0   0:00.00 z_unlinked_drai
  588 root      39  19       0      0      0 S   0.0  0.0   0:00.00 z_indirect_cond
  589 root      39  19       0      0      0 S   0.0  0.0   0:00.00 z_livelist_dest
  590 root      39  19       0      0      0 S   0.0  0.0   0:00.00 z_livelist_cond
  591 root      39  19       0      0      0 S   0.0  0.0   0:00.00 z_checkpoint_di
```

@freqlabs did the testing for the FreeBSD bits manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
