### PR TITLE
Rename Ignore "Type: Understood" to "Bot: Not Stale"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ only: issues
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "Type: Feature"
-  - "Type: Understood"
+  - "Bot: Not Stale"
 # Label to use when marking an issue as stale
 staleLabel: "Status: Stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
### Motivation and Context
As layed out in: #10802

Design wise it was never the goal to have all "understood" issues ignored by the StaleBot.
It serves the goal of making sure issues are still present in the current version of OpenZFS and are not already fixed.
Primarily by having people confirm the issue (thats why it doesn't close issues very soon after marking them as stale).

The current tag also gives people the (false) impression that their issue might not be understood if they don't get the flag, even if the cause is understood but we just don't want to have the bot ignore it (because, for example, we expect it to be solved very soon by another PR.

This gets even worse if we look into Questions, sometimes we might want to have a bot ignore questions and "Type: understood" gives the wrong impression on that. (the question might not actually by understood at all for exmaple)

### Description
This Commits changes the general ignore tag for StaleBot from:
"Type: Understood"
to
"Bot: Not Stale"

### How Has This Been Tested?
- It's not, its a name change of a github tag

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

closes #10802
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style