### PR TITLE
[WIP] Implement per-pool L2ARC stats

### DIFF
--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -785,22 +785,10 @@ typedef struct arc_stats {
 	 * L2ARC. Updated during writing of L2ARC log blocks.
 	 */
 	kstat_named_t arcstat_l2_log_blk_writes;
-	/*
-	 * Moving average of the aligned size of the L2ARC log blocks, in
-	 * bytes. Updated during L2ARC rebuild and during writing of L2ARC
-	 * log blocks.
-	 */
-	kstat_named_t arcstat_l2_log_blk_avg_asize;
 	/* Aligned size of L2ARC log blocks on L2ARC devices. */
 	kstat_named_t arcstat_l2_log_blk_asize;
 	/* Number of L2ARC log blocks present on L2ARC devices. */
 	kstat_named_t arcstat_l2_log_blk_count;
-	/*
-	 * Moving average of the aligned size of L2ARC restored data, in bytes,
-	 * to the aligned size of their metadata in L2ARC, in bytes.
-	 * Updated during L2ARC rebuild and during writing of L2ARC log blocks.
-	 */
-	kstat_named_t arcstat_l2_data_to_meta_ratio;
 	/*
 	 * Number of times the L2ARC rebuild was successful for an L2ARC device.
 	 */

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -952,6 +952,44 @@ typedef struct spa_iostats {
 	kstat_named_t	simple_trim_bytes_skipped;
 	kstat_named_t	simple_trim_extents_failed;
 	kstat_named_t	simple_trim_bytes_failed;
+	kstat_named_t	l2_hits;
+	kstat_named_t	l2_misses;
+	kstat_named_t	l2_prefetch_asize;
+	kstat_named_t	l2_mfu_asize;
+	kstat_named_t	l2_mru_asize;
+	kstat_named_t	l2_bufc_data_asize;
+	kstat_named_t	l2_bufc_metadata_asize;
+	kstat_named_t	l2_feeds;
+	kstat_named_t	l2_rw_clash;
+	kstat_named_t	l2_read_bytes;
+	kstat_named_t	l2_write_bytes;
+	kstat_named_t	l2_writes_sent;
+	kstat_named_t	l2_writes_done;
+	kstat_named_t	l2_writes_error;
+	kstat_named_t	l2_writes_lock_retry;
+	kstat_named_t	l2_evict_lock_retry;
+	kstat_named_t	l2_evict_reading;
+	kstat_named_t	l2_evict_l1cached;
+	kstat_named_t	l2_free_on_write;
+	kstat_named_t	l2_abort_lowmem;
+	kstat_named_t	l2_cksum_bad;
+	kstat_named_t	l2_io_error;
+	kstat_named_t	l2_size;
+	kstat_named_t	l2_asize;
+	kstat_named_t	l2_log_blk_writes;
+	kstat_named_t	l2_log_blk_asize;
+	kstat_named_t	l2_log_blk_count;
+	kstat_named_t	l2_rebuild_success;
+	kstat_named_t	l2_rebuild_unsupported;
+	kstat_named_t	l2_rebuild_io_errors;
+	kstat_named_t	l2_rebuild_dh_errors;
+	kstat_named_t	l2_rebuild_cksum_lb_errors;
+	kstat_named_t	l2_rebuild_lowmem;
+	kstat_named_t	l2_rebuild_size;
+	kstat_named_t	l2_rebuild_asize;
+	kstat_named_t	l2_rebuild_bufs;
+	kstat_named_t	l2_rebuild_bufs_precached;
+	kstat_named_t	l2_rebuild_log_blks;
 } spa_iostats_t;
 
 extern void spa_stats_init(spa_t *spa);
@@ -971,6 +1009,21 @@ extern int spa_mmp_history_set(spa_t *spa, uint64_t mmp_kstat_id, int io_error,
 extern void spa_mmp_history_add(spa_t *spa, uint64_t txg, uint64_t timestamp,
     uint64_t mmp_delay, vdev_t *vd, int label, uint64_t mmp_kstat_id,
     int error);
+extern void spa_iostats_l2(spa_t *spa, uint64_t hits, uint64_t misses,
+    uint64_t prefetch, uint64_t mfu, uint64_t mru, uint64_t data,
+    uint64_t metadata, uint64_t feeds, uint64_t rw_clash, uint64_t read_bytes,
+    uint64_t write_bytes, uint64_t writes_sent, uint64_t writes_done,
+    uint64_t writes_error, uint64_t writes_lock_retry,
+    uint64_t evict_lock_retry, uint64_t evict_reading, uint64_t evict_l1cached,
+    uint64_t free_on_write, uint64_t abort_lowmem, uint64_t cksum_bad,
+    uint64_t io_error, uint64_t l2_size, uint64_t l2_asize,
+    uint64_t log_blk_writes, uint64_t log_blk_asize, uint64_t log_blk_count);
+extern void spa_iostats_l2_rebuild(spa_t *spa, uint64_t rebuild_success,
+    uint64_t rebuild_unsupported, uint64_t rebuild_io_errors,
+    uint64_t rebuild_dh_errors, uint64_t cksum_lb_errors,
+    uint64_t rebuild_lowmem, uint64_t rebuild_size, uint64_t rebuild_asize,
+    uint64_t rebuild_bufs, uint64_t rebuild_bufs_precached,
+    uint64_t rebuild_log_blks);
 extern void spa_iostats_trim_add(spa_t *spa, trim_type_t type,
     uint64_t extents_written, uint64_t bytes_written,
     uint64_t extents_skipped, uint64_t bytes_skipped,

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -897,10 +897,127 @@ static spa_iostats_t spa_iostats_template = {
 	{ "simple_trim_bytes_skipped",		KSTAT_DATA_UINT64 },
 	{ "simple_trim_extents_failed",		KSTAT_DATA_UINT64 },
 	{ "simple_trim_bytes_failed",		KSTAT_DATA_UINT64 },
+	{ "l2_hits",				KSTAT_DATA_UINT64 },
+	{ "l2_misses",				KSTAT_DATA_UINT64 },
+	{ "l2_prefetch_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_mfu_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_mru_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_bufc_data_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_bufc_metadata_asize",		KSTAT_DATA_UINT64 },
+	{ "l2_feeds",				KSTAT_DATA_UINT64 },
+	{ "l2_rw_clash",			KSTAT_DATA_UINT64 },
+	{ "l2_read_bytes",			KSTAT_DATA_UINT64 },
+	{ "l2_write_bytes",			KSTAT_DATA_UINT64 },
+	{ "l2_writes_sent",			KSTAT_DATA_UINT64 },
+	{ "l2_writes_done",			KSTAT_DATA_UINT64 },
+	{ "l2_writes_error",			KSTAT_DATA_UINT64 },
+	{ "l2_writes_lock_retry",		KSTAT_DATA_UINT64 },
+	{ "l2_evict_lock_retry",		KSTAT_DATA_UINT64 },
+	{ "l2_evict_reading",			KSTAT_DATA_UINT64 },
+	{ "l2_evict_l1cached",			KSTAT_DATA_UINT64 },
+	{ "l2_free_on_write",			KSTAT_DATA_UINT64 },
+	{ "l2_abort_lowmem",			KSTAT_DATA_UINT64 },
+	{ "l2_cksum_bad",			KSTAT_DATA_UINT64 },
+	{ "l2_io_error",			KSTAT_DATA_UINT64 },
+	{ "l2_size",				KSTAT_DATA_UINT64 },
+	{ "l2_asize",				KSTAT_DATA_UINT64 },
+	{ "l2_log_blk_writes",			KSTAT_DATA_UINT64 },
+	{ "l2_log_blk_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_log_blk_count",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_success",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_unsupported",		KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_io_errors",		KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_dh_errors",		KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_cksum_lb_errors",		KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_lowmem",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_size",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_asize",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_bufs",			KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_bufs_precached",		KSTAT_DATA_UINT64 },
+	{ "l2_rebuild_log_blks",		KSTAT_DATA_UINT64 },
 };
 
 #define	SPA_IOSTATS_ADD(stat, val) \
     atomic_add_64(&iostats->stat.value.ui64, (val));
+
+void
+spa_iostats_l2(spa_t *spa, uint64_t hits, uint64_t misses,
+    uint64_t prefetch, uint64_t mfu, uint64_t mru, uint64_t data,
+    uint64_t metadata, uint64_t feeds, uint64_t rw_clash, uint64_t read_bytes,
+    uint64_t write_bytes, uint64_t writes_sent, uint64_t writes_done,
+    uint64_t writes_error, uint64_t writes_lock_retry,
+    uint64_t evict_lock_retry, uint64_t evict_reading, uint64_t evict_l1cached,
+    uint64_t free_on_write, uint64_t abort_lowmem, uint64_t cksum_bad,
+    uint64_t io_error, uint64_t l2_size, uint64_t l2_asize,
+    uint64_t log_blk_writes, uint64_t log_blk_asize, uint64_t log_blk_count)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.iostats;
+	kstat_t *ksp = shk->kstat;
+	spa_iostats_t *iostats;
+
+	if (ksp == NULL)
+		return;
+
+	iostats = ksp->ks_data;
+
+	SPA_IOSTATS_ADD(l2_hits, hits);
+	SPA_IOSTATS_ADD(l2_misses, misses);
+	SPA_IOSTATS_ADD(l2_prefetch_asize, prefetch);
+	SPA_IOSTATS_ADD(l2_mfu_asize, mfu);
+	SPA_IOSTATS_ADD(l2_mru_asize, mru);
+	SPA_IOSTATS_ADD(l2_bufc_data_asize, data);
+	SPA_IOSTATS_ADD(l2_bufc_metadata_asize, metadata);
+	SPA_IOSTATS_ADD(l2_feeds, feeds);
+	SPA_IOSTATS_ADD(l2_rw_clash, rw_clash);
+	SPA_IOSTATS_ADD(l2_read_bytes, read_bytes);
+	SPA_IOSTATS_ADD(l2_write_bytes, write_bytes);
+	SPA_IOSTATS_ADD(l2_writes_sent, writes_sent);
+	SPA_IOSTATS_ADD(l2_writes_done, writes_done);
+	SPA_IOSTATS_ADD(l2_writes_error, writes_error);
+	SPA_IOSTATS_ADD(l2_writes_lock_retry, writes_lock_retry);
+	SPA_IOSTATS_ADD(l2_evict_lock_retry, evict_lock_retry);
+	SPA_IOSTATS_ADD(l2_evict_reading, evict_reading);
+	SPA_IOSTATS_ADD(l2_evict_l1cached, evict_l1cached);
+	SPA_IOSTATS_ADD(l2_free_on_write, free_on_write);
+	SPA_IOSTATS_ADD(l2_abort_lowmem, abort_lowmem);
+	SPA_IOSTATS_ADD(l2_cksum_bad, cksum_bad);
+	SPA_IOSTATS_ADD(l2_io_error, io_error);
+	SPA_IOSTATS_ADD(l2_size, l2_size);
+	SPA_IOSTATS_ADD(l2_asize, l2_asize);
+	SPA_IOSTATS_ADD(l2_log_blk_writes, log_blk_writes);
+	SPA_IOSTATS_ADD(l2_log_blk_asize, log_blk_asize);
+	SPA_IOSTATS_ADD(l2_log_blk_count, log_blk_count);
+}
+
+void
+spa_iostats_l2_rebuild(spa_t *spa, uint64_t rebuild_success,
+    uint64_t rebuild_unsupported, uint64_t rebuild_io_errors,
+    uint64_t rebuild_dh_errors, uint64_t cksum_lb_errors,
+    uint64_t rebuild_lowmem, uint64_t rebuild_size, uint64_t rebuild_asize,
+    uint64_t rebuild_bufs, uint64_t rebuild_bufs_precached,
+    uint64_t rebuild_log_blks)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.iostats;
+	kstat_t *ksp = shk->kstat;
+	spa_iostats_t *iostats;
+
+	if (ksp == NULL)
+		return;
+
+	iostats = ksp->ks_data;
+
+	SPA_IOSTATS_ADD(l2_rebuild_success, rebuild_success);
+	SPA_IOSTATS_ADD(l2_rebuild_unsupported, rebuild_unsupported);
+	SPA_IOSTATS_ADD(l2_rebuild_io_errors, rebuild_io_errors);
+	SPA_IOSTATS_ADD(l2_rebuild_dh_errors, rebuild_dh_errors);
+	SPA_IOSTATS_ADD(l2_rebuild_cksum_lb_errors, cksum_lb_errors);
+	SPA_IOSTATS_ADD(l2_rebuild_lowmem, rebuild_lowmem);
+	SPA_IOSTATS_ADD(l2_rebuild_size, rebuild_size);
+	SPA_IOSTATS_ADD(l2_rebuild_asize, rebuild_asize);
+	SPA_IOSTATS_ADD(l2_rebuild_bufs, rebuild_bufs);
+	SPA_IOSTATS_ADD(l2_rebuild_bufs_precached, rebuild_bufs_precached);
+	SPA_IOSTATS_ADD(l2_rebuild_log_blks, rebuild_log_blks);
+}
 
 void
 spa_iostats_trim_add(spa_t *spa, trim_type_t type,

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -4173,6 +4173,26 @@ function get_arcstat # stat
 	esac
 }
 
+function get_iostat # pool stat
+{
+	typeset pool=$1
+	typeset stat=$2
+
+	case $(uname) in
+	FreeBSD)
+		sysctl -n kstat.zfs.misc.$pool.iostats.$stat
+		;;
+	Linux)
+		typeset zfs_iostats="/proc/spl/kstat/zfs/$pool/iostats"
+		[[ -f "$zfs_iostats" ]] || return 1
+		grep $stat $zfs_iostats | awk '{print $3}'
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
 #
 # Given an array of pids, wait until all processes
 # have completed and check their return status.

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_001_pos.ksh
@@ -33,7 +33,7 @@
 #	5. Read the amount of log blocks written from the header of the
 #		L2ARC device.
 #	6. Import pool.
