### PR TITLE
Fix objtool configure check

### DIFF
--- a/config/kernel-objtool.m4
+++ b/config/kernel-objtool.m4
@@ -6,10 +6,11 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_OBJTOOL], [
 	dnl # 4.6 API for compile-time stack validation
 	ZFS_LINUX_TEST_SRC([objtool], [
 		#undef __ASSEMBLY__
+		#include <asm/ptrace.h>
 		#include <asm/frame.h>
 	],[
 		#if !defined(FRAME_BEGIN)
-		CTASSERT(1);
+		#error "FRAME_BEGIN is not defined"
 		#endif
 	])
 
@@ -18,7 +19,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_OBJTOOL], [
 		#include <linux/frame.h>
 	],[
 		#if !defined(STACK_FRAME_NON_STANDARD)
-		CTASSERT(1);
+		#error "STACK_FRAME_NON_STANDARD is not defined."
 		#endif
 	])
 ])

--- a/include/sys/frame.h
+++ b/include/sys/frame.h
@@ -23,7 +23,8 @@
 extern "C" {
 #endif
 
-#if defined(__KERNEL__) && defined(HAVE_STACK_FRAME_NON_STANDARD)
+#if defined(__KERNEL__) && defined(HAVE_KERNEL_OBJTOOL) && \
+    defined(HAVE_STACK_FRAME_NON_STANDARD)
 #include <linux/frame.h>
 #else
 #define	STACK_FRAME_NON_STANDARD(func)


### PR DESCRIPTION
### Motivation and Context

Resolve Fedora 32 build failures with 5.8.11-200 kernel:

http://build.zfsonlinux.org/builders/Fedora%2032%20x86_64%20%28TEST%29/builds/1371

### Description

The m4 objtool configure check can incorrectly fail because of a
missing header in the test.  This appears to be the result of a
recent kernel change and was observed on the Fedora 5.8.11-200
kernel.

```
  In file included from /home/fedora/zfs/build/objtool/objtool.c:75:
  ./arch/x86/include/asm/frame.h:100:57: error: 'struct pt_regs'
      declared inside parameter list will not be visible outside
      of this definition or declaration [-Werror]
```

The consequence of this is that the "stack_frame_non_standard"
check is never run and HAVE_STACK_FRAME_NON_STANDARD is set
incorrectly which results in a build failure.  This change adds
the appropriate header to the "objtool" check so it now behaves
as intended.

### How Has This Been Tested?

Locally compiled on Fedora 32 with the 5.8.11-200 kernel.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
