### PR TITLE
StaleBot Tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve OpenZFS
 title: ''
-labels: 'Type: Defect'
+labels: 'Type: Defect', 'Status: Triage Needed'
 assignees: ''
 
 ---

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,14 @@ only: issues
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "Type: Feature"
-  - "Type: Understood"
+  - "Bot: Not Stale"
+  - "Status: Work in Progress"
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
 # Label to use when marking an issue as stale
 staleLabel: "Status: Stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable
@@ -15,3 +22,5 @@ markComment: >
   This issue has been automatically marked as "stale" because it has not had
   any activity for a while. It will be closed in 90 days if no further activity occurs. 
   Thank you for your contributions.
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 6


### PR DESCRIPTION
### Motivation and Context
As discussed on #10793 StaleBot there are a few fears of StaleBot misbehaving:
- Marking active issues as "Stale"
- Marking existing defects as "Stale"
- Creating spam when marking many issues at once

This PR is meant to alleviate some of those issues.
The goal was to find a middleground between #10793 (which basically disables the Bot for all defects) and the current "heavy garbage cleanup" where every issue is marked as stale if inactive.

The argument behind the StaleBot is still:
It's important for issues (including defects) to be reconfirmed once in a while, in this case once every year of inactivity.

However:
Some issues by their very nature seem to be inactive (and are hence marked as "stale") but are actually being worked on. We should at the very least make sure those issues are not marked as stale and it's unreasonable to expect people to reconfirm those every year.

For other issues everone with writeaccess can still override the Bot on a case-by-case basis. That is not going to change.
However: There might also be situations where maintainers don't notice important issues that require to be manually ignored by the bot, due to the automatic tagging on issue creation. It should be clear for maintainers which issues still require a (first) look.

### Description

- This PR adds a maximum of 6 StaleBot actions per hour.
If in the future many issues get stale, it at least spams the people involved in a more organic and managable fasion
- This PR excludes issues with a "Status: Work in Progress" tag from being marked as stale
The "Status: Work in Progress"  tag is exclusively added to issues that are actually being worked on, but just take a lot of time. If a issue is being worked on, it's definately an active issue and should not be marked as stale.
- This PR excludes issues attached to a project from being marked "stale"
We can expect issues attached to a project to be worked on or at least be an existing issue. These shouldn't be closed even though they appear inactive.
- This PR excludes issues with someone assigned from being marker "stale"
If a maintainer (or someone with write access) is assigned, it's their responsibility to make sure the issue is still actually valid and close it if it's not. Bots should not mess with issues where someone is assignened to manage it.
- This PR excludes issues added to a milestone from being marker "stale"
While we don't actively use milestones, it's inline with the previous things being ignored not to mark these as "stale"
- This PR renames the 'Exclude from StaleBot' tag from "Type: Understood" to "Bot: Not Stale"
The "understood" status is confusing, because it's just a stalebot override and doesn't mean anything about the issue itself. (Not every issue that is understood should be ignored by the Bot and not every issue that should be ignored by the bot is Understood), "Bot: Not Stale" is a lot more clear: It's just about the bot and just about the issue not being marked as stale. It does what it says on the package.
- This PR adds a tag "Status: Triage Needed" to all new "Type: Defect" issues
This PR adds a "Status: Triage Needed" to all new defects, to make clear they need a Maintainer to look at them. This makes sure every issue that requires it gets the attention it needs.

This solves everything in the Bot config related to #10793 which doesn't directly mean disabling the bot for all (defect) issues.

### How Has This Been Tested?
- By the bot developers, it's their config settings at work here

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #10793
Closes #10802

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style