### PR TITLE
Replace ZFS on Linux references with OpenZFS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
 The [OpenZFS Code of Conduct](http://www.open-zfs.org/wiki/Code_of_Conduct)
-applies to spaces associated with the ZFS on Linux project, including GitHub.
+applies to spaces associated with the OpenZFS project, including GitHub.

--- a/cmd/arc_summary/arc_summary2
+++ b/cmd/arc_summary/arc_summary2
@@ -42,7 +42,7 @@
 Provides basic information on the ARC, its efficiency, the L2ARC (if present),
 the Data Management Unit (DMU), Virtual Devices (VDEVs), and tunables. See the
 in-source documentation and code at
-https://github.com/zfsonlinux/zfs/blob/master/module/zfs/arc.c for details.
+https://github.com/openzfs/zfs/blob/master/module/zfs/arc.c for details.
 """
 
 import getopt

--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -32,7 +32,7 @@
 Provides basic information on the ARC, its efficiency, the L2ARC (if present),
 the Data Management Unit (DMU), Virtual Devices (VDEVs), and tunables. See
 the in-source documentation and code at
-https://github.com/zfsonlinux/zfs/blob/master/module/zfs/arc.c for details.
+https://github.com/openzfs/zfs/blob/master/module/zfs/arc.c for details.
 The original introduction to arc_summary can be found at
 http://cuddletech.com/?p=454
 """
@@ -43,7 +43,7 @@ import subprocess
 import sys
 import time
 
-DESCRIPTION = 'Print ARC and other statistics for ZFS on Linux'
+DESCRIPTION = 'Print ARC and other statistics for OpenZFS'
 INDENT = ' '*8
 LINE_LENGTH = 72
 DATE_FORMAT = '%a %b %d %H:%M:%S %Y'
@@ -860,7 +860,7 @@ def section_vdev(kstats_dict):
 
     # Currently [Nov 2017] the VDEV cache is disabled, because it is actually
     # harmful. When this is the case, we just skip the whole entry. See
-    # https://github.com/zfsonlinux/zfs/blob/master/module/zfs/vdev_cache.c
+    # https://github.com/openzfs/zfs/blob/master/module/zfs/vdev_cache.c
     # for details
     tunables = get_vdev_params()
 
@@ -886,7 +886,7 @@ def section_vdev(kstats_dict):
 
 def section_zil(kstats_dict):
     """Collect information on the ZFS Intent Log. Some of the information
-    taken from https://github.com/zfsonlinux/zfs/blob/master/include/sys/zil.h
+    taken from https://github.com/openzfs/zfs/blob/master/include/sys/zil.h
     """
 
     zil_stats = isolate_section('zil', kstats_dict)

--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -177,9 +177,9 @@ zfs_agent_post_event(const char *class, const char *subclass, nvlist_t *nvl)
 	}
 
 	/*
-	 * On ZFS on Linux, we don't get the expected FM_RESOURCE_REMOVED
-	 * ereport from vdev_disk layer after a hot unplug. Fortunately we
-	 * get a EC_DEV_REMOVE from our disk monitor and it is a suitable
+	 * On Linux, we don't get the expected FM_RESOURCE_REMOVED ereport
+	 * from the vdev_disk layer after a hot unplug. Fortunately we do
+	 * get an EC_DEV_REMOVE from our disk monitor and it is a suitable
 	 * proxy so we remap it here for the benefit of the diagnosis engine.
 	 */
 	if ((strcmp(class, EC_DEV_REMOVE) == 0) &&

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -63,9 +63,7 @@
  * If the device could not be replaced, then the second online attempt will
  * trigger the FMA fault that we skipped earlier.
  *
- * ZFS on Linux porting notes:
- *	Linux udev provides a disk insert for both the disk and the partition
- *
+ * On Linux udev provides a disk insert for both the disk and the partition.
  */
 
 #include <ctype.h>

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -364,7 +364,7 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 		return;
 
 	/*
-	 * Note: on zfsonlinux statechange events are more than just
+	 * Note: on linux statechange events are more than just
 	 * healthy ones so we need to confirm the actual state value.
 	 */
 	if (strcmp(class, "resource.fs.zfs.statechange") == 0 &&

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -364,7 +364,7 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 		return;
 
 	/*
-	 * Note: on linux statechange events are more than just
+	 * Note: on Linux statechange events are more than just
 	 * healthy ones so we need to confirm the actual state value.
 	 */
 	if (strcmp(class, "resource.fs.zfs.statechange") == 0 &&

--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed.h
+++ b/cmd/zed/zed.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed.h
+++ b/cmd/zed/zed.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_event.h
+++ b/cmd/zed/zed_event.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_event.h
+++ b/cmd/zed/zed_event.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_exec.h
+++ b/cmd/zed/zed_exec.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_exec.h
+++ b/cmd/zed/zed_exec.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_file.h
+++ b/cmd/zed/zed_file.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_file.h
+++ b/cmd/zed/zed_file.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_log.c
+++ b/cmd/zed/zed_log.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_log.c
+++ b/cmd/zed/zed_log.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_log.h
+++ b/cmd/zed/zed_log.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_log.h
+++ b/cmd/zed/zed_log.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zed/zed_strings.h
+++ b/cmd/zed/zed_strings.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the ZFS Event Daemon (ZED)
- * for ZFS on Linux (ZoL) <http://zfsonlinux.org/>.
+ *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
  * Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/cmd/zed/zed_strings.h
+++ b/cmd/zed/zed_strings.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ZFS Event Daemon (ZED)
+ * This file is part of the ZFS Event Daemon (ZED).
  *
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
  * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.

--- a/cmd/zvol_id/Makefile.am
+++ b/cmd/zvol_id/Makefile.am
@@ -1,7 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
 # Disable GCC stack protection for zvol_id.  This is a kludge and should be
-# removed once https://github.com/zfsonlinux/zfs/issues/569 is resolved.
+# removed once https://github.com/openzfs/zfs/issues/569 is resolved.
 AM_CFLAGS += -fno-stack-protector
 
 udev_PROGRAMS = zvol_id

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -41,7 +41,8 @@ install() {
 	dracut_install @bindir@/zgenhostid
 	dracut_install @sbindir@/zfs
 	dracut_install @sbindir@/zpool
-	# Workaround for zfsonlinux/zfs#4749 by ensuring libgcc_s.so(.1) is included
+	# Workaround for https://github.com/openzfs/zfs/issues/4749 by
+	# ensuring libgcc_s.so(.1) is included
 	if [[ -n "$(ldd @sbindir@/zpool | grep -F 'libgcc_s.so')" ]]; then
 		# Dracut will have already tracked and included it
 		:;

--- a/contrib/pyzfs/README
+++ b/contrib/pyzfs/README
@@ -25,4 +25,4 @@ a temporary directory specified by, for instance, TMP environment
 variable on a memory backed filesystem.
 
 Package documentation: http://pyzfs.readthedocs.org
-Package development: https://github.com/zfsonlinux/zfs
+Package development: https://github.com/openzfs/zfs

--- a/contrib/pyzfs/libzfs_core/__init__.py
+++ b/contrib/pyzfs/libzfs_core/__init__.py
@@ -32,7 +32,7 @@ of the error codes to the exceptions by interpreting a context
 in which the error code is produced.
 
 To submit an issue or contribute to development of this package
-please visit its `GitHub repository <https://github.com/zfsonlinux/zfs>`_.
+please visit its `GitHub repository <https://github.com/openzfs/zfs>`_.
 
 .. data:: MAXNAMELEN
 

--- a/copy-builtin
+++ b/copy-builtin
@@ -35,9 +35,9 @@ config ZFS
 	select ZLIB_INFLATE
 	select ZLIB_DEFLATE
 	help
-	  This is the ZFS filesystem from the ZFS On Linux project.
+	  This is the ZFS filesystem from the OpenZFS project.
 
-	  See https://zfsonlinux.org/
+	  See https://github.com/openzfs/zfs
 
 	  To compile this file system support as a module, choose M here.
 

--- a/etc/init.d/README.md
+++ b/etc/init.d/README.md
@@ -16,7 +16,7 @@ DESCRIPTION
 
 SUPPORT
   If you find that they don't work for your platform, please report this
-  at the ZFS On Linux issue tracker at https://github.com/zfsonlinux/zfs/issues.
+  at the OpenZFS issue tracker at https://github.com/openzfs/zfs/issues.
 
   Please include:
 

--- a/include/os/freebsd/spl/sys/kstat.h
+++ b/include/os/freebsd/spl/sys/kstat.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/freebsd/spl/sys/sunddi.h
+++ b/include/os/freebsd/spl/sys/sunddi.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/rpc/xdr.h
+++ b/include/os/linux/spl/rpc/xdr.h
@@ -3,7 +3,6 @@
  *  Written by Ricardo Correia <Ricardo.M.Correia@Sun.COM>
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/acl.h
+++ b/include/os/linux/spl/sys/acl.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/atomic.h
+++ b/include/os/linux/spl/sys/atomic.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/byteorder.h
+++ b/include/os/linux/spl/sys/byteorder.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/callb.h
+++ b/include/os/linux/spl/sys/callb.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/callo.h
+++ b/include/os/linux/spl/sys/callo.h
@@ -5,7 +5,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/cmn_err.h
+++ b/include/os/linux/spl/sys/cmn_err.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/condvar.h
+++ b/include/os/linux/spl/sys/condvar.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/console.h
+++ b/include/os/linux/spl/sys/console.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/cred.h
+++ b/include/os/linux/spl/sys/cred.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/ctype.h
+++ b/include/os/linux/spl/sys/ctype.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/disp.h
+++ b/include/os/linux/spl/sys/disp.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/dkio.h
+++ b/include/os/linux/spl/sys/dkio.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/fcntl.h
+++ b/include/os/linux/spl/sys/fcntl.h
@@ -5,7 +5,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/file.h
+++ b/include/os/linux/spl/sys/file.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/inttypes.h
+++ b/include/os/linux/spl/sys/inttypes.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/isa_defs.h
+++ b/include/os/linux/spl/sys/isa_defs.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/kmem_cache.h
+++ b/include/os/linux/spl/sys/kmem_cache.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/kstat.h
+++ b/include/os/linux/spl/sys/kstat.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/list.h
+++ b/include/os/linux/spl/sys/list.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/mod_os.h
+++ b/include/os/linux/spl/sys/mod_os.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/mutex.h
+++ b/include/os/linux/spl/sys/mutex.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/param.h
+++ b/include/os/linux/spl/sys/param.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/proc.h
+++ b/include/os/linux/spl/sys/proc.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/processor.h
+++ b/include/os/linux/spl/sys/processor.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/random.h
+++ b/include/os/linux/spl/sys/random.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/rwlock.h
+++ b/include/os/linux/spl/sys/rwlock.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/shrinker.h
+++ b/include/os/linux/spl/sys/shrinker.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/sid.h
+++ b/include/os/linux/spl/sys/sid.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/signal.h
+++ b/include/os/linux/spl/sys/signal.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/simd.h
+++ b/include/os/linux/spl/sys/simd.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/stat.h
+++ b/include/os/linux/spl/sys/stat.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/strings.h
+++ b/include/os/linux/spl/sys/strings.h
@@ -4,7 +4,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/sunddi.h
+++ b/include/os/linux/spl/sys/sunddi.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/sysmacros.h
+++ b/include/os/linux/spl/sys/sysmacros.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/systeminfo.h
+++ b/include/os/linux/spl/sys/systeminfo.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/taskq.h
+++ b/include/os/linux/spl/sys/taskq.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/thread.h
+++ b/include/os/linux/spl/sys/thread.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/time.h
+++ b/include/os/linux/spl/sys/time.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/timer.h
+++ b/include/os/linux/spl/sys/timer.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/tsd.h
+++ b/include/os/linux/spl/sys/tsd.h
@@ -5,7 +5,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/types.h
+++ b/include/os/linux/spl/sys/types.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/types32.h
+++ b/include/os/linux/spl/sys/types32.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -7,7 +7,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/user.h
+++ b/include/os/linux/spl/sys/user.h
@@ -4,7 +4,6 @@
  *  Written by Richard Yao <richard.yao@clusterhq.com>.
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/vfs.h
+++ b/include/os/linux/spl/sys/vfs.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/vmem.h
+++ b/include/os/linux/spl/sys/vmem.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/vmsystm.h
+++ b/include/os/linux/spl/sys/vmsystm.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/vnode.h
+++ b/include/os/linux/spl/sys/vnode.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/wait.h
+++ b/include/os/linux/spl/sys/wait.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/zmod.h
+++ b/include/os/linux/spl/sys/zmod.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/os/linux/spl/sys/zone.h
+++ b/include/os/linux/spl/sys/zone.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/sys/mod.h
+++ b/include/sys/mod.h
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/include/sys/pathname.h
+++ b/include/sys/pathname.h
@@ -54,10 +54,6 @@ extern "C" {
  */
 typedef struct pathname {
 	char	*pn_buf;		/* underlying storage */
-#if 0 /* unused in ZoL */
-	char	*pn_path;		/* remaining pathname */
-	size_t	pn_pathlen;		/* remaining length */
-#endif
 	size_t	pn_bufsize;		/* total size of pn_buf */
 } pathname_t;
 

--- a/lib/libzfsbootenv/libzfsbootenv.pc.in
+++ b/lib/libzfsbootenv/libzfsbootenv.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libzfsbootenv
 Description: LibZFSBootENV library
 Version: @VERSION@
-URL: https://zfsonlinux.org
+URL: https://github.com/openzfs/zfs
 Requires: libzfs libnvpair
 Cflags: -I${includedir}
 Libs: -L${libdir} -lzfsbootenv

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -813,9 +813,9 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 	 *	env ZFS_VDEV_DEVID_OPT_OUT=YES zpool import dozer
 	 *
 	 * explanation:
-	 * Older ZFS on Linux implementations had issues when attempting to
-	 * display pool config VDEV names if a "devid" NVP value is present
-	 * in the pool's config.
+	 * Older OpenZFS implementations had issues when attempting to
+	 * display pool config VDEV names if a "devid" NVP value is
+	 * present in the pool's config.
 	 *
 	 * For example, a pool that originated on illumos platform would
 	 * have a devid value in the config and "zpool status" would fail

--- a/man/man1/raidz_test.1
+++ b/man/man1/raidz_test.1
@@ -94,4 +94,4 @@ Debugging option. Specify to attach gdb when SIGSEGV or SIGABRT are received.
 .SH "SEE ALSO"
 .BR "ztest (1)"
 .SH "AUTHORS"
-vdev_raidz, created for ZFS on Linux by Gvozden Nešković <neskovic@gmail.com>
+vdev_raidz, created for OpenZFS by Gvozden Nešković <neskovic@gmail.com>

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1573,7 +1573,7 @@ Default value: \fB500,000\fR.
 .RS 12n
 Disables requirement for IVset guids to be present and match when doing a raw
 receive of encrypted datasets. Intended for users whose pools were created with
-ZFS on Linux pre-release versions and now have compatibility issues.
+OpenZFS pre-release versions and now have compatibility issues.
 .sp
 Default value: \fB0\fR.
 .RE

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -1,5 +1,5 @@
 .\"
-.\" This file is part of the ZFS Event Daemon (ZED)
+.\" This file is part of the ZFS Event Daemon (ZED).
 .\" Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
 .\" Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
 .\" Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -1,5 +1,5 @@
 .\"
-.\" This file is part of the OpenZFS Event Daemon (ZED)
+.\" This file is part of the ZFS Event Daemon (ZED)
 .\" Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
 .\" Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
 .\" Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -1,6 +1,5 @@
 .\"
-.\" This file is part of the ZFS Event Daemon (ZED)
-.\" for ZFS on Linux (ZoL) <https://zfsonlinux.org/>.
+.\" This file is part of the OpenZFS Event Daemon (ZED)
 .\" Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
 .\" Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
 .\" Refer to the ZoL git commit log for authoritative copyright attribution.

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -503,7 +503,7 @@ command line option.
 .El
 .Bl -tag -width "ZFS_VDEV_DEVID_OPT_OUT"
 .It Ev ZFS_VDEV_DEVID_OPT_OUT
-Older ZFS on Linux implementations had issues when attempting to display pool
+Older OpenZFS implementations had issues when attempting to display pool
 config VDEV names if a
 .Sy devid
 NVP value is present in the pool's config.

--- a/module/os/linux/spl/README.md
+++ b/module/os/linux/spl/README.md
@@ -1,5 +1,5 @@
 The Solaris Porting Layer, SPL, is a Linux kernel module which provides a
-compatibility layer used by the [ZFS on Linux](https://zfsonlinux.org) project.
+compatibility layer used by the [OpenZFS](https://github.com/openzfs/zfs) project.
 
 # Installation
 

--- a/module/os/linux/spl/spl-atomic.c
+++ b/module/os/linux/spl/spl-atomic.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-condvar.c
+++ b/module/os/linux/spl/spl-condvar.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-cred.c
+++ b/module/os/linux/spl/spl-cred.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-err.c
+++ b/module/os/linux/spl/spl-err.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the
@@ -217,7 +216,7 @@ spl_kmem_alloc_impl(size_t size, int flags, int node)
 	    !(flags & KM_VMEM)) {
 		printk(KERN_WARNING
 		    "Large kmem_alloc(%lu, 0x%x), please file an issue at:\n"
-		    "https://github.com/zfsonlinux/zfs/issues/new\n",
+		    "https://github.com/openzfs/zfs/issues/new\n",
 		    (unsigned long)size, flags);
 		dump_stack();
 	}

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-tsd.c
+++ b/module/os/linux/spl/spl-tsd.c
@@ -5,7 +5,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-vmem.c
+++ b/module/os/linux/spl/spl-vmem.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-xdr.c
+++ b/module/os/linux/spl/spl-xdr.c
@@ -3,7 +3,6 @@
  *  Written by Ricardo Correia <Ricardo.M.Correia@Sun.COM>
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/os/linux/spl/spl-zlib.c
+++ b/module/os/linux/spl/spl-zlib.c
@@ -6,7 +6,6 @@
  *  UCRL-CODE-235197
  *
  *  This file is part of the SPL, Solaris Porting Layer.
- *  For details, see <http://zfsonlinux.org/>.
  *
  *  The SPL is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the

--- a/module/zfs/pathname.c
+++ b/module/zfs/pathname.c
@@ -73,10 +73,6 @@ pn_alloc_sz(struct pathname *pnp, size_t sz)
 {
 	pnp->pn_buf = kmem_alloc(sz, KM_SLEEP);
 	pnp->pn_bufsize = sz;
-#if 0 /* unused in ZoL */
-	pnp->pn_path = pnp->pn_buf;
-	pnp->pn_pathlen = 0;
-#endif
 }
 
 /*
@@ -89,8 +85,4 @@ pn_free(struct pathname *pnp)
 	kmem_free(pnp->pn_buf, pnp->pn_bufsize);
 	pnp->pn_buf = NULL;
 	pnp->pn_bufsize = 0;
-#if 0 /* unused in ZoL */
-	pnp->pn_path = NULL;
-	pnp->pn_pathlen = 0;
-#endif
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1260,7 +1260,7 @@ spa_activate(spa_t *spa, spa_mode_t mode)
 	/*
 	 * This taskq is used to perform zvol-minor-related tasks
 	 * asynchronously. This has several advantages, including easy
-	 * resolution of various deadlocks (zfsonlinux bug #3681).
+	 * resolution of various deadlocks.
 	 *
 	 * The taskq must be single threaded to ensure tasks are always
 	 * processed in the order in which they were dispatched.

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1433,7 +1433,7 @@ vdev_uberblock_compare(const uberblock_t *ub1, const uberblock_t *ub2)
 
 	/*
 	 * If MMP_VALID(ub) && MMP_SEQ_VALID(ub) then the host has an MMP-aware
-	 * ZFS, e.g. zfsonlinux >= 0.7.
+	 * ZFS, e.g. OpenZFS >= 0.7.
 	 *
 	 * If one ub has MMP and the other does not, they were written by
 	 * different hosts, which matters for MMP.  So we treat no MMP/no SEQ as

--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -18,7 +18,7 @@ Summary:        Kernel module(s) (dkms)
 
 Group:          System Environment/Kernel
 License:        @ZFS_META_LICENSE@
-URL:            https://zfsonlinux.org/
+URL:            https://github.com/openzfs/zfs
 Source0:        %{module}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -48,7 +48,7 @@ Summary:        Kernel module(s)
 
 Group:          System Environment/Kernel
 License:        @ZFS_META_LICENSE@
-URL:            https://zfsonlinux.org/
+URL:            https://github.com/openzfs/zfs
 Source0:        %{module}-%{version}.tar.gz
 Source10:       kmodtool
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -117,7 +117,7 @@ Summary:        Commands to control the kernel modules and libraries
 
 Group:          System Environment/Kernel
 License:        @ZFS_META_LICENSE@
-URL:            https://zfsonlinux.org/
+URL:            https://github.com/openzfs/zfs
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       libzpool2 = %{version}
@@ -191,7 +191,7 @@ Summary:        Solaris userland utility library for Linux
 Group:          System Environment/Kernel
 
 %description -n libuutil1
-This library provides a variety of compatibility functions for ZFS on Linux:
+This library provides a variety of compatibility functions for OpenZFS:
  * libspl: The Solaris Porting Layer userland library, which provides APIs
    that make it possible to run Solaris user code in a Linux environment
    with relatively minimal modification.

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -8,7 +8,7 @@ Release:        @RELEASE@%{?dist}
 Summary:        Kernel module(s)
 Group:          System Environment/Kernel
 License:        @ZFS_META_LICENSE@
-URL:            https://zfsonlinux.org/
+URL:            https://github.com/openzfs/zfs
 BuildRequires:  %kernel_module_package_buildreqs
 Source0:        @PACKAGE@-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)

--- a/scripts/zimport.sh
+++ b/scripts/zimport.sh
@@ -39,7 +39,7 @@
 #      -s "zfs-0.6.2 master installed" \
 #      -p "zevo-1.1.1 zol-0.6.2 zol-0.6.2-173 master installed"
 #
-# --------------------- ZFS on Linux Source Versions --------------
+# ------------------------ OpenZFS Source Versions ----------------
 #                 zfs-0.6.2       master          0.6.2-175_g36eb554
 # -----------------------------------------------------------------
 # Clone ZFS       Local		Local		Skip
@@ -68,9 +68,9 @@ TEST_DIR=$(mktemp -u -d -p /var/tmp zimport.XXXXXXXX)
 KEEP="no"
 VERBOSE="no"
 COLOR="yes"
-REPO="https://github.com/zfsonlinux"
+REPO="https://github.com/openzfs"
 IMAGES_DIR="$SCRIPTDIR/zfs-images/"
-IMAGES_TAR="https://github.com/zfsonlinux/zfs-images/tarball/master"
+IMAGES_TAR="https://github.com/openzfs/zfs-images/tarball/master"
 ERROR=0
 
 CONFIG_LOG="configure.log"
@@ -365,7 +365,7 @@ if [ ! -d "$SRC_DIR" ]; then
 fi
 
 # Print a header for all tags which are being tested.
-echo "--------------------- ZFS on Linux Source Versions --------------"
+echo "------------------------ OpenZFS Source Versions ----------------"
 printf "%-16s" " "
 for TAG in $SRC_TAGS; do
 	src_set_vars "$TAG"

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
@@ -25,7 +25,6 @@
 #
 # DESCRIPTION:
 #	Verify that ACLs survive remount.
-#	Regression test for https://github.com/zfsonlinux/zfs/issues/4520
 #
 # STRATEGY:
 #	1. Test presence of default and regular ACLs after remount

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_number_props.zcp
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_number_props.zcp
@@ -41,7 +41,7 @@ props['logicalused']          = {{true,       nil}, {nil,  nil}, {true,       ni
 props['logicalreferenced']    = {{true,       nil}, {true, nil}, {true,       nil}}
 props['quota']                = {{true, 'default'}, {nil,  nil}, {nil,        nil}}
 props['reservation']          = {{true, 'default'}, {nil,  nil}, {true, 'default'}}
--- Note that zfsonlinux allows volsize for snapshot which differs from openzfs
+-- Note that OpenZFS allows volsize for snapshot
 -- props['volsize']           = {{nil,        nil}, {nil,  nil}, {true,       vol}}
 props['refquota']             = {{true, 'default'}, {nil,  nil}, {nil,        nil}}
 props['refreservation']       = {{true, 'default'}, {nil,  nil}, {true,       vol}}

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_test_race.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_test_race.ksh
@@ -26,7 +26,7 @@
 # under race condition which resulted in undefined mount order.  The purpose
 # of this test is to verify `zfs unmount -a` succeeds (not `zfs mount -a`
 # succeeds, it always does) after `zfs mount -a`, which could fail if threads
-# race.  See github.com/zfsonlinux/zfs/issues/{8450,8833,8878} for details.
+# race.  See github.com/openzfs/zfs/issues/{8450,8833,8878} for details.
 #
 # STRATEGY:
 # 1. Create pools and filesystems.

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
@@ -24,7 +24,7 @@
 # 1. Create sparse files of various size
 # 2. Snapshot and send these sparse files
 # 3. Verify these files are received correctly and we don't trigger any issue
-#    like the one described in https://github.com/zfsonlinux/zfs/pull/6760
+#    like the one described in https://github.com/openzfs/zfs/pull/6760
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/rsend/rsend_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_008_pos.ksh
@@ -43,7 +43,7 @@
 
 verify_runnable "both"
 
-# See issue: https://github.com/zfsonlinux/zfs/issues/6066
+# See issue: https://github.com/openzfs/zfs/issues/6066
 log_unsupported "Occasionally hangs"
 
 #		Origin			Clone

--- a/tests/zfs-tests/tests/functional/rsend/send_freeobjects.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_freeobjects.ksh
@@ -21,7 +21,7 @@
 #
 # Description:
 # Verify FREEOBJECTS record frees sequential objects (See
-# https://github.com/zfsonlinux/zfs/issues/6694)
+# https://github.com/openzfs/zfs/issues/6694)
 #
 # Strategy:
 # 1. Create three files with sequential object numbers, f1 f2 and f3


### PR DESCRIPTION
### Motivation and Context

Fully transition to using the OpenZFS name for the project.

### Description

This change updates the documentation to refer to the project
as OpenZFS instead ZFS on Linux.  Web links have been updated
to refer to https://github.com/openzfs/zfs.zfs.  The extraneous
zfsonlinux.org web links in the ZED and SPL sources have been
dropped.

### How Has This Been Tested?

Locally compiled, manually inspected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
