### PR TITLE
vdev_id: Support daisy-chained JBODs in multipath mode

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -79,6 +79,20 @@
 # channel 86:00.0 1         A
 # channel 86:00.0 0         B
 
+# #
+# # Example vdev_id.conf - multipath / multijbod-daisychaining
+# #
+#
+# multipath yes
+# multijbod yes
+#
+# #       PCI_ID  HBA PORT  CHANNEL NAME
+# channel 85:00.0 1         A
+# channel 85:00.0 0         B
+# channel 86:00.0 1         A
+# channel 86:00.0 0         B
+
+# #
 # # Example vdev_id.conf - multipath / mixed
 # #
 #
@@ -107,7 +121,6 @@ CONFIG=/etc/zfs/vdev_id.conf
 PHYS_PER_PORT=
 DEV=
 MULTIPATH=
-MULTIJBOD=
 TOPOLOGY=
 BAY=
 
@@ -161,25 +174,25 @@ map_channel() {
 	printf "%s" ${MAPPED_CHAN}
 }
 
-	# The bsg driver knows the difference between a SAS expander and fanout expander.
-	# The scsi H:B:T:L address of the primary enclosure expander is included in the 
-	# symlink target within sysfs for the block device being assessed. Comparing that
-	# H:B:T:L to a list of expanders produced by lsscsi provides a method to distinguish
-	# the JBOD enclosure the block device exist within. No custom fields are needed in
-	# vdev_id.conf as the enumeration of JBODs is dynamic and not dependent on hardware
-	# specific values such as WWN.
+	# map_jbod explainer: The bsg driver knows the difference between a SAS
+	# expander and fanout expander. Use hostX instance along with top-level
+	# (whole enclosure) expander instances in /sys/class/enclosure and
+	# matching a field in an array of expanders, using the index of the
+	# matched array field as the enclosure instance, thereby making jbod IDs
+	# dynamic. Avoids reliance on high overrhead userspace commands like
+	# multipath and lsscsi and instead uses existing sysfs data.  $HOSTCHAN
+	# variable derived from devpath gymnastics in sas_handler() function.
 
 map_jbod() {
 	if [ "$MULTIJBOD_MODE" = "yes" ] ; then
 	local DEV=$1
-	ENC_ORDER=0
-       	DEVEXP=`ls -l /sys/block/$DEV/device/ | grep enclos | awk -F/ '{print $(NF-1) }'`
-	HBA_CHAN=`echo $DEVEXP | awk -F: -vOFS=':' '{print $1, $2}'`
-	for EXPND in `lsscsi -t | grep -E "$HBA_CHAN.*enclos" | awk '{gsub(/\[|\]/, ""); print $1}'`
+     	DEVEXP=`ls -l /sys/block/$DEV/device/ | grep enclos | awk -F/ '{print $(NF-1) }'`
+	JBODS=$(ls -l /sys/class/enclosure | grep host${HOSTCHAN}/port-${HOSTCHAN}:${PORT} | awk '{print $9}')
+	JBOD=($JBODS)
+	for i in "${!JBOD[@]}"
 	do
-        	((ENC_ORDER++))
-		if [ "$EXPND" = "$DEVEXP" ] ; then
-			MAPPED_JBOD=$ENC_ORDER
+		if [ "${JBOD[$i]}" = "$DEVEXP" ] ; then
+			MAPPED_JBOD=$i
 			break
 		fi
 	done
@@ -232,10 +245,23 @@ sas_handler() {
 			return
 		fi
 
-		# Get the raw scsi device name from multipath -ll. Strip off
-		# leading pipe symbols to make field numbering consistent.
-		DEV=`multipath -ll $DM_NAME |
-			awk '/running/{gsub("^[|]"," "); print $3 ; exit}'`
+		# Utilize DM device name to gather subordinate block devices
+		# using sysfs to avoid userspace utilities 
+		DMDEV=`ls -l --full-time /dev/mapper |
+				awk "/$DM_NAME/{ gsub(\"../\",\"\",\\$NF); print \\$NF}"`	
+
+		# Use sysfs pointers in /sys/block/dm-X/slaves because using
+		# userspace tools creates lots of overhead and should be avoided
+		# whenever possible. Use awk to isolate lowest instance of sd device 
+		# member in dm device group regardless of string length.
+
+		DEV=`ls /sys/block/$DMDEV/slaves | awk '
+			{ len=sprintf ("%20s",length($0)); gsub(/ /,0,str); a[NR]=len "_" $0; }
+			END {
+				asort(a)
+				print substr(a[1],22)
+			    }'`
+
 		if [ -z "$DEV" ] ; then
 			return
 		fi
@@ -260,6 +286,9 @@ sas_handler() {
 		echo $d | grep -q -E '^host[0-9]+$' && break
 		i=$(($i + 1))
 	done
+
+	# Lets grab the SAS host channel number and save it for JBOD sorting later
+	HOSTCHAN=`echo $d | awk -F/ '{ gsub("host","",$NF); print $NF}'`
 
 	if [ $i = $num_dirs ] ; then
 		return
@@ -302,10 +331,11 @@ sas_handler() {
 		i=$(($i + 1))
 	done
 
-        # Add 'mix' slot type for environments where dm-multipath devices include end-devices connected via
-        # SAS expanders or direct connection to SAS HBA. A mixed connectivity environment such as
-        # pool disk contained in a SAS JBOD and spare drives or log devices directly connected in a
-        # server backplane without expanders in the I/O path.
+        # Add 'mix' slot type for environments where dm-multipath devices
+	# include end-devices connected via SAS expanders or direct connection
+	# to SAS HBA. A mixed connectivity environment such as # pool disk
+	# contained in a SAS JBOD and spare drives or log devices directly
+	# connected in a server backplane without expanders in the I/O path.
 
 	SLOT=
 	case $BAY in
@@ -318,7 +348,7 @@ sas_handler() {
                 else
                         SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
                 fi
-                ;;
+                ;;		
 	"phy")
 		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
 		;;

--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -68,6 +68,17 @@
 # channel 4            D
 
 # #
+# # Example vdev_id.conf - multipath
+# #
+#
+# multipath yes
+#
+# #       PCI_ID  HBA PORT  CHANNEL NAME
+# channel 85:00.0 1         A
+# channel 85:00.0 0         B
+# channel 86:00.0 1         A
+# channel 86:00.0 0         B
+
 # # Example vdev_id.conf - multipath / mixed
 # #
 #
@@ -81,19 +92,6 @@
 # channel 86:00.0 2         B
 # channel af:00.0 0         C
 # channel af:00.0 1         C
-
-
-# #
-# # Example vdev_id.conf - multipath
-# #
-#
-# multipath yes
-#
-# #       PCI_ID  HBA PORT  CHANNEL NAME
-# channel 85:00.0 1         A
-# channel 85:00.0 0         B
-# channel 86:00.0 1         A
-# channel 86:00.0 0         B
 
 # #
 # # Example vdev_id.conf - alias
@@ -109,6 +107,7 @@ CONFIG=/etc/zfs/vdev_id.conf
 PHYS_PER_PORT=
 DEV=
 MULTIPATH=
+MULTIJBOD=
 TOPOLOGY=
 BAY=
 
@@ -123,6 +122,7 @@ Usage: vdev_id [-h]
   -e    Create enclose device symlinks only (/dev/by-enclosure)
   -g    Storage network topology [default="$TOPOLOGY"]
   -m    Run in multipath mode
+  -j    Run in multijbod mode
   -p    number of phy's per switch port [default=$PHYS_PER_PORT]
   -h    show this summary
 EOF
@@ -161,6 +161,32 @@ map_channel() {
 	printf "%s" ${MAPPED_CHAN}
 }
 
+	# The bsg driver knows the difference between a SAS expander and fanout expander.
+	# The scsi H:B:T:L address of the primary enclosure expander is included in the 
+	# symlink target within sysfs for the block device being assessed. Comparing that
+	# H:B:T:L to a list of expanders produced by lsscsi provides a method to distinguish
+	# the JBOD enclosure the block device exist within. No custom fields are needed in
+	# vdev_id.conf as the enumeration of JBODs is dynamic and not dependent on hardware
+	# specific values such as WWN.
+
+map_jbod() {
+	if [ "$MULTIJBOD_MODE" = "yes" ] ; then
+	local DEV=$1
+	ENC_ORDER=0
+       	DEVEXP=`ls -l /sys/block/$DEV/device/ | grep enclos | awk -F/ '{print $(NF-1) }'`
+	HBA_CHAN=`echo $DEVEXP | awk -F: -vOFS=':' '{print $1, $2}'`
+	for EXPND in `lsscsi -t | grep -E "$HBA_CHAN.*enclos" | awk '{gsub(/\[|\]/, ""); print $1}'`
+	do
+        	((ENC_ORDER++))
+		if [ "$EXPND" = "$DEVEXP" ] ; then
+			MAPPED_JBOD=$ENC_ORDER
+			break
+		fi
+	done
+	fi
+	printf "%d" ${MAPPED_JBOD}
+}
+
 sas_handler() {
 	if [ -z "$PHYS_PER_PORT" ] ; then
 		PHYS_PER_PORT=`awk "\\$1 == \"phys_per_port\" \
@@ -174,6 +200,11 @@ sas_handler() {
 
 	if [ -z "$MULTIPATH_MODE" ] ; then
 		MULTIPATH_MODE=`awk "\\$1 == \"multipath\" \
+			{print \\$2; exit}" $CONFIG`
+	fi
+
+	if [ -z "$MULTIJBOD_MODE" ] ; then
+		MULTIJBOD_MODE=`awk "\\$1 == \"multijbod\" \
 			{print \\$2; exit}" $CONFIG`
 	fi
 
@@ -271,10 +302,10 @@ sas_handler() {
 		i=$(($i + 1))
 	done
 
-	# Add 'mix' slot type for environments where dm-multipath devices include end-devices connected via
-	# SAS expanders or direct connection to SAS HBA. A mixed connectivity environment such as
-	# pool disk contained in a SAS JBOD and spare drives or log devices directly connected in a
-	# server backplane without expanders in the I/O path.
+        # Add 'mix' slot type for environments where dm-multipath devices include end-devices connected via
+        # SAS expanders or direct connection to SAS HBA. A mixed connectivity environment such as
+        # pool disk contained in a SAS JBOD and spare drives or log devices directly connected in a
+        # server backplane without expanders in the I/O path.
 
 	SLOT=
 	case $BAY in
@@ -282,12 +313,12 @@ sas_handler() {
 		SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
 		;;
 	"mix")
-		if [[ `cat $end_device_dir/bay_identifier 2>/dev/null` ]] ; then
-			SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
-		else
-			SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
-		fi
-		;;
+                if [[ `cat $end_device_dir/bay_identifier 2>/dev/null` ]] ; then
+                        SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
+                else
+                        SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
+                fi
+                ;;
 	"phy")
 		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
 		;;
@@ -327,12 +358,22 @@ sas_handler() {
 		return
 	fi
 
-	CHAN=`map_channel $PCI_ID $PORT`
-	SLOT=`map_slot $SLOT $CHAN`
-	if [ -z "$CHAN" ] ; then
-		return
-	fi
-	echo ${CHAN}${SLOT}${PART}
+	if [ "$MULTIJBOD_MODE" = "yes" ] ; then
+		CHAN=`map_channel $PCI_ID $PORT`
+		SLOT=`map_slot $SLOT $CHAN`
+		JBOD=`map_jbod $DEV`
+		if [ -z "$CHAN" ] ; then
+			return
+		fi
+		echo ${CHAN}-${JBOD}-${SLOT}${PART}
+        else
+		CHAN=`map_channel $PCI_ID $PORT`
+		SLOT=`map_slot $SLOT $CHAN`
+		if [ -z "$CHAN" ] ; then
+			return
+		fi
+		echo ${CHAN}${SLOT}${PART}
+        fi
 }
 
 scsi_handler() {
@@ -540,7 +581,7 @@ alias_handler () {
 	done
 }
 
-while getopts 'c:d:eg:mp:h' OPTION; do
+while getopts 'c:d:eg:jmp:h' OPTION; do
 	case ${OPTION} in
 	c)
 		CONFIG=${OPTARG}
@@ -563,6 +604,9 @@ while getopts 'c:d:eg:mp:h' OPTION; do
 		;;
 	p)
 		PHYS_PER_PORT=${OPTARG}
+		;;
+	j)
+		MULTIJBOD_MODE=yes
 		;;
 	m)
 		MULTIPATH_MODE=yes

--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -68,6 +68,22 @@
 # channel 4            D
 
 # #
+# # Example vdev_id.conf - multipath / mixed
+# #
+#
+# multipath yes
+# slot mix
+#
+# #       PCI_ID  HBA PORT  CHANNEL NAME
+# channel 85:00.0 3         A
+# channel 85:00.0 2         B
+# channel 86:00.0 3         A
+# channel 86:00.0 2         B
+# channel af:00.0 0         C
+# channel af:00.0 1         C
+
+
+# #
 # # Example vdev_id.conf - multipath
 # #
 #
@@ -255,10 +271,22 @@ sas_handler() {
 		i=$(($i + 1))
 	done
 
+	# Add 'mix' slot type for environments where dm-multipath devices include end-devices connected via
+	# SAS expanders or direct connection to SAS HBA. A mixed connectivity environment such as
+	# pool disk contained in a SAS JBOD and spare drives or log devices directly connected in a
+	# server backplane without expanders in the I/O path.
+
 	SLOT=
 	case $BAY in
 	"bay")
 		SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
+		;;
+	"mix")
+		if [[ `cat $end_device_dir/bay_identifier 2>/dev/null` ]] ; then
+			SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
+		else
+			SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
+		fi
 		;;
 	"phy")
 		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`


### PR DESCRIPTION
### Motivation and Context
The current version of vdev_id is not able to differentiate between devices in multiple/daisy-chained JBOD enclosures. 

### Description
Within function sas_handler() userspace commands like /usr/sbin/multipath have been replaced with sourcing device details from within sysfs which reduced a significant amount of overhead and processing time. Multiple JBOD enclosures and their order are sourced from the bsg driver (/sys/class/enclosure) to isolate chassis top-level expanders, which are then dynamically indexed based on host channel of the multipath subordinate disk member device being processed. Additionally added a "mixed" mode for slot identification for environments where a ZFS server system may contain SAS disk slots where there is no expander (direct connect to HBA) while an attached external JBOD with an expander have different slot identifier methods. 

### How Has This Been Tested?
Testing was performed on a AMD EPYC based dual-server high-availability multipath environment with multiple HBAs per ZFS server and four SAS JBODs. The two primary JBODs were multipath/cross-connected between the two ZFS-HA servers. The secondary JBODs were daisy-chained off of the primary JBODs using aligned SAS expander channels (JBOD-0 expanderA--->JBOD-1 expanderA, JBOD-0 expanderB--->JBOD-1 expanderB, etc). Pools were created, exported and re-imported, imported globally with `zpool import -a -d /dev/disk/by-vdev`. Low level udev debug outputs were traced to isolate and resolve errors.

Initial testing of a previous version of this change showed how reliance on userspace utilities like /usr/sbin/multipath and /usr/bin/lsscsi were exacerbated by increasing numbers of disks and JBODs. With four 60-disk SAS JBODs and 240 disks the time to process a `udevadm trigger` was 3 minutes 30 seconds during which nearly all CPU cores were above 80% utilization. By switching reliance on userspace utilities to sysfs in this version, the `udevadm trigger` processing time was reduced to 12.2 seconds and negligible CPU load.

##### /dev/disk/by-vdev
```
# ls /dev/disk/by-vdev/
A-0-0   A-0-14  A-0-2   A-0-25  A-0-30  A-0-36  A-0-41  A-0-47  A-0-52  A-0-58  A-1-0   A-1-14  A-1-2   A-1-25  A-1-30  A-1-36  A-1-41  A-1-47  A-1-52  A-1-58  B-0-0   B-0-14  B-0-2   B-0-25  B-0-30  B-0-36  B-0-41  B-0-47  B-0-52  B-0-58  B-1-0   B-1-14  B-1-2   B-1-25  B-1-30  B-1-36  B-1-41  B-1-47  B-1-52  B-1-58
A-0-1   A-0-15  A-0-20  A-0-26  A-0-31  A-0-37  A-0-42  A-0-48  A-0-53  A-0-59  A-1-1   A-1-15  A-1-20  A-1-26  A-1-31  A-1-37  A-1-42  A-1-48  A-1-53  A-1-59  B-0-1   B-0-15  B-0-20  B-0-26  B-0-31  B-0-37  B-0-42  B-0-48  B-0-53  B-0-59  B-1-1   B-1-15  B-1-20  B-1-26  B-1-31  B-1-37  B-1-42  B-1-48  B-1-53  B-1-59
A-0-10  A-0-16  A-0-21  A-0-27  A-0-32  A-0-38  A-0-43  A-0-49  A-0-54  A-0-6   A-1-10  A-1-16  A-1-21  A-1-27  A-1-32  A-1-38  A-1-43  A-1-49  A-1-54  A-1-6   B-0-10  B-0-16  B-0-21  B-0-27  B-0-32  B-0-38  B-0-43  B-0-49  B-0-54  B-0-6   B-1-10  B-1-16  B-1-21  B-1-27  B-1-32  B-1-38  B-1-43  B-1-49  B-1-54  B-1-6
A-0-11  A-0-17  A-0-22  A-0-28  A-0-33  A-0-39  A-0-44  A-0-5   A-0-55  A-0-7   A-1-11  A-1-17  A-1-22  A-1-28  A-1-33  A-1-39  A-1-44  A-1-5   A-1-55  A-1-7   B-0-11  B-0-17  B-0-22  B-0-28  B-0-33  B-0-39  B-0-44  B-0-5   B-0-55  B-0-7   B-1-11  B-1-17  B-1-22  B-1-28  B-1-33  B-1-39  B-1-44  B-1-5   B-1-55  B-1-7
A-0-12  A-0-18  A-0-23  A-0-29  A-0-34  A-0-4   A-0-45  A-0-50  A-0-56  A-0-8   A-1-12  A-1-18  A-1-23  A-1-29  A-1-34  A-1-4   A-1-45  A-1-50  A-1-56  A-1-8   B-0-12  B-0-18  B-0-23  B-0-29  B-0-34  B-0-4   B-0-45  B-0-50  B-0-56  B-0-8   B-1-12  B-1-18  B-1-23  B-1-29  B-1-34  B-1-4   B-1-45  B-1-50  B-1-56  B-1-8
A-0-13  A-0-19  A-0-24  A-0-3   A-0-35  A-0-40  A-0-46  A-0-51  A-0-57  A-0-9   A-1-13  A-1-19  A-1-24  A-1-3   A-1-35  A-1-40  A-1-46  A-1-51  A-1-57  A-1-9   B-0-13  B-0-19  B-0-24  B-0-3   B-0-35  B-0-40  B-0-46  B-0-51  B-0-57  B-0-9   B-1-13  B-1-19  B-1-24  B-1-3   B-1-35  B-1-40  B-1-46  B-1-51  B-1-57  B-1-9
```
##### zpool status
```
# zpool status
  pool: jb0-pool0
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb0-pool0   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-0-0   ONLINE       0     0     0
	    A-0-1   ONLINE       0     0     0
	    A-0-2   ONLINE       0     0     0
	    A-0-3   ONLINE       0     0     0
	    A-0-4   ONLINE       0     0     0
	    A-0-5   ONLINE       0     0     0
	    A-0-6   ONLINE       0     0     0
	    A-0-7   ONLINE       0     0     0
	    A-0-8   ONLINE       0     0     0
	    A-0-9   ONLINE       0     0     0
	    A-0-10  ONLINE       0     0     0
	    A-0-11  ONLINE       0     0     0
	    A-0-12  ONLINE       0     0     0
	    A-0-13  ONLINE       0     0     0
	    A-0-14  ONLINE       0     0     0

errors: No known data errors

  pool: jb0-pool1
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb0-pool1   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-0-15  ONLINE       0     0     0
	    A-0-16  ONLINE       0     0     0
	    A-0-17  ONLINE       0     0     0
	    A-0-18  ONLINE       0     0     0
	    A-0-19  ONLINE       0     0     0
	    A-0-20  ONLINE       0     0     0
	    A-0-21  ONLINE       0     0     0
	    A-0-22  ONLINE       0     0     0
	    A-0-23  ONLINE       0     0     0
	    A-0-24  ONLINE       0     0     0
	    A-0-25  ONLINE       0     0     0
	    A-0-26  ONLINE       0     0     0
	    A-0-27  ONLINE       0     0     0
	    A-0-28  ONLINE       0     0     0
	    A-0-29  ONLINE       0     0     0

errors: No known data errors

  pool: jb0-pool2
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb0-pool2   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-0-30  ONLINE       0     0     0
	    A-0-31  ONLINE       0     0     0
	    A-0-32  ONLINE       0     0     0
	    A-0-33  ONLINE       0     0     0
	    A-0-34  ONLINE       0     0     0
	    A-0-35  ONLINE       0     0     0
	    A-0-36  ONLINE       0     0     0
	    A-0-37  ONLINE       0     0     0
	    A-0-38  ONLINE       0     0     0
	    A-0-39  ONLINE       0     0     0
	    A-0-40  ONLINE       0     0     0
	    A-0-41  ONLINE       0     0     0
	    A-0-42  ONLINE       0     0     0
	    A-0-43  ONLINE       0     0     0
	    A-0-44  ONLINE       0     0     0

errors: No known data errors

  pool: jb0-pool3
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb0-pool3   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-0-45  ONLINE       0     0     0
	    A-0-46  ONLINE       0     0     0
	    A-0-47  ONLINE       0     0     0
	    A-0-48  ONLINE       0     0     0
	    A-0-49  ONLINE       0     0     0
	    A-0-50  ONLINE       0     0     0
	    A-0-51  ONLINE       0     0     0
	    A-0-52  ONLINE       0     0     0
	    A-0-53  ONLINE       0     0     0
	    A-0-54  ONLINE       0     0     0
	    A-0-55  ONLINE       0     0     0
	    A-0-56  ONLINE       0     0     0
	    A-0-57  ONLINE       0     0     0
	    A-0-58  ONLINE       0     0     0
	    A-0-59  ONLINE       0     0     0

errors: No known data errors

  pool: jb1-pool0
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb1-pool0   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-1-0   ONLINE       0     0     0
	    A-1-1   ONLINE       0     0     0
	    A-1-2   ONLINE       0     0     0
	    A-1-3   ONLINE       0     0     0
	    A-1-4   ONLINE       0     0     0
	    A-1-5   ONLINE       0     0     0
	    A-1-6   ONLINE       0     0     0
	    A-1-7   ONLINE       0     0     0
	    A-1-8   ONLINE       0     0     0
	    A-1-9   ONLINE       0     0     0
	    A-1-10  ONLINE       0     0     0
	    A-1-11  ONLINE       0     0     0
	    A-1-12  ONLINE       0     0     0
	    A-1-13  ONLINE       0     0     0
	    A-1-14  ONLINE       0     0     0

errors: No known data errors

  pool: jb1-pool1
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb1-pool1   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-1-15  ONLINE       0     0     0
	    A-1-16  ONLINE       0     0     0
	    A-1-17  ONLINE       0     0     0
	    A-1-18  ONLINE       0     0     0
	    A-1-19  ONLINE       0     0     0
	    A-1-20  ONLINE       0     0     0
	    A-1-21  ONLINE       0     0     0
	    A-1-22  ONLINE       0     0     0
	    A-1-23  ONLINE       0     0     0
	    A-1-24  ONLINE       0     0     0
	    A-1-25  ONLINE       0     0     0
	    A-1-26  ONLINE       0     0     0
	    A-1-27  ONLINE       0     0     0
	    A-1-28  ONLINE       0     0     0
	    A-1-29  ONLINE       0     0     0

errors: No known data errors

  pool: jb1-pool2
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb1-pool2   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-1-30  ONLINE       0     0     0
	    A-1-31  ONLINE       0     0     0
	    A-1-32  ONLINE       0     0     0
	    A-1-33  ONLINE       0     0     0
	    A-1-34  ONLINE       0     0     0
	    A-1-35  ONLINE       0     0     0
	    A-1-36  ONLINE       0     0     0
	    A-1-37  ONLINE       0     0     0
	    A-1-38  ONLINE       0     0     0
	    A-1-39  ONLINE       0     0     0
	    A-1-40  ONLINE       0     0     0
	    A-1-41  ONLINE       0     0     0
	    A-1-42  ONLINE       0     0     0
	    A-1-43  ONLINE       0     0     0
	    A-1-44  ONLINE       0     0     0

errors: No known data errors

  pool: jb1-pool3
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM
	jb1-pool3   ONLINE       0     0     0
	  raidz2-0  ONLINE       0     0     0
	    A-1-45  ONLINE       0     0     0
	    A-1-46  ONLINE       0     0     0
	    A-1-47  ONLINE       0     0     0
	    A-1-48  ONLINE       0     0     0
	    A-1-49  ONLINE       0     0     0
	    A-1-50  ONLINE       0     0     0
	    A-1-51  ONLINE       0     0     0
	    A-1-52  ONLINE       0     0     0
	    A-1-53  ONLINE       0     0     0
	    A-1-54  ONLINE       0     0     0
	    A-1-55  ONLINE       0     0     0
	    A-1-56  ONLINE       0     0     0
	    A-1-57  ONLINE       0     0     0
	    A-1-58  ONLINE       0     0     0
	    A-1-59  ONLINE       0     0     0

errors: No known data errors
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements]
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document]
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`]