### PR TITLE
draft: Reads from secondarycache=none datasets shouldn't count as l2arc misses.

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6281,8 +6281,8 @@ top:
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,
-    							  arc_buf_hdr_t *,
-    							  hdr);
+								    arc_buf_hdr_t *,
+								    hdr);
 					ARCSTAT_BUMP(arcstat_l2_misses);
 				}
 			}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6268,8 +6268,10 @@ top:
 		} else {
 			if (vd != NULL)
 				spa_config_exit(spa, SCL_L2ARC, vd);
-			/* If it wasn't even supposed to be in L2, that's
-			 * not a miss */
+			/*
+			 * If it wasn't even supposed to be in L2, that's
+			 * not a miss
+			 */
 			if (l2arc_ndev != 0 && HDR_L2CACHE(hdr)) {
 				/*
 				 * Skip ARC stat bump for block pointers
@@ -6279,7 +6281,8 @@ top:
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,
-								  arc_buf_hdr_t *, hdr);
+    							  arc_buf_hdr_t *,
+    							  hdr);
 					ARCSTAT_BUMP(arcstat_l2_misses);
 				}
 			}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6281,8 +6281,8 @@ top:
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,
-								    arc_buf_hdr_t *,
-								    hdr);
+					    arc_buf_hdr_t *,
+					    hdr);
 					ARCSTAT_BUMP(arcstat_l2_misses);
 				}
 			}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6281,8 +6281,8 @@ top:
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,
-								    arc_buf_hdr_t *,
-								    hdr);
+							    arc_buf_hdr_t *,
+							    hdr);
 					ARCSTAT_BUMP(arcstat_l2_misses);
 				}
 			}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6281,8 +6281,8 @@ top:
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,
-							    arc_buf_hdr_t *,
-							    hdr);
+								    arc_buf_hdr_t *,
+								    hdr);
 					ARCSTAT_BUMP(arcstat_l2_misses);
 				}
 			}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6167,7 +6167,7 @@ top:
 		}
 
 		if (vd != NULL && l2arc_ndev != 0 &&
-			HDR_L2CACHE(hdr) && !(l2arc_norw && devw)) {
+		    HDR_L2CACHE(hdr) && !(l2arc_norw && devw)) {
 			/*
 			 * Read from the L2ARC if the following are true:
 			 * 1. The L2ARC vdev was previously cached.
@@ -6268,12 +6268,14 @@ top:
 		} else {
 			if (vd != NULL)
 				spa_config_exit(spa, SCL_L2ARC, vd);
-			/* If it wasn't even supposed to be in L2, that's not a miss */
+			/* If it wasn't even supposed to be in L2, that's
+			 * not a miss */
 			if (l2arc_ndev != 0 && HDR_L2CACHE(hdr)) {
 				/*
-				 * Skip ARC stat bump for block pointers with
-				 * embedded data. The data are read from the blkptr
-				 * itself via decode_embedded_bp_compressed().
+				 * Skip ARC stat bump for block pointers
+				 * with embedded data. The data are read from
+				 * the blkptr itself via
+				 * decode_embedded_bp_compressed().
 				 */
 				if (!embedded_bp) {
 					DTRACE_PROBE1(l2arc__miss,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partial fix for #10913

### Description
<!--- Describe your changes in detail -->
This fixes l2arc miss accounting for reads from datasets with secondarycache!=all; a read for data which doesn't belong in l2arc doesn't count as an l2arc miss.  For accuracy this somewhat requires trusting that ARC_FLAG_L2CACHE is set correctly in buf->b_hdr or the fresh header created by read_arc() from *arc_flags.  This appears to be the case but I haven't fully eyeballed all the paths to arc_read().

This includes a change that also checks for ARC_FLAG_L2CACHE before even attempting a read from l2arc; I intended this as an optimization but it's also possibly a behavioural change so I'm not wed to it for this issue.

This is only a *partial* fix for #10913 because it doesn't improve mis-accounting when reading from a dataset with secondarycache!=none in a pool which doesn't actually have an l2arc, where there are other pools also on the system which do.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested with multiple pools on the system, some with l2arc and some not, and a mix of secondarycache settings across datasets on these pools.

Watching /proc/spl/kstat/zfs/arcstats with this PR I note that:
* L2 hits and misses still appear correctly accounted on a pool with l2arc and secondarycache!=none
* no L2 hit or miss accounting happens for secondarycache==none
* no L2 hit or miss accounting happens for pools which do not have an l2arc, but only if secondarycache==none on datasets on those pools.  This is an improvement over previous behavior but it shouldn't require secondarycache==none on non-l2arc pools for correct accounting, hence why this PR is only a partial fix.

<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu 18.04.05, Ubuntu HWE kernel 5.4.0-42-generic, git zfs zfs-2.0-release @ 8e7fe49b25d63e855a8d230d2775f99d722818ff + PR cherrypick.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
