### PR TITLE
Ignore special vdev ashift for spa ashift min/max

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1286,9 +1286,9 @@ vdev_metaslab_group_create(vdev_t *vd)
 		    spa->spa_alloc_count);
 
 		/*
-		 * The spa ashift values currently only reflect the
-		 * general vdev classes. Class destination is late
-		 * binding so ashift checking had to wait until now
+		 * The spa ashift min/max only apply for the normal metaslab
+		 * class. Class destination is late binding so ashift boundry
+		 * setting had to wait until now.
 		 */
 		if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
 		    mc == spa_normal_class(spa) && vd->vdev_aux == NULL) {
@@ -1950,18 +1950,6 @@ vdev_open(vdev_t *vd)
 		vdev_set_state(vd, B_TRUE, VDEV_STATE_FAULTED,
 		    VDEV_AUX_ERR_EXCEEDED);
 		return (error);
-	}
-
-	/*
-	 * Track the min and max ashift values for normal data devices.
-	 */
-	if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
-	    vd->vdev_alloc_bias == VDEV_BIAS_NONE &&
-	    vd->vdev_islog == 0 && vd->vdev_aux == NULL) {
-		if (vd->vdev_ashift > spa->spa_max_ashift)
-			spa->spa_max_ashift = vd->vdev_ashift;
-		if (vd->vdev_ashift < spa->spa_min_ashift)
-			spa->spa_min_ashift = vd->vdev_ashift;
 	}
 
 	/*

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -2033,7 +2033,8 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	/*
 	 * A removed special/dedup vdev must have same ashift as normal class.
 	 */
-	if (vd->vdev_alloc_bias != VDEV_BIAS_NONE && !vd->vdev_islog &&
+	ASSERT(!vd->vdev_islog);
+	if (vd->vdev_alloc_bias != VDEV_BIAS_NONE &&
 	    vd->vdev_ashift != spa->spa_max_ashift) {
 		return (SET_ERROR(EINVAL));
 	}
@@ -2051,12 +2052,10 @@ spa_vdev_remove_top_check(vdev_t *vd)
 		 * A removed special/dedup vdev must have the same ashift
 		 * across all vdevs in its class.
 		 */
-		if (cvd->vdev_alloc_bias != VDEV_BIAS_NONE &&
-		    !cvd->vdev_islog) {
-			if (cvd->vdev_alloc_bias == vd->vdev_alloc_bias &&
-			    cvd->vdev_ashift != vd->vdev_ashift) {
-				return (SET_ERROR(EINVAL));
-			}
+		if (vd->vdev_alloc_bias != VDEV_BIAS_NONE &&
+		    cvd->vdev_alloc_bias == vd->vdev_alloc_bias &&
+		    cvd->vdev_ashift != vd->vdev_ashift) {
+			return (SET_ERROR(EINVAL));
 		}
 		if (cvd->vdev_ashift != 0 &&
 		    cvd->vdev_alloc_bias == VDEV_BIAS_NONE)

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
  */
 
@@ -2031,6 +2031,14 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	}
 
 	/*
+	 * A removed special/dedup vdev must have same ashift as normal class.
+	 */
+	if (vd->vdev_alloc_bias != VDEV_BIAS_NONE && !vd->vdev_islog &&
+	    vd->vdev_ashift != spa->spa_max_ashift) {
+		return (SET_ERROR(EINVAL));
+	}
+
+	/*
 	 * All vdevs in normal class must have the same ashift
 	 * and not be raidz.
 	 */
@@ -2038,7 +2046,20 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	int num_indirect = 0;
 	for (uint64_t id = 0; id < rvd->vdev_children; id++) {
 		vdev_t *cvd = rvd->vdev_child[id];
-		if (cvd->vdev_ashift != 0 && !cvd->vdev_islog)
+
+		/*
+		 * A removed special/dedup vdev must have the same ashift
+		 * across all vdevs in its class.
+		 */
+		if (cvd->vdev_alloc_bias != VDEV_BIAS_NONE &&
+		    !cvd->vdev_islog) {
+			if (cvd->vdev_alloc_bias == vd->vdev_alloc_bias &&
+			    cvd->vdev_ashift != vd->vdev_ashift) {
+				return (SET_ERROR(EINVAL));
+			}
+		}
+		if (cvd->vdev_ashift != 0 &&
+		    cvd->vdev_alloc_bias == VDEV_BIAS_NONE)
 			ASSERT3U(cvd->vdev_ashift, ==, spa->spa_max_ashift);
 		if (cvd->vdev_ops == &vdev_indirect_ops)
 			num_indirect++;


### PR DESCRIPTION
### Motivation and Context
The removal of a vdev in the normal class would fail if there was a `special` or `deup` vdev that had a different `ashift` than the vdevs in the `normal` class.

Addresses issue #9363 and issue #9364

### Description
Moved the initialization of `spa_min_ashift` / `spa_max_ashift` from `vdev_open` so that it occurs after the vdev allocation bias was initialized (i.e. after `vdev_load`).

Caveat -- In order to remove a special/dedup vdev it must have the same `ashift` as the normal pool vdevs.
This could perhaps be lifted in the future (i.e. for the case where there is ample space in any surviving special class vdevs).

### How Has This Been Tested?
ZTS -- ran functional tests for alloc_class and removal.
ztest runs
Manual run of failure case:
```
$ sudo zpool create vote sdb sdc sdd
$ sudo zdb -l /dev/sdb1 | grep ashift
        ashift: 9
$ sudo zpool add -o ashift=12 vote special sdf
$ sudo zdb -l /dev/sdf1 | grep ashift
        ashift: 12
$ sudo zpool export vote
$ sudo zpool import vote
$ sudo zpool status -P vote
  pool: vote
 state: ONLINE
config:

	NAME         STATE     READ WRITE CKSUM
	vote         ONLINE       0     0     0
	  /dev/sdb1  ONLINE       0     0     0
	  /dev/sdc1  ONLINE       0     0     0
	  /dev/sdd1  ONLINE       0     0     0
	special
	  /dev/sdf1  ONLINE       0     0     0

errors: No known data errors
$ sudo zpool remove vote sdd
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
