### PR TITLE
Add "Status: Triage Needed" to bugreports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve OpenZFS
 title: ''
-labels: 'Type: Defect'
+labels: 'Type: Defect', 'Status: Triage Needed'
 assignees: ''
 
 ---


### PR DESCRIPTION
### Motivation and Context
Currently "Type: Defect" is auto added.
This might have the side effect of Maintainers missing new issues, because it isn't always clear if an issue has been reviewed by a maintainer already or not.

Currently issues also get flagged "stale" after a year and closed 3 months later if still inactive.
It's possible for maintainers to override this behavoir with the "Type: Understood"

However: ( as suggested in #10793) if a maintainer doesn't review/triage new issues, high importance issues might not get correctly tagged with "Type: Understood" and closed by accident.

Adding a tag to make clear that maintainer triage is still needed would solve this issue

### Description
This PR adds a triage tag, makingsure all issues are reviewed by a maintainer
It also opens up some options to priorities defects in the near future.

As this would also mean that during triage every maintainer can overrule the bot (by setting "Type: Understood"), this closes #10793 as every issue would get manually vetted if they need the bot to be disabled. However: The bot is still the default.

### How Has This Been Tested?
- uhmm... Clicking the big issue button?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style
Closes #10793