### PR TITLE
Annotate FreeBSD sysctls as MPSAFE

### DIFF
--- a/module/os/freebsd/spl/spl_kstat.c
+++ b/module/os/freebsd/spl/spl_kstat.c
@@ -349,50 +349,50 @@ kstat_install_named(kstat_t *ksp)
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_S32 | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "I", namelast);
+			    CTLTYPE_S32 | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "I", namelast);
 			break;
 		case KSTAT_DATA_UINT32:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_U32 | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "IU", namelast);
+			    CTLTYPE_U32 | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "IU", namelast);
 			break;
 		case KSTAT_DATA_INT64:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_S64 | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "Q", namelast);
+			    CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "Q", namelast);
 			break;
 		case KSTAT_DATA_UINT64:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_U64 | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "QU", namelast);
+			    CTLTYPE_U64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "QU", namelast);
 			break;
 		case KSTAT_DATA_LONG:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_LONG | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "L", namelast);
+			    CTLTYPE_LONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "L", namelast);
 			break;
 		case KSTAT_DATA_ULONG:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_ULONG | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl, "LU", namelast);
+			    CTLTYPE_ULONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl, "LU", namelast);
 			break;
 		case KSTAT_DATA_STRING:
 			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, namelast,
-			    CTLTYPE_STRING | CTLFLAG_RD, ksp, i,
-			    kstat_sysctl_string, "A", namelast);
+			    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, i, kstat_sysctl_string, "A", namelast);
 			break;
 		default:
 			panic("unsupported type: %d", typelast);
@@ -417,14 +417,14 @@ kstat_install(kstat_t *ksp)
 			root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, ksp->ks_name,
-			    CTLTYPE_STRING | CTLFLAG_RD, ksp, 0,
-			    kstat_sysctl_raw, "A", ksp->ks_name);
+			    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, 0, kstat_sysctl_raw, "A", ksp->ks_name);
 		} else {
 			root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, ksp->ks_name,
-			    CTLTYPE_OPAQUE | CTLFLAG_RD, ksp, 0,
-			    kstat_sysctl_raw, "", ksp->ks_name);
+			    CTLTYPE_OPAQUE | CTLFLAG_RD | CTLFLAG_MPSAFE,
+			    ksp, 0, kstat_sysctl_raw, "", ksp->ks_name);
 		}
 		VERIFY(root != NULL);
 		break;
@@ -432,8 +432,8 @@ kstat_install(kstat_t *ksp)
 		root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 		    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 		    OID_AUTO, ksp->ks_name,
-		    CTLTYPE_STRING | CTLFLAG_RD, ksp, 0,
-		    kstat_sysctl_io, "A", ksp->ks_name);
+		    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE,
+		    ksp, 0, kstat_sysctl_io, "A", ksp->ks_name);
 		break;
 	case KSTAT_TYPE_TIMER:
 	case KSTAT_TYPE_INTR:

