### PR TITLE
Retain thread name when resuming a zthr

### DIFF
--- a/module/zfs/zthr.c
+++ b/module/zfs/zthr.c
@@ -56,7 +56,7 @@
  *
  * == ZTHR creation
  *
- * Every zthr needs three inputs to start running:
+ * Every zthr needs four inputs to start running:
  *
  * 1] A user-defined checker function (checkfunc) that decides whether
  *    the zthr should start working or go to sleep. The function should
@@ -71,6 +71,9 @@
  *
  * 3] A void args pointer that will be passed to checkfunc and func
  *    implicitly by the infrastructure.
+ *
+ * 4] A name for the thread. This string must be valid for the lifetime
+ *    of the zthr.
  *
  * The reason why the above API needs two different functions,
  * instead of one that both checks and does the work, has to do with
@@ -221,6 +224,7 @@ struct zthr {
 	zthr_checkfunc_t	*zthr_checkfunc;
 	zthr_func_t	*zthr_func;
 	void		*zthr_arg;
+	const char	*zthr_name;
 };
 
 static void
@@ -296,6 +300,7 @@ zthr_create_timer(const char *zthr_name, zthr_checkfunc_t *checkfunc,
 	t->zthr_func = func;
 	t->zthr_arg = arg;
 	t->zthr_sleep_timeout = max_sleep;
+	t->zthr_name = zthr_name;
 
 	t->zthr_thread = thread_create_named(zthr_name, NULL, 0,
 	    zthr_procedure, t, 0, &p0, TS_RUN, minclsyspri);
@@ -422,8 +427,8 @@ zthr_resume(zthr_t *t)
 	 *     no-op.
 	 */
 	if (t->zthr_thread == NULL) {
-		t->zthr_thread = thread_create(NULL, 0, zthr_procedure, t,
-		    0, &p0, TS_RUN, minclsyspri);
+		t->zthr_thread = thread_create_named(t->zthr_name, NULL, 0,
+		    zthr_procedure, t, 0, &p0, TS_RUN, minclsyspri);
 	}
 
 	mutex_exit(&t->zthr_state_lock);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When created, a zthr is given a name to identify it by.  This name is
lost when a cancelled zthr is resumed.

### Description
<!--- Describe your changes in detail -->
Retain the name of a zthr so it can be used when resuming.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
`while :; do ps axH | grep zthr; done` to look for zthr_procedure while running tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
