### PR TITLE
Improve documentation of zpool import -d/-c vs -s

### DIFF
--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -70,9 +70,10 @@
 .Xc
 Lists pools available to import.
 If the
-.Fl d
-option is not specified, this command searches for devices in
-.Pa /dev .
+.Fl d or
+.Fl c
+options are not specified, this command searches for devices using libblkid
+on Linux and geom on FreeBSD.
 The
 .Fl d
 option can be specified multiple times, and all directories are searched.


### PR DESCRIPTION
Specify that, by default, zpool import uses the libblkid
cache, and only scans when -d/-s is provided.

Closes #7656