--- a/module/os/freebsd/spl/spl_kstat.c
+++ b/module/os/freebsd/spl/spl_kstat.c
@@ -247,28 +247,28 @@ __kstat_create(const char *module, int instance, const char *name,
 	ksp->ks_lock = &ksp->ks_private_lock;
 
 	switch (ksp->ks_type) {
-		case KSTAT_TYPE_RAW:
-			ksp->ks_ndata = 1;
-			ksp->ks_data_size = ks_ndata;
-			break;
-		case KSTAT_TYPE_NAMED:
-			ksp->ks_ndata = ks_ndata;
-			ksp->ks_data_size = ks_ndata * sizeof (kstat_named_t);
-			break;
-		case KSTAT_TYPE_INTR:
-			ksp->ks_ndata = ks_ndata;
-			ksp->ks_data_size = ks_ndata * sizeof (kstat_intr_t);
-			break;
-		case KSTAT_TYPE_IO:
-			ksp->ks_ndata = ks_ndata;
-			ksp->ks_data_size = ks_ndata * sizeof (kstat_io_t);
-			break;
-		case KSTAT_TYPE_TIMER:
-			ksp->ks_ndata = ks_ndata;
-			ksp->ks_data_size = ks_ndata * sizeof (kstat_timer_t);
-			break;
-		default:
-			panic("Undefined kstat type %d\n", ksp->ks_type);
+	case KSTAT_TYPE_RAW:
+		ksp->ks_ndata = 1;
+		ksp->ks_data_size = ks_ndata;
+		break;
+	case KSTAT_TYPE_NAMED:
+		ksp->ks_ndata = ks_ndata;
+		ksp->ks_data_size = ks_ndata * sizeof (kstat_named_t);
+		break;
+	case KSTAT_TYPE_INTR:
+		ksp->ks_ndata = ks_ndata;
+		ksp->ks_data_size = ks_ndata * sizeof (kstat_intr_t);
+		break;
+	case KSTAT_TYPE_IO:
+		ksp->ks_ndata = ks_ndata;
+		ksp->ks_data_size = ks_ndata * sizeof (kstat_io_t);
+		break;
+	case KSTAT_TYPE_TIMER:
+		ksp->ks_ndata = ks_ndata;
+		ksp->ks_data_size = ks_ndata * sizeof (kstat_timer_t);
+		break;
+	default:
+		panic("Undefined kstat type %d\n", ksp->ks_type);
 	}
 
 	if (ksp->ks_flags & KSTAT_FLAG_VIRTUAL) {
@@ -342,64 +342,62 @@ kstat_install_named(kstat_t *ksp)
 			namelast = ksent->name;
 		}
 		switch (typelast) {
-			case KSTAT_DATA_CHAR:
-				/* Not Implemented */
-				break;
-			case KSTAT_DATA_INT32:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_S32 | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "I", namelast);
-				break;
-			case KSTAT_DATA_UINT32:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_U32 | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "IU", namelast);
-				break;
-			case KSTAT_DATA_INT64:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_S64 | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "Q", namelast);
-				break;
-			case KSTAT_DATA_UINT64:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_U64 | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "QU", namelast);
-				break;
-			case KSTAT_DATA_LONG:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_LONG | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "L", namelast);
-				break;
-			case KSTAT_DATA_ULONG:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_ULONG | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl, "LU", namelast);
-				break;
-			case KSTAT_DATA_STRING:
-				SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, namelast,
-				    CTLTYPE_STRING | CTLFLAG_RD, ksp, i,
-				    kstat_sysctl_string, "A", namelast);
-				break;
-			default:
-				panic("unsupported type: %d", typelast);
+		case KSTAT_DATA_CHAR:
+			/* Not Implemented */
+			break;
+		case KSTAT_DATA_INT32:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_S32 | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "I", namelast);
+			break;
+		case KSTAT_DATA_UINT32:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_U32 | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "IU", namelast);
+			break;
+		case KSTAT_DATA_INT64:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_S64 | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "Q", namelast);
+			break;
+		case KSTAT_DATA_UINT64:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_U64 | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "QU", namelast);
+			break;
+		case KSTAT_DATA_LONG:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_LONG | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "L", namelast);
+			break;
+		case KSTAT_DATA_ULONG:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_ULONG | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl, "LU", namelast);
+			break;
+		case KSTAT_DATA_STRING:
+			SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, namelast,
+			    CTLTYPE_STRING | CTLFLAG_RD, ksp, i,
+			    kstat_sysctl_string, "A", namelast);
+			break;
+		default:
+			panic("unsupported type: %d", typelast);
 		}
-
 	}
-
 }
 
 void
