### PR TITLE
freebsd: make adjustments for the standalone environment

### DIFF
--- a/include/os/freebsd/linux/compiler.h
+++ b/include/os/freebsd/linux/compiler.h
@@ -68,7 +68,7 @@
 #define	noinline			__noinline
 #define	____cacheline_aligned		__aligned(CACHE_LINE_SIZE)
 
-#ifndef _KERNEL
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 #define	likely(x)			__builtin_expect(!!(x), 1)
 #define	unlikely(x)			__builtin_expect(!!(x), 0)
 #endif

--- a/include/os/freebsd/spl/rpc/xdr.h
+++ b/include/os/freebsd/spl/rpc/xdr.h
@@ -33,7 +33,7 @@
 #include <rpc/types.h>
 #include_next <rpc/xdr.h>
 
-#ifndef _KERNEL
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 
 #include <assert.h>
 
@@ -66,6 +66,6 @@ xdrmem_control(XDR *xdrs, int request, void *info)
 	    xdrmem_control((xdrs), (req), (op)) :			\
 	    (*(xdrs)->x_ops->x_control)(xdrs, req, op))
 
-#endif	/* !_KERNEL */
+#endif	/* !_KERNEL && !_STANDALONE */
 
 #endif	/* !_OPENSOLARIS_RPC_XDR_H_ */

--- a/include/os/freebsd/spl/sys/atomic.h
+++ b/include/os/freebsd/spl/sys/atomic.h
@@ -29,6 +29,8 @@
 #ifndef _OPENSOLARIS_SYS_ATOMIC_H_
 #define	_OPENSOLARIS_SYS_ATOMIC_H_
 
+#ifndef _STANDALONE
+
 #include <sys/types.h>
 #include <machine/atomic.h>
 
@@ -178,5 +180,14 @@ atomic_cas_ptr(volatile void *target, void *cmp,  void *newval)
 	    (uint32_t)cmp, (uint32_t)newval));
 }
 #endif	/* !defined(COMPAT_32BIT) && defined(__LP64__) */
+
+#else /* _STANDALONE */
+/*
+ * sometimes atomic_add_64 is defined, sometimes not, but the
+ * following is always right for the boot loader.
+ */
+#undef atomic_add_64
+#define	atomic_add_64(ptr, val) *(ptr) += val
+#endif /* !_STANDALONE */
 
 #endif	/* !_OPENSOLARIS_SYS_ATOMIC_H_ */

--- a/include/os/freebsd/spl/sys/byteorder.h
+++ b/include/os/freebsd/spl/sys/byteorder.h
@@ -80,10 +80,11 @@
 #define	BE_64(x)	BSWAP_64(x)
 #endif
 
+#if !defined(_STANDALONE)
 #if BYTE_ORDER == _BIG_ENDIAN
 #define	htonll(x)	BMASK_64(x)
 #define	ntohll(x)	BMASK_64(x)
-#else
+#else /* BYTE_ORDER == _LITTLE_ENDIAN */
 #ifndef __LP64__
 static __inline__ uint64_t
 htonll(uint64_t n)
@@ -96,11 +97,12 @@ ntohll(uint64_t n)
 {
 	return ((((uint64_t)ntohl(n)) << 32) + ntohl(n >> 32));
 }
-#else
+#else	/* !__LP64__ */
 #define	htonll(x)	BSWAP_64(x)
 #define	ntohll(x)	BSWAP_64(x)
-#endif
-#endif
+#endif	/* __LP64__ */
+#endif	/* BYTE_ORDER */
+#endif	/* _STANDALONE */
 
 #define	BE_IN32(xa)	htonl(*((uint32_t *)(void *)(xa)))
 

