### PR TITLE
Fix verify zfs module loaded before starting services for --enable-linux-builtin (using ConditionPathIsDirectory)

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -9,11 +9,11 @@ After=multipathd.target
 After=systemd-remount-fs.service
 Before=zfs-import.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 
 [Install]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -8,11 +8,11 @@ After=cryptsetup.target
 After=multipathd.target
 Before=zfs-import.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 
 [Install]

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -7,11 +7,11 @@ After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target
 Before=systemd-random-seed.service
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zfs mount -a
 
 [Install]


### PR DESCRIPTION
### Motivation and Context
This fixes #10627 for situations where the zfs module is built-in to the kernel via --enable-linux-builtin. It avoids the need for a revert in #10660. It's a refactor of #10661 using built-in checks.

### Description
This updates the systemd service template's ExecCondition from checking for a dynamically loaded module in `/proc/modules` to checking for the presence of a module directory under `/sys/module`. The presence of a `/sys/module/zfs` directory indicates zfs is present, whether it's dynamically loaded or built in to the kernel. systemd will check for this with `ConditionPathIsDirectory=/sys/module/zfs` and skip the service if the condition is unmet (i.e. the module is not present/loaded).

### How Has This Been Tested?
Verified working with dynamic modules on Arch Linux.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
