### PR TITLE
ARC reads from pools without an l2arc should not be accounted as l2arc misses

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -899,7 +899,7 @@ post =
 tags = ['functional', 'log_spacemap']
 
 [tests/functional/l2arc]
-tests = ['l2arc_arcstats_pos', 'l2arc_mfuonly_pos',
+tests = ['l2arc_arcstats_pos', 'l2arc_mfuonly_pos', 'l2arc_l2miss_pos',
     'persist_l2arc_001_pos', 'persist_l2arc_002_pos',
     'persist_l2arc_003_neg', 'persist_l2arc_004_pos', 'persist_l2arc_005_pos',
     'persist_l2arc_006_pos', 'persist_l2arc_007_pos', 'persist_l2arc_008_pos']

--- a/tests/zfs-tests/tests/functional/l2arc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/l2arc/Makefile.am
@@ -3,6 +3,7 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
 	l2arc_arcstats_pos.ksh \
+	l2arc_l2miss_pos.ksh \
 	l2arc_mfuonly_pos.ksh \
 	persist_l2arc_001_pos.ksh \
 	persist_l2arc_002_pos.ksh \

--- a/tests/zfs-tests/tests/functional/l2arc/l2arc.cfg
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc.cfg
@@ -24,6 +24,7 @@ export SIZE=1G
 export VDIR=$TESTDIR/disk.l2arc
 export VDEV="$VDIR/a"
 export VDEV_CACHE="$VDIR/b"
+export VDEV1="$VDIR/c"
 
 # fio options
 export DIRECTORY=/$TESTPOOL

--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_l2miss_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_l2miss_pos.ksh
@@ -1,0 +1,94 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020, Adam Moss. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+
+#
+# DESCRIPTION:
+#	l2arc_misses does not increment upon reads from a pool without l2arc
+#
+# STRATEGY:
+#	1. Create pool with a cache device.
+#	2. Create pool without a cache device.
+#	3. Create a random file in the no-cache-device pool,
+#		and random read for 10 sec.
+#	4. Check that l2arc_misses hasn't risen
+#	5. Create a random file in the pool with the cache device,
+#		and random read for 10 sec.
+#	6. Check that l2arc_misses has risen
+#
+
+verify_runnable "global"
+
+log_assert "l2arc_misses does not increment upon reads from a pool without l2arc."
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+	if poolexists $TESTPOOL1 ; then
+		destroy_pool $TESTPOOL1
+	fi
+}
+log_onexit cleanup
+
+typeset fill_mb=800
+typeset cache_sz=$(( 1.4 * $fill_mb ))
+export FILE_SIZE=$(( floor($fill_mb / $NUMJOBS) ))M
+
+log_must truncate -s ${cache_sz}M $VDEV_CACHE
+
+log_must zpool create -O compression=off -f $TESTPOOL $VDEV cache $VDEV_CACHE
+log_must zpool create -O compression=off -f $TESTPOOL1 $VDEV1
+
+# I/O to pool without l2arc - expect that l2_misses stays constant
+export DIRECTORY=/$TESTPOOL1
+log_must fio $FIO_SCRIPTS/mkfiles.fio
+log_must fio $FIO_SCRIPTS/random_reads.fio
+# attempt to remove entries for pool from ARC so we would try
+#    to hit the nonexistent L2ARC for subsequent reads
+log_must zpool export $TESTPOOL1
+log_must zpool import $TESTPOOL1 -d $VDEV1
+
+typeset starting_miss_count=$(get_arcstat l2_misses)
+
+log_must fio $FIO_SCRIPTS/random_reads.fio
+log_must test $(get_arcstat l2_misses) -eq $starting_miss_count
+
+# I/O to pool with l2arc - expect that l2_misses rises
+export DIRECTORY=/$TESTPOOL
+log_must fio $FIO_SCRIPTS/mkfiles.fio
+log_must fio $FIO_SCRIPTS/random_reads.fio
+# wait for L2ARC writes to actually happen
+arcstat_quiescence_noecho l2_size
+# attempt to remove entries for pool from ARC so we would try
+#    to hit L2ARC for subsequent reads
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL -d $VDEV
+
+log_must fio $FIO_SCRIPTS/random_reads.fio
+log_must test $(get_arcstat l2_misses) -gt $starting_miss_count
+
+log_must zpool destroy -f $TESTPOOL
+log_must zpool destroy -f $TESTPOOL1
+
+log_pass "l2arc_misses does not increment upon reads from a pool without l2arc."

--- a/tests/zfs-tests/tests/functional/l2arc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/setup.ksh
@@ -25,5 +25,6 @@ verify_runnable "global"
 log_must rm -rf $VDIR
 log_must mkdir -p $VDIR
 log_must mkfile $SIZE $VDEV
+log_must mkfile $SIZE $VDEV1
 
 log_pass


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

The other half of the fix for issue #10913 ; this PR only eliminates l2 arcstat mis-counting for pools without l2arcs.  (Versus the intersecting-but-separate PR #10914 which only ignores misses from datasets with secondarycache!=all)

Note, this change doesn't affect situations where all the pools on a system have an l2arc or all the pools on a system don't have l2arc; it only changes the mixed case.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

IMHO the current l2_misses accounting behavior is a bug; it treats all reads to pools without a configured l2arc as an l2arc miss, IFF there is at least one _other_ pool on the system which does have an l2arc configured.

This makes it extremely hard to tune for an improved l2arc hit/miss ratio because this ratio will be modulated by reads from pools which do not (and should not) have l2arc devices; its upper limit will depend on the ratio of reads from l2arc'd pools and non-l2arc'd pools.

### Description
<!--- Describe your changes in detail -->

This PR prevents ARC reads affecting l2arc stats (n.b. l2_misses is the only relevant one) where the target spa doesn't have an l2arc.

Note I've added a couple of paragraphs of hand-wringing around arc.c:6170 to clarify(?) exactly what's being checked for / ignored for the sake of cheapness.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I've tested on a mix of pools where some have l2arc and some do not.  L2 hits and misses are accounted correctly when reading from l2arc-backed pools, L2 misses (and hits) do not affect accounting when reading from non-l2arc-backed pools.  An upper limit of ~100% l2_hits/l2_misses ratio is attainable with this change regardless of traffic on pools which do not use l2arc.

I've tested the behavior of secondarycache=... and it remains unaffected.  (That possibly-more-controversial change is covered by PR #10914 )

Ubuntu 18.04.05, Ubuntu HWE kernel 5.4.0-42-generic, git zfs zfs-2.0-release @ 8e7fe49 + PR cherrypick.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