--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -113,9 +113,9 @@ extern "C" {
 #define	__VPRINTFLIKE(__n)	__sun_attr__((__VPRINTFLIKE__(__n)))
 #define	__KPRINTFLIKE(__n)	__sun_attr__((__KPRINTFLIKE__(__n)))
 #define	__KVPRINTFLIKE(__n)	__sun_attr__((__KVPRINTFLIKE__(__n)))
-#ifdef _KERNEL
+#if	defined(_KERNEL) || defined(_STANDALONE)
 #define	__NORETURN		__sun_attr__((__noreturn__))
-#endif
+#endif /* _KERNEL || _STANDALONE */
 #define	__CONST			__sun_attr__((__const__))
 #define	__PURE			__sun_attr__((__pure__))
 
@@ -174,7 +174,7 @@ typedef int enum_t;
 #define	__exit
 #endif
 
-#ifdef _KERNEL
+#if defined(_KERNEL) || defined(_STANDALONE)
 #define	param_set_charp(a, b) (0)
 #define	ATTR_UID AT_UID
 #define	ATTR_GID AT_GID
@@ -183,9 +183,15 @@ typedef int enum_t;
 #define	ATTR_CTIME	AT_CTIME
 #define	ATTR_MTIME	AT_MTIME
 #define	ATTR_ATIME	AT_ATIME
+#if defined(_STANDALONE)
+#define	vmem_free kmem_free
+#define	vmem_zalloc kmem_zalloc
+#define	vmem_alloc kmem_zalloc
+#else
 #define	vmem_free zfs_kmem_free
 #define	vmem_zalloc(size, flags) zfs_kmem_alloc(size, flags | M_ZERO)
 #define	vmem_alloc zfs_kmem_alloc
+#endif
 #define	MUTEX_NOLOCKDEP 0
 #define	RW_NOLOCKDEP 0
 

--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -52,42 +52,33 @@ extern "C" {
 /*PRINTFLIKE2*/
 extern void cmn_err(int, const char *, ...)
     __KPRINTFLIKE(2);
-#pragma rarely_called(cmn_err)
 
 extern void vzcmn_err(zoneid_t, int, const char *, __va_list)
     __KVPRINTFLIKE(3);
-#pragma rarely_called(vzcmn_err)
 
 extern void vcmn_err(int, const char *, __va_list)
     __KVPRINTFLIKE(2);
-#pragma rarely_called(vcmn_err)
 
 /*PRINTFLIKE3*/
 extern void zcmn_err(zoneid_t, int, const char *, ...)
     __KPRINTFLIKE(3);
-#pragma rarely_called(zcmn_err)
 
 extern void vzprintf(zoneid_t, const char *, __va_list)
     __KVPRINTFLIKE(2);
-#pragma rarely_called(vzprintf)
 
 /*PRINTFLIKE2*/
 extern void zprintf(zoneid_t, const char *, ...)
     __KPRINTFLIKE(2);
-#pragma rarely_called(zprintf)
 
 extern void vuprintf(const char *, __va_list)
     __KVPRINTFLIKE(1);
-#pragma rarely_called(vuprintf)
 
 /*PRINTFLIKE1*/
 extern void panic(const char *, ...)
     __KPRINTFLIKE(1) __NORETURN;
-#pragma rarely_called(panic)
 
 extern void vpanic(const char *, __va_list)
     __KVPRINTFLIKE(1) __NORETURN;
-#pragma rarely_called(vpanic)
 
 #endif /* !_ASM */
 

--- a/include/os/freebsd/spl/sys/condvar.h
+++ b/include/os/freebsd/spl/sys/condvar.h
@@ -36,6 +36,7 @@
 #include <sys/spl_condvar.h>
 #include <sys/mutex.h>
 #include <sys/time.h>
+#include <sys/errno.h>
 
 /*
  * cv_timedwait() is similar to cv_wait() except that it additionally expects

--- a/include/os/freebsd/spl/sys/kmem.h
+++ b/include/os/freebsd/spl/sys/kmem.h
@@ -29,6 +29,7 @@
 #ifndef _OPENSOLARIS_SYS_KMEM_H_
 #define	_OPENSOLARIS_SYS_KMEM_H_
 
+#ifdef _KERNEL
 #include <sys/param.h>
 #include <sys/malloc.h>
 #include <sys/vmem.h>
@@ -93,5 +94,14 @@ void *calloc(size_t n, size_t s);
 	zfs_kmem_alloc((size), (kmflags) | M_ZERO)
 #define	kmem_free(buf, size)		zfs_kmem_free((buf), (size))
 
+#endif	/* _KERNEL */
+
+#ifdef _STANDALONE
+/*
+ * At the moment, we just need it for the type. We redirect the alloc/free
+ * routines to the usual Free and Malloc in that environment.
+ */
+typedef int kmem_cache_t;
+#endif /* _STANDALONE */
 
 #endif	/* _OPENSOLARIS_SYS_KMEM_H_ */

--- a/include/os/freebsd/spl/sys/kmem_cache.h
+++ b/include/os/freebsd/spl/sys/kmem_cache.h
@@ -30,6 +30,7 @@
 #ifndef _SPL_KMEM_CACHE_H
 #define	_SPL_KMEM_CACHE_H
 
+#ifdef _KERNEL
 #include <sys/taskq.h>
 
 /* kmem move callback return values */
@@ -45,5 +46,7 @@ extern void spl_kmem_cache_set_move(kmem_cache_t *,
     kmem_cbrc_t (*)(void *, void *, size_t, void *));
 
 #define	kmem_cache_set_move(skc, move)	spl_kmem_cache_set_move(skc, move)
+
+#endif /* _KERNEL */
 
 #endif

--- a/include/os/freebsd/spl/sys/kstat.h
+++ b/include/os/freebsd/spl/sys/kstat.h
@@ -23,8 +23,11 @@
 
 #ifndef _SPL_KSTAT_H
 #define	_SPL_KSTAT_H
+
 #include <sys/types.h>
+#ifndef _STANDALONE
 #include <sys/sysctl.h>
+#endif
 struct list_head {};
 #include <sys/mutex.h>
 #include <sys/proc.h>
@@ -128,9 +131,10 @@ struct kstat_s {
 	kstat_raw_ops_t	ks_raw_ops;		/* ops table for raw type */
 	char		*ks_raw_buf;		/* buf used for raw ops */
 	size_t		ks_raw_bufsize;		/* size of raw ops buffer */
+#ifndef _STANDALONE
 	struct sysctl_ctx_list ks_sysctl_ctx;
 	struct sysctl_oid *ks_sysctl_root;
-
+#endif /* _STANDALONE */
 };
 
 typedef struct kstat_named_s {
@@ -215,10 +219,16 @@ extern void kstat_runq_exit(kstat_io_t *);
     __kstat_set_seq_raw_ops(k, h, d, a)
 #define	kstat_set_raw_ops(k, h, d, a) \
     __kstat_set_raw_ops(k, h, d, a)
+#ifndef _STANDALONE
 #define	kstat_create(m, i, n, c, t, s, f) \
     __kstat_create(m, i, n, c, t, s, f)
 
 #define	kstat_install(k)		__kstat_install(k)
 #define	kstat_delete(k)			__kstat_delete(k)
+#else
+#define	kstat_create(m, i, n, c, t, s, f)	((kstat_t *)0)
+#define	kstat_install(k)
+#define	kstat_delete(k)
+#endif
 
 #endif  /* _SPL_KSTAT_H */

--- a/include/os/freebsd/spl/sys/proc.h
+++ b/include/os/freebsd/spl/sys/proc.h
@@ -41,7 +41,7 @@
 #include <sys/kmem.h>
 #include <sys/malloc.h>
 
-
+#ifdef _KERNEL
 #define	CPU		curcpu
 #define	minclsyspri	PRIBIO
 #define	defclsyspri minclsyspri
@@ -111,4 +111,5 @@ zfs_proc_is_caller(proc_t *p)
 	return (p == curproc);
 }
 
+#endif	/* _KERNEL */
 #endif	/* _OPENSOLARIS_SYS_PROC_H_ */

--- a/include/os/freebsd/spl/sys/procfs_list.h
+++ b/include/os/freebsd/spl/sys/procfs_list.h
@@ -25,6 +25,8 @@
 #ifndef	_SPL_PROCFS_LIST_H
 #define	_SPL_PROCFS_LIST_H
 
+#ifndef _STANDALONE
+
 #include <sys/kstat.h>
 #include <sys/mutex.h>
 
@@ -63,5 +65,9 @@ void procfs_list_install(const char *module,
 void procfs_list_uninstall(procfs_list_t *procfs_list);
 void procfs_list_destroy(procfs_list_t *procfs_list);
 void procfs_list_add(procfs_list_t *procfs_list, void *p);
+
+#else
+typedef int procfs_list_t;
+#endif /* !_STANDALONE */
 
 #endif	/* _SPL_PROCFS_LIST_H */

--- a/include/os/freebsd/spl/sys/sig.h
+++ b/include/os/freebsd/spl/sys/sig.h
@@ -29,6 +29,8 @@
 #ifndef _OPENSOLARIS_SYS_SIG_H_
 #define	_OPENSOLARIS_SYS_SIG_H_
 
+#ifndef _STANDALONE
+
 #include_next <sys/signal.h>
 #include <sys/param.h>
 #include <sys/lock.h>
@@ -62,4 +64,7 @@ issig(int why)
 	}
 	return (0);
 }
+
+#endif /* !_STANDALONE */
+
 #endif	/* _OPENSOLARIS_SYS_SIG_H_ */

--- a/include/os/freebsd/spl/sys/sysmacros.h
+++ b/include/os/freebsd/spl/sys/sysmacros.h
@@ -31,6 +31,7 @@
 #define	_SYS_SYSMACROS_H
 
 #include <sys/param.h>
+#include <sys/systm.h>
 #include <sys/isa_defs.h>
 #include <sys/libkern.h>
 #include <sys/zone.h>
@@ -71,7 +72,11 @@ extern "C" {
 #define	DIV_ROUND_UP(n, d)	(((n) + (d) - 1) / (d))
 #endif
 
+#ifdef _STANDALONE
+#define	boot_ncpus 1
+#else /* _STANDALONE */
 #define	boot_ncpus mp_ncpus
+#endif /* _STANDALONE */
 #define	kpreempt_disable() critical_enter()
 #define	kpreempt_enable() critical_exit()
 #define	CPU_SEQID curcpu
@@ -319,7 +324,7 @@ extern unsigned char bcd_to_byte[256];
 
 /* avoid any possibility of clashing with <stddef.h> version */
 
-#define	offsetof(s, m)	((size_t)(&(((s *)0)->m)))
+#define	offsetof(type, field)	__offsetof(type, field)
 #endif
 
 /*

--- a/include/os/freebsd/spl/sys/taskq.h
+++ b/include/os/freebsd/spl/sys/taskq.h
@@ -26,6 +26,8 @@
 #ifndef	_SYS_TASKQ_H
 #define	_SYS_TASKQ_H
 
+#ifdef _KERNEL
+
 #include <sys/types.h>
 #include <sys/proc.h>
 #include <sys/taskqueue.h>
@@ -111,5 +113,12 @@ void	taskq_resume(taskq_t *);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* _KERNEL */
+
+#ifdef _STANDALONE
+typedef int taskq_ent_t;
+#define	taskq_init_ent(x)
+#endif /* _STANDALONE */
 
 #endif	/* _SYS_TASKQ_H */

--- a/include/os/freebsd/spl/sys/uio.h
+++ b/include/os/freebsd/spl/sys/uio.h
@@ -29,6 +29,8 @@
 #ifndef _OPENSOLARIS_SYS_UIO_H_
 #define	_OPENSOLARIS_SYS_UIO_H_
 
+#ifndef _STANDALONE
+
 #include_next <sys/uio.h>
 #include <sys/_uio.h>
 #include <sys/debug.h>
@@ -106,5 +108,7 @@ uio_index_at_offset(uio_t *uio, offset_t off, uint_t *vec_idx)
 
 	return (off);
 }
+
+#endif /* !_STANDALONE */
 
 #endif	/* !_OPENSOLARIS_SYS_UIO_H_ */

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -62,7 +62,7 @@ typedef enum {
 	DATA_TYPE_UINT8,
 	DATA_TYPE_BOOLEAN_ARRAY,
 	DATA_TYPE_INT8_ARRAY,
-#if !defined(_KERNEL)
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 	DATA_TYPE_UINT8_ARRAY,
 	DATA_TYPE_DOUBLE
 #else
@@ -191,7 +191,7 @@ int nvlist_add_uint64_array(nvlist_t *, const char *, uint64_t *, uint_t);
 int nvlist_add_string_array(nvlist_t *, const char *, char *const *, uint_t);
 int nvlist_add_nvlist_array(nvlist_t *, const char *, nvlist_t **, uint_t);
 int nvlist_add_hrtime(nvlist_t *, const char *, hrtime_t);
-#if !defined(_KERNEL)
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 int nvlist_add_double(nvlist_t *, const char *, double);
 #endif
 
@@ -228,7 +228,7 @@ int nvlist_lookup_nvlist_array(nvlist_t *, const char *,
     nvlist_t ***, uint_t *);
 int nvlist_lookup_hrtime(nvlist_t *, const char *, hrtime_t *);
 int nvlist_lookup_pairs(nvlist_t *, int, ...);
-#if !defined(_KERNEL)
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 int nvlist_lookup_double(nvlist_t *, const char *, double *);
 #endif
 
@@ -269,7 +269,7 @@ int nvpair_value_uint64_array(nvpair_t *, uint64_t **, uint_t *);
 int nvpair_value_string_array(nvpair_t *, char ***, uint_t *);
 int nvpair_value_nvlist_array(nvpair_t *, nvlist_t ***, uint_t *);
 int nvpair_value_hrtime(nvpair_t *, hrtime_t *);
-#if !defined(_KERNEL)
+#if !defined(_KERNEL) && !defined(_STANDALONE)
 int nvpair_value_double(nvpair_t *, double *);
 #endif
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -32,7 +32,15 @@
 extern "C" {
 #endif
 
-#ifdef __KERNEL__
+/*
+ * This code compiles in three different contexts. When __KERNEL__ is defined,
+ * the code uses "unix-like" kernel interfaces. When _STANDALONE is defined, the
+ * code is running in a reduced capacity environment of the boot loader which is
+ * generally a subset of both POSIX and kernel interfaces (with a few unique
+ * interfaces too). When neither are defined, it's in a userland POSIX or
+ * similar environment.
+ */
+#if defined(__KERNEL__) || defined(_STANDALONE)
 #include <sys/note.h>
 #include <sys/types.h>
 #include <sys/atomic.h>
@@ -65,7 +73,7 @@ extern "C" {
 #include <sys/procfs_list.h>
 #include <sys/mod.h>
 #include <sys/zfs_context_os.h>
-#else /* _KERNEL */
+#else /* _KERNEL || _STANDALONE */
 
 #define	_SYS_MUTEX_H
 #define	_SYS_RWLOCK_H
@@ -759,7 +767,7 @@ extern int kmem_cache_reap_active(void);
 #define	__init
 #define	__exit
 
-#endif /* _KERNEL */
+#endif  /* _KERNEL || _STANDALONE */
 
 #ifdef __cplusplus
 };

--- a/lib/libspl/include/os/freebsd/sys/param.h
+++ b/lib/libspl/include/os/freebsd/sys/param.h
@@ -45,10 +45,6 @@
  */
 #define	MAXNAMELEN	256
 
-#ifndef IN_BASE
-#define	UID_NOBODY	60001		/* user ID no body */
-#define	GID_NOBODY	UID_NOBODY
-#endif
 #define	UID_NOACCESS	60002		/* user ID no access */
 
 #define	MAXUID		UINT32_MAX	/* max user id */

--- a/module/os/freebsd/spl/list.c
+++ b/module/os/freebsd/spl/list.c
@@ -27,10 +27,10 @@
  * Generic doubly-linked list implementation
  */
 
+#include <sys/param.h>
 #include <sys/list.h>
 #include <sys/list_impl.h>
 #include <sys/types.h>
-#include <sys/sysmacros.h>
 #include <sys/debug.h>
 
 #define	list_d2l(a, obj) ((list_node_t *)(((char *)obj) + (a)->list_offset))


### PR DESCRIPTION
In FreeBSD, there's three compile environments that are supported:
userland, the kernel and the bootloader / standalone. Adjust the
headers to compile in the standalone environment. Limit kernel-only
items from view when _STANDALONE is defined.

Signed-off-by: Warner Losh <imp@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Changes to allow ZFS files to compile in FreeBSD's standalone environment (which is neither Kernel nor Userland) to allow integration of zstd compression into our boot loader.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD has a boot loader we use to boot systems. We'd like to support zstd compression in that boot loader. However, the standalone environment is not quite the same as the kernel, nor quite the same as userland so small tweaks are needed to make it work.

### Description
<!--- Describe your changes in detail -->
Change the visibility of different functions that aren't applicable to the standalone environment. Change some 'redefinitions' to be the FreeBSD standard definition so there's no redefinition warnings. Subset some features, such as statistical counters, which are not relevant to booting and which would consume space in the boot loader that's somewhat at a premium in some of our booting environments.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I've booted this on FreeBSD and my existing zfs volumes are fine, some with zstd enabled, some without. Others have tested booting a zstd enabled dataset.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
