### PR TITLE
zfs list: Allow more fields in ZFS_ITER_SIMPLE mode

### DIFF
--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -144,19 +144,20 @@ zfs_callback(zfs_handle_t *zhp, void *data)
 		    (cb->cb_types &
 		    (ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME))) &&
 		    zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM) {
-			(void) zfs_iter_filesystems(zhp, zfs_callback, data);
+			(void) zfs_iter_filesystems(zhp, cb->cb_flags,
+			    zfs_callback, data);
 		}
 
 		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
 		    ZFS_TYPE_BOOKMARK)) == 0) && include_snaps) {
-			(void) zfs_iter_snapshots(zhp,
-			    (cb->cb_flags & ZFS_ITER_SIMPLE) != 0,
+			(void) zfs_iter_snapshots(zhp, cb->cb_flags,
 			    zfs_callback, data, 0, 0);
 		}
 
 		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
 		    ZFS_TYPE_BOOKMARK)) == 0) && include_bmarks) {
-			(void) zfs_iter_bookmarks(zhp, zfs_callback, data);
+			(void) zfs_iter_bookmarks(zhp, cb->cb_flags,
+			    zfs_callback, data);
 		}
 
 		cb->cb_depth--;
@@ -212,11 +213,58 @@ zfs_free_sort_columns(zfs_sort_column_t *sc)
 	}
 }
 
-int
-zfs_sort_only_by_name(const zfs_sort_column_t *sc)
+/*
+ * Return true if all of the properties to be sorted are populated by
+ * dsl_dataset_fast_stat(). Note that sc == NULL (no sort) means we
+ * don't need any extra properties, so returns true.
+ */
+boolean_t
+zfs_sort_only_by_fast(const zfs_sort_column_t *sc)
 {
-	return (sc != NULL && sc->sc_next == NULL &&
-	    sc->sc_prop == ZFS_PROP_NAME);
+	while (sc != NULL) {
+		switch (sc->sc_prop) {
+		case ZFS_PROP_NAME:
+		case ZFS_PROP_GUID:
+		case ZFS_PROP_CREATETXG:
+		case ZFS_PROP_NUMCLONES:
+		case ZFS_PROP_INCONSISTENT:
+		case ZFS_PROP_REDACTED:
+		case ZFS_PROP_ORIGIN:
+			break;
+		default:
+			return (B_FALSE);
+		}
+		sc = sc->sc_next;
+	}
+
+	return (B_TRUE);
+}
+
+boolean_t
+zfs_list_only_by_fast(const zprop_list_t *p)
+{
+	if (p == NULL) {
+		/* NULL means 'all' so we can't use simple mode */
+		return (B_FALSE);
+	}
+
+	while (p != NULL) {
+		switch (p->pl_prop) {
+		case ZFS_PROP_NAME:
+		case ZFS_PROP_GUID:
+		case ZFS_PROP_CREATETXG:
+		case ZFS_PROP_NUMCLONES:
+		case ZFS_PROP_INCONSISTENT:
+		case ZFS_PROP_REDACTED:
+		case ZFS_PROP_ORIGIN:
+			break;
+		default:
+			return (B_FALSE);
+		}
+		p = p->pl_next;
+	}
+
+	return (B_TRUE);
 }
 
 /* ARGSUSED */

--- a/cmd/zfs/zfs_iter.h
+++ b/cmd/zfs/zfs_iter.h
@@ -40,19 +40,13 @@ typedef struct zfs_sort_column {
 	boolean_t		sc_reverse;
 } zfs_sort_column_t;
 
-#define	ZFS_ITER_RECURSE	   (1 << 0)
-#define	ZFS_ITER_ARGS_CAN_BE_PATHS (1 << 1)
-#define	ZFS_ITER_PROP_LISTSNAPS    (1 << 2)
-#define	ZFS_ITER_DEPTH_LIMIT	   (1 << 3)
-#define	ZFS_ITER_RECVD_PROPS	   (1 << 4)
-#define	ZFS_ITER_LITERAL_PROPS	   (1 << 5)
-#define	ZFS_ITER_SIMPLE		   (1 << 6)
-
 int zfs_for_each(int, char **, int options, zfs_type_t,
     zfs_sort_column_t *, zprop_list_t **, int, zfs_iter_f, void *);
 int zfs_add_sort_column(zfs_sort_column_t **, const char *, boolean_t);
 void zfs_free_sort_columns(zfs_sort_column_t *);
