### PR TITLE
zpool command complains about /etc/exports.d

### DIFF
--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -393,6 +393,14 @@ static char *
 nfs_init_tmpfile(void)
 {
 	char *tmpfile = NULL;
+	struct stat sb;
+
+	if (stat(ZFS_EXPORTS_DIR, &sb) < 0 &&
+	    mkdir(ZFS_EXPORTS_DIR, 0755) < 0) {
+		fprintf(stderr, "failed to create %s: %s\n",
+		    ZFS_EXPORTS_DIR, strerror(errno));
+		return (NULL);
+	}
 
 	if (asprintf(&tmpfile, "%s%s", ZFS_EXPORTS_FILE, ".XXXXXXXX") == -1) {
 		fprintf(stderr, "Unable to allocate temporary file\n");
@@ -481,36 +489,49 @@ nfs_copy_entries(char *filename, const char *mountpoint)
 	size_t buflen = 0;
 	int error = SA_OK;
 
-	/*
-	 * If the file doesn't exist then there is nothing more
-	 * we need to do.
-	 */
 	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "r");
-	if (oldfp == NULL)
-		return (SA_OK);
-
 	FILE *newfp = fopen(filename, "w+");
+	if (newfp == NULL) {
+		fprintf(stderr, "failed to open %s file: %s", filename,
+		    strerror(errno));
+		fclose(oldfp);
+		return (SA_SYSTEM_ERR);
+	}
 	fputs(FILE_HEADER, newfp);
-	while ((getline(&buf, &buflen, oldfp)) != -1) {
-		char *space = NULL;
 
-		if (buf[0] == '\n' || buf[0] == '#')
-			continue;
+	/*
+	 * The ZFS_EXPORTS_FILE may not exist yet. If that's the
+	 * case then just write out the new file.
+	 */
+	if (oldfp != NULL) {
+		while (getline(&buf, &buflen, oldfp) != -1) {
+			char *space = NULL;
 
-		if ((space = strchr(buf, ' ')) != NULL) {
-			int mountpoint_len = strlen(mountpoint);
-
-			if (space - buf == mountpoint_len &&
-			    strncmp(mountpoint, buf, mountpoint_len) == 0) {
+			if (buf[0] == '\n' || buf[0] == '#')
 				continue;
+
+			if ((space = strchr(buf, ' ')) != NULL) {
+				int mountpoint_len = strlen(mountpoint);
+
+				if (space - buf == mountpoint_len &&
+				    strncmp(mountpoint, buf,
+				    mountpoint_len) == 0) {
+					continue;
+				}
 			}
+			fputs(buf, newfp);
 		}
-		fputs(buf, newfp);
+
+		if (ferror(oldfp) != 0) {
+			error = ferror(oldfp);
+		}
+		if (fclose(oldfp) != 0) {
+			fprintf(stderr, "Unable to close file %s: %s\n",
+			    filename, strerror(errno));
+			error = error != 0 ? error : SA_SYSTEM_ERR;
+		}
 	}
 
-	if (oldfp != NULL && ferror(oldfp) != 0) {
-		error = ferror(oldfp);
-	}
 	if (error == 0 && ferror(newfp) != 0) {
 		error = ferror(newfp);
 	}
@@ -521,8 +542,6 @@ nfs_copy_entries(char *filename, const char *mountpoint)
 		    filename, strerror(errno));
 		error = error != 0 ? error : SA_SYSTEM_ERR;
 	}
-	fclose(oldfp);
-
 	return (error);
 }
 
@@ -701,13 +720,5 @@ static const sa_share_ops_t nfs_shareops = {
 void
 libshare_nfs_init(void)
 {
-	struct stat sb;
-
 	nfs_fstype = register_fstype("nfs", &nfs_shareops);
-
-	if (stat(ZFS_EXPORTS_DIR, &sb) < 0 &&
-	    mkdir(ZFS_EXPORTS_DIR, 0755) < 0) {
-		fprintf(stderr, "failed to create %s: %s\n",
-		    ZFS_EXPORTS_DIR, strerror(errno));
-	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the /etc/exports.d directory does not exist, then running zfs/zpool commands as a non-privileged user will result in an error being reported. 

### Description
<!--- Describe your changes in detail -->
If the /etc/exports.d directory does not exist, then we should only create it when we're performing an action which already requires root privileges.

This commit moves the directory creation to the enable/disable code path which ensures that we have the appropriate privileges.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
