### PR TITLE
contrib/initramfs: add shebang, fix resulting shellcheck errors

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -15,8 +15,8 @@
 # See "4.5 Disable root prompt on the initramfs" of Securing Debian Manual:
 # https://www.debian.org/doc/manuals/securing-debian-howto/ch4.en.html
 shell() {
-	if type panic > /dev/null 2>&1; then
-		panic $@
+	if command -v panic > /dev/null 2>&1; then
+		panic
 	else
 		/bin/sh
 	fi
@@ -26,22 +26,23 @@ shell() {
 # pools and mounting any filesystems.
 pre_mountroot()
 {
-	if type run_scripts > /dev/null 2>&1 && \
-	    [ -f "/scripts/local-top" -o -d "/scripts/local-top" ]
+	if command -v run_scripts > /dev/null 2>&1
 	then
-		[ "$quiet" != "y" ] && \
-		    zfs_log_begin_msg "Running /scripts/local-top"
-		run_scripts /scripts/local-top
-		[ "$quiet" != "y" ] && zfs_log_end_msg
-	fi
+		if [ -f "/scripts/local-top" ] || [ -d "/scripts/local-top" ]
+		then
+			[ "$quiet" != "y" ] && \
+			    zfs_log_begin_msg "Running /scripts/local-top"
+			run_scripts /scripts/local-top
+			[ "$quiet" != "y" ] && zfs_log_end_msg
+		fi
 
-	if type run_scripts > /dev/null 2>&1 && \
-	    [ -f "/scripts/local-premount" -o -d "/scripts/local-premount" ]
-	then
-		[ "$quiet" != "y" ] && \
-		    zfs_log_begin_msg "Running /scripts/local-premount"
-		run_scripts /scripts/local-premount
-		[ "$quiet" != "y" ] && zfs_log_end_msg
+	  if [ -f "/scripts/local-premount" ] || [ -d "/scripts/local-premount" ]
+	  then
+			[ "$quiet" != "y" ] && \
+			    zfs_log_begin_msg "Running /scripts/local-premount"
+			run_scripts /scripts/local-premount
+			[ "$quiet" != "y" ] && zfs_log_end_msg
+		fi
 	fi
 }
 
@@ -57,10 +58,10 @@ disable_plymouth()
 # Get a ZFS filesystem property value.
 get_fs_value()
 {
-	local fs="$1"
-	local value=$2
+	fs="$1"
+	value=$2
 
-	"${ZFS}" get -H -ovalue $value "$fs" 2> /dev/null
+	"${ZFS}" get -H -ovalue "$value" "$fs" 2> /dev/null
 }
 
 # Find the 'bootfs' property on pool $1.
@@ -68,7 +69,7 @@ get_fs_value()
 # pool by exporting it again.
 find_rootfs()
 {
-	local pool="$1"
+	pool="$1"
 
 	# If 'POOL_IMPORTED' isn't set, no pool imported and therefore
 	# we won't be able to find a root fs.
@@ -84,7 +85,7 @@ find_rootfs()
 
 	# Make sure it's not '-' and that it starts with /.
 	if [ "${ZFS_BOOTFS}" != "-" ] && \
-		$(get_fs_value "${ZFS_BOOTFS}" mountpoint | grep -q '^/$')
+		get_fs_value "${ZFS_BOOTFS}" mountpoint | grep -q '^/$'
 	then
 		# Keep it mounted
 		POOL_IMPORTED=1
@@ -101,14 +102,13 @@ find_rootfs()
 # Support function to get a list of all pools, separated with ';'
 find_pools()
 {
-	local CMD="$*"
-	local pools pool
+	CMD="$*"
 
 	pools=$($CMD 2> /dev/null | \
 		grep -E "pool:|^[a-zA-Z0-9]" | \
 		sed 's@.*: @@' | \
-		while read pool; do \
-		    echo -n "$pool;"
+		while read -r pool; do \
+		    printf "%s" "$pool;"
 		done)
 
 	echo "${pools%%;}" # Return without the last ';'.
@@ -117,8 +117,6 @@ find_pools()
 # Get a list of all available pools
 get_pools()
 {
-	local available_pools npools
-
 	if [ -n "${ZFS_POOL_IMPORT}" ]; then
 		echo "$ZFS_POOL_IMPORT"
 		return 0
@@ -159,9 +157,8 @@ get_pools()
 	# Filter out any exceptions...
 	if [ -n "$ZFS_POOL_EXCEPTIONS" ]
 	then
-		local found=""
-		local apools=""
-		local pool exception
+		found=""
+		apools=""
 		OLD_IFS="$IFS" ; IFS=";"
 
 		for pool in $available_pools
@@ -194,8 +191,7 @@ get_pools()
 # Import given pool $1
 import_pool()
 {
-	local pool="$1"
-	local dirs dir
+	pool="$1"
 
 	# Verify that the pool isn't already imported
 	# Make as sure as we can to not require '-f' to import.
@@ -205,7 +201,7 @@ import_pool()
 	# to something we can use later with the real import(s). We want to
 	# make sure we find all by* dirs, BUT by-vdev should be first (if it
 	# exists).
-	if [ -n "$USE_DISK_BY_ID" -a -z "$ZPOOL_IMPORT_PATH" ]
+	if [ -n "$USE_DISK_BY_ID" ] && [ -z "$ZPOOL_IMPORT_PATH" ]
 	then
 		dirs="$(for dir in $(echo /dev/disk/by-*)
 		do
@@ -213,7 +209,7 @@ import_pool()
 			echo "$dir" | grep -q /by-vdev && continue
 			[ ! -d "$dir" ] && continue
 
-			echo -n "$dir:"
+			printf "%s" "$dir:"
 		done | sed 's,:$,,g')"
 
 		if [ -d "/dev/disk/by-vdev" ]
@@ -277,7 +273,7 @@ import_pool()
 # with more logging etc.
 load_module_initrd()
 {
-	if [ "$ZFS_INITRD_PRE_MOUNTROOT_SLEEP" > 0 ]
+	if [ "$ZFS_INITRD_PRE_MOUNTROOT_SLEEP" -gt 0 ] 2>/dev/null
 	then
 		if [ "$quiet" != "y" ]; then
 			zfs_log_begin_msg "Sleeping for" \
@@ -288,9 +284,9 @@ load_module_initrd()
 	fi
 
 	# Wait for all of the /dev/{hd,sd}[a-z] device nodes to appear.
-	if type wait_for_udev > /dev/null 2>&1 ; then
+	if command -v wait_for_udev > /dev/null 2>&1 ; then
 		wait_for_udev 10
-	elif type wait_for_dev > /dev/null 2>&1 ; then
+	elif command -v wait_for_dev > /dev/null 2>&1 ; then
 		wait_for_dev
 	fi
 
@@ -300,7 +296,7 @@ load_module_initrd()
 	# Load the module
 	load_module "zfs" || return 1
 
-	if [ "$ZFS_INITRD_POST_MODPROBE_SLEEP" > 0 ]
+	if [ "$ZFS_INITRD_POST_MODPROBE_SLEEP" -gt 0 ] 2>/dev/null
 	then
 		if [ "$quiet" != "y" ]; then
 			zfs_log_begin_msg "Sleeping for" \
@@ -316,12 +312,10 @@ load_module_initrd()
 # Mount a given filesystem
 mount_fs()
 {
-	local fs="$1"
-	local mountpoint
+	fs="$1"
 
 	# Check that the filesystem exists
-	"${ZFS}" list -oname -tfilesystem -H "${fs}" > /dev/null 2>&1
-	[ "$?" -ne 0 ] && return 1
+	"${ZFS}" list -oname -tfilesystem -H "${fs}" > /dev/null 2>&1 ||  return 1
 
 	# Skip filesystems with canmount=off.  The root fs should not have
 	# canmount=off, but ignore it for backwards compatibility just in case.
@@ -333,14 +327,14 @@ mount_fs()
 
 	# Need the _original_ datasets mountpoint!
 	mountpoint=$(get_fs_value "$fs" mountpoint)
-	if [ "$mountpoint" = "legacy" -o "$mountpoint" = "none" ]; then
+	if [ "$mountpoint" = "legacy" ] || [ "$mountpoint" = "none" ]; then
 		# Can't use the mountpoint property. Might be one of our
 		# clones. Check the 'org.zol:mountpoint' property set in
 		# clone_snap() if that's usable.
 		mountpoint=$(get_fs_value "$fs" org.zol:mountpoint)
-		if [ "$mountpoint" = "legacy" -o \
-		    "$mountpoint" = "none" -o \
-		    "$mountpoint" = "-" ]
+		if [ "$mountpoint" = "legacy" ] ||
+		   [ "$mountpoint" = "none" ] ||
+		   [ "$mountpoint" = "-" ]
 		then
 			if [ "$fs" != "${ZFS_BOOTFS}" ]; then
 				# We don't have a proper mountpoint and this
@@ -396,10 +390,10 @@ mount_fs()
 # Unlock a ZFS native encrypted filesystem.
 decrypt_fs()
 {
-	local fs="$1"
-	
+	fs="$1"
+
 	# If pool encryption is active and the zfs command understands '-o encryption'
-	if [ "$(zpool list -H -o feature@encryption $(echo "${fs}" | awk -F\/ '{print $1}'))" = 'active' ]; then
+	if [ "$(zpool list -H -o feature@encryption "$(echo "${fs}" | awk -F/ '{print $1}')")" = 'active' ]; then
 
 		# Determine dataset that holds key for root dataset
 		ENCRYPTIONROOT="$(get_fs_value "${fs}" encryptionroot)"
@@ -427,7 +421,7 @@ decrypt_fs()
 					TRY_COUNT=$((TRY_COUNT - 1))
 				done
 
-			# Prompt with systemd, if active 
+			# Prompt with systemd, if active
 			elif [ -e /run/systemd/system ]; then
 				echo "systemd-ask-password" > /run/zfs_console_askpwd_cmd
 				while [ $TRY_COUNT -gt 0 ]; do
@@ -454,7 +448,7 @@ decrypt_fs()
 # Destroy a given filesystem.
 destroy_fs()
 {
-	local fs="$1"
+	fs="$1"
 
 	[ "$quiet" != "y" ] && \
 	    zfs_log_begin_msg "Destroying '$fs'"
@@ -489,9 +483,9 @@ destroy_fs()
 # mounted with a 'zfs mount -a' in the init/systemd scripts).
 clone_snap()
 {
-	local snap="$1"
-	local destfs="$2"
-	local mountpoint="$3"
+	snap="$1"
+	destfs="$2"
+	mountpoint="$3"
 
 	[ "$quiet" != "y" ] && zfs_log_begin_msg "Cloning '$snap' to '$destfs'"
 
@@ -529,7 +523,7 @@ clone_snap()
 # Rollback a given snapshot.
 rollback_snap()
 {
-	local snap="$1"
+	snap="$1"
 
 	[ "$quiet" != "y" ] && zfs_log_begin_msg "Rollback $snap"
 
@@ -559,9 +553,8 @@ rollback_snap()
 # to the user to choose from.
 ask_user_snap()
 {
-	local fs="$1"
-	local i=1
-	local SNAP snapnr snap debug
+	fs="$1"
+	i=1
 
 	# We need to temporarily disable debugging. Set 'debug' so we
 	# remember to enabled it again.
@@ -574,16 +567,16 @@ ask_user_snap()
 	# Because we need the resulting snapshot, which is sent on
 	# stdout to the caller, we use stderr for our questions.
 	echo "What snapshot do you want to boot from?" > /dev/stderr
-	while read snap; do
+	while read -r snap; do
 	    echo "  $i: ${snap}" > /dev/stderr
-	    eval `echo SNAP_$i=$snap`
+	    eval "$(echo SNAP_$i=$snap)"
 	    i=$((i + 1))
 	done <<EOT
 $("${ZFS}" list -H -oname -tsnapshot -r "${fs}")
 EOT
 
-	echo -n "  Snap nr [1-$((i-1))]? " > /dev/stderr
-	read snapnr
+	echo "%s" "  Snap nr [1-$((i-1))]? " > /dev/stderr
+	read -r snapnr
 
 	# Re-enable debugging.
 	if [ -n "${debug}" ]; then
@@ -591,16 +584,16 @@ EOT
 		set -x
 	fi
 
-	echo "$(eval echo "$"SNAP_$snapnr)"
+	echo "$(eval echo '$SNAP_'$snapnr)"
 }
 
 setup_snapshot_booting()
 {
-	local snap="$1"
-	local s destfs subfs mountpoint retval=0 filesystems fs
+	snap="$1"
+	retval=0
 
-	# Make sure that the snapshot specified actually exist.
-	if [ ! $(get_fs_value "${snap}" type) ]
+	# Make sure that the snapshot specified actually exists.
+	if [ ! "$(get_fs_value "${snap}" type)" ]
 	then
 		# Snapshot does not exist (...@<null> ?)
 		# ask the user for a snapshot to use.
@@ -617,7 +610,7 @@ setup_snapshot_booting()
 	then
 		# If the destination dataset for the clone
 		# already exists, destroy it. Recursively
-		if [ $(get_fs_value "${rootfs}_${snapname}" type) ]; then
+		if [ "$(get_fs_value "${rootfs}_${snapname}" type)" ]; then
 			filesystems=$("${ZFS}" list -oname -tfilesystem -H \
 			    -r -Sname "${ZFS_BOOTFS}")
 			for fs in $filesystems; do
@@ -652,8 +645,8 @@ setup_snapshot_booting()
 			# with clone_snap(). If legacy or none, then use
 			# the sub fs value.
 			mountpoint=$(get_fs_value "${s%%@*}" mountpoint)
-			if [ "$mountpoint" = "legacy" -o \
-			    "$mountpoint" = "none" ]
+			if [ "$mountpoint" = "legacy" ] || \
+			   [ "$mountpoint" = "none" ]
 			then
 				if [ -n "${subfs}" ]; then
 					mountpoint="${subfs}"
@@ -678,8 +671,6 @@ setup_snapshot_booting()
 # This is the main function.
 mountroot()
 {
-	local snaporig snapsub destfs pool POOLS
-
 	# ----------------------------------------------------------------
 	# I N I T I A L   S E T U P
 
@@ -742,7 +733,7 @@ mountroot()
 	# No longer set in the defaults file, but it could have been set in
 	# get_pools() in some circumstances. If it's something, but not 'yes',
 	# it's no good to us.
-	[ -n "$USE_DISK_BY_ID" -a "$USE_DISK_BY_ID" != 'yes' ] && \
+	[ -n "$USE_DISK_BY_ID" ] && [ "$USE_DISK_BY_ID" != 'yes' ] && \
 	    unset USE_DISK_BY_ID
 
 	# ----------------------------------------------------------------
@@ -788,12 +779,12 @@ mountroot()
 	# ------------
 	# If we have 'ROOT' (see above), but not 'ZFS_BOOTFS', then use
 	# 'ROOT'
-	[ -n "$ROOT" -a -z "${ZFS_BOOTFS}" ] && ZFS_BOOTFS="$ROOT"
+	[ -n "$ROOT" ] && [ -z "${ZFS_BOOTFS}" ] && ZFS_BOOTFS="$ROOT"
 
 	# ------------
 	# Check for the `-B zfs-bootfs=%s/%u,...` kind of parameter.
 	# NOTE: Only use the pool name and dataset. The rest is not
-	#       supported by ZoL (whatever it's for).
+	#       supported by OpenZFS (whatever it's for).
 	if [ -z "$ZFS_RPOOL" ]
 	then
 		# The ${zfs-bootfs} variable is set at the kernel command
@@ -809,11 +800,11 @@ mountroot()
 
 	# ------------
 	# No root fs or pool specified - do auto detect.
-	if [ -z "$ZFS_RPOOL" -a -z "${ZFS_BOOTFS}" ]
+	if [ -z "$ZFS_RPOOL" ] && [ -z "${ZFS_BOOTFS}" ]
 	then
 		# Do auto detect. Do this by 'cheating' - set 'root=zfs:AUTO'
 		# which will be caught later
-		ROOT=zfs:AUTO
+		ROOT='zfs:AUTO'
 	fi
 
 	# ----------------------------------------------------------------
@@ -858,7 +849,7 @@ mountroot()
 	fi
 
 	# Import the pool (if not already done so in the AUTO check above).
-	if [ -n "$ZFS_RPOOL" -a -z "${POOL_IMPORTED}" ]
+	if [ -n "$ZFS_RPOOL" ] && [ -z "${POOL_IMPORTED}" ]
 	then
 		[ "$quiet" != "y" ] && \
 		    zfs_log_begin_msg "Importing ZFS root pool '$ZFS_RPOOL'"
@@ -971,7 +962,7 @@ mountroot()
 
 	touch /run/zfs_unlock_complete
 	if [ -e /run/zfs_unlock_complete_notify ]; then
-		read zfs_unlock_complete_notify < /run/zfs_unlock_complete_notify
+		read -r zfs_unlock_complete_notify < /run/zfs_unlock_complete_notify
 	fi
 
 	# ------------
@@ -989,8 +980,8 @@ mountroot()
 		echo
 
 		echo "=> waiting for ENTER before continuing because of 'zfsdebug=1'. "
-		echo -n "   'c' for shell, 'r' for reboot, 'ENTER' to continue. "
-		read b
+		printf "%s" "   'c' for shell, 'r' for reboot, 'ENTER' to continue. "
+		read -r b
 
 		[ "$b" = "c" ] && /bin/sh
 		[ "$b" = "r" ] && reboot -f
@@ -1000,12 +991,14 @@ mountroot()
 
 	# ------------
 	# Run local bottom script
-	if type run_scripts > /dev/null 2>&1 && \
-	    [ -f "/scripts/local-bottom" -o -d "/scripts/local-bottom" ]
+	if command -v run_scripts > /dev/null 2>&1
 	then
-		[ "$quiet" != "y" ] && \
-		    zfs_log_begin_msg "Running /scripts/local-bottom"
-		run_scripts /scripts/local-bottom
-		[ "$quiet" != "y" ] && zfs_log_end_msg
+		if [ -f "/scripts/local-bottom" ] || [ -d "/scripts/local-bottom" ]
+		then
+			[ "$quiet" != "y" ] && \
+			    zfs_log_begin_msg "Running /scripts/local-bottom"
+			run_scripts /scripts/local-bottom
+			[ "$quiet" != "y" ] && zfs_log_end_msg
+		fi
 	fi
 }


### PR DESCRIPTION
### Motivation and Context
#10908

### Description
~~`-gt 0` actually tests for inequality, the redirexion silences an error if the `*_SLEEP` variable wasn't an integer.~~
The missing shebang meant this wasn't picked up for automatic checking; I added one and iterated on `shellcheck contrib/initramfs/scripts/zfs --color`.

### How Has This Been Tested?
~~I replaced those lines in an initrd and the branch wasn't taken.~~
I replaced the equivalent file on a `zfs-initramfs` installation, regenerated, rebooted; it booted.
As for the code paths that weren't taken: I just looked at it really hard and tested the bits I wasn't sure about.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. — none needed
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. — none needed
- [ ] I have run the ZFS Test Suite with this change applied. — not applicable(?)
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
