### PR TITLE
Fix incorrect deletion order in range_tree_add_impl gap case

### DIFF
--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -314,7 +314,6 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 			return;
 		}
 
-		zfs_btree_remove(&rt->rt_root, rs);
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 			rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
 
@@ -326,6 +325,7 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 		end = MAX(end, rend);
 		size = end - start;
 
+		zfs_btree_remove(&rt->rt_root, rs);
 		range_tree_add_impl(rt, start, size, fill);
 		return;
 	}


### PR DESCRIPTION
This addresses issue #11044

### Motivation and Context
After a side-effectful call like add or remove, references to range segs stored in btrees can no longer be used safely.

### Description
We move the remove call to just before the reinsertion call so that the seg remains valid for as long as we need it.

### How Has This Been Tested?
zfs-precommit run

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
