### PR TITLE
zpool(8): fix raidz par[i]ty typo

### DIFF
--- a/man/man8/zpoolprops.8
+++ b/man/man8/zpoolprops.8
@@ -77,7 +77,7 @@ The zpool
 .Sy free
 property is not generally useful for this purpose, and can be substantially more than the zfs
 .Sy available
-space. This discrepancy is due to several factors, including raidz party; zfs
+space. This discrepancy is due to several factors, including raidz parity; zfs
 reservation, quota, refreservation, and refquota properties; and space set aside by
 .Sy spa_slop_shift
 (see


### PR DESCRIPTION
### Motivation and Context
There was a raidz party and I hadn't been invited.

### Description
The party was dealt with.

### How Has This Been Tested?
I no longer feel left out.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). ‒ not applicable
- [ ] I have updated the documentation accordingly. ‒ not applicable
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. ‒ not applicable
- [ ] I have run the ZFS Test Suite with this change applied. ‒ not applicable
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
