### PR TITLE
Fixes for running FreeBSD buildworld on Linux/macOS hosts

### DIFF
--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -206,8 +206,10 @@ typedef int enum_t;
 #define	__XSI_VISIBLE 1000
 #endif
 #define	ARRAY_SIZE(a) (sizeof (a) / sizeof (a[0]))
-#define	open64 open
 #define	mmap64 mmap
+/* Note: this file can be used on linux/macOS when bootstrapping tools. */
+#if defined(__FreeBSD__)
+#define	open64 open
 #define	pwrite64 pwrite
 #define	ftruncate64 ftruncate
 #define	lseek64 lseek
@@ -217,6 +219,7 @@ typedef int enum_t;
 #define	statfs64 statfs
 #define	readdir64 readdir
 #define	dirent64 dirent
+#endif
 #define	P2ALIGN(x, align)		((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
 #define	P2ROUNDUP(x, align)		((((x) - 1) | ((align) - 1)) + 1)

--- a/lib/libspl/include/os/freebsd/sys/stat.h
+++ b/lib/libspl/include/os/freebsd/sys/stat.h
@@ -28,6 +28,8 @@
 
 #include_next <sys/stat.h>
 
+/* Note: this file can be used on linux/macOS when bootstrapping tools. */
+#if defined(__FreeBSD__)
 #include <sys/mount.h> /* for BLKGETSIZE64 */
 
 #define	stat64	stat
@@ -68,4 +70,5 @@ fstat64_blk(int fd, struct stat64 *st)
 
 	return (0);
 }
+#endif /* defined(__FreeBSD__) */
 #endif /* _LIBSPL_SYS_STAT_H */


### PR DESCRIPTION
# Motivation and Context
This change is required to allow FreeBSD buildworld to succeed after the OpenZFS import.

### Description
Adding an `#ifdef __FreeBSD__` to a FreeBSD-specific header may seem odd, but
these headers are used on non-FreeBSD systems during the bootstrap tools
phase.
Originally submitted downstream as https://reviews.freebsd.org/D26193

### How Has This Been Tested?
FreeBSD buildworld on macOS and Linux fails without this change, succeeds after this and the remaining build system changes from https://reviews.freebsd.org/D26193 are applied.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
