### PR TITLE
Add "features" property for zpool feature sets.

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -31,6 +31,7 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>
+ * Copyright (c) 2020, Google LLC.
  */
 
 #include <assert.h>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -28,6 +28,7 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>
+ * Copyright (c) 2020, Google LLC.
  */
 
 #include <errno.h>

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
+ * Copyright (c) 2020 by Google LLC.
  */
 
 /*

--- a/man/man8/zpoolprops.8
+++ b/man/man8/zpoolprops.8
@@ -26,6 +26,7 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2020 Google LLC.
 .\"
 .Dd August 9, 2019
 .Dt ZPOOLPROPS 8

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -32,6 +32,7 @@
  * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2020 by Google LLC.
  */
 
 /*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -334,7 +334,8 @@ tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
     'zpool_create_encrypted', 'zpool_create_crypt_combos',
     'zpool_create_features_001_pos', 'zpool_create_features_002_pos',
     'zpool_create_features_003_pos', 'zpool_create_features_004_neg',
-    'zpool_create_features_005_pos',
+    'zpool_create_features_005_pos', 'zpool_create_features_006_neg',
+    'zpool_create_features_007_pos',
     'create-o_ashift', 'zpool_create_tempname']
 tags = ['functional', 'cli_root', 'zpool_create']
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
@@ -32,6 +32,8 @@ dist_pkgdata_SCRIPTS = \
 	zpool_create_features_003_pos.ksh \
 	zpool_create_features_004_neg.ksh \
 	zpool_create_features_005_pos.ksh \
+	zpool_create_features_006_neg.ksh \
+	zpool_create_features_007_pos.ksh \
 	create-o_ashift.ksh \
 	zpool_create_tempname.ksh
 


### PR DESCRIPTION
### Motivation and Context

With the advent of zpool features, it is sometimes desirable to specify 'sets' of features to be applied to a zpool - for example, "all features supported by the current version of grub" and to limit the features applied by (eg) `zpool create` or `zpool upgrade` to not inadvertently enable unwanted features (in the case of grub incompatibility, this might result in an unbootable system).

Ubuntu have addressed this by hard-coding the pool name `bpool` to be immune to `zpool upgrade` and suppressing the warning about disabled features in `zpool status` when this pool name is encountered. Obviously, this is a very limited way of solving the problem.

After a discussion with @rlaager on the Debian ZFS package maintainers mailing list, I became aware of the "default features" proposal discussed at the OpenZFS leadership team [meeting of 2019-03-26]( https://docs.google.com/document/d/1w2jv2XVYFmBVvG1EGf-9A5HBVsjAYoLIFZAnWHhV-BM/edit?usp=sharing). This PR is an attempt to implement the necessary functionality.

### Description
An on-disk zpool property "features" is added, with the enum value `ZPOOL_PROP_FEATURES`.
This property may be unset, take one of the special values `all` or `none`, or be set to a "feature set" name.
Feature sets refer to files in the current filesystem, either absolute pathnames, or relative to `/etc/zfs/features.d` (as currently implemented).
If the referenced file exists, the desired features are loaded from it; it is expected to contain the user-facing feature names, whitespace or comma-separated. Comments are allowed.
If a valid feature set is read, `zpool create` modifies its behavior to only apply features present in the set. (the `-d` flag inhibits automatic feature creation as usual), and `zpool upgrade` modifies its behavior likewise. `zpool status` will not print warnings about disabled features unless they are present in the set. The intention is that, when a feature set is specified, only those features are considered to be "all features" for the `zpool` command.

Example:
```
# cat /etc/zfs/features.d/grub
# Only features which are supported by GRUB2
async_destroy
bookmarks
embedded_data
empty_bpobj
enabled_txg
extensible_dataset
filesystem_limits
hole_birth
large_blocks
lz4_compress
spacemap_histogram
userobj_accounting
# zpool create -o ashift=12 -o features=grub -O mountpoint=/ -R /mnt bootpool /dev/disk/bootdisk
```


**Key Implementation Details**

In `zpool_main.c`, watch out for the `features` property and populate a boolean array of desired features when it is seen. When this occurs, modify the behavior of the `zpool_do_create()` function. In `upgrade_enable_all()`, explicitly look up this property and only apply features which are present in the set.

In `libzfs_pool.c` add the function `zpool_load_features()` which, given a feature property value, locates and reads the specified file, matching keywords against feature unames, and populating a boolean array with TRUE/FALSE accordingly. This function is called in `zpool_valid_proplist()` to validate that the property file is present and correct.

In `libzfs_status.c`, the `check_status()` function is modified to likewise read the features property, load the relevant feature sets, and only flag missing features if they are present in the set. **Note** that I needed to pass the features property explicitly in to this function, as I could find no way to retrieve it using just the `config` nvlist which was passed in. Someone more familiar with the data structures might be able to suggest a cleaner approach here.

**Things I'm unsure about...**

The `features` property is always shown as `default` source in `zpool get` for pools where it is set; I couldn't determine exactly how this happens (vs. `local` which is what I'd expect).

I have not had time to understand the test infrastructure for this project, so there are no unit tests for this specific functionality.

The interaction between the `features` property and the `-d` flag in `zpool create` is not quite as was previously discussed; after a little back and forth, I feel that my implementation is most consistent.
                                                                                              
### How Has This Been Tested?
This only affects the operation of the command-line `zpool create`, `zpool upgrade` and `zpool status` commands (with a smaller influence on `zpool import`). I created various pools with suitable combinations of the `-d` flag, the `-o features` property, features files containing valid and invalid feature names, and verified that correct behavior resulted in all cases. Similarly, the behavior of `zpool upgrade` was observed to work as designed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