-int zfs_sort_only_by_name(const zfs_sort_column_t *);
+boolean_t zfs_sort_only_by_fast(const zfs_sort_column_t *);
+boolean_t zfs_list_only_by_fast(const zprop_list_t *);
+
 
 #ifdef	__cplusplus
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8814,7 +8814,7 @@ check_unsupp_fs(zfs_handle_t *zhp, void *unsupp_fs)
 		(*count)++;
 	}
 
-	zfs_iter_filesystems(zhp, check_unsupp_fs, unsupp_fs);
+	zfs_iter_filesystems(zhp, 0, check_unsupp_fs, unsupp_fs);
 
 	zfs_close(zhp);
 

--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -532,7 +532,7 @@ zfs_key_config_get_dataset(zfs_key_config_t *config)
 			return (NULL);
 		}
 
-		(void) zfs_iter_filesystems(zhp, find_dsname_by_prop_value,
+		(void) zfs_iter_filesystems(zhp, 0, find_dsname_by_prop_value,
 		    config);
 		zfs_close(zhp);
 		char *dsname = config->dsname;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -644,19 +644,27 @@ _LIBZFS_H void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
 /*
  * Iterator functions.
  */
+#define	ZFS_ITER_RECURSE		(1 << 0)
+#define	ZFS_ITER_ARGS_CAN_BE_PATHS	(1 << 1)
+#define	ZFS_ITER_PROP_LISTSNAPS		(1 << 2)
+#define	ZFS_ITER_DEPTH_LIMIT		(1 << 3)
+#define	ZFS_ITER_RECVD_PROPS		(1 << 4)
+#define	ZFS_ITER_LITERAL_PROPS		(1 << 5)
+#define	ZFS_ITER_SIMPLE			(1 << 6)
+
 typedef int (*zfs_iter_f)(zfs_handle_t *, void *);
 _LIBZFS_H int zfs_iter_root(libzfs_handle_t *, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_children(zfs_handle_t *, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_dependents(zfs_handle_t *, boolean_t, zfs_iter_f,
+_LIBZFS_H int zfs_iter_children(zfs_handle_t *, int, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_dependents(zfs_handle_t *, int, boolean_t, zfs_iter_f,
     void *);
-_LIBZFS_H int zfs_iter_filesystems(zfs_handle_t *, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_snapshots(zfs_handle_t *, boolean_t, zfs_iter_f, void *,
+_LIBZFS_H int zfs_iter_filesystems(zfs_handle_t *, int, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_snapshots(zfs_handle_t *, int, zfs_iter_f, void *,
     uint64_t, uint64_t);
-_LIBZFS_H int zfs_iter_snapshots_sorted(zfs_handle_t *, zfs_iter_f, void *,
+_LIBZFS_H int zfs_iter_snapshots_sorted(zfs_handle_t *, int, zfs_iter_f, void *,
     uint64_t, uint64_t);
-_LIBZFS_H int zfs_iter_snapspec(zfs_handle_t *, const char *, zfs_iter_f,
+_LIBZFS_H int zfs_iter_snapspec(zfs_handle_t *, int, const char *, zfs_iter_f,
     void *);
-_LIBZFS_H int zfs_iter_bookmarks(zfs_handle_t *, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_bookmarks(zfs_handle_t *, int, zfs_iter_f, void *);
 _LIBZFS_H int zfs_iter_mounted(zfs_handle_t *, zfs_iter_f, void *);
 
 typedef struct get_all_cb {

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -4009,13 +4009,14 @@
   <abi-instr address-size='64' path='libzfs_iter.c' language='LANG_C99'>
     <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
       <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='simple'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <parameter type-id='9c313c2d' name='min_txg'/>
@@ -4024,12 +4025,14 @@
     </function-decl>
     <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
       <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
       <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='callback'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <parameter type-id='9c313c2d' name='min_txg'/>
@@ -4038,6 +4041,7 @@
     </function-decl>
     <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
       <parameter type-id='9200a744' name='fs_zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='80f4b756' name='spec_orig'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='arg'/>
@@ -4045,12 +4049,14 @@
     </function-decl>
     <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
       <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
       <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='c19b74c3' name='allowrecursion'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -551,7 +551,7 @@ change_one(zfs_handle_t *zhp, void *data)
 		}
 
 		if (!clp->cl_alldependents)
-			ret = zfs_iter_children(zhp, change_one, data);
+			ret = zfs_iter_children(zhp, 0, change_one, data);
 
 		/*
 		 * If we added the handle to the changelist, we will re-use it
@@ -721,11 +721,11 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 			return (NULL);
 		}
 	} else if (clp->cl_alldependents) {
-		if (zfs_iter_dependents(zhp, B_TRUE, change_one, clp) != 0) {
+		if (zfs_iter_dependents(zhp, 0, B_TRUE, change_one, clp) != 0) {
 			changelist_free(clp);
 			return (NULL);
 		}
-	} else if (zfs_iter_children(zhp, change_one, clp) != 0) {
+	} else if (zfs_iter_children(zhp, 0, change_one, clp) != 0) {
 		changelist_free(clp);
 		return (NULL);
 	}

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -1226,7 +1226,7 @@ load_keys_cb(zfs_handle_t *zhp, void *arg)
 		cb->cb_numfailed++;
 
 out:
-	(void) zfs_iter_filesystems(zhp, load_keys_cb, cb);
+	(void) zfs_iter_filesystems(zhp, 0, load_keys_cb, cb);
 	zfs_close(zhp);
 
 	/* always return 0, since this function is best effort */

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -529,9 +529,17 @@ make_dataset_simple_handle_zc(zfs_handle_t *pzhp, zfs_cmd_t *zc)
 
 	zhp->zfs_hdl = pzhp->zfs_hdl;
 	(void) strlcpy(zhp->zfs_name, zc->zc_name, sizeof (zhp->zfs_name));
-	zhp->zfs_head_type = pzhp->zfs_type;
-	zhp->zfs_type = ZFS_TYPE_SNAPSHOT;
 	zhp->zpool_hdl = zpool_handle(zhp);
+	zhp->zfs_dmustats = zc->zc_objset_stats; /* structure assignment */
+	zhp->zfs_head_type = pzhp->zfs_type;
+	if (zhp->zfs_dmustats.dds_is_snapshot)
+		zhp->zfs_type = ZFS_TYPE_SNAPSHOT;
+	else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZVOL)
+		zhp->zfs_type = ZFS_TYPE_VOLUME;
+	else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZFS)
+		zhp->zfs_type = ZFS_TYPE_FILESYSTEM;
+	else
+		abort();	/* we should never see any other types */
 
 	return (zhp);
 }
@@ -737,7 +745,7 @@ zfs_open(libzfs_handle_t *hdl, const char *path, int types)
 		 * Iterate bookmarks to find the right one.
 		 */
 		errno = 0;
-		if ((zfs_iter_bookmarks(pzhp, zfs_open_bookmarks_cb,
+		if ((zfs_iter_bookmarks(pzhp, 0, zfs_open_bookmarks_cb,
 		    &cb_data) == 0) && (cb_data.zhp == NULL)) {
 			(void) zfs_error(hdl, EZFS_NOENT, errbuf);
 			zfs_close(pzhp);
@@ -2087,7 +2095,8 @@ getprop_string(zfs_handle_t *zhp, zfs_prop_t prop, char **source)
 static boolean_t
 zfs_is_recvd_props_mode(zfs_handle_t *zhp)
 {
-	return (zhp->zfs_props == zhp->zfs_recvd_props);
+	return (zhp->zfs_props != NULL &&
+	    zhp->zfs_props == zhp->zfs_recvd_props);
 }
 
 static void
@@ -2292,6 +2301,20 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		*val = zhp->zfs_dmustats.dds_redacted;
 		break;
 
+	case ZFS_PROP_GUID:
+		if (zhp->zfs_dmustats.dds_guid != 0)
+			*val = zhp->zfs_dmustats.dds_guid;
+		else
+			*val = getprop_uint64(zhp, prop, source);
+		break;
+
+	case ZFS_PROP_CREATETXG:
+		if (zhp->zfs_dmustats.dds_creation_txg != 0)
+			*val = zhp->zfs_dmustats.dds_creation_txg;
+		else
+			*val = getprop_uint64(zhp, prop, source);
+		break;
+
 	default:
 		switch (zfs_prop_get_type(prop)) {
 		case PROP_TYPE_NUMBER:
@@ -2435,7 +2458,7 @@ get_clones_cb(zfs_handle_t *zhp, void *arg)
 	}
 
 out:
-	(void) zfs_iter_children(zhp, get_clones_cb, gca);
+	(void) zfs_iter_children(zhp, 0, get_clones_cb, gca);
 	zfs_close(zhp);
 	return (0);
 }
@@ -2722,7 +2745,9 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 		break;
 
 	case ZFS_PROP_ORIGIN:
-		str = getprop_string(zhp, prop, &source);
+		str = (char *)&zhp->zfs_dmustats.dds_origin;
+		if (*str == '\0')
+			str = zfs_prop_default_string(prop);
 		if (str == NULL)
 			return (-1);
 		(void) strlcpy(propbuf, str, proplen);
@@ -3857,7 +3882,7 @@ zfs_check_snap_cb(zfs_handle_t *zhp, void *arg)
 	if (lzc_exists(name))
 		verify(nvlist_add_boolean(dd->nvl, name) == 0);
 
-	rv = zfs_iter_filesystems(zhp, zfs_check_snap_cb, dd);
+	rv = zfs_iter_filesystems(zhp, 0, zfs_check_snap_cb, dd);
 	zfs_close(zhp);
 	return (rv);
 }
@@ -4098,7 +4123,7 @@ zfs_snapshot_cb(zfs_handle_t *zhp, void *arg)
 
 		fnvlist_add_boolean(sd->sd_nvl, name);
 
-		rv = zfs_iter_filesystems(zhp, zfs_snapshot_cb, sd);
+		rv = zfs_iter_filesystems(zhp, 0, zfs_snapshot_cb, sd);
 	}
 	zfs_close(zhp);
 
@@ -4273,7 +4298,7 @@ rollback_destroy(zfs_handle_t *zhp, void *data)
 	rollback_data_t *cbp = data;
 
 	if (zfs_prop_get_int(zhp, ZFS_PROP_CREATETXG) > cbp->cb_create) {
-		cbp->cb_error |= zfs_iter_dependents(zhp, B_FALSE,
+		cbp->cb_error |= zfs_iter_dependents(zhp, 0, B_FALSE,
 		    rollback_destroy_dependent, cbp);
 
 		cbp->cb_error |= zfs_destroy(zhp, B_FALSE);
@@ -4313,10 +4338,10 @@ zfs_rollback(zfs_handle_t *zhp, zfs_handle_t *snap, boolean_t force)
 	if (cb.cb_create > 0)
 		min_txg = cb.cb_create;
 
-	(void) zfs_iter_snapshots(zhp, B_FALSE, rollback_destroy, &cb,
+	(void) zfs_iter_snapshots(zhp, 0, rollback_destroy, &cb,
 	    min_txg, 0);
 
-	(void) zfs_iter_bookmarks(zhp, rollback_destroy, &cb);
+	(void) zfs_iter_bookmarks(zhp, 0, rollback_destroy, &cb);
 
 	if (cb.cb_error)
 		return (-1);
@@ -4908,7 +4933,7 @@ zfs_hold_one(zfs_handle_t *zhp, void *arg)
 		fnvlist_add_string(ha->nvl, name, ha->tag);
 
 	if (ha->recursive)
-		rv = zfs_iter_filesystems(zhp, zfs_hold_one, ha);
+		rv = zfs_iter_filesystems(zhp, 0, zfs_hold_one, ha);
 	zfs_close(zhp);
 	return (rv);
 }
@@ -5039,7 +5064,7 @@ zfs_release_one(zfs_handle_t *zhp, void *arg)
 	}
 
 	if (ha->recursive)
-		rv = zfs_iter_filesystems(zhp, zfs_release_one, ha);
+		rv = zfs_iter_filesystems(zhp, 0, zfs_release_one, ha);
 	zfs_close(zhp);
 	return (rv);
 }

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1128,7 +1128,7 @@ zfs_iter_cb(zfs_handle_t *zhp, void *data)
 	}
 
 	libzfs_add_handle(cbp, zhp);
-	if (zfs_iter_filesystems(zhp, zfs_iter_cb, cbp) != 0) {
+	if (zfs_iter_filesystems(zhp, 0, zfs_iter_cb, cbp) != 0) {
 		zfs_close(zhp);
 		return (-1);
 	}
@@ -1475,7 +1475,7 @@ zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 	 * over all child filesystems.
 	 */
 	libzfs_add_handle(&cb, zfsp);
-	if (zfs_iter_filesystems(zfsp, zfs_iter_cb, &cb) != 0)
+	if (zfs_iter_filesystems(zfsp, 0, zfs_iter_cb, &cb) != 0)
 		goto out;
 
 	/*

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -597,7 +597,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 			min_txg = fromsnap_txg;
 		if (!sd->replicate && tosnap_txg != 0)
 			max_txg = tosnap_txg;
-		(void) zfs_iter_snapshots_sorted(zhp, send_iterate_snap, sd,
+		(void) zfs_iter_snapshots_sorted(zhp, 0, send_iterate_snap, sd,
 		    min_txg, max_txg);
 	} else {
 		char snapname[MAXPATHLEN] = { 0 };
@@ -640,7 +640,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 
 	/* iterate over children */
 	if (sd->recursive)
-		rv = zfs_iter_filesystems(zhp, send_iterate_fs, sd);
+		rv = zfs_iter_filesystems(zhp, 0, send_iterate_fs, sd);
 
 out:
 	sd->parent_fromsnap_guid = parent_fromsnap_guid_save;
@@ -1212,7 +1212,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 		if (!sdd->replicate && sdd->tosnap != NULL)
 			max_txg = get_snap_txg(zhp->zfs_hdl, zhp->zfs_name,
 			    sdd->tosnap);
-		rv = zfs_iter_snapshots_sorted(zhp, dump_snapshot, arg,
+		rv = zfs_iter_snapshots_sorted(zhp, 0, dump_snapshot, arg,
 		    min_txg, max_txg);
 	} else {
 		char snapname[MAXPATHLEN] = { 0 };
@@ -2959,9 +2959,9 @@ guid_to_name_cb(zfs_handle_t *zhp, void *arg)
 		return (EEXIST);
 	}
 
-	err = zfs_iter_children(zhp, guid_to_name_cb, gtnd);
+	err = zfs_iter_children(zhp, 0, guid_to_name_cb, gtnd);
 	if (err != EEXIST && gtnd->bookmark_ok)
-		err = zfs_iter_bookmarks(zhp, guid_to_name_cb, gtnd);
+		err = zfs_iter_bookmarks(zhp, 0, guid_to_name_cb, gtnd);
 	zfs_close(zhp);
 	return (err);
 }
@@ -3015,9 +3015,10 @@ guid_to_name_redact_snaps(libzfs_handle_t *hdl, const char *parent,
 			continue;
 		int err = guid_to_name_cb(zfs_handle_dup(zhp), &gtnd);
 		if (err != EEXIST)
-			err = zfs_iter_children(zhp, guid_to_name_cb, &gtnd);
+			err = zfs_iter_children(zhp, 0, guid_to_name_cb, &gtnd);
 		if (err != EEXIST && bookmark_ok)
-			err = zfs_iter_bookmarks(zhp, guid_to_name_cb, &gtnd);
+			err = zfs_iter_bookmarks(zhp, 0, guid_to_name_cb,
+			    &gtnd);
 		zfs_close(zhp);
 		if (err == EEXIST)
 			return (0);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2044,7 +2044,7 @@ zfs_ioc_objset_stats_impl(zfs_cmd_t *zc, objset_t *os)
 
 	dmu_objset_fast_stat(os, &zc->zc_objset_stats);
 
-	if (zc->zc_nvlist_dst != 0 &&
+	if (!zc->zc_simple && zc->zc_nvlist_dst != 0 &&
 	    (error = dsl_prop_get_all(os, &nv)) == 0) {
 		dmu_objset_stats(os, nv);
 		/*
@@ -2331,6 +2331,7 @@ zfs_ioc_snapshot_list_next(zfs_cmd_t *zc)
 		}
 
 		if (zc->zc_simple) {
+			dsl_dataset_fast_stat(ds, &zc->zc_objset_stats);
 			dsl_dataset_rele(ds, FTAG);
 			break;
 		}


### PR DESCRIPTION
If the fields to be listed and sorted by is constrained to those populated by dsl_dataset_fast_stat(), then
zfs list is much faster, as it does not need to open each objset and reads its properties.

A previous optimization by Pawel Dawidek (0cee24064a79f9c01fc4521543c37acea538405f) took advantage of this to make listing snapshot names sorted only by name much faster.

However, it was limited to `-o name -s name`, this work extends this optimization to work with:
  - name
  - guid
  - createtxg
  - numclones
  - inconsistent
  - redacted
  - origin

and to work for filesystems as well as snapshots. 
This could be further extended to any other properties supported by dsl_dataset_fast_stat() or similar, that do not require extra locking or reading from disk.

Additional optimizations could be made by making some internal processes, like listing snapshots for deletion
use this "fast" mode, since only the name needs to be looked up, but that is left as future work.

Signed-off-by: Allan Jude <allan@klarasystems.com>

### Motivation and Context
Make `zfs list -H -o name,guid` faster

### Description
Expand the list of properties that trigger 'simple' mode for the zfs list IOCTL
The addition of `createtxg` to the list of optimized properties also means the default sort order no longer requires fetching properties.

### How Has This Been Tested?
Comparing the speed of `zfs list` of 20000 datasets (304% improvement):

`time zfs list -H -o name -s name > /dev/null`
or
`time zfs list -H -o name,guid > /dev/null`
```
x patched_list_name.time
+ unpatched_list_name.time
    N           Min           Max        Median           Avg        Stddev
x  20          1.35          1.37          1.36         1.361  0.0055250625
+  20           5.5          5.52           5.5        5.5055  0.0068633274
Difference at 95.0% confidence
        4.1445 +/- 0.00398763
        304.519% +/- 0.777466%
        (Student's t, pooled s = 0.00623023)
```

as well as `zfs list -t snapshot` for 10 datasets each with 2000 snapshots (20000 snapshots), the improvement was 378%

`time zfs list -H -t snapshot -o name,guid > /dev/null`
```
x patched_list_snapguid.time
+ unpatched_list_snapguid.time
+------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  20          1.56          1.58          1.57          1.57  0.0056195149
+  20          7.49          7.54         7.515         7.517   0.015252265
Difference at 95.0% confidence
        5.947 +/- 0.00735649
        378.79% +/- 0.891556%
        (Student's t, pooled s = 0.0114937)
```

To confirm that these changes did not disturb the original enhancement:

`time zfs list -H -t snapshot -o name -s name > /dev/null`
```
x patched_list_snapname.time
+ unpatched_list_snapname.time
+------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  20          1.49          1.52           1.5        1.5015  0.0074515982
+  20          1.49          1.51           1.5        1.4975   0.007163504
No difference proven at 95.0% confidence
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
