### PR TITLE
libzfs_core: Initialize fail_ioc_cmd to ZFS_IOC_LAST

### DIFF
--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -97,7 +97,7 @@ static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static int g_refcount;
 
 #ifdef ZFS_DEBUG
-static zfs_ioc_t fail_ioc_cmd;
+static zfs_ioc_t fail_ioc_cmd = ZFS_IOC_LAST;
 static zfs_errno_t fail_ioc_err;
 
 static void
@@ -118,7 +118,7 @@ libzfs_core_debug_ioc(void)
 	 * cannot checkpoint 'tank': the loaded zfs module does not support
 	 * this operation. A reboot may be required to enable this operation.
 	 */
-	if (fail_ioc_cmd == 0) {
+	if (fail_ioc_cmd == ZFS_IOC_LAST) {
 		char *ioc_test = getenv("ZFS_IOC_TEST");
 		unsigned int ioc_num = 0, ioc_err = 0;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In debug builds, libzfs_core checks if the requested ioctl cmd matches a value configured via an environment variable.
If the command number matches, that ioctl fails with a configured error. This is used for testing.

FreeBSD numbers `ZFS_IOC_*` starting at `0`, so `ZFS_IOC_POOL_CREATE` overlaps with the sentinel value.

As luck would have it, `ZFS_IOC_POOL_CREATE` isn't used in libzfs_core, so this is a non-issue in practice.

### Description
<!--- Describe your changes in detail -->
Use `ZFS_IOC_LAST` as the sentinel value, if only for the peace of mind.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
