### PR TITLE
Note that keys must be loaded if encrypted datasets exist for top-level vdevs to be removed

### DIFF
--- a/man/man8/zpool-remove.8
+++ b/man/man8/zpool-remove.8
@@ -50,7 +50,8 @@
 .Op Fl npw
 .Ar pool Ar device Ns ...
 .Xc
-Removes the specified device from the pool.
+Removes the specified device from the pool. Note that keys for all encrypted
+datasets must be loaded for top-level vdevs to be removed.
 This command supports removing hot spare, cache, log, and both mirrored and
 non-redundant primary top-level vdevs, including dedup and special vdevs.
 When the primary pool storage includes a top-level raidz vdev only hot spare,


### PR DESCRIPTION
This change is relation to https://github.com/openzfs/zfs/issues/10939

### Motivation and Context
The error returned when keys aren't loaded when a top-level vdev is attempted to be removed isn't descriptive, and the man pages make no note that keys need to be loaded. This MR obviously doesn't resolve the error message, but at least the man pages will make a note that keys need to be loaded

### Description
Just a quick man page addition to ensure that it's clear that keys need to be loaded for encrypted datasets to be able to remove a top-level vdev

### How Has This Been Tested?
N/A

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
