### PR TITLE
Auto close "Status: Feedback requested" after a month

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 31
+# Label requiring a response
+responseRequiredLabel: "Status: Feedback requested"
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
### Motivation and Context
As described in: #10807

When an issue is tagged with: "Status: Feedback requested"

While it might be a valid issue regardless if requested feedback is given, it is very unlikely that said issue is going to be resolved without said feedback anyhow. 
So If no response is given within that timeframe or the tag isn't removed, the issue should be closed.
people are free to file a new issue (if they are not the original reporter) or reopen their old issue (if they are the original reporter) if they want to add feedback at a later stage.

### Description
This PR closes issues labeled with:
 "Status: Feedback requested"
after 1 month, if the label is not removed
or
The author has not responded

Bot to be addedL
https://github.com/apps/no-response

### Possible future issues
As with any bot there are some issues we may encounter:
- Bot not closing issues after timeout
There are some reports of the bot not closing issues. Investigation indicated those people didn't use the recommended syntax. No known solution if it happens, need to look into it if it does. No consequences for the user submitting the issue.
- Bot inconsistent closing
There are some delays of the bot not closing issues on the exact day they should be but a few days later, this should not prove to be an issue for us, as closing is a last result anyway
- Manually closed issues being reopened
If you manually close a issues flagged with "Status: Feedback requested", the bot will reopen in some cases. please remove the tag before closing any "Status: Feedback requested" issues manually.

### How Has This Been Tested?
- Not much

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #10807
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style