### PR TITLE
Don't leak zstream_t allocations.

### DIFF
--- a/include/sys/dmu_zfetch.h
+++ b/include/sys/dmu_zfetch.h
@@ -61,7 +61,6 @@ typedef struct zstream {
 	hrtime_t	zs_atime;	/* time last prefetch issued */
 	hrtime_t	zs_start_time;	/* start of last prefetch */
 	list_node_t	zs_node;	/* link for zf_stream */
-	zfetch_t	*zs_fetch;	/* parent fetch */
 	zfs_refcount_t	zs_blocks; /* number of pending blocks in the stream */
 } zstream_t;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

zfetch is leaking zstream_t allocations.  Only one ~204-bytes leak per stream created.

This is reported in dmesg upon unloading a debug (linux) zfs module i.e. after running the zfs test suite.

### Description
<!--- Describe your changes in detail -->

dmu_zfetch_fini() previously called dmu_zfetch_stream_orphan() on each stream in the fetch's list, upon fetch destruction.

dmu_zfetch_stream_orphan() doesn't free the stream structures, it does what it claims to do - orphans them from their associated fetch.

Unfortunately nobody else (as far as I can grok) is holding a copy of this list or pointers to the streams inside it, dmu_zfetch_stream_orphan() subsequently destroys the list, so any streams that didn't already get reaped from inside dmu_zfetch_stream_create() are truly leaked forever. 

I've gotten rid of dmu_zfetch_stream_orphan() and replaced its use with an expanded dmu_zfetch_stream_remove() which asserts non-liveness of the stream being removed and frees the underlying zstream_t.  It still detects unexpected liveness and does the same as dmu_zfetch_stream_orphan() used to in that case (but with an assert in debug).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Local test suite run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