-#	7. Read the amount of log blocks rebuilt in arcstats and compare to
+#	7. Read the amount of log blocks rebuilt in pool iostats and compare to
 #		(4).
 #	8. Check if the labels of the L2ARC device are intact.
 #
@@ -88,15 +88,13 @@ log_must zpool export $TESTPOOL
 typeset l2_dh_log_blk=$(zdb -l $VDEV_CACHE | grep log_blk_count | \
 	awk '{print $2}')
 
-typeset l2_rebuild_log_blk_start=$(get_arcstat l2_rebuild_log_blks)
-
 log_must zpool import -d $VDIR $TESTPOOL
 
 sleep 2
 
-typeset l2_rebuild_log_blk_end=$(get_arcstat l2_rebuild_log_blks)
+typeset l2_rebuild_log_blk=$(get_iostat $TESTPOOL l2_rebuild_log_blks)
 
-log_must test $l2_dh_log_blk -eq $(( $l2_rebuild_log_blk_end - $l2_rebuild_log_blk_start ))
+log_must test $l2_dh_log_blk -eq $l2_rebuild_log_blk
 log_must test $l2_dh_log_blk -gt 0
 
 log_must zdb -lll $VDEV_CACHE

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_002_pos.ksh
@@ -36,7 +36,7 @@
 #		L2ARC device.
 #	5. Import pool.
 #	6. Mount the encrypted ZFS file system.
