### PR TITLE
module/zstd: pass -U__BMI__

### DIFF
--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -356,4 +356,4 @@ CFLAGS.zil.c= -Wno-cast-qual
 CFLAGS.zio.c= -Wno-cast-qual
 CFLAGS.zrlock.c= -Wno-cast-qual
 CFLAGS.zfs_zstd.c= -Wno-cast-qual -Wno-pointer-arith
-CFLAGS.zstd.c= -fno-tree-vectorize
+CFLAGS.zstd.c= -fno-tree-vectorize -U__BMI__

--- a/module/zstd/Makefile.in
+++ b/module/zstd/Makefile.in
@@ -20,6 +20,9 @@ ccflags-y += -O3
 # Set it for other compilers, too.
 $(obj)/lib/zstd.o: c_flags += -fno-tree-vectorize
 
+# SSE register return with SSE disabled if -march=znverX is passed
+$(obj)/lib/zstd.o: c_flags += -U__BMI__
+
 # Quiet warnings about frame size due to unused code in unmodified zstd lib
 $(obj)/lib/zstd.o: c_flags += -Wframe-larger-than=20480
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix for https://github.com/openzfs/zfs/issues/10758
if kernel is compiled with `-march=znver1` or `-march=znver2` zstd module compilation will fail due to SSE register return with SSE disabled.
what's interesting, is that `-march=skylake` also implies `-mbmi` which defines `__BMI__` but compilation succeeds.
It is probably due to different BMI implementations on AMD and INTEL processors and the way compiler uses instructions.

### Description
<!--- Describe your changes in detail -->
pass `-U__BMI__` while compiling zstd.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

build-tested. error is gone. I can't actually run this as I don't have AMD ZEN CPU hardware.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
