### PR TITLE
Make dbufstat work on FreeBSD

### DIFF
--- a/cmd/dbufstat/dbufstat.in
+++ b/cmd/dbufstat/dbufstat.in
@@ -113,6 +113,21 @@ cmd = ("Usage: dbufstat [-bdhnrtvx] [-i file] [-f fields] [-o file] "
 raw = 0
 
 
+if sys.platform.startswith("freebsd"):
+    import io
+    # Requires py-sysctl on FreeBSD
+    import sysctl
+
+    def default_ifile():
+        dbufs = sysctl.filter("kstat.zfs.misc.dbufs")[0].value
+        sys.stdin = io.StringIO(dbufs)
+        return "-"
+
+elif sys.platform.startswith("linux"):
+    def default_ifile():
+        return "/proc/spl/kstat/zfs/dbufs"
+
+
 def print_incompat_helper(incompat):
     cnt = 0
     for key in sorted(incompat):
@@ -645,7 +660,7 @@ def main():
             sys.exit(1)
 
     if not ifile:
-        ifile = '/proc/spl/kstat/zfs/dbufs'
+        ifile = default_ifile()
 
     if ifile is not "-":
         try:

--- a/module/os/freebsd/spl/spl_kstat.c
+++ b/module/os/freebsd/spl/spl_kstat.c
@@ -231,6 +231,7 @@ restart:
 	}
 	free(ksp->ks_raw_buf, M_TEMP);
 	mutex_exit(ksp->ks_lock);
+	sbuf_trim(sb);
 	rc = sbuf_finish(sb);
 	if (rc == 0)
 		rc = SYSCTL_OUT(req, sbuf_data(sb), sbuf_len(sb));

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -30,6 +30,11 @@ tests = ['alloc_class_001_pos', 'alloc_class_002_neg', 'alloc_class_003_pos',
     'alloc_class_013_pos']
 tags = ['functional', 'alloc_class']
 
+[tests/functional/arc]
+tests = ['dbufstats_001_pos', 'dbufstats_002_pos', 'dbufstats_003_pos',
+    'arcstats_runtime_tuning']
+tags = ['functional', 'arc']
+
 [tests/functional/atime]
 tests = ['atime_001_pos', 'atime_002_neg', 'root_atime_off', 'root_atime_on']
 tags = ['functional', 'atime']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -26,11 +26,6 @@ tags = ['functional']
 tests = ['posix_001_pos', 'posix_002_pos', 'posix_003_pos']
 tags = ['functional', 'acl', 'posix']
 
-[tests/functional/arc:Linux]
-tests = ['dbufstats_001_pos', 'dbufstats_002_pos', 'dbufstats_003_pos',
-    'arcstats_runtime_tuning']
-tags = ['functional', 'arc']
-
 [tests/functional/atime:Linux]
 tests = ['atime_003_pos', 'root_relatime_on']
 tags = ['functional', 'atime']

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -4154,18 +4154,36 @@ function ls_xattr # path
 	esac
 }
 
+function kstat # stat flags?
+{
+	typeset stat=$1
+	typeset flags=${2-"-n"}
+
+	case $(uname) in
+	FreeBSD)
+		sysctl $flags kstat.zfs.misc.$stat
+		;;
+	Linux)
+		typeset zfs_kstat="/proc/spl/kstat/zfs/$stat"
+		[[ -f "$zfs_kstat" ]] || return 1
+		cat $zfs_kstat
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
 function get_arcstat # stat
 {
 	typeset stat=$1
 
 	case $(uname) in
 	FreeBSD)
-		sysctl -n kstat.zfs.misc.arcstats.$stat
+		kstat arcstats.$stat
 		;;
 	Linux)
-		typeset zfs_arcstats="/proc/spl/kstat/zfs/arcstats"
-		[[ -f "$zfs_arcstats" ]] || return 1
-		grep $stat $zfs_arcstats | awk '{print $3}'
+		kstat arcstats | awk "/$stat/ { print \$3 }"
 		;;
 	*)
 		false

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
@@ -58,10 +58,10 @@ log_onexit cleanup
 log_must file_write -o create -f "$TESTDIR/file" -b 1048576 -c 1 -d R
 log_must zpool sync
 
-objid=$(stat --format="%i" "$TESTDIR/file")
+objid=$(get_objnum "$TESTDIR/file")
 log_note "Object ID for $TESTDIR/file is $objid"
 
-log_must eval "cat /proc/spl/kstat/zfs/dbufs > $DBUFS_FILE"
+log_must eval "kstat dbufs > $DBUFS_FILE"
 dbuf=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid" | wc -l)
 mru=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid,list=1" | wc -l)
 mfu=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid,list=3" | wc -l)
@@ -70,7 +70,7 @@ verify_ne "0" "$mru" "mru count"
 verify_eq "0" "$mfu" "mfu count"
 
 log_must eval "cat $TESTDIR/file > /dev/null"
-log_must eval "cat /proc/spl/kstat/zfs/dbufs > $DBUFS_FILE"
+log_must eval "kstat dbufs > $DBUFS_FILE"
 dbuf=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid" | wc -l)
 mru=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid,list=1" | wc -l)
 mfu=$(dbufstat -bxn -i "$DBUFS_FILE" -F "object=$objid,list=3" | wc -l)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With procfs_list kstats implemented for FreeBSD, dbufs are now exposed
as kstat.zfs.misc.dbufs.

On FreeBSD, dbufstat can use the sysctl instead of procfs when no
input file has been given.

### Description
<!--- Describe your changes in detail -->
* Modify dbufstat to read dbufs from the kstat sysctl on FreeBSD
* Fix a slight formatting error in the sysctl value by trimming trailing white space before finishing the sbuf
* Create a `kstat` function in libtest to abstract the major difference between how kstats are accessed on FreeBSD vs Linux
* Fix and enable the arc tests for FreeBSD

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Ran ZTS arc tag on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
