### PR TITLE
dmu_redact_snap: fix crash caused by invalid snapshot names in redactnvl

### DIFF
--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1062,9 +1062,9 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 
 		}
 	}
-	VERIFY3P(nvlist_next_nvpair(redactnvl, pair), ==, NULL);
 	if (err != 0)
 		goto out;
+	VERIFY3P(nvlist_next_nvpair(redactnvl, pair), ==, NULL);
 
 	boolean_t resuming = B_FALSE;
 	zfs_bookmark_phys_t bookmark;

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
@@ -56,6 +56,8 @@ done
 log_mustnot zfs redact $sendfs@snap1
 log_mustnot zfs redact $sendfs@snap1 book
 log_mustnot zfs redact $sendfs#book1 book4 $clone1
+log_mustnot zfs redact $sendfs@snap1 book snap2 snap3
+log_mustnot zfs redact $sendfs@snap1 book @snap2 @snap3
 log_mustnot eval "zfs send --redact $sendfs#book $sendfs@snap >/dev/null"
 
 # Redaction snapshots not a descendant of tosnap


### PR DESCRIPTION
This is a fixup of commit 0fdd6106bb cc @ahrens 

See added test case for a reproducer.

Stack trace:

    panic: VERIFY3(nvlist_next_nvpair(redactnvl, pair) == NULL) failed (0xfffff80003ce5d18x == 0x)

    cpuid = 7
    time = 1602212370
    KDB: stack backtrace:
    #0 0xffffffff80c1d297 at kdb_backtrace+0x67
    #1 0xffffffff80bd05cd at vpanic+0x19d
    #2 0xffffffff828446fa at spl_panic+0x3a
    #3 0xffffffff828af85d at dmu_redact_snap+0x39d
    #4 0xffffffff829c0370 at zfs_ioc_redact+0xa0
    #5 0xffffffff829bba44 at zfsdev_ioctl_common+0x4a4
    #6 0xffffffff8284c3ed at zfsdev_ioctl+0x14d
    #7 0xffffffff80a85ead at devfs_ioctl+0xad
    #8 0xffffffff8122a46c at VOP_IOCTL_APV+0x7c
    #9 0xffffffff80cb0a3a at vn_ioctl+0x16a
    #10 0xffffffff80a8649f at devfs_ioctl_f+0x1f
    #11 0xffffffff80c3b55e at kern_ioctl+0x2be
    #12 0xffffffff80c3b22d at sys_ioctl+0x15d
    #13 0xffffffff810a88e4 at amd64_syscall+0x364
    #14 0xffffffff81082330 at fast_syscall_common+0x101

Signed-off-by: Christian Schwarz <me@cschwarz.com>

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

---

There still isn't a lot (now enough?) of argument checking in the path from CLI argv to `dmu_objset_*()` calls.
I don't have the time to fix that, though.