@@ -411,39 +409,38 @@ kstat_install(kstat_t *ksp)
 		VERIFY(ksp->ks_type == KSTAT_TYPE_RAW);
 
 	switch (ksp->ks_type) {
-		case KSTAT_TYPE_NAMED:
-			return (kstat_install_named(ksp));
-			break;
-		case KSTAT_TYPE_RAW:
-			if (ksp->ks_raw_ops.data) {
-				root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, ksp->ks_name,
-				    CTLTYPE_STRING | CTLFLAG_RD, ksp, 0,
-				    kstat_sysctl_raw, "A", ksp->ks_name);
-			} else {
-				root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
-				    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
-				    OID_AUTO, ksp->ks_name,
-				    CTLTYPE_OPAQUE | CTLFLAG_RD, ksp, 0,
-				    kstat_sysctl_raw, "", ksp->ks_name);
-			}
-			VERIFY(root != NULL);
-			break;
-		case KSTAT_TYPE_IO:
+	case KSTAT_TYPE_NAMED:
+		return (kstat_install_named(ksp));
+		break;
+	case KSTAT_TYPE_RAW:
+		if (ksp->ks_raw_ops.data) {
 			root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
 			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
 			    OID_AUTO, ksp->ks_name,
 			    CTLTYPE_STRING | CTLFLAG_RD, ksp, 0,
-			    kstat_sysctl_io, "A", ksp->ks_name);
-			break;
-		case KSTAT_TYPE_TIMER:
-		case KSTAT_TYPE_INTR:
-		default:
-			panic("unsupported kstat type %d\n", ksp->ks_type);
+			    kstat_sysctl_raw, "A", ksp->ks_name);
+		} else {
+			root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+			    OID_AUTO, ksp->ks_name,
+			    CTLTYPE_OPAQUE | CTLFLAG_RD, ksp, 0,
+			    kstat_sysctl_raw, "", ksp->ks_name);
+		}
+		VERIFY(root != NULL);
+		break;
+	case KSTAT_TYPE_IO:
+		root = SYSCTL_ADD_PROC(&ksp->ks_sysctl_ctx,
+		    SYSCTL_CHILDREN(ksp->ks_sysctl_root),
+		    OID_AUTO, ksp->ks_name,
+		    CTLTYPE_STRING | CTLFLAG_RD, ksp, 0,
+		    kstat_sysctl_io, "A", ksp->ks_name);
+		break;
+	case KSTAT_TYPE_TIMER:
+	case KSTAT_TYPE_INTR:
+	default:
+		panic("unsupported kstat type %d\n", ksp->ks_type);
 	}
 	ksp->ks_sysctl_root = root;
-
 }
 
 void

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -242,8 +242,9 @@ sysctl_vfs_zfs_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_no_grow_shift, CTLTYPE_U32 | CTLFLAG_RWTUN,
-    0, sizeof (uint32_t), sysctl_vfs_zfs_arc_no_grow_shift, "U",
+SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_no_grow_shift,
+    CTLTYPE_U32 | CTLFLAG_RWTUN | CTLFLAG_MPSAFE, 0, sizeof (uint32_t),
+    sysctl_vfs_zfs_arc_no_grow_shift, "U",
     "log2(fraction of ARC which must be free to allow growing)");
 
 int
@@ -274,10 +275,12 @@ param_set_arc_int(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_min, CTLTYPE_ULONG | CTLFLAG_RWTUN,
+SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_min,
+    CTLTYPE_ULONG | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
     &zfs_arc_min, sizeof (zfs_arc_min), param_set_arc_long, "LU",
     "min arc size (LEGACY)");
-SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_max, CTLTYPE_ULONG | CTLFLAG_RWTUN,
+SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_max,
+    CTLTYPE_ULONG | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
     &zfs_arc_max, sizeof (zfs_arc_max), param_set_arc_long, "LU",
     "max arc size (LEGACY)");
 
@@ -557,11 +560,13 @@ param_set_max_auto_ashift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-SYSCTL_PROC(_vfs_zfs, OID_AUTO, min_auto_ashift, CTLTYPE_U64 | CTLFLAG_RWTUN,
+SYSCTL_PROC(_vfs_zfs, OID_AUTO, min_auto_ashift,
+    CTLTYPE_U64 | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
     &zfs_vdev_min_auto_ashift, sizeof (zfs_vdev_min_auto_ashift),
     param_set_min_auto_ashift, "QU",
     "Min ashift used when creating new top-level vdev. (LEGACY)");
-SYSCTL_PROC(_vfs_zfs, OID_AUTO, max_auto_ashift, CTLTYPE_U64 | CTLFLAG_RWTUN,
+SYSCTL_PROC(_vfs_zfs, OID_AUTO, max_auto_ashift,
+    CTLTYPE_U64 | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
     &zfs_vdev_max_auto_ashift, sizeof (zfs_vdev_max_auto_ashift),
     param_set_max_auto_ashift, "QU",
     "Max ashift used when optimizing for logical -> physical sector size on "


### PR DESCRIPTION
### Motivation and Context
sysctl handlers on FreeBSD currently have to be annotated to indicate that they are SMP-safe. For now at least, the default behaviour is to assume that they are not, in which case they are serialized by a global mutex. Many sysctl handlers in the OpenZFS kernel module are not annotated as SMP-safe.

### Description
The change adds CTLFLAG_MPSAFE to all custom sysctl handlers in the OpenZFS kernel module. No code in ZFS requires the aforementioned global mutex.

### How Has This Been Tested?
I installed the updated module and verified that various command line tools (top(1), systat(1), etc.) no longer acquire the Giant lock when they poll ZFS for stats. I am confident that nothing in ZFS relies on the serialization provided by Giant.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
