### PR TITLE
Fix Linux modules uninstall

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -96,7 +96,7 @@ modules_install: modules_install-@ac_system@
 
 modules_uninstall-Linux:
 	@# Uninstall the kernel modules
-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@ \
+	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
 	for objdir in $(ZFS_MODULES); do \
 		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$objdir; \
 	done


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

A missing semicolon between kmoddir variable declaration and the
unistall for loop caused modules_uninstall-Linux to fail with:

    Syntax error: "do" unexpected


<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this fix, the modules_uninstall-Linux rule will always fail without doing anything.

### Description
<!--- Describe your changes in detail -->
I added a single semi-colon to properly separate the variable declaration from the for loop.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I ran through the configure, make, install and uninstall process twice on an amd64 Ubuntu 20.04 machine with current master, 
first without then with this change.
With this change, the uninstall succeeded and actually removed the modules.
```
make[1]: Entering directory '/home/jaadams/zfs/module'
kmoddir=/lib/modules/5.4.0-48-generic \
for objdir in spl/ avl/ icp/ lua/ nvpair/ unicode/ zcommon/ zfs/ zstd/; do \
        rm -f -R $kmoddir/extra/$objdir; \
done
/bin/sh: 2: Syntax error: "do" unexpected
make[1]: *** [Makefile:99: modules_uninstall-Linux] Error 2
make[1]: Leaving directory '/home/jaadams/zfs/module'
make: *** [Makefile:881: uninstall-recursive] Error 1
$ ls /lib/modules/5.4.0-48-generic/extra/
avl  icp  lua  nvpair  spl  unicode  zcommon  zfs  zstd
$
```
vs.
```
make[1]: Entering directory '/home/jaadams/zfs/module'
kmoddir=/lib/modules/5.4.0-48-generic; \
for objdir in spl/ avl/ icp/ lua/ nvpair/ unicode/ zcommon/ zfs/ zstd/; do \
        rm -f -R $kmoddir/extra/$objdir; \
done
make[1]: Leaving directory '/home/jaadams/zfs/module'
make[1]: Entering directory '/home/jaadams/zfs'
 ( cd '/usr/local/src/zfs-2.0.0' && rm -f zfs.release.in zfs_config.h.in )
 ( cd '/usr/local/src/zfs-2.0.0/5.4.0-48-generic' && rm -f zfs.release zfs_config.h Module.symvers )
make[1]: Leaving directory '/home/jaadams/zfs'
$ ls /lib/modules/5.4.0-48-generic/extra/
$
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. N/A
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. N/A
- [ ] I have run the ZFS Test Suite with this change applied. N/A
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
