### PR TITLE
Fix stack frame sizes in 3 functions

### DIFF
--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1078,6 +1078,8 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 		dsl_pool_rele(dp, FTAG);
 		kmem_free(newredactbook,
 		    sizeof (char) * ZFS_MAX_DATASET_NAME_LEN);
+		if (args != NULL)
+			kmem_free(args, numsnaps * sizeof (*args));
 		return (SET_ERROR(ENAMETOOLONG));
 	}
 	err = dsl_bookmark_lookup(dp, newredactbook, NULL, &bookmark);

--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1006,9 +1006,13 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 	objset_t *os;
 	struct redact_thread_arg *args = NULL;
 	redaction_list_t *new_rl = NULL;
+	char *newredactbook;
 
 	if ((err = dsl_pool_hold(snapname, FTAG, &dp)) != 0)
 		return (err);
+
+	newredactbook = kmem_zalloc(sizeof (char) * ZFS_MAX_DATASET_NAME_LEN,
+	    KM_SLEEP);
 
 	if ((err = dsl_dataset_hold_flags(dp, snapname, DS_HOLD_FLAG_DECRYPT,
 	    FTAG, &ds)) != 0) {
@@ -1063,7 +1067,6 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 		goto out;
 
 	boolean_t resuming = B_FALSE;
-	char newredactbook[ZFS_MAX_DATASET_NAME_LEN];
 	zfs_bookmark_phys_t bookmark;
 
 	(void) strlcpy(newredactbook, snapname, ZFS_MAX_DATASET_NAME_LEN);
@@ -1073,6 +1076,8 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 	    "#%s", redactbook);
 	if (n >= ZFS_MAX_DATASET_NAME_LEN - (c - newredactbook)) {
 		dsl_pool_rele(dp, FTAG);
+		kmem_free(newredactbook,
+		    sizeof (char) * ZFS_MAX_DATASET_NAME_LEN);
 		return (SET_ERROR(ENAMETOOLONG));
 	}
 	err = dsl_bookmark_lookup(dp, newredactbook, NULL, &bookmark);
@@ -1145,16 +1150,23 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 		(void) thread_create(NULL, 0, redact_traverse_thread, rta,
 		    0, curproc, TS_RUN, minclsyspri);
 	}
-	struct redact_merge_thread_arg rmta = { { {0} } };
-	(void) bqueue_init(&rmta.q, zfs_redact_queue_ff,
+
+	struct redact_merge_thread_arg *rmta;
+	rmta = kmem_zalloc(sizeof (struct redact_merge_thread_arg), KM_SLEEP);
+
+	(void) bqueue_init(&rmta->q, zfs_redact_queue_ff,
 	    zfs_redact_queue_length, offsetof(struct redact_record, ln));
-	rmta.numsnaps = numsnaps;
-	rmta.spa = os->os_spa;
-	rmta.thr_args = args;
-	(void) thread_create(NULL, 0, redact_merge_thread, &rmta, 0, curproc,
+	rmta->numsnaps = numsnaps;
+	rmta->spa = os->os_spa;
+	rmta->thr_args = args;
+	(void) thread_create(NULL, 0, redact_merge_thread, rmta, 0, curproc,
 	    TS_RUN, minclsyspri);
-	err = perform_redaction(os, new_rl, &rmta);
+	err = perform_redaction(os, new_rl, rmta);
+	kmem_free(rmta, sizeof (struct redact_merge_thread_arg));
+
 out:
+	kmem_free(newredactbook, sizeof (char) * ZFS_MAX_DATASET_NAME_LEN);
+
 	if (new_rl != NULL) {
 		dsl_redaction_list_long_rele(new_rl, FTAG);
 		dsl_redaction_list_rele(new_rl, FTAG);


### PR DESCRIPTION
### Motivation and Context

When configuring OpenZFS with `--enable-debug` on Linux, three functions in total exceed the maximum stack frame size and the compilation fails with an appropriate error.


### Description
This PR are 3 commits changing functions `dmu_redact_snap`, `dnode_dirty_l1range` and `spa_livelist_delete_cb`, in order as they pop up with make after `--enable-debug`. The `dnode_dirty_l1range` function is changed only in debug mode so that performance isn't affected, the other two functions aren't called so often in most use-cases, so for readability I didn't #ifdef anything there.

### How Has This Been Tested?

Tested in regular development workflow, yet to be deployed in production, but these are simple changes; the question is, whether this is the best approach to reduce the stack sizes in those codepaths.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
