### PR TITLE
Update issue templates, commitcheck and Contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,8 +126,8 @@ feature needed?  What problem does it solve?
 
 #### General
 
-* All pull requests must be based on the current master branch and apply
-without conflicts.
+* All pull requests, except backports and releases, must be based on the current master branch 
+and should apply without conflicts.
 * Please attempt to limit pull requests to a single commit which resolves
 one specific issue.
 * Make sure your commit messages are in the correct format. See the
@@ -213,70 +213,6 @@ why the proposed approach was chosen or what bug you are
 attempting to solve.
 
 Signed-off-by: Contributor <contributor@email.com>
-```
-
-#### OpenZFS Patch Ports
-If you are porting OpenZFS patches, the commit message must meet
-the following guidelines:
-* The first line must be the summary line from the most important OpenZFS commit being ported.
-It must begin with `OpenZFS dddd, dddd - ` where `dddd` are OpenZFS issue numbers.
-* Provides a `Authored by:` line to attribute each patch for each original author.
-* Provides the `Reviewed by:` and `Approved by:` lines from each original
-OpenZFS commit.
-* Provides a `Ported-by:` line with the developer's name followed by
-their email for each OpenZFS commit.
-* Provides a `OpenZFS-issue:` line with link for each original illumos
-issue.
-* Provides a `OpenZFS-commit:` line with link for each original OpenZFS commit.
-* If necessary, provide some porting notes to describe any deviations from
-the original OpenZFS commits.
-
-An example OpenZFS patch port commit message for a single patch is provided
-below.
-```
-OpenZFS 1234 - Summary from the original OpenZFS commit
-
-Authored by: Original Author <original@email.com>
-Reviewed by: Reviewer One <reviewer1@email.com>
-Reviewed by: Reviewer Two <reviewer2@email.com>
-Approved by: Approver One <approver1@email.com>
-Ported-by: ZFS Contributor <contributor@email.com>
-
-Provide some porting notes here if necessary.
-
-OpenZFS-issue: https://www.illumos.org/issues/1234
-OpenZFS-commit: https://github.com/openzfs/openzfs/commit/abcd1234
-```
-
-If necessary, multiple OpenZFS patches can be combined in a single port.
-This is useful when you are porting a new patch and its subsequent bug
-fixes. An example commit message is provided below.
-```
-OpenZFS 1234, 5678 - Summary of most important OpenZFS commit
-
-1234 Summary from original OpenZFS commit for 1234
-
-Authored by: Original Author <original@email.com>
-Reviewed by: Reviewer Two <reviewer2@email.com>
-Approved by: Approver One <approver1@email.com>
-Ported-by: ZFS Contributor <contributor@email.com>
-
-Provide some porting notes here for 1234 if necessary.
-
-OpenZFS-issue: https://www.illumos.org/issues/1234
-OpenZFS-commit: https://github.com/openzfs/openzfs/commit/abcd1234
-
-5678 Summary from original OpenZFS commit for 5678
-
-Authored by: Original Author2 <original2@email.com>
-Reviewed by: Reviewer One <reviewer1@email.com>
-Approved by: Approver Two <approver2@email.com>
-Ported-by: ZFS Contributor <contributor@email.com>
-
-Provide some porting notes here for 5678 if necessary.
-
-OpenZFS-issue: https://www.illumos.org/issues/5678
-OpenZFS-commit: https://github.com/openzfs/openzfs/commit/efgh5678
 ```
 
 #### Coverity Defect Fixes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OpenZFS Community Support Mailing list (Linux)
+    url: https://zfsonlinux.topicbox.com/groups/zfs-discuss
+    about: Get community support for OpenZFS on Linux
+  - name: FreeBSD Community Support Mailing list
+    url: https://lists.freebsd.org/mailman/listinfo/freebsd-fs
+    about: Get community support for OpenZFS on FreeBSD
+  - name: OpenZFS on IRC
+    url: https://webchat.freenode.net/#openzfs
+    about: Use IRC to get community support for OpenZFS

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -89,56 +89,6 @@ function new_change_commit()
     return $error
 }
 
-function is_openzfs_port()
-{
-    # subject starts with OpenZFS means it's an openzfs port
-    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^OpenZFS')
-    if [ -n "$subject" ]; then
-        return 0
-    fi
-
-    return 1
-}
-
-function openzfs_port_commit()
-{
-    error=0
-
-    # subject starts with OpenZFS dddd
-    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^OpenZFS [[:digit:]]+(, [[:digit:]]+)* - ')
-    if [ -z "$subject" ]; then
-        echo "error: OpenZFS patch ports must have a subject line that starts with \"OpenZFS dddd - \""
-        error=1
-    fi
-
-    # need an authored by line
-    if ! check_tagged_line "Authored by" ; then
-        error=1
-    fi
-
-    # need a reviewed by line
-    if ! check_tagged_line "Reviewed by" ; then
-        error=1
-    fi
-
-    # need ported by line
-    if ! check_tagged_line "Ported-by" ; then
-        error=1
-    fi
-
-    # need a url to openzfs commit and it should be valid
-    if ! check_tagged_line_with_url "OpenZFS-commit" ; then
-        error=1
-    fi
-
-    # need a url to illumos issue and it should be valid
-    if ! check_tagged_line_with_url "OpenZFS-issue" ; then
-        error=1
-    fi
-
-    return $error
-}
-
 function is_coverity_fix()
 {
     # subject starts with Fix coverity defects means it's a coverity fix
@@ -190,15 +140,6 @@ function coverity_fix_commit()
 
 if [ -n "$1" ]; then
     REF="$1"
-fi
-
-# if openzfs port, test against that
-if is_openzfs_port; then
-    if ! openzfs_port_commit ; then
-        exit 1
-    else
-        exit 0
-    fi
 fi
 
 # if coverity fix, test against that


### PR DESCRIPTION
### Motivation and Context
This PR aims to seperate the non-controversial changes from #10853 and squashes those together for a quick-and-easy merge.
It removes unused content from the commit check and contributing.md
and
also adds links to the mailinglists/irc to the issue creator.

Thats all.

### Description
- Removes OpenZFS ports from commit check
- Removes OpenZFS ports from CONTRIBUTING.md
- Adds mailingslists and irc to issue template selector
- Remove blank issue option from issue creator

### How Has This Been Tested?
Manually, seperate repo, like #10853

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style