### PR TITLE
Embrace Conventional Commits

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -192,9 +192,10 @@ git config --local core.whitespace trailing-space,space-before-tab,indent-with-n
 
 ### Commit Message Formats
 #### New Changes
-Commit messages for new changes must meet the following guidelines:
-* In 72 characters or less, provide a summary of the change as the
+Commit messages for new changes must meet the [Conventional Commits](https://www.conventionalcommits.org/) guidelines:
+* In 72 characters or less, excluding the `type:` prefix, provide a summary of the change as the
 first line in the commit message.
+* Every header should contain a `type:` prefix. See the [Commit Types](#commit-types) section for more information
 * A body which provides a description of the change. If necessary,
 please summarize important information such as why the proposed
 approach was chosen or a brief description of the bug you are resolving.
@@ -205,7 +206,7 @@ Each line of the body must be 72 characters or less.
 An example commit message for new changes is provided below.
 
 ```
-This line is a brief summary of your change
+docs: This line is a brief summary of your change
 
 Please provide at least a couple sentences describing the
 change. If necessary, please summarize decisions such as
@@ -220,7 +221,7 @@ If you are submitting a fix to a
 [Coverity defect](https://scan.coverity.com/projects/zfsonlinux-zfs),
 the commit message should meet the following guidelines:
 * Provides a subject line in the format of
-`Fix coverity defects: CID dddd, dddd...` where `dddd` represents
+`coverity: CID dddd, dddd...` where `dddd` represents
 each CID fixed by the commit.
 * Provides a body which lists each Coverity defect and how it was corrected.
 * The last line must be a `Signed-off-by:` tag. See the
@@ -228,7 +229,7 @@ each CID fixed by the commit.
 
 An example Coverity defect fix commit message is provided below.
 ```
-Fix coverity defects: CID 12345, 67890
+coverity: CID 12345, 67890
 
 CID 12345: Logically dead code (DEADCODE)
 
@@ -241,6 +242,21 @@ Ensure free is called after allocating memory in function().
 
 Signed-off-by: Contributor <contributor@email.com>
 ```
+
+#### Commit Types
+OpenZFS commit types to differentiate between different types of commits.
+Every commit should include a type prefix in its header. Possible types:
+
+- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests
+- **coverity**: Fixing a coverity defect. See: [Coverity Defect Fixes](#coverity-defect-fixes)
 
 #### Signed Off By
 A line tagged as `Signed-off-by:` must contain the developer's

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 REF="HEAD"
+types=(build ci docs feat fix perf refactor revert style coverity test)
 
 # test a url
 function test_url()
@@ -68,6 +69,12 @@ function check_tagged_line_with_url()
 function new_change_commit()
 {
     error=0
+    type_subject=$(git log -n 1 --pretty=%s "$REF" | cut -d: -f1)
+	# shellcheck disable=SC2076
+	[[ " ${types[*]} " =~ " ${type_subject} " ]] && error=0 || error=1; \
+	echo "error: the commit subject line must start with a valid type, ${type_subject}
+	is not a recognized type. Valid types are: ${types[*}"
+
 
     # subject is not longer than 72 characters
     long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{73}')
@@ -106,7 +113,7 @@ function coverity_fix_commit()
 
     # subject starts with Fix coverity defects: CID dddd, dddd...
     subject=$(git log -n 1 --pretty=%s "$REF" |
-        grep -E -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
+        grep -E -m 1 'coverity: CID [[:digit:]]+(, [[:digit:]]+)*')
     if [ -z "$subject" ]; then
         echo "error: Coverity defect fixes must have a subject line that starts with \"Fix coverity defects: CID dddd\""
         error=1


### PR DESCRIPTION
### Motivation and Context

Conventional Commits is the de-facto standard in commit structure. It should be relatively non-controversial and non-problematic to start using it to its full potential.

We currently almost use convential commits, but not completely (yet).

While this is a change everyone needs to adapt to, it's a rather small one:
Every commit just needs a little tag in front, thats all.

It would make it much more easy to cherry pick commits for backporting, changelogs etc.

Change is as non-controversial as possible and doesn't include any big restructures except just using conventional commit tags on commits.

### Description
This commit adapts the contribution guidelines to be fully Conventional Commits compatible.
And changes coverity fixes commit syntaxis to comply to Conventional Commits

Adding more types is also not a problem at all, so please shout out of you want any!

It also adds clear guidelines for the commit types available.
And makes sure commits are types are checked on stylecheck

### How Has This Been Tested?
Seperate repo and draft-PR runs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #10852
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Requires-builders: style