-#	7. Read the amount of log blocks rebuilt in arcstats and compare to
+#	7. Read the amount of log blocks rebuilt in pool iostats and compare to
 #		(5).
 #	8. Check if the labels of the L2ARC device are intact.
 #
@@ -93,16 +93,14 @@ sleep 2
 typeset l2_dh_log_blk=$(zdb -l $VDEV_CACHE | grep log_blk_count | \
 	awk '{print $2}')
 
-typeset l2_rebuild_log_blk_start=$(get_arcstat l2_rebuild_log_blks)
-
 log_must zpool import -d $VDIR $TESTPOOL
 log_must eval "echo $PASSPHRASE | zfs mount -l $TESTPOOL/$TESTFS1"
 
 sleep 2
 
-typeset l2_rebuild_log_blk_end=$(get_arcstat l2_rebuild_log_blks)
+typeset l2_rebuild_log_blk=$(get_iostat $TESTPOOL l2_rebuild_log_blks)
 
-log_must test $l2_dh_log_blk -eq $(( $l2_rebuild_log_blk_end - $l2_rebuild_log_blk_start ))
+log_must test $l2_dh_log_blk -eq $l2_rebuild_log_blk
 log_must test $l2_dh_log_blk -gt 0
 
 log_must zdb -lq $VDEV_CACHE

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_003_neg.ksh
@@ -33,7 +33,7 @@
 #	5. Import pool.
 #	6. Check in zpool iostat if the cache device has space allocated.
 #	7. Read the file written in (2) and check if l2_hits in
