### PR TITLE
Fix commitcheck on FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,7 +154,7 @@ checkbashisms:
 				-o -name 'make_gitrev.sh' -prune \
 				-o -type f ! -name 'config*' \
 				! -name 'libtool' \
-			-exec bash -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \
+			-exec sh -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \
 	else \
 		echo "skipping checkbashisms because checkbashisms is not installed"; \
 	fi

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -1,23 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 REF="HEAD"
 
-# test a url
-function test_url()
-{
-    url="$1"
-    if ! curl --output /dev/null --max-time 60 \
-		--silent --head --fail "$url" ; then
-        echo "\"$url\" is unreachable"
-        return 1
-    fi
-
-    return 0
-}
-
 # test commit body for length
 # lines containing urls are exempt for the length limit.
-function test_commit_bodylength()
+test_commit_bodylength()
 {
     length="72"
     body=$(git log -n 1 --pretty=%b "$REF" | grep -Ev "http(s)*://" | grep -E -m 1 ".{$((length + 1))}")
@@ -30,9 +17,9 @@ function test_commit_bodylength()
 }
 
 # check for a tagged line
-function check_tagged_line()
+check_tagged_line()
 {
-    regex='^\s*'"$1"':\s[[:print:]]+\s<[[:graph:]]+>$'
+    regex='^[[:space:]]*'"$1"':[[:space:]][[:print:]]+[[:space:]]<[[:graph:]]+>$'
     foundline=$(git log -n 1 "$REF" | grep -E -m 1 "$regex")
     if [ -z "$foundline" ]; then
         echo "error: missing \"$1\""
@@ -42,30 +29,8 @@ function check_tagged_line()
     return 0
 }
 
-# check for a tagged line and check that the link is valid
-function check_tagged_line_with_url()
-{
-    regex='^\s*'"$1"':\s\K([[:graph:]]+)$'
-    foundline=$(git log -n 1 "$REF" | grep -Po "$regex")
-    if [ -z "$foundline" ]; then
-        echo "error: missing \"$1\""
-        return 1
-    fi
-
-    OLDIFS=$IFS
-    IFS=$'\n'
-    for url in $(echo -e "$foundline"); do
-        if ! test_url "$url"; then
-            return 1
-        fi
-    done
-    IFS=$OLDIFS
-
-    return 0
-}
-
 # check commit message for a normal commit
-function new_change_commit()
+new_change_commit()
 {
     error=0
 
@@ -89,7 +54,7 @@ function new_change_commit()
     return $error
 }
 
-function is_coverity_fix()
+is_coverity_fix()
 {
     # subject starts with Fix coverity defects means it's a coverity fix
     subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^Fix coverity defects')
@@ -100,7 +65,7 @@ function is_coverity_fix()
     return 1
 }
 
-function coverity_fix_commit()
+coverity_fix_commit()
 {
     error=0
 
@@ -119,11 +84,12 @@ function coverity_fix_commit()
 
     # test each summary line for the proper format
     OLDIFS=$IFS
-    IFS=$'\n'
+    IFS='
+'
     for line in $(git log -n 1 --pretty=%b "$REF" | grep -E '^CID'); do
         echo "$line" | grep -E '^CID [[:digit:]]+: ([[:graph:]]+|[[:space:]])+ \(([[:upper:]]|\_)+\)' > /dev/null
         # shellcheck disable=SC2181
-        if [[ $? -ne 0 ]]; then
+        if [ $? -ne 0 ]; then
             echo "error: commit message has an improperly formatted CID defect line"
             error=1
         fi


### PR DESCRIPTION
Convert from bash to sh, avoid Perl regexes and \s, prune unused
functions.

Signed-off-by: Ryan Moeller <freqlabs@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
