### PR TITLE
Fix CONFIG_DEBUG_LOCK_ALLOC configure check

### DIFF
--- a/config/kernel-config-defined.m4
+++ b/config/kernel-config-defined.m4
@@ -91,7 +91,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_CONFIG_DEBUG_LOCK_ALLOC], [
 
 AC_DEFUN([ZFS_AC_KERNEL_CONFIG_DEBUG_LOCK_ALLOC], [
 	AC_MSG_CHECKING([whether mutex_lock() is GPL-only])
-	ZFS_LINUX_TEST_RESULT([config_debug_lock_alloc], [
+	ZFS_LINUX_TEST_RESULT([config_debug_lock_alloc_license], [
 		AC_MSG_RESULT(no)
 	],[
 		AC_MSG_RESULT(yes)


### PR DESCRIPTION
### Motivation and Context

Fix `CONFIG_DEBUG_LOCK_ALLOC ` check which was not correctly
detecting if the kernel was  built with this option.

### Description

This check was accidentally broken when the KABI checks were updated
to run in parallel, commit 608f874.  The check must be for the
config_debug_lock_alloc_license name to determine if the symbol
is license compatible.

### How Has This Been Tested?

When compiling against the Fedora `kernel-debug-devel` package, which
sets `CONFIG_DEBUG_LOCK_ALLOC `, the build fails at configure time
with the expected error.  Previously it did not and the error would only be
reported when linking.

```
checking whether mutex_lock() is GPL-only... yes
configure: error: 
	*** Kernel built with CONFIG_DEBUG_LOCK_ALLOC which is incompatible
	*** with the CDDL license and will prevent the module linking stage
	*** from succeeding.  You must rebuild your kernel without this
	*** option enabled.
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).