### PR TITLE
Auto-Label PR's

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,7 @@
+"Component: Test Suite": ["tests"]
+"Component: Systemd": ["etc/systemd"]
+"Component: Dracut": ["contrib/dracut"]
+"Component: Packaging": ["rpm"]
+"Component: ZED": ["cmd/zed"]
+"Component: Share": ["lib/libshare"]
+"Component: Initramfs": ["contrib/initramfs"]


### PR DESCRIPTION
### Motivation and Context
As stated in: #10799

Currently we have a multitude of great "Component: " Github tags.
However: Those are used infrequently and use is, mostly, limited to Issues currently

It would be great to look into automatically adding github "component: " tags to new PR's based on the edited files.
This change would be relatively easy, but it would also be a great tool for contributors to filter which PR's they should review or test.

### Description
This PR automatically add labels to PR's, using the following bot:
https://github.com/mithro/autolabeler

It's a simple bot that does what it says on the tin, nothing more nothing less.
These labels are based on the files changed.

Known limitations:
- Currently these labels will be added if any change in a certain directory is detected a commit.
They are **not** automatically removed.
- Manually removing the labels when file changes in the listed folders are still there, is possible. But the labels will be re-added as soon as a new commit adds file changes to those folders again

### How Has This Been Tested?
- In a seperate Repo:
https://github.com/Ornias1993/zfs/pull/9

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #10799
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style