### PR TITLE
Fix -Werror,-Wmacro-redefined in limits.h

### DIFF
--- a/lib/libspl/include/limits.h
+++ b/lib/libspl/include/limits.h
@@ -25,16 +25,21 @@
  */
 
 #include_next <limits.h>
+#include <float.h>
 
 #ifndef _LIBSPL_LIMITS_H
 #define	_LIBSPL_LIMITS_H
 
+#ifndef DBL_DIG
 #define	DBL_DIG		15
 #define	DBL_MAX		1.7976931348623157081452E+308
 #define	DBL_MIN		2.2250738585072013830903E-308
+#endif
 
+#ifndef FLT_DIG
 #define	FLT_DIG		6
 #define	FLT_MAX		3.4028234663852885981170E+38F
 #define	FLT_MIN		1.1754943508222875079688E-38F
+#endif
 
 #endif /* _LIBSPL_LIMITS_H */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
FreeBSD buildworld with CROSS_TOOLCHAIN=llvm10 fails without this change.
Originally submitted downstream as https://reviews.freebsd.org/D26196

### Description
Those macros are also defined by the compiler-provided float.h which
will be included later on (at least in the FreeBSD buildworld case) and
triggers these -Werror warnings. Including <float.h> first and only
defining the macros when DBL_DIG/FLT_DIG is missing fixes this problem.

### How Has This Been Tested?
FreeBSD `make buildworld CROSS_TOOLCHAIN=llvm10` fails without this change, succeeds with it applied.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
