### PR TITLE
'zfs share -a' should clean noauto exports

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6634,8 +6634,11 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 		 */
 		if (op == OP_MOUNT)
 			return (0);
-		if (op == OP_SHARE && !zfs_is_mounted(zhp, NULL))
+		if (op == OP_SHARE && !zfs_is_mounted(zhp, NULL)) {
+			/* also purge it from existing exports */
+			zfs_unshareall_bypath(zhp, mountpoint);
 			return (0);
+		}
 	}
 
 	/*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -52,7 +52,8 @@ tests = ['zfs_mount_006_pos', 'zfs_mount_008_pos', 'zfs_multi_mount']
 tags = ['functional', 'cli_root', 'zfs_mount']
 
 [tests/functional/cli_root/zfs_share:Linux]
-tests = ['zfs_share_005_pos', 'zfs_share_007_neg', 'zfs_share_009_neg']
+tests = ['zfs_share_005_pos', 'zfs_share_007_neg', 'zfs_share_009_neg',
+    'zfs_share_012_pos']
 tags = ['functional', 'cli_root', 'zfs_share']
 
 [tests/functional/cli_root/zfs_sysfs:Linux]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/Makefile.am
@@ -13,6 +13,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_share_009_neg.ksh \
 	zfs_share_010_neg.ksh \
 	zfs_share_011_pos.ksh \
+	zfs_share_012_pos.ksh \
 	zfs_share_concurrent_shares.ksh
 
 dist_pkgdata_DATA = \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_012_pos.ksh
@@ -1,0 +1,79 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION: Unmounted canmount=noauto export is removed during zfs share -a
+#
+# STRATEGY:
+# 1. Share a dataset that also has canmount set to noauto
+# 2. Capture the zfs exports file when the dataset is mounted + shared
+# 3. Simulate a reboot by unmounting the dataset and restoring the exports file
+# 4. Verify that 'zfs share -a' removes the export since dataset is not mounted
+#
+
+verify_runnable "both"
+
+dataset="$TESTPOOL/$TESTFS"
+mountpt=$(get_prop mountpoint $dataset)
+
+function cleanup
+{
+	zfs set canmount=on $dataset
+	zfs set sharenfs=off $dataset
+	zfs mount -a
+	rm /etc/exports.d/zfs.exports
+	zfs share -a
+}
+
+log_assert "Unmounted canmount=noauto export is removed during zfs share -a"
+log_onexit cleanup
+
+log_must zfs set canmount=noauto $dataset
+zfs mount $dataset > /dev/null 2>&1
+log_must mounted $dataset
+log_must zfs set sharenfs=on $dataset
+log_must is_exported $mountpt
+
+log_must cp /etc/exports.d/zfs.exports /etc/exports.d/zfs.exports.save
+log_must zfs umount $dataset
+log_must unmounted $dataset
+log_mustnot is_exported $mountpt
+
+# simulate a reboot condition
+log_must mv /etc/exports.d/zfs.exports.save /etc/exports.d/zfs.exports
+
+log_must is_exported $mountpt
+log_must zfs share -a
+log_mustnot is_exported $mountpt
+
+log_pass "Unmounted canmount=noauto export is removed during zfs share -a"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_012_pos.ksh
@@ -51,6 +51,12 @@ function cleanup
 	zfs set canmount=on $dataset
 	zfs set sharenfs=off $dataset
 	zfs mount -a
+
+	#
+	# unset __ZFS_POOL_EXCLUDE so that we include all file systems when
+	# rebuilding the exports file
+	#
+	unset __ZFS_POOL_EXCLUDE
 	rm /etc/exports.d/zfs.exports
 	zfs share -a
 }


### PR DESCRIPTION
### Motivation and Context
This is a follow on to PR-10688 where `zfs share -a` allows the sharing of `canmount=noauto` datasets if they are mounted.
However, when a dataset with `canmount=noauto` is **not** mounted, the command should also purge any existing entries from the exports file. Otherwise, after a reboot, the nfs server attempts to export the underlying mountpath, not the dataset. This can lead to a hard hang for existing client mounts.

Reference:  https://access.redhat.com/solutions/3540591

### Description
Instead of just skipping the adding of an export if not mounted and `canmount=noauto`, have it also remove an existing export of the dataset so that, after a reboot, we don't export an unmounted dataset.

### How Has This Been Tested?
ZTS - `functional/cli_root/zfs_share/zfs_share_012_pos.ksh` (new test to verify behavior)

Also tested in our internal testing workflows that was previously causing a hard hang

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
