### PR TITLE
FreeBSD: Reduce stack usage of Lua

### DIFF
--- a/include/sys/lua/luaconf.h
+++ b/include/sys/lua/luaconf.h
@@ -368,11 +368,7 @@ extern int lcompat_hashnum(int64_t);
 @@ LUAL_BUFFERSIZE is the buffer size used by the lauxlib buffer system.
 ** CHANGE it if it uses too much C-stack space.
 */
-#ifdef __linux__
 #define LUAL_BUFFERSIZE		512
-#else
-#define LUAL_BUFFERSIZE		1024
-#endif
 
 
 /*

--- a/module/lua/llimits.h
+++ b/module/lua/llimits.h
@@ -126,16 +126,7 @@ typedef LUAI_UACNUMBER l_uacNumber;
  * Minimum amount of available stack space (in bytes) to make a C call.  With
  * gsub() recursion, the stack space between each luaD_call() is 1256 bytes.
  */
-#if defined(__FreeBSD__)
-/*
- * FreeBSD needs a few extra bytes in unoptimized debug builds to avoid a
- * double-fault handling the error when the max call depth is exceeded just
- * before the C stack runs out.  64 bytes seems to do the trick.
- */
-#define LUAI_MINCSTACK		4160
-#else
 #define LUAI_MINCSTACK		4096
-#endif
 
 /*
 ** maximum number of upvalues in a closure (both C and Lua). (Value


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a panic on FreeBSD HEAD in the channel program gsub test, which is designed to exhaust stack space.

### Description
<!--- Describe your changes in detail -->
Use the same reduced buffer size for lauxlib that is used on Linux.

With this we can remove the special case to reserve more stack space
on FreeBSD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS passed 90 iterations of lua_core and 5 iterations of synctask_core on FreeBSD head.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
