### PR TITLE
Mark lua setjmp/longjmp for powerpc weak

### DIFF
--- a/module/lua/setjmp/setjmp_ppc.S
+++ b/module/lua/setjmp/setjmp_ppc.S
@@ -56,7 +56,7 @@
 #define	ENTRY(name) \
 	.align 2 ; \
 	.type name,@function; \
-	.globl name; \
+	.weak name; \
 name:
 
 #else /* PPC64_ELF_ABI_v1 */
@@ -65,8 +65,8 @@ name:
 #define	GLUE(a,b) XGLUE(a,b)
 #define	ENTRY(name) \
 	.align 2 ; \
-	.globl name; \
-	.globl GLUE(.,name); \
+	.weak name; \
+	.weak GLUE(.,name); \
 	.pushsection ".opd","aw"; \
 name: \
 	.quad GLUE(.,name); \
@@ -83,8 +83,8 @@ GLUE(.,name):
 #define	ENTRY(name) \
 	.text; \
 	.p2align 4; \
-	.globl  name; \
-	.type   name,@function; \
+	.weak name; \
+	.type name,@function; \
 name:
 
 #endif /* __powerpc64__ */


### PR DESCRIPTION
### Motivation and Context
Linux already defines setjmp/longjmp for powerpc, which leads to
duplicate symbols in a statically linked build.

### Description
s/globl/weak/

### How Has This Been Tested?
Tested on Gentoo running kernel 5.8, both builtin and kmod.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