-#		/proc/spl/kstat/zfs/arcstats increased.
+#		pool iostats increased.
 #
 
 verify_runnable "global"
@@ -72,12 +72,12 @@ log_must fio $FIO_SCRIPTS/random_reads.fio
 
 log_must zpool export $TESTPOOL
 
-typeset l2_success_start=$(get_arcstat l2_rebuild_success)
+typeset l2_success_start=$(get_iostat $TESTPOOL l2_rebuild_success)
 
 log_must zpool import -d $VDIR $TESTPOOL
 log_mustnot test "$(zpool iostat -Hpv $TESTPOOL $VDEV_CACHE | awk '{print $2}')" -gt 80000000
 
-typeset l2_success_end=$(get_arcstat l2_rebuild_success)
+typeset l2_success_end=$(get_iostat $TESTPOOL l2_rebuild_success)
 
 log_mustnot test $l2_success_end -gt $l2_success_start
 

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_004_pos.ksh
@@ -35,7 +35,7 @@
 #	6. Read amount of log blocks built.
 #	7. Compare the two amounts
 #	8. Read the file written in (2) and check if l2_hits in
-#		/proc/spl/kstat/zfs/arcstats increased.
+#		pool iostats increased.
 #	9. Check if the labels of the L2ARC device are intact.
 #
 
