### PR TITLE
KMC_KVMEM should use kvmalloc()

### DIFF
--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -160,10 +160,12 @@ taskq_t *spl_kmem_cache_taskq;		/* Task queue for aging / reclaim */
 
 static void spl_cache_shrink(spl_kmem_cache_t *skc, void *obj);
 
+int alloc_offset = 1;
+
 static void *
 kv_alloc(spl_kmem_cache_t *skc, int size, int flags)
 {
-	return (spl_kvmalloc(size, kmem_flags_convert(flags)));
+	return (spl_kvmalloc(size + alloc_offset, kmem_flags_convert(flags)) + alloc_offset);
 }
 
 static void
@@ -179,7 +181,7 @@ kv_free(spl_kmem_cache_t *skc, void *ptr, int size)
 	if (current->reclaim_state)
 		current->reclaim_state->reclaimed_slab += size >> PAGE_SHIFT;
 
-	spl_kmem_free_impl(ptr, size);
+	spl_kmem_free_impl(ptr - alloc_offset, size + alloc_offset);
 }
 
 /*

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -197,12 +197,11 @@ zio_init(void)
 		align = 8 * SPA_MINBLOCKSIZE;
 #else
 		if (size < PAGESIZE) {
-			align = SPA_MINBLOCKSIZE;
+			align = 64;
 		} else if (IS_P2ALIGNED(size, p2 >> 2)) {
-			align = PAGESIZE;
+			align = 64;
 		}
 #endif
-
 		if (align != 0) {
 			char name[36];
 			(void) snprintf(name, sizeof (name), "zio_buf_%lu",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`KMC_KVMEM` was designed to use `kvmalloc()` (see #9034).  However, this
was changed by #9813 to use `vmalloc()`, because `kvmalloc()` doesn't
always return page-aligned addresses.  However, the SPL kmem-cache
implementation doesn't need page-aligned addresses, because no SPL
caches request any particular alignment.
### Description
<!--- Describe your changes in detail -->
This commit changes `KMC_KVMEM` to use `kvmalloc()`, removes the
assertion that it returns page-aligned addresses, and asserts that SPL
caches to not request any particular alignment.

Note: this PR depends on https://github.com/openzfs/zfs/pull/10673, and includes that commit.  Please review the most recent commit (https://github.com/openzfs/zfs/commit/1b1fe1392113c7543fec1336d41b66a6cef1a9cc).

cc @c0d3z3r0 @loli10K 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS

I could use help testing this with a KASAN build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
