### PR TITLE
zvol_wait: Ignore locked zvols

### DIFF
--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -28,15 +28,17 @@ filter_out_deleted_zvols() {
 list_zvols() {
 	read -r default_volmode < /sys/module/zfs/parameters/zvol_volmode
 	zfs list -t volume -H -o \
-	    name,volmode,receive_resume_token,redact_snaps |
-	    while IFS="	" read -r name volmode token redacted; do # IFS=\t here!
+	    name,volmode,receive_resume_token,redact_snaps,keystatus |
+	    while IFS="	" read -r name volmode token redacted keystatus; do # IFS=\t here!
 
-		# /dev links are not created for zvols with volmode = "none"
-		# or for redacted zvols.
+		# /dev links are not created for zvols with volmode = "none",
+		# redacted zvols, or encrypted zvols for which the key has not
+		# been loaded.
 		[ "$volmode" = "none" ] && continue
 		[ "$volmode" = "default" ] && [ "$default_volmode" = "3" ] &&
 		    continue
 		[ "$redacted" = "-" ] || continue
+		[ "$keystatus" = "unavailable" ] && continue
 
 		# We also ignore partially received zvols if it is
 		# not an incremental receive, as those won't even have a block


### PR DESCRIPTION
# Motivation and Context
"When an encrypted zvol is locked the zfs-volume-wait service does not start. The /sbin/zvol_wait should not wait for links when the volume has property keystatus=unavailable."
-- https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1888405

This patch is an attempt to merge the idea of the fix into the existing property checks that exist in `zvol_wait` in `master`. The original bug report and fix were from James Dingwall <james-launchpad@dingwall.me.uk>. You can see his patch at: https://launchpadlibrarian.net/489480437/zfs-patch

### Description
This ignores zvols that have `keystatus` of `unavailable`.

### How Has This Been Tested?
This idea has been in the Debian package for a while. However, I had to rebase it on master.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