@@ -63,8 +63,6 @@ export FILE_SIZE=$(( floor($fill_mb / $NUMJOBS) ))M
 
 log_must truncate -s ${cache_sz}M $VDEV_CACHE
 
-typeset log_blk_start=$(get_arcstat l2_log_blk_writes)
-
 log_must zpool create -f $TESTPOOL $VDEV cache $VDEV_CACHE
 
 log_must fio $FIO_SCRIPTS/mkfiles.fio
@@ -72,25 +70,19 @@ log_must fio $FIO_SCRIPTS/random_reads.fio
 
 log_must zpool export $TESTPOOL
 
-sleep 2
-
-typeset log_blk_end=$(get_arcstat l2_log_blk_writes)
-
-typeset log_blk_rebuild_start=$(get_arcstat l2_rebuild_log_blks)
+typeset l2_dh_log_blk=$(zdb -l $VDEV_CACHE | grep log_blk_count | \
+	awk '{print $2}')
 
 log_must zpool import -d $VDIR $TESTPOOL
 
-typeset l2_hits_start=$(get_arcstat l2_hits)
+typeset l2_hits_start=$(get_iostat $TESTPOOL l2_hits)
 
 log_must fio $FIO_SCRIPTS/random_reads.fio
 
-typeset l2_hits_end=$(get_arcstat l2_hits)
+typeset l2_hits_end=$(get_iostat $TESTPOOL l2_hits)
+typeset log_blk_rebuild=$(get_iostat $TESTPOOL l2_rebuild_log_blks)
 
