### PR TITLE
blkg_tryget config test: initialize struct

### DIFF
--- a/config/kernel-bio.m4
+++ b/config/kernel-bio.m4
@@ -344,7 +344,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKG_TRYGET], [
 		#include <linux/bio.h>
 		#include <linux/fs.h>
 	],[
-		struct blkcg_gq blkg __attribute__ ((unused));
+		struct blkcg_gq blkg __attribute__ ((unused)) = {};
 		bool rc __attribute__ ((unused));
 		rc = blkg_tryget(&blkg);
 	], [], [$ZFS_META_LICENSE])


### PR DESCRIPTION
This patch fixes building on CentOS 8 Stream (next CentOS/RHEL 8 release).

### Motivation and Context
Build fix, cf #10713.

### Description
Missing struct initialization in a config test making the compiler not happy.

### How Has This Been Tested?
This has only been tested on 0.8.x.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
