### PR TITLE
libzstd: Don't warn about stack frame size in userspace

### DIFF
--- a/lib/libzstd/Makefile.am
+++ b/lib/libzstd/Makefile.am
@@ -2,8 +2,9 @@ include $(top_srcdir)/config/Rules.am
 
 VPATH = $(top_srcdir)/module/zstd
 
-# Includes kernel code, generate warnings for large stack frames
-AM_CFLAGS += $(FRAME_LARGER_THAN)
+# -fno-tree-vectorize is set for gcc in zstd/common/compiler.h
+# Set it for other compilers, too.
+AM_CFLAGS += -fno-tree-vectorize
 
 noinst_LTLIBRARIES = libzstd.la
 
@@ -12,12 +13,3 @@ KERNEL_C = \
 	zfs_zstd.c
 
 nodist_libzstd_la_SOURCES = $(KERNEL_C)
-
-# -fno-tree-vectorize is set for gcc in zstd/common/compiler.h
-# Set it for other compilers, too.
-lib/zstd.$(OBJEXT):  CFLAGS += -fno-tree-vectorize
-lib/zstd.l$(OBJEXT): CFLAGS += -fno-tree-vectorize
-
-# Quiet warnings about frame size due to unused code in unmodified zstd lib
-lib/zstd.$(OBJEXT):  CFLAGS += -Wframe-larger-than=20480
-lib/zstd.l$(OBJEXT): CFLAGS += -Wframe-larger-than=20480


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the current way CFLAGS are modified in libzstd, CFLAGS passed on
the make command line will cause the CFLAGS in the Makefile for zstd.c
to be discarded, but not AM_CFLAGS.  This causes a smaller frame size
limit to be used, and the build fails.

This was the actual cause of #10772

### Description
<!--- Describe your changes in detail -->
We don't need to worry about stack frame sizes in userspace.  Drop the
extra flags.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
`gmake CFLAGS=-march=native`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
