### PR TITLE
FreeBSD: Clean up some jail <-> zone translations

### DIFF
--- a/include/os/freebsd/spl/sys/cred.h
+++ b/include/os/freebsd/spl/sys/cred.h
@@ -93,7 +93,7 @@ extern cred_t *zone_kcred(void);
 extern gid_t crgetrgid(const cred_t *);
 extern gid_t crgetsgid(const cred_t *);
 
-#define	crgetzoneid(x) (0)
+#define	crgetzoneid(cr) ((cr)->cr_prison->pr_id)
 extern projid_t crgetprojid(const cred_t *);
 
 extern cred_t *crgetmapped(const cred_t *);

--- a/include/os/freebsd/spl/sys/zone.h
+++ b/include/os/freebsd/spl/sys/zone.h
@@ -29,6 +29,8 @@
 #ifndef _OPENSOLARIS_SYS_ZONE_H_
 #define	_OPENSOLARIS_SYS_ZONE_H_
 
+#include <sys/jail.h>
+
 /*
  * Macros to help with zone visibility restrictions.
  */
@@ -36,12 +38,9 @@
 #define	GLOBAL_ZONEID	0
 
 /*
- * Is thread in the global zone?
+ * Is proc in the global zone?
  */
-#define	INGLOBALZONE(p)	in_globalzone((p))
-
-
-extern boolean_t in_globalzone(struct proc *);
+#define	INGLOBALZONE(proc)	(!jailed((proc)->p_ucred))
 
 /*
  * Attach the given dataset to the given jail.

--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -27,7 +27,6 @@ USER_C = \
 	strlcat.c \
 	strlcpy.c \
 	timestamp.c \
-	zone.c \
 	include/sys/list.h \
 	include/sys/list_impl.h
 
@@ -35,7 +34,8 @@ if BUILD_LINUX
 USER_C += \
 	os/linux/getexecname.c \
 	os/linux/gethostid.c \
-	os/linux/getmntany.c
+	os/linux/getmntany.c \
+	os/linux/zone.c
 endif
 
 if BUILD_FREEBSD
@@ -43,7 +43,8 @@ USER_C += \
 	os/freebsd/getexecname.c \
 	os/freebsd/gethostid.c \
 	os/freebsd/getmntany.c \
-	os/freebsd/mnttab.c
+	os/freebsd/mnttab.c \
+	os/freebsd/zone.c
 endif
 
 libspl_la_SOURCES = \

--- a/lib/libspl/include/zone.h
+++ b/lib/libspl/include/zone.h
@@ -26,25 +26,16 @@
 #ifndef _LIBSPL_ZONE_H
 #define	_LIBSPL_ZONE_H
 
-
-
 #include <sys/types.h>
 #include <sys/zone.h>
-#include <sys/priv.h>
 
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
 #define	GLOBAL_ZONEID		0
-#define	GLOBAL_ZONEID_NAME	"global"
 
-/*
- * Functions for mapping between id and name for active zones.
- */
 extern zoneid_t		getzoneid(void);
-extern zoneid_t		getzoneidbyname(const char *);
-extern ssize_t		getzonenamebyid(zoneid_t, char *, size_t);
 
 #ifdef	__cplusplus
 }

--- a/lib/libspl/os/freebsd/zone.c
+++ b/lib/libspl/os/freebsd/zone.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2007 Pawel Jakub Dawidek <pjd@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <zone.h>
+
+zoneid_t
+getzoneid(void)
+{
+	size_t size;
+	int jailid;
+
+	/* Information that we are in jail or not is enough for our needs. */
+	size = sizeof (jailid);
+	if (sysctlbyname("security.jail.jailed", &jailid, &size, NULL, 0) == -1)
+		assert(!"No security.jail.jailed sysctl!");
+	return ((zoneid_t)jailid);
+}

--- a/lib/libspl/os/linux/zone.c
+++ b/lib/libspl/os/linux/zone.c
@@ -24,40 +24,9 @@
  */
 
 #include <zone.h>
-#include <string.h>
-#include <errno.h>
 
 zoneid_t
 getzoneid()
 {
 	return (GLOBAL_ZONEID);
-}
-
-zoneid_t
-getzoneidbyname(const char *name)
-{
-	if (name == NULL)
-		return (GLOBAL_ZONEID);
-
-	if (strcmp(name, GLOBAL_ZONEID_NAME) == 0)
-		return (GLOBAL_ZONEID);
-
-	return (EINVAL);
-}
-
-ssize_t
-getzonenamebyid(zoneid_t id, char *buf, size_t buflen)
-{
-	if (id != GLOBAL_ZONEID)
-		return (EINVAL);
-
-	ssize_t ret = strlen(GLOBAL_ZONEID_NAME) + 1;
-
-	if (buf == NULL || buflen == 0)
-		return (ret);
-
-	strncpy(buf, GLOBAL_ZONEID_NAME, buflen);
-	buf[buflen - 1] = '\0';
-
-	return (ret);
 }

--- a/module/os/freebsd/spl/spl_zone.c
+++ b/module/os/freebsd/spl/spl_zone.c
@@ -242,12 +242,6 @@ zone_get_hostid(void *ptr)
 	return ((uint32_t)curthread->td_ucred->cr_prison->pr_hostid);
 }
 
-boolean_t
-in_globalzone(struct proc *p)
-{
-	return (!jailed(FIRST_THREAD_IN_PROC((p))->td_ucred));
-}
-
 static void
 zone_sysinit(void *arg __unused)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous ZFS implementation on FreeBSD had ifdefs to use jailed()
instead of crgetzoneid() in dsl_dir.c, however we can simply provide an
appropriate definition of crgetzoneid for the same effect. Currently we
treat every process as if it were in the global zone, so this change fixes
a bug.

---

FreeBSD's previous ZFS implemented INGLOBALZONE(thread) as
(!jailed((thread)->td_ucred)) and passed curthread to INGLOBALZONE.

We pass curproc instead of curthread, so we can achieve the same effect
with (!jailed((proc)->p_ucred)).  The implementation is trivial enough
to fit on a single line in a define.  We don't really need a whole
separate function for something that's already macros all the way down.

---

FreeBSD has the concept of jails, a precursor to Solaris's zones, which
can be mapped to the required zones interface with relative ease.  The
previous ZFS implementation in FreeBSD did so, and we should continue
to provide an appropriate implementation in OpenZFS as well.

### Description
<!--- Describe your changes in detail -->
Define crgetzoneid(cr) as (cr->cr_prison->pr_id).

---

Eliminate in_globalzone.

---

Move lib/libspl/zone.c into platform code and adopt the correct
implementation for FreeBSD.

While here, prune unused code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Compiled and ran ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
