### PR TITLE
Snapshot directory entries missing from zfs/.snapshot

### DIFF
--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -248,7 +248,8 @@ zpl_snapdir_iterate(struct file *filp, zpl_dir_context_t *ctx)
 	if (!zpl_dir_emit_dots(filp, ctx))
 		goto out;
 
-	pos = ctx->pos;
+	// Start the position at 0 if it already emitted . and ..
+	pos = (ctx->pos == 2 ? 0 : ctx->pos);
 	while (error == 0) {
 		dsl_pool_config_enter(dmu_objset_pool(zfsvfs->z_os), FTAG);
 		error = -dmu_snapshot_list_next(zfsvfs->z_os, MAXNAMELEN,


### PR DESCRIPTION
The microzap hash can sometimes be zero for single digit snapnames.
The zap cursor can then have a serialized value of two (for . and ..),
and skip the first entry in the avl tree for the .zfs/snapshot directory
listing, and therefore does not return all snapshots.

Signed-off-by: Tony Perkins <tperkins@datto.com>



This will start pos at 0, instead of 2. This will allow the zap cursor serialized value to start at 0.
The problem is that some snapshot names that have single characters could hash to 0.

### Motivation and Context
During testing, we have noticed that ls -1 /pool/fs/.zfs/snapshot does not return all of the snapshots.
It provides inconsistent behavior depending on the hash values of the snapdir entries within the microzap.
Sometimes it will return one less than the actual number of entries.

### Description
After emitting . and .., the pos is set to 0, instead of 2.

### How Has This Been Tested?
There is a test included in the zfs_snapshot directory that utilizes single character snapnames.



### Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ X] I have run the ZFS Test Suite with this change applied.
- [ X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
