### PR TITLE
Added a reproducer for #10931

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -119,7 +119,7 @@ tests = ['libaio']
 tags = ['functional', 'io']
 
 [tests/functional/mmap:Linux]
-tests = ['mmap_libaio_001_pos']
+tests = ['mmap_libaio_001_pos','mmap_read_002_pos']
 tags = ['functional', 'mmap']
 
 [tests/functional/mmp:Linux]

--- a/tests/zfs-tests/tests/functional/mmap/mmap_read_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/mmap/mmap_read_002_pos.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmap/mmap.cfg
+
+#
+# DESCRIPTION:
+# read()s from mmap()'ed file contain correct data.
+#
+# STRATEGY:
+# 1. Create a pool & dataset
+# 2. Call readmmap binary
+# 3. unmount this file system
+# 4. Verify the integrity of this pool & dateset
+#
+ 
+verify_runnable "global"
+
+log_assert "read()s from mmap()'ed file contain correct data."
+
+log_must chmod 777 $TESTDIR
+log_must echo "123456123456123456" > $TESTDIR/test-read-file
+typeset checksum=$(sha256digest /$TESTDIR/test-read-file)
+log_must zfs snapshot $TESTPOOL/$TESTFS@original
+log_must readmmap $TESTDIR/test-read-file
+log_note "Overwriting file with new contents"
+log_must echo "234561234561234561" > $TESTDIR/test-read-file
+typeset checksum_new=$(sha256digest /$TESTDIR/test-read-file)
+log_must readmmap $TESTDIR/test-read-file
+log_note "Rolling back file with old contents, in theory"
+log_must zfs rollback $TESTPOOL/$TESTFS@original
+log_must readmmap $TESTDIR/test-read-file
+typeset checksum_still=$(sha256digest /$TESTDIR/test-read-file)
+
+[[ "$checksum_still" == "$checksum_new" ]] || \
+    log_fail "checksum stale after rollback"
+[[ "$checksum_still" == "$checksum" ]] || \
+    log_note Meow $(cat /$TESTDIR/test-read-file)
+    log_note "checksum success ($checksum_still == $checksum) ($checksum_new)"
+
+log_must zfs unmount $TESTPOOL/$TESTFS
+
+typeset dir=$(get_device_dir $DISKS)
+verify_filesys "$TESTPOOL" "$TESTPOOL/$TESTFS" "$dir"
+
+log_pass "read(2) calls from a mmap(2)'ed file rolled back succeeded."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Just wrote a quick reproducer case for the behavior observed in #10931 , integrated into ZTS.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just wrote a quick reproducer case for the behavior observed in #10931 , integrated into ZTS, because I was surprised nothing had caught this before, and wanted to be sure it would be caught if it's fixed and not happen again.
### Description
<!--- Describe your changes in detail -->
Added a test case, verified that the behavior was as described and expected.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Reproduces the problem behavior every time I've run it locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x]  All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
