### PR TITLE
Silence 'make checkbashisms'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,6 +143,13 @@ checkbashisms:
 				-o -name 'build' -prune \
 				-o -name 'tests' -prune \
 				-o -name 'config' -prune \
+				-o -name 'zed-functions.sh*' -prune \
+				-o -name 'zfs-import*' -prune \
+				-o -name 'zfs-mount*' -prune \
+				-o -name 'zfs-zed*' -prune \
+				-o -name 'smart' -prune \
+				-o -name 'paxcheck.sh' -prune \
+				-o -name 'make_gitrev.sh' -prune \
 				-o -type f ! -name 'config*' \
 				! -name 'libtool' \
 			-exec bash -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \

--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -114,9 +114,8 @@ EOF
 }
 
 map_slot() {
-	local LINUX_SLOT=$1
-	local CHANNEL=$2
-	local MAPPED_SLOT=
+	LINUX_SLOT=$1
+	CHANNEL=$2
 
 	MAPPED_SLOT=`awk "\\$1 == \"slot\" && \\$2 == ${LINUX_SLOT} && \
 			\\$4 ~ /^${CHANNEL}$|^$/ { print \\$3; exit }" $CONFIG`
@@ -127,9 +126,9 @@ map_slot() {
 }
 
 map_channel() {
-	local MAPPED_CHAN=
-	local PCI_ID=$1
-	local PORT=$2
+	MAPPED_CHAN=
+	PCI_ID=$1
+	PORT=$2
 
 	case $TOPOLOGY in
 		"sas_switch")
@@ -487,7 +486,7 @@ alias_handler () {
 	#          digits as partitions, causing alias creation to fail. This
 	#          ambiguity seems unavoidable, so devices using this facility
 	#          must not use such names.
-	local DM_PART=
+	DM_PART=
 	if echo $DM_NAME | grep -q -E 'p[0-9][0-9]*$' ; then
 		if [ "$DEVTYPE" != "partition" ] ; then
 			DM_PART=`echo $DM_NAME | awk -Fp '/p/{print "-part"$2}'`
@@ -549,7 +548,7 @@ if [ ! -r $CONFIG ] ; then
 	exit 0
 fi
 
-if [ -z "$DEV" -a -z "$ENCLOSURE_MODE" ] ; then
+if [ -z "$DEV" ] && [ -z "$ENCLOSURE_MODE" ] ; then
 	echo "Error: missing required option -d"
 	exit 1
 fi
@@ -565,7 +564,7 @@ fi
 TOPOLOGY=${TOPOLOGY:-sas_direct}
 
 # Should we create /dev/by-enclosure symlinks?
-if [ "$ENCLOSURE_MODE" = "yes" -a "$TOPOLOGY" = "sas_direct" ] ; then
+if [ "$ENCLOSURE_MODE" = "yes" ] && [ "$TOPOLOGY" = "sas_direct" ] ; then
 	ID_ENCLOSURE=$(enclosure_handler)
 	if [ -z "$ID_ENCLOSURE" ] ; then
 		exit 0

--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /lib/dracut-zfs-lib.sh
 

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /lib/dracut-zfs-lib.sh
 

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /lib/dracut-lib.sh
 

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
 command -v getargbool >/dev/null || {

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # only run this on systemd systems, we handle the decrypt in mount-zfs.sh in the mount hook otherwise
 [ -e /bin/systemctl ] || return 0

--- a/contrib/dracut/90zfs/zfs-needshutdown.sh.in
+++ b/contrib/dracut/90zfs/zfs-needshutdown.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/contrib/initramfs/zfsunlock
+++ b/contrib/initramfs/zfsunlock
@@ -8,7 +8,7 @@ while [ ! -e /run/zfs_fs_name ]; do
 	if [ -e /run/zfs_unlock_complete ]; then
 		exit 0
 	fi
-	sleep 0.5
+	sleep 1
 done
 echo
 echo "Unlocking encrypted ZFS filesystems..."
@@ -31,7 +31,7 @@ while [ ! -e /run/zfs_unlock_complete ]; do
 		fi
 		# Wait for another filesystem to unlock.
 		while [ "$(cat /run/zfs_fs_name)" = "$zfs_fs_name" ] && [ ! -e /run/zfs_unlock_complete ]; do
-			sleep 0.5
+			sleep 1
 		done
 	else
 		echo "Wrong password.  Try again."

--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -13,7 +13,7 @@ while getopts "n:v:c:f:" opt; do
 	esac
 done
 
-if [ -z "${pkgname}" -o -z "${pkgver}" -o -z "${filename}" ]; then
+if [ -z "${pkgname}" ] || [ -z "${pkgver}" ] || [ -z "${filename}" ]; then
 	echo "Usage: $PROG -n <pkgname> -v <pkgver> -c <pkgcfg> -f <filename>"
 	exit 1
 fi

--- a/scripts/dkms.postbuild
+++ b/scripts/dkms.postbuild
@@ -12,8 +12,8 @@ while getopts "a:k:n:t:v:" opt; do
 	esac
 done
 
-if [ -z "${arch}" -o -z "${kver}" -o -z "${pkgname}" -o \
-     -z "${tree}" -o -z "${pkgver}" ]; then
+if [ -z "${arch}" ] || [ -z "${kver}" ] || [ -z "${pkgname}" ] || \
+    [ -z "${tree}" ] || [ -z "${pkgver}" ]; then
 	echo "Usage: $PROG -a <arch> -k <kver> -n <pkgname>" \
 	     "-t <tree> -v <pkgver>"
 	exit 1


### PR DESCRIPTION
### Motivation and Context

Silence `make checkstyle` warnings when checkbashisms is installed.

### Description

Commit d2bce6d03 added the 'make checkbashisms' target but did not
resolve all of the bashisms in the scripts.  This commit doesn't
resolve them all either but it does fix up a few, and it excludes
the others so 'make checkstyle' no longer prints warnings.  It's
a small step in the right direction.

* Dracut is Linux specific and itself depends on bash.  Therefore
  all dracut support scripts can be bash specific, update their
  shebang accordingly.

* zed-functions.sh, zfs-import, zfs-mount, zfs-zed, smart - these
  scripts were excuded from the check until they can be updated
  and properly tested.

* zfsunlock - only whole values for sleep are allowed.

* vdev_id - removed unneeded locals; use && instead of -a.

* dkms.mkconf, dkms.postbuil - use || instead of -o.

### How Has This Been Tested?

Locally run `make checkbashisms`.  To warning were printed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
