### PR TITLE
Fix verify zfs module loaded before starting services for --enable-linux-builtin

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -61,6 +61,7 @@ install() {
 	dracut_install basename
 	dracut_install cut
 	dracut_install head
+	dracut_install test
 	dracut_install @udevdir@/zvol_id
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
 	if [ -n "$systemdutildir" ] ; then

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -13,7 +13,7 @@ ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
+ExecCondition=/usr/bin/test -d /sys/module/zfs
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 
 [Install]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -12,7 +12,7 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
+ExecCondition=/usr/bin/test -d /sys/module/zfs
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 
 [Install]

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -11,7 +11,7 @@ Before=systemd-random-seed.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
+ExecCondition=/usr/bin/test -d /sys/module/zfs
 ExecStart=@sbindir@/zfs mount -a
 
 [Install]


### PR DESCRIPTION
### Motivation and Context
This fixes #10627 for situations where the zfs module is built-in to the kernel via --enable-linux-builtin. It avoids the need for a revert in #10660 .

### Description
This updates the systemd service template's ExecCondition from checking for a dynamically loaded module in `/proc/modules` to checking for the presence of a module under `/sys/module`. The presence of `/sys/module/zfs` indicates zfs is present, whether it's dynamically loaded or built in to the kernel.

### How Has This Been Tested?
Verified working with dynamic modules on Arch Linux.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
