### PR TITLE
Disable zimport test on staging branch

### DIFF
--- a/TEST
+++ b/TEST
@@ -109,3 +109,6 @@ if [ $(getconf LONG_BIT) = "32" ]; then
     TEST_XFSTESTS_SKIP="yes"
     TEST_ZFSSTRESS_SKIP="yes"
 fi
+
+# Disable zimport on staging branch
+TEST_ZIMPORT_SKIP="yes"


### PR DESCRIPTION


### Motivation and Context
Disable zimport test manually on staging branch until we can disable it in buildbot.

### Description
Disable zimport tests on staging branch

### How Has This Been Tested?
Wait for buildbot results

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
