### PR TITLE
Avoid snprintf warnings on gcc 7.1+

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -179,7 +179,7 @@ typedef struct ddt_ops {
 	int (*ddt_op_count)(objset_t *os, uint64_t object, uint64_t *count);
 } ddt_ops_t;
 
-#define	DDT_NAMELEN	102
+#define	DDT_NAMELEN	107
 
 extern void ddt_object_name(ddt_t *ddt, enum ddt_type type,
     enum ddt_class clazz, char *name);

--- a/lib/libspl/include/os/freebsd/sys/mnttab.h
+++ b/lib/libspl/include/os/freebsd/sys/mnttab.h
@@ -43,7 +43,7 @@
 #define	MS_NOMNTTAB		0x0
 #define	MS_RDONLY		0x1
 #define	umount2(p, f)	unmount(p, f)
-#define	MNT_LINE_MAX	4096
+#define	MNT_LINE_MAX	4108
 
 #define	MNT_TOOLONG	1	/* entry exceeds MNT_LINE_MAX */
 #define	MNT_TOOMANY	2	/* too many fields in line */

--- a/lib/libspl/include/os/linux/sys/mnttab.h
+++ b/lib/libspl/include/os/linux/sys/mnttab.h
@@ -40,7 +40,7 @@
 #endif /* MNTTAB */
 
 #define	MNTTAB		"/proc/self/mounts"
-#define	MNT_LINE_MAX	4096
+#define	MNT_LINE_MAX	4108
 
 #define	MNT_TOOLONG	1	/* entry exceeds MNT_LINE_MAX */
 #define	MNT_TOOMANY	2	/* too many fields in line */


### PR DESCRIPTION
These warnings were turned to errors when --enable-debug was specified to configure, noticed via Fedora 32's GCC 10.0.1 as per #10712 .

I might need some help in choosing the proper function when snprintf indeed does overwrite a too-small buffer.  Currently I use panic() in module code and abort() in lib code.