### PR TITLE
Always track temporary fses and snapshots for accounting

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -121,13 +121,6 @@
  * and updated by dsl_fs_ss_count_adjust(). A new limit value is setup in
  * dsl_dir_activate_fs_ss_limit() and the counts are adjusted, if necessary, by
  * dsl_dir_init_fs_ss_count().
- *
- * There is a special case when we receive a filesystem that already exists. In
- * this case a temporary clone name of %X is created (see dmu_recv_begin). We
- * never update the filesystem counts for temporary clones.
- *
- * Likewise, we do not update the snapshot counts for temporary snapshots,
- * such as those created by zfs diff.
  */
 
 extern inline dsl_dir_phys_t *dsl_dir_phys(dsl_dir_t *dd);
@@ -593,11 +586,9 @@ dsl_dir_init_fs_ss_count(dsl_dir_t *dd, dmu_tx_t *tx)
 		    &chld_dd));
 
 		/*
-		 * Ignore hidden ($FREE, $MOS & $ORIGIN) objsets and
-		 * temporary datasets.
+		 * Ignore hidden ($FREE, $MOS & $ORIGIN) objsets.
 		 */
-		if (chld_dd->dd_myname[0] == '$' ||
-		    chld_dd->dd_myname[0] == '%') {
+		if (chld_dd->dd_myname[0] == '$') {
 			dsl_dir_rele(chld_dd, FTAG);
 			continue;
 		}
@@ -910,14 +901,12 @@ dsl_fs_ss_count_adjust(dsl_dir_t *dd, int64_t delta, const char *prop,
 	    strcmp(prop, DD_FIELD_SNAPSHOT_COUNT) == 0);
 
 	/*
-	 * When we receive an incremental stream into a filesystem that already
-	 * exists, a temporary clone is created.  We don't count this temporary
-	 * clone, whose name begins with a '%'. We also ignore hidden ($FREE,
-	 * $MOS & $ORIGIN) objsets.
+	 * We don't do accounting for hidden ($FREE, $MOS & $ORIGIN) objsets.
 	 */
-	if ((dd->dd_myname[0] == '%' || dd->dd_myname[0] == '$') &&
-	    strcmp(prop, DD_FIELD_FILESYSTEM_COUNT) == 0)
+	if (dd->dd_myname[0] == '$' && strcmp(prop,
+	    DD_FIELD_FILESYSTEM_COUNT) == 0) {
 		return;
+	}
 
 	/*
 	 * e.g. if renaming a dataset with no snapshots, count adjustment is 0

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -216,7 +216,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_016_pos', 'receive-o-x_props_override',
     'zfs_receive_from_encrypted', 'zfs_receive_to_encrypted',
     'zfs_receive_raw', 'zfs_receive_raw_incremental', 'zfs_receive_-e',
-    'zfs_receive_raw_-d', 'zfs_receive_from_zstd']
+    'zfs_receive_raw_-d', 'zfs_receive_from_zstd', 'zfs_receive_new_props']
 tags = ['functional', 'cli_root', 'zfs_receive']
 
 [tests/functional/cli_root/zfs_rename]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
@@ -21,6 +21,7 @@ dist_pkgdata_SCRIPTS = \
 	receive-o-x_props_override.ksh \
 	zfs_receive_from_encrypted.ksh \
 	zfs_receive_from_zstd.ksh \
+	zfs_receive_new_props.ksh \
 	zfs_receive_to_encrypted.ksh \
 	zfs_receive_raw.ksh \
 	zfs_receive_raw_incremental.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_new_props.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_new_props.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS receive test to handle Issue #10698
+#
+# STRATEGY:
+# 1. Create a pool with filesystem_limits disabled
+# 2. Create a filesystem on that pool
+# 3. Enable filesystem limits on that pool
+# 4. On a pool with filesystem limits enabled, create a filesystem and set a
+#    limit
+# 5. Snapshot limited filesystem
+# 6. send -R limited filesystem and receive over filesystem with limits disabled
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	destroy_pool "$poolname"
+	destroy_pool "$rpoolname"
+	log_must rm -f "$vdevfile"
+	log_must rm -f "$rvdevfile"
+	log_must rm -f "$streamfile"
+}
+
+log_onexit cleanup
+
+log_assert "ZFS should handle receiving streams with filesystem limits on \
+	pools where the feature was recently enabled"
+
+poolname=sendpool
+rpoolname=recvpool
+vdevfile="$TEST_BASE_DIR/vdevfile.$$"
+rvdevfile="$TEST_BASE_DIR/rvdevfile.$$"
+sendfs="$poolname/fs"
+recvfs="$rpoolname/rfs"
+streamfile="$TEST_BASE_DIR/streamfile.$$"
+
+log_must truncate -s $MINVDEVSIZE "$rvdevfile"
+log_must truncate -s $MINVDEVSIZE "$vdevfile"
+log_must zpool create -O mountpoint=none -o feature@filesystem_limits=disabled \
+	 "$rpoolname" "$rvdevfile"
+log_must zpool create -O mountpoint=none "$poolname" "$vdevfile"
+
+log_must zfs create "$recvfs"
+log_must zpool set feature@filesystem_limits=enabled "$rpoolname"
+
+log_must zfs create -o filesystem_limit=100 "$sendfs"
+log_must zfs snapshot "$sendfs@a"
+
+log_must zfs send -R "$sendfs@a" >"$streamfile"
+log_must eval "zfs recv -svuF $recvfs <$streamfile"
+
+log_pass "ZFS can handle receiving streams with filesystem limits on \
+	pools where the feature was recently enabled"


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Issue #10698

### Description
The root cause of the issue is that we only occasionally do as the comments in the code suggest and actually ignore the %recv dataset when it comes to filesystem limit tracking. Specifically, the only time we ignore it is when initializing the filesystem and snapshot limit values; when creating a new %recv dataset or deleting one, we always update the bookeeping. This causes a problem if you init the fs count on a filesystem that already has a %recv dataset, since the bookmarking will be decremented but not incremented. This is resolved in this patch by simply always tracking the %recv dataset as a child.

### How Has This Been Tested?
A new test has been added to verify that the issue that started this investigation doesn't occur anymore.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