-typeset log_blk_rebuild_end=$(get_arcstat l2_rebuild_log_blks)
-
-log_must test $(( $log_blk_rebuild_end - $log_blk_rebuild_start )) -eq \
-	$(( $log_blk_end - $log_blk_start ))
-
+log_must test $log_blk_rebuild -eq $l2_dh_log_blk
 log_must test $l2_hits_end -gt $l2_hits_start
 
 log_must zdb -lq $VDEV_CACHE

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_007_pos.ksh
@@ -32,7 +32,7 @@
 #		L2ARC device.
 #	4. Offline the L2ARC device.
 #	5. Online the L2ARC device.
-#	6. Read the amount of log blocks rebuilt in arcstats and compare to
+#	6. Read the amount of log blocks rebuilt in pool iostats and compare to
 #		(3).
 #	7. Check if the labels of the L2ARC device are intact.
 #
@@ -72,10 +72,6 @@ log_must fio $FIO_SCRIPTS/random_reads.fio
 
 log_must zpool offline $TESTPOOL $VDEV_CACHE
 
-sleep 10
-
-typeset l2_rebuild_log_blk_start=$(get_arcstat l2_rebuild_log_blks)
-
 typeset l2_dh_log_blk=$(zdb -l $VDEV_CACHE | grep log_blk_count | \
 	awk '{print $2}')
 
@@ -83,9 +79,9 @@ log_must zpool online $TESTPOOL $VDEV_CACHE
 
 sleep 10
 
-typeset l2_rebuild_log_blk_end=$(get_arcstat l2_rebuild_log_blks)
+typeset l2_rebuild_log_blk=$(get_iostat $TESTPOOL l2_rebuild_log_blks)
 
-log_must test $l2_dh_log_blk -eq $(( $l2_rebuild_log_blk_end - $l2_rebuild_log_blk_start ))
+log_must test $l2_dh_log_blk -eq $l2_rebuild_log_blk
 log_must test $l2_dh_log_blk -gt 0
 
 log_must zdb -lq $VDEV_CACHE


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Based on the discussion @richardelling triggered in the September 2020 leadership meeting (https://www.youtube.com/watch?v=fVcNnFHDwHY, 5:10), I drafted a WIP to make L2ARC stats appear per pool. In this PR these are developed as spa_iostats and appear in Linux under /proc/spl/kstat/zfs/poolname/iostats and in FreeBSD under sysctl. Right now only the non-persistent L2ARC stats are treated that way. The persistent L2ARC stats will eventually be moved there too, and the l2_* arcstats will be removed.

### Description
Implement L2ARC arcstats as spa_iostats and remove the common for all pools L2ARC arcstats. This is more suited to L2ARC, as the L2ARC is per-pool contrary to ARC which is common for all pools. Currently the implementation of L2ARC stats as spa_iostats follows closely the implementation of TRIM stats: we define a function in spa_stats.c, and make use of macros of this function in arc.c.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The tests in functional/l2arc are adapted to use the new L2ARC per-pool iostats.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

### To-do:
- [x] Implement persistent L2ARC stats per-pool.
- [x] Fix the tests in functional/l2arc.
- [ ] Remove shared L2ARC arcstats.
- [ ] Update documentation.
- [ ] Update arc_summary{2,3}
