### PR TITLE
Linux 5.9 compat: NR_SLAB_RECLAIMABLE

### DIFF
--- a/config/kernel-global_page_state.m4
+++ b/config/kernel-global_page_state.m4
@@ -94,9 +94,6 @@ AC_DEFUN([ZFS_AC_KERNEL_GLOBAL_ZONE_PAGE_STATE_SANITY], [
 	ZFS_AC_KERNEL_GLOBAL_PAGE_STATE_ENUM_CHECK([NR_FILE_PAGES])
 	ZFS_AC_KERNEL_GLOBAL_PAGE_STATE_ENUM_CHECK([NR_INACTIVE_ANON])
 	ZFS_AC_KERNEL_GLOBAL_PAGE_STATE_ENUM_CHECK([NR_INACTIVE_FILE])
-    AS_IF([test -z "$ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B"],[
-	    ZFS_AC_KERNEL_GLOBAL_PAGE_STATE_ENUM_CHECK([NR_SLAB_RECLAIMABLE])
-    ])
 
 	AC_MSG_RESULT(yes)
 ])
@@ -119,18 +116,12 @@ AC_DEFUN([ZFS_AC_KERNEL_GLOBAL_PAGE_STATE], [
 	    [node_stat_item], [$LINUX/include/linux/mmzone.h])
 	ZFS_AC_KERNEL_ENUM_MEMBER([NR_INACTIVE_FILE],
 	    [node_stat_item], [$LINUX/include/linux/mmzone.h])
-	ZFS_AC_KERNEL_ENUM_MEMBER([NR_SLAB_RECLAIMABLE],
-	    [node_stat_item], [$LINUX/include/linux/mmzone.h])
-	ZFS_AC_KERNEL_ENUM_MEMBER([NR_SLAB_RECLAIMABLE_B],
-	    [node_stat_item], [$LINUX/include/linux/mmzone.h])
 
 	ZFS_AC_KERNEL_ENUM_MEMBER([NR_FILE_PAGES],
 	    [zone_stat_item], [$LINUX/include/linux/mmzone.h])
 	ZFS_AC_KERNEL_ENUM_MEMBER([NR_INACTIVE_ANON],
 	    [zone_stat_item], [$LINUX/include/linux/mmzone.h])
 	ZFS_AC_KERNEL_ENUM_MEMBER([NR_INACTIVE_FILE],
-	    [zone_stat_item], [$LINUX/include/linux/mmzone.h])
-	ZFS_AC_KERNEL_ENUM_MEMBER([NR_SLAB_RECLAIMABLE],
 	    [zone_stat_item], [$LINUX/include/linux/mmzone.h])
 
 	ZFS_AC_KERNEL_GLOBAL_ZONE_PAGE_STATE_SANITY

--- a/include/os/linux/kernel/linux/page_compat.h
+++ b/include/os/linux/kernel/linux/page_compat.h
@@ -35,16 +35,6 @@
 #else
 #define	nr_inactive_file_pages() global_zone_page_state(NR_INACTIVE_FILE)
 #endif
-#if	defined(ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B)
-#define	nr_slab_reclaimable_pages() \
-	global_node_page_state(NR_SLAB_RECLAIMABLE_B)
-#else
-#if	defined(ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE)
-#define	nr_slab_reclaimable_pages() global_node_page_state(NR_SLAB_RECLAIMABLE)
-#else
-#define	nr_slab_reclaimable_pages() global_zone_page_state(NR_SLAB_RECLAIMABLE)
-#endif
-#endif
 
 #elif	defined(ZFS_GLOBAL_NODE_PAGE_STATE)
 
@@ -64,16 +54,6 @@
 #else
 #define	nr_inactive_file_pages() global_page_state(NR_INACTIVE_FILE)
 #endif
-#if	defined(ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B)
-#define	nr_slab_reclaimable_pages() \
-	global_node_page_state(NR_SLAB_RECLAIMABLE_B)
-#else
-#if	defined(ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE)
-#define	nr_slab_reclaimable_pages() global_node_page_state(NR_SLAB_RECLAIMABLE)
-#else
-#define	nr_slab_reclaimable_pages() global_page_state(NR_SLAB_RECLAIMABLE)
-#endif
-#endif
 
 #else
 
@@ -81,11 +61,6 @@
 #define	nr_file_pages()			global_page_state(NR_FILE_PAGES)
 #define	nr_inactive_anon_pages()	global_page_state(NR_INACTIVE_ANON)
 #define	nr_inactive_file_pages()	global_page_state(NR_INACTIVE_FILE)
-#ifdef ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B
-#define	nr_slab_reclaimable_pages()	global_page_state(NR_SLAB_RECLAIMABLE_B)
-#else
-#define	nr_slab_reclaimable_pages()	global_page_state(NR_SLAB_RECLAIMABLE)
-#endif /* ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B */
 
 #endif /* ZFS_GLOBAL_ZONE_PAGE_STATE */
 

--- a/include/os/linux/spl/sys/vmsystm.h
+++ b/include/os/linux/spl/sys/vmsystm.h
@@ -47,17 +47,6 @@
 
 #define	membar_producer()		smp_wmb()
 #define	physmem				zfs_totalram_pages
-#ifdef ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B
-#define	freemem			(nr_free_pages() + \
-				global_page_state(NR_INACTIVE_FILE) + \
-				global_page_state(NR_INACTIVE_ANON) + \
-				global_page_state(NR_SLAB_RECLAIMABLE_B))
-#else
-#define	freemem			(nr_free_pages() + \
-				global_page_state(NR_INACTIVE_FILE) + \
-				global_page_state(NR_INACTIVE_ANON) + \
-				global_page_state(NR_SLAB_RECLAIMABLE))
-#endif /* ZFS_ENUM_NODE_STAT_ITEM_NR_SLAB_RECLAIMABLE_B */
 
 #define	xcopyin(from, to, size)		copy_from_user(to, from, size)
 #define	xcopyout(from, to, size)	copy_to_user(to, from, size)

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -113,8 +113,7 @@ arc_free_memory(void)
 	return (ptob(si.freeram - si.freehigh));
 #else
 	return (ptob(nr_free_pages() +
-	    nr_inactive_file_pages() +
-	    nr_slab_reclaimable_pages()));
+	    nr_inactive_file_pages()));
 #endif /* CONFIG_HIGHMEM */
 }
 


### PR DESCRIPTION
### Motivation and Context

Fix the arc_free_memory() calculation when using a 5.9 kernel with ZFS.  The
following VM_WARN_ON_ONCE is hit when loading the kmods.

```
static inline unsigned long global_node_page_state(enum node_stat_item item)
{       
        VM_WARN_ON_ONCE(vmstat_item_in_bytes(item));
        return global_node_page_state_pages(item);
}
```

### Description

Commit dcdc12e added compatibility code to treat NR_SLAB_RECLAIMABLE_B
as if it were the same as NR_SLAB_RECLAIMABLE.  However, the new value
is in bytes while the old value was in pages which means they are not
interchangeable.

The only place the reclaimable slab size is used is as a component of
the calculation done by arc_free_memory().  This function returns the
amount of memory the ARC considers to be free or reclaimable at little
cost.  Rather than switch to a new interface to get this value it has
been removed it from the calculation.  It is normally a minor component
compared to the number of inactive or free pages, and removing it
aligns the behavior with the FreeBSD version of arc_free_memory().

### How Has This Been Tested?

Compiled against the 5.9-rc2 kernel on Fedora 32, verified the
warning was not printed and that the ARC free memory reported
was as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
