### PR TITLE
Project Structure Rework (documentation, commits, branching, versioning)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,7 +126,7 @@ feature needed?  What problem does it solve?
 
 #### General
 
-* All pull requests, except backports and releases, must be based on the current master branch 
+* All pull requests, except backports and releases, must be based on the current dev branch 
 and should apply without conflicts.
 * Please attempt to limit pull requests to a single commit which resolves
 one specific issue.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -207,9 +207,10 @@ git config --local core.whitespace trailing-space,space-before-tab,indent-with-n
 
 ### Commit Message Formats
 #### New Changes
-Commit messages for new changes must meet the following guidelines:
-* In 72 characters or less, provide a summary of the change as the
+Commit messages for new changes must meet the [Conventional Commits](https://www.conventionalcommits.org/) guidelines:
+* In 72 characters or less, excluding the `type:` prefix, provide a summary of the change as the
 first line in the commit message.
+* Every header should contain a `type:` prefix. See the [Commit Types](#commit-types) section for more information
 * A body which provides a description of the change. If necessary,
 please summarize important information such as why the proposed
 approach was chosen or a brief description of the bug you are resolving.
@@ -220,7 +221,7 @@ Each line of the body must be 72 characters or less.
 An example commit message for new changes is provided below.
 
 ```
-This line is a brief summary of your change
+docs: This line is a brief summary of your change
 
 Please provide at least a couple sentences describing the
 change. If necessary, please summarize decisions such as
@@ -235,7 +236,7 @@ If you are submitting a fix to a
 [Coverity defect](https://scan.coverity.com/projects/zfsonlinux-zfs),
 the commit message should meet the following guidelines:
 * Provides a subject line in the format of
-`Fix coverity defects: CID dddd, dddd...` where `dddd` represents
+`coverity: CID dddd, dddd...` where `dddd` represents
 each CID fixed by the commit.
 * Provides a body which lists each Coverity defect and how it was corrected.
 * The last line must be a `Signed-off-by:` tag. See the
@@ -243,7 +244,7 @@ each CID fixed by the commit.
 
 An example Coverity defect fix commit message is provided below.
 ```
-Fix coverity defects: CID 12345, 67890
+coverity: CID 12345, 67890
 
 CID 12345: Logically dead code (DEADCODE)
 
@@ -256,6 +257,21 @@ Ensure free is called after allocating memory in function().
 
 Signed-off-by: Contributor <contributor@email.com>
 ```
+
+#### Commit Types
+OpenZFS commit types to differentiate between different types of commits.
+Every commit should include a type prefix in its header. Possible types:
+
+- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests
+- **coverity**: Fixing a coverity defect. See: [Coverity Defect Fixes](#coverity-defect-fixes)
 
 #### Signed Off By
 A line tagged as `Signed-off-by:` must contain the developer's

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -260,18 +260,46 @@ Signed-off-by: Contributor <contributor@email.com>
 
 #### Commit Types
 OpenZFS commit types to differentiate between different types of commits.
-Every commit should include a type prefix in its header. Possible types:
+Every commit should include a type prefix in its header. Each type also refers to a specific versioning change, see [Versioning](#versioning) for more information
 
+Possible types, grouped by version change:
+
+**Major:**
+- None.
+
+**Minor:**
+- **feat**: A new feature
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+
+**Patch:**
 - **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 - **docs**: Documentation only changes
-- **feat**: A new feature
 - **fix**: A bug fix
 - **perf**: A code change that improves performance
-- **refactor**: A code change that neither fixes a bug nor adds a feature
 - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - **test**: Adding missing tests or correcting existing tests
 - **coverity**: Fixing a coverity defect. See: [Coverity Defect Fixes](#coverity-defect-fixes)
+
+#### Versioning
+OpenZFS uses semantic versioning where possible. This means versioning follows the following format:
+`Major.Mionor.Patch`
+
+**Major:**
+A breaking or very big change. Considering OpenZFS has strict backwards compatibility, these are almost never used.
+
+**Minor:**
+A change that introduces new features or significant code changes. Mostly user-facing changes or changes that could significantly change how the user experiences the software
+
+**Patch:**
+A small change that would not be actively noticed by most users. Often a bugfix, an addition to the test suite, removing typo's, update to documentation etc.
+
+##### Versioning and Commits
+As stated under [Commit Types](#commit-types), every commit type is linked to a specific versioning change. However: the commit with the highest versioning "level" in a release, dictates what next version is going to be.
+For example: if the previous release is 1.2.3 and a new release adds 6 fixes and 1 feature, next release level would be 1.3.0
+
+##### Versioning and backporting
+Only *patch* commits qualify to be backported. However: Backporting *patch* commits is decided on a case-by-case basis. Something being a patch, does not guarantee approval to be backported.
 
 #### Signed Off By
 A line tagged as `Signed-off-by:` must contain the developer's

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: OpenZFS Community Support Mailing list (Linux)
-    url: https://zfsonlinux.topicbox.com/groups/zfs-discuss
-    about: Get community support for OpenZFS on Linux
-  - name: FreeBSD Community Support Mailing list
-    url: https://lists.freebsd.org/mailman/listinfo/freebsd-fs
-    about: Get community support for OpenZFS on FreeBSD
+  - name: OpenZFS Community Support Mailing list
+    url: https://openzfs.topicbox.com/groups/discuss
+    about: Get community support for OpenZFS
   - name: OpenZFS on IRC
     url: https://webchat.freenode.net/#openzfs
     about: Use IRC to get community support for OpenZFS

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 REF="HEAD"
+types=(build chore ci docs feat fix perf refactor revert style coverity test)
 
 # test a url
 function test_url()
@@ -68,6 +69,11 @@ function check_tagged_line_with_url()
 function new_change_commit()
 {
     error=0
+    type_subject=$(git log -n 1 --pretty=%s "$REF" | cut -d: -f1)
+	# shellcheck disable=SC2076
+	[[ " ${types[*]} " =~ " ${type_subject} " ]] && error=0 || error=1; \
+	echo "error: ${type_subject} is not a valid subject type"
+
 
     # subject is not longer than 72 characters
     long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{73}')
@@ -106,7 +112,7 @@ function coverity_fix_commit()
 
     # subject starts with Fix coverity defects: CID dddd, dddd...
     subject=$(git log -n 1 --pretty=%s "$REF" |
-        grep -E -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
+        grep -E -m 1 'coverity: CID [[:digit:]]+(, [[:digit:]]+)*')
     if [ -z "$subject" ]; then
         echo "error: Coverity defect fixes must have a subject line that starts with \"Fix coverity defects: CID dddd\""
         error=1


### PR DESCRIPTION
### Motivation, Context and Description
There are a lot of legacy inefficiencies in the current OpenZFS project structure.

In the past weeks i've submitted a number of automation reworks, but working on those a lot more came to light and it isn't feasable to create seperate PR's for every little change. I also came to the conclusion that some of the changes that are required are only relevant if seen in the context of a bigger picture, which was often lacking.

This PR is focussed on documenting and restructuringa lot of these issues.
It has not been squashed on purpose, to clearly seperate commits by purpose.

One of the side goals is to not increase the amount of effort or rules for users and maintainers significantly

### Change shortlist:
- Remove OpenZFS Ports section from Contribution Guidelines
- Remove OpenZFS Ports section from stylechecks
- Redesign repo branching guidelines (#10849)
- Document branching structure in contribution guidelines (#10849)
- Add Mailinglist and IRQ links to issues creator
- Disable link to blank-issue creation on issue creator
- Make the Contribution Guidelines compatible with [Conventional Commits](https://www.conventionalcommits.org/) (#10852)
- Add commit types to Contribution Guidelines (#10852)
- Have stylechecks utilise types from [Conventional Commits](https://www.conventionalcommits.org/)
- Adapt Coverity Fixes guidelines to comply with [Conventional Commits](https://www.conventionalcommits.org/)
- Link commit types to semantic versioning (#10334)
- Describe versioning procedure (#10334)
- Describe backport procedure and limits (#10334)

### Pre-merge requirements from maintainers:
This section lists things the maintainers need to add/change before this should be merged. Those aren't supposed to be big changes, but just things we can't fix with a PR.

- Requires the main branch to be renamed to dev (#10849)
- Requires a release branch to be created based on last release (#10849)
- Requires a staging branch to be created based on 2.0 RC1 (#10849)
- Requires opening a OpenZFS discuss mailinglist (#10845)

### How Has This Been Tested?
- The stylecheck changes has been tested by the CI
- The issue creator changes have been tested in a seperate repo

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #10845
Closes #10849
Closes #10852
Closes #10334
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style