### PR TITLE
Support forced export of ZFS pools

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -8910,9 +8910,10 @@ dump_mos_leaks(spa_t *spa)
 	mos_obj_refd(spa->spa_condensing_indirect_phys.
 	    scip_prev_obsolete_sm_object);
 	if (spa->spa_condensing_indirect_phys.scip_next_mapping_object != 0) {
-		vdev_indirect_mapping_t *vim =
-		    vdev_indirect_mapping_open(mos,
-		    spa->spa_condensing_indirect_phys.scip_next_mapping_object);
+		vdev_indirect_mapping_t *vim;
+		VERIFY0(vdev_indirect_mapping_open(mos,
+		    spa->spa_condensing_indirect_phys.scip_next_mapping_object,
+		    &vim));
 		mos_obj_refd(vim->vim_phys->vimp_counts_object);
 		vdev_indirect_mapping_close(vim);
 	}

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -9099,9 +9099,10 @@ dump_mos_leaks(spa_t *spa)
 	mos_obj_refd(spa->spa_condensing_indirect_phys.
 	    scip_prev_obsolete_sm_object);
 	if (spa->spa_condensing_indirect_phys.scip_next_mapping_object != 0) {
-		vdev_indirect_mapping_t *vim =
-		    vdev_indirect_mapping_open(mos,
-		    spa->spa_condensing_indirect_phys.scip_next_mapping_object);
+		vdev_indirect_mapping_t *vim;
+		VERIFY0(vdev_indirect_mapping_open(mos,
+		    spa->spa_condensing_indirect_phys.scip_next_mapping_object,
+		    &vim));
 		mos_obj_refd(vim->vim_phys->vimp_counts_object);
 		vdev_indirect_mapping_close(vim);
 	}

--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -1196,12 +1196,12 @@ zhack_mos_leak_sync(void *arg, dmu_tx_t *tx)
 	objset_t *mos = spa->spa_meta_objset;
 
 	for (uint64_t i = 0; i < inject->zli_clone_count; i++) {
-		inject->zli_clone_objs[i] = zap_create(mos, DMU_OT_DSL_CLONES,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx,
+		    inject->zli_clone_objs + i));
 	}
 	for (uint64_t i = 0; i < inject->zli_spacemap_count; i++) {
-		inject->zli_spacemap_objs[i] = space_map_alloc(mos,
-		    SPA_MINBLOCKSIZE, tx);
+		VERIFY0(space_map_alloc(mos, SPA_MINBLOCKSIZE, tx,
+		    inject->zli_spacemap_objs + i));
 	}
 
 	spa_history_log_internal(spa, "zhack mos leak", tx,

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2347,16 +2347,20 @@ int
 zpool_do_destroy(int argc, char **argv)
 {
 	boolean_t force = B_FALSE;
+	boolean_t hardforce = B_FALSE;
 	int c;
 	char *pool;
 	zpool_handle_t *zhp;
 	int ret;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "f")) != -1) {
+	while ((c = getopt(argc, argv, "fF")) != -1) {
 		switch (c) {
 		case 'f':
 			force = B_TRUE;
+			break;
+		case 'F':
+			force = hardforce = B_TRUE;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -2380,7 +2384,17 @@ zpool_do_destroy(int argc, char **argv)
 
 	pool = argv[0];
 
-	if ((zhp = zpool_open_canfail(g_zfs, pool)) == NULL) {
+	if (hardforce) {
+		/*
+		 * The hardforce code path should reach the kernel w/o extra
+		 * locks to break through and initiate forced exit.
+		 */
+		zhp = zpool_open_unchecked(g_zfs, pool);
+	} else {
+		zhp = zpool_open_canfail(g_zfs, pool);
+	}
+
+	if (zhp == NULL) {
 		/*
 		 * As a special case, check for use of '/' in the name, and
 		 * direct the user to use 'zfs destroy' instead.
@@ -2391,7 +2405,7 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_disable_datasets(zhp, force, B_FALSE) != 0) {
+	if (zpool_disable_datasets(zhp, force, hardforce) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
@@ -2401,7 +2415,7 @@ zpool_do_destroy(int argc, char **argv)
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;
 
-	ret = (zpool_destroy(zhp, history_str) != 0);
+	ret = (zpool_destroy(zhp, force, hardforce, history_str) != 0);
 
 	zpool_close(zhp);
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -486,7 +486,7 @@ get_usage(zpool_help_t idx)
 	case HELP_DETACH:
 		return (gettext("\tdetach <pool> <device>\n"));
 	case HELP_EXPORT:
-		return (gettext("\texport [-af] <pool> ...\n"));
+		return (gettext("\texport [-afF] <pool> ...\n"));
 	case HELP_HISTORY:
 		return (gettext("\thistory [-il] [<pool>] ...\n"));
 	case HELP_IMPORT:
@@ -2391,7 +2391,7 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_disable_datasets(zhp, force) != 0) {
+	if (zpool_disable_datasets(zhp, force, B_FALSE) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
@@ -2437,7 +2437,7 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 	if (cb->taskq != NULL)
 		(void) pthread_mutex_lock(&cb->mnttab_lock);
 
-	int retval = zpool_disable_datasets(zhp, cb->force);
+	int retval = zpool_disable_datasets(zhp, cb->force, cb->hardforce);
 
 	if (cb->taskq != NULL)
 		(void) pthread_mutex_unlock(&cb->mnttab_lock);
@@ -2503,10 +2503,14 @@ zpool_export_one_async(zpool_handle_t *zhp, void *data)
  *
  *	-a	Export all pools
  *	-f	Forcefully unmount datasets
+ *	-F	Forcefully drop dirty data if the pool is suspended,
+ *		implies -f.
  *
  * Export the given pools.  By default, the command will attempt to cleanly
  * unmount any active datasets within the pool.  If the '-f' flag is specified,
- * then the datasets will be forcefully unmounted.
+ * then the datasets will be forcefully unmounted.  If the '-F' flag is
+ * specified, the pool's dirty data if any will simply be dropped if the pool
+ * is found in suspended state or gets suspended during the export.
  */
 int
 zpool_do_export(int argc, char **argv)
@@ -2515,7 +2519,8 @@ zpool_do_export(int argc, char **argv)
 	boolean_t do_all = B_FALSE;
 	boolean_t force = B_FALSE;
 	boolean_t hardforce = B_FALSE;
-	int c, ret;
+	zpool_handle_t *zhp;
+	int c, ret, i;
 
 	/* check options */
 	while ((c = getopt(argc, argv, "afF")) != -1) {
@@ -2527,7 +2532,7 @@ zpool_do_export(int argc, char **argv)
 			force = B_TRUE;
 			break;
 		case 'F':
-			hardforce = B_TRUE;
+			force = hardforce = B_TRUE;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -2574,8 +2579,24 @@ zpool_do_export(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
-	ret = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
-	    B_FALSE, zpool_export_one, &cb);
+	if (hardforce) {
+		/*
+		 * The hardforce code path should reach the kernel w/o extra
+		 * locks to break through and initiate forced exit.
+		 */
+		for (i = 0; i < argc; i++) {
+			zhp = zpool_open_unchecked(g_zfs, argv[i]);
+			if (zhp == NULL)
+				return (EINVAL);
+			ret = zpool_export_one(zhp, &cb);
+			zpool_close(zhp);
+			if (ret != 0)
+				return (ret);
+		}
+	} else {
+		ret = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
+		    B_FALSE, zpool_export_one, &cb);
+	}
 
 	return (ret);
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -476,7 +476,7 @@ get_usage(zpool_help_t idx)
 	case HELP_DETACH:
 		return (gettext("\tdetach <pool> <device>\n"));
 	case HELP_EXPORT:
-		return (gettext("\texport [-af] <pool> ...\n"));
+		return (gettext("\texport [-afF] <pool> ...\n"));
 	case HELP_HISTORY:
 		return (gettext("\thistory [-il] [<pool>] ...\n"));
 	case HELP_IMPORT:
@@ -2396,7 +2396,7 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_disable_datasets(zhp, force) != 0) {
+	if (zpool_disable_datasets(zhp, force, B_FALSE) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
@@ -2442,7 +2442,7 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 	if (cb->taskq != NULL)
 		(void) pthread_mutex_lock(&cb->mnttab_lock);
 
-	int retval = zpool_disable_datasets(zhp, cb->force);
+	int retval = zpool_disable_datasets(zhp, cb->force, cb->hardforce);
 
 	if (cb->taskq != NULL)
 		(void) pthread_mutex_unlock(&cb->mnttab_lock);
@@ -2508,10 +2508,14 @@ zpool_export_one_async(zpool_handle_t *zhp, void *data)
  *
  *	-a	Export all pools
  *	-f	Forcefully unmount datasets
+ *	-F	Forcefully drop dirty data if the pool is suspended,
+ *		implies -f.
  *
  * Export the given pools.  By default, the command will attempt to cleanly
  * unmount any active datasets within the pool.  If the '-f' flag is specified,
- * then the datasets will be forcefully unmounted.
+ * then the datasets will be forcefully unmounted.  If the '-F' flag is
+ * specified, the pool's dirty data if any will simply be dropped if the pool
+ * is found in suspended state or gets suspended during the export.
  */
 int
 zpool_do_export(int argc, char **argv)
@@ -2520,7 +2524,8 @@ zpool_do_export(int argc, char **argv)
 	boolean_t do_all = B_FALSE;
 	boolean_t force = B_FALSE;
 	boolean_t hardforce = B_FALSE;
-	int c, ret;
+	zpool_handle_t *zhp;
+	int c, ret, i;
 
 	/* check options */
 	while ((c = getopt(argc, argv, "afF")) != -1) {
@@ -2532,7 +2537,7 @@ zpool_do_export(int argc, char **argv)
 			force = B_TRUE;
 			break;
 		case 'F':
-			hardforce = B_TRUE;
+			force = hardforce = B_TRUE;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -2579,8 +2584,24 @@ zpool_do_export(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
-	ret = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
-	    B_FALSE, zpool_export_one, &cb);
+	if (hardforce) {
+		/*
+		 * The hardforce code path should reach the kernel w/o extra
+		 * locks to break through and initiate forced exit.
+		 */
+		for (i = 0; i < argc; i++) {
+			zhp = zpool_open_unchecked(g_zfs, argv[i]);
+			if (zhp == NULL)
+				return (EINVAL);
+			ret = zpool_export_one(zhp, &cb);
+			zpool_close(zhp);
+			if (ret != 0)
+				return (ret);
+		}
+	} else {
+		ret = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
+		    B_FALSE, zpool_export_one, &cb);
+	}
 
 	return (ret);
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2352,16 +2352,20 @@ int
 zpool_do_destroy(int argc, char **argv)
 {
 	boolean_t force = B_FALSE;
+	boolean_t hardforce = B_FALSE;
 	int c;
 	char *pool;
 	zpool_handle_t *zhp;
 	int ret;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "f")) != -1) {
+	while ((c = getopt(argc, argv, "fF")) != -1) {
 		switch (c) {
 		case 'f':
 			force = B_TRUE;
+			break;
+		case 'F':
+			force = hardforce = B_TRUE;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -2385,7 +2389,17 @@ zpool_do_destroy(int argc, char **argv)
 
 	pool = argv[0];
 
-	if ((zhp = zpool_open_canfail(g_zfs, pool)) == NULL) {
+	if (hardforce) {
+		/*
+		 * The hardforce code path should reach the kernel w/o extra
+		 * locks to break through and initiate forced exit.
+		 */
+		zhp = zpool_open_unchecked(g_zfs, pool);
+	} else {
+		zhp = zpool_open_canfail(g_zfs, pool);
+	}
+
+	if (zhp == NULL) {
 		/*
 		 * As a special case, check for use of '/' in the name, and
 		 * direct the user to use 'zfs destroy' instead.
@@ -2396,7 +2410,7 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_disable_datasets(zhp, force, B_FALSE) != 0) {
+	if (zpool_disable_datasets(zhp, force, hardforce) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
@@ -2406,7 +2420,7 @@ zpool_do_destroy(int argc, char **argv)
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;
 
-	ret = (zpool_destroy(zhp, history_str) != 0);
+	ret = (zpool_destroy(zhp, force, hardforce, history_str) != 0);
 
 	zpool_close(zhp);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6635,7 +6635,9 @@ ztest_verify_dnode_bt(ztest_ds_t *zd, uint64_t id)
 			ztest_bt_verify(bt, os, obj, doi.doi_dnodesize,
 			    bt->bt_offset, bt->bt_gen, bt->bt_txg,
 			    bt->bt_crtxg);
-			ztest_verify_unused_bonus(db, bt, obj, os, bt->bt_gen);
+			if (!ZTEST_HFE_ACTIVE())
+				ztest_verify_unused_bonus(db, bt, obj, os,
+				    bt->bt_gen);
 		}
 
 		dmu_buf_rele(db, FTAG);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5156,7 +5156,7 @@ ztest_dmu_object_alloc_free(ztest_ds_t *zd, uint64_t id)
 		return;
 	}
 
-	while (ztest_random(4 * batchsize) != 0)
+	while (ztest_random(4 * batchsize) != 0 && !ZTEST_HFE_ACTIVE())
 		ztest_io(zd, od[ztest_random(batchsize)].od_object,
 		    ztest_random(ZTEST_RANGE_LOCKS) << SPA_MAXBLOCKSHIFT);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3219,9 +3219,12 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	ztest_shared_opts_t *zo = &ztest_opts;
 	spa_t *spa;
 	nvlist_t *nvroot;
+	int err;
 
 	if (zo->zo_mmp_test)
 		return;
+
+	mutex_enter(&ztest_vdev_lock);
 
 	/*
 	 * Attempt to create using a bad file.
@@ -3260,15 +3263,21 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 *	For the case that there is another ztest thread doing
 	 *	an export concurrently.
 	 */
-	VERIFY0(spa_open(zo->zo_pool, &spa, FTAG));
+	err = spa_open(zo->zo_pool, &spa, FTAG);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 	int error = spa_destroy(zo->zo_pool, B_FALSE, B_FALSE);
-	if (error != EBUSY && error != ZFS_ERR_EXPORT_IN_PROGRESS) {
+	if (error != EBUSY && error != EAGAIN &&
+	    error != ZFS_ERR_EXPORT_IN_PROGRESS && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE, "spa_destroy(%s) returned unexpected value %d",
 		    spa->spa_name, error);
 	}
 	spa_close(spa, FTAG);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	mutex_exit(&ztest_vdev_lock);
 }
 
 /*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4856,40 +4856,43 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	return (0);
 }
 
-static boolean_t
+static int
 ztest_snapshot_create(char *osname, uint64_t id)
 {
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];
-	int error;
+	int err = 0;
 
 	(void) snprintf(snapname, sizeof (snapname), "%"PRIu64"", id);
 
-	error = dmu_objset_snapshot_one(osname, snapname);
-	if (error == ENOSPC) {
+	err = dmu_objset_snapshot_one(osname, snapname);
+	if (err == ENOSPC) {
 		ztest_record_enospc(FTAG);
-		return (B_FALSE);
+		return (err);
 	}
-	if (error != 0 && error != EEXIST && error != ECHRNG) {
-		fatal(B_FALSE, "ztest_snapshot_create(%s@%s) = %d", osname,
-		    snapname, error);
+	if (err != 0 && err != EEXIST && err != ECHRNG) {
+		if (!ZTEST_HFE_ACTIVE())
+			fatal(B_FALSE, "ztest_snapshot_create(%s@%s) = %d",
+			    osname, snapname, err);
 	}
-	return (B_TRUE);
+	return (err);
 }
 
-static boolean_t
+static int
 ztest_snapshot_destroy(char *osname, uint64_t id)
 {
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];
-	int error;
+	int error = 0;
 
 	(void) snprintf(snapname, sizeof (snapname), "%s@%"PRIu64"",
 	    osname, id);
 
 	error = dsl_destroy_snapshot(snapname, B_FALSE);
-	if (error != 0 && error != ENOENT && error != ECHRNG)
-		fatal(B_FALSE, "ztest_snapshot_destroy(%s) = %d",
-		    snapname, error);
-	return (B_TRUE);
+	if (error != 0 && error != ENOENT && error != ECHRNG) {
+		if (!ZTEST_HFE_ACTIVE())
+			fatal(B_FALSE, "ztest_snapshot_destroy(%s) = %d",
+			    snapname, error);
+	}
+	return (error);
 }
 
 void
@@ -5037,9 +5040,12 @@ out:
 void
 ztest_dmu_snapshot_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
+	int err;
+
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
-	(void) ztest_snapshot_destroy(zd->zd_name, id);
-	(void) ztest_snapshot_create(zd->zd_name, id);
+	err = ztest_snapshot_destroy(zd->zd_name, id);
+	if (err == 0 || err == ENOENT)
+		err = ztest_snapshot_create(zd->zd_name, id);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5890,11 +5890,11 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	objset_t *os = zd->zd_os;
 	ztest_od_t *od;
 	uint64_t object;
-	uint64_t txg, last_txg;
+	uint64_t txg = 0, last_txg;
 	uint64_t value[ZTEST_ZAP_MAX_INTS];
 	uint64_t zl_ints, zl_intsize, prop;
 	int i, ints;
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
 	char propname[100], txgname[100];
 	int error;
 	const char *const hc[2] = { "s.acl.h", ".s.open.h.hyLZlg" };
@@ -5919,21 +5919,35 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 		goto out;
 	for (i = 0; i < 2; i++) {
 		value[i] = i;
-		VERIFY0(zap_add(os, object, hc[i], sizeof (uint64_t),
-		    1, &value[i], tx));
+		error = zap_add(os, object, hc[i], sizeof (uint64_t),
+		    1, &value[i], tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	}
 	for (i = 0; i < 2; i++) {
-		VERIFY3U(EEXIST, ==, zap_add(os, object, hc[i],
-		    sizeof (uint64_t), 1, &value[i], tx));
-		VERIFY0(
-		    zap_length(os, object, hc[i], &zl_intsize, &zl_ints));
+		error = zap_add(os, object, hc[i],
+		    sizeof (uint64_t), 1, &value[i], tx);
+		if (!(error == EEXIST) && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY3U(error, ==, EEXIST);
+
+		error = zap_length(os, object, hc[i], &zl_intsize, &zl_ints);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
+
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, 1);
 	}
 	for (i = 0; i < 2; i++) {
-		VERIFY0(zap_remove(os, object, hc[i], tx));
+		error = zap_remove(os, object, hc[i], tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	}
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Generate a bunch of random entries.
@@ -5954,22 +5968,33 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, 1);
 
-		VERIFY0(zap_lookup(os, object, txgname, zl_intsize,
-		    zl_ints, &last_txg));
+		error = zap_lookup(os, object, txgname, zl_intsize,
+		    zl_ints, &last_txg);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
-		VERIFY0(zap_length(os, object, propname, &zl_intsize,
-		    &zl_ints));
+		error = zap_length(os, object, propname, &zl_intsize,
+		    &zl_ints);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, ints);
 
-		VERIFY0(zap_lookup(os, object, propname, zl_intsize,
-		    zl_ints, value));
+		error = zap_lookup(os, object, propname, zl_intsize,
+		    zl_ints, value);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
 		for (i = 0; i < ints; i++) {
 			ASSERT3U(value[i], ==, last_txg + object + i);
 		}
 	} else {
+		if (!(error == ENOENT) && ZTEST_HFE_ACTIVE())
+			goto out;
 		ASSERT3U(error, ==, ENOENT);
 	}
 
@@ -5993,12 +6018,19 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	for (i = 0; i < ints; i++)
 		value[i] = txg + object + i;
 
-	VERIFY0(zap_update(os, object, txgname, sizeof (uint64_t),
-	    1, &txg, tx));
-	VERIFY0(zap_update(os, object, propname, sizeof (uint64_t),
-	    ints, value, tx));
+	error = zap_update(os, object, txgname, sizeof (uint64_t),
+	    1, &txg, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+	error = zap_update(os, object, propname, sizeof (uint64_t),
+	    ints, value, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Remove a random pair of entries.
@@ -6011,7 +6043,8 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 
 	if (error == ENOENT)
 		goto out;
-
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 
 	tx = dmu_tx_create(os);
@@ -6019,10 +6052,18 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
 	if (txg == 0)
 		goto out;
-	VERIFY0(zap_remove(os, object, txgname, tx));
-	VERIFY0(zap_remove(os, object, propname, tx));
-	dmu_tx_commit(tx);
+	error = zap_remove(os, object, txgname, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+	error = zap_remove(os, object, propname, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+
 out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
 	umem_free(od, sizeof (ztest_od_t));
 }
 
@@ -6064,6 +6105,11 @@ ztest_fzap(ztest_ds_t *zd, uint64_t id)
 			goto out;
 		error = zap_add(os, object, name, sizeof (uint64_t), 1,
 		    &value, tx);
+		if (!(error == 0 || error == EEXIST) &&
+		    ZTEST_HFE_ACTIVE()) {
+			dmu_tx_commit(tx);
+			goto out;
+		}
 		ASSERT(error == 0 || error == EEXIST);
 		dmu_tx_commit(tx);
 	}
@@ -6078,7 +6124,7 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 	objset_t *os = zd->zd_os;
 	ztest_od_t *od;
 	uint64_t txg, object, count, wsize, wc, zl_wsize, zl_wc;
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
 	int i, namelen, error;
 	int micro = ztest_random(2);
 	char name[20], string_value[20];
@@ -6119,7 +6165,12 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 	}
 
 	count = -1ULL;
-	VERIFY0(zap_count(os, object, &count));
+	error = zap_count(os, object, &count);
+	if (error && ZTEST_HFE_ACTIVE()) {
+		umem_free(od, sizeof (ztest_od_t));
+		return;
+	}
+	VERIFY0(error);
 	ASSERT3S(count, !=, -1ULL);
 
 	/*
@@ -6150,7 +6201,8 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 			ASSERT3U(wsize, ==, zl_wsize);
 			ASSERT3U(wc, ==, zl_wc);
 		} else {
-			ASSERT3U(error, ==, ENOENT);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOENT);
 		}
 		break;
 
@@ -6162,22 +6214,27 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 				fatal(B_FALSE, "name '%s' != val '%s' len %d",
 				    name, (char *)data, namelen);
 		} else {
-			ASSERT3U(error, ==, ENOENT);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOENT);
 		}
 		break;
 
 	case 2:
 		error = zap_add(os, object, name, wsize, wc, data, tx);
-		ASSERT(error == 0 || error == EEXIST);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == EEXIST);
 		break;
 
 	case 3:
-		VERIFY0(zap_update(os, object, name, wsize, wc, data, tx));
+		error = zap_update(os, object, name, wsize, wc, data, tx);
+		if (!ZTEST_HFE_ACTIVE())
+			VERIFY0(error);
 		break;
 
 	case 4:
 		error = zap_remove(os, object, name, tx);
-		ASSERT(error == 0 || error == ENOENT);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == ENOENT);
 		break;
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5093,21 +5093,21 @@ ztest_dsl_dataset_cleanup(char *osname, uint64_t id)
 	    clone1name, id);
 
 	error = dsl_destroy_head(clone2name);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_head(%s) = %d", clone2name, error);
 	error = dsl_destroy_snapshot(snap3name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap3name, error);
 	error = dsl_destroy_snapshot(snap2name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap2name, error);
 	error = dsl_destroy_head(clone1name);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_head(%s) = %d", clone1name, error);
 	error = dsl_destroy_snapshot(snap1name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap1name, error);
 
@@ -5160,6 +5160,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_take_snapshot(%s) = %d", snap1name, error);
 	}
 
@@ -5169,6 +5171,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", clone1name, error);
 	}
 
@@ -5178,6 +5182,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_open_snapshot(%s) = %d", snap2name, error);
 	}
 
@@ -5187,6 +5193,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_open_snapshot(%s) = %d", snap3name, error);
 	}
 
@@ -5196,27 +5204,32 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", clone2name, error);
 	}
 
 	error = ztest_dmu_objset_own(snap2name, DMU_OST_ANY, B_TRUE, B_TRUE,
 	    FTAG, &os);
-	if (error)
+	if (error) {
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_own(%s) = %d", snap2name, error);
+	}
 	error = dsl_dataset_promote(clone2name, NULL);
 	if (error == ENOSPC) {
 		dmu_objset_disown(os, B_TRUE, FTAG);
 		ztest_record_enospc(FTAG);
 		goto out;
 	}
-	if (error != EBUSY)
+	if (error != EBUSY && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_dataset_promote(%s), %d, not EBUSY",
 		    clone2name, error);
 	dmu_objset_disown(os, B_TRUE, FTAG);
 
-out:
 	ztest_dsl_dataset_cleanup(osname, id);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 
 	umem_free(snap1name, ZFS_MAX_DATASET_NAME_LEN);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8493,7 +8493,9 @@ ztest_run(ztest_shared_t *zs)
 		ASSERT3U(ztest_opts.zo_raidz_expand_test, ==,
 		    RAIDZ_EXPAND_NONE);
 
-		int d = ztest_random(ztest_opts.zo_datasets);
+		int d, ndatasets;
+		ndatasets = MIN(ztest_opts.zo_datasets, ztest_opts.zo_threads);
+		d = ztest_random(ndatasets);
 		ztest_dataset_destroy(d);
 		txg_wait_synced(spa_get_dsl(spa), 0);
 	}

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3525,7 +3525,7 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	uint64_t leaves;
 	uint64_t guid;
 	uint64_t raidz_children;
@@ -3537,6 +3537,7 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		return;
 
 	mutex_enter(&ztest_vdev_lock);
+	spa = ztest_spa;
 	raidz_children = ztest_get_raidz_children(spa);
 	leaves = MAX(zs->zs_mirrors + zs->zs_splits, 1) * raidz_children;
 
@@ -3582,6 +3583,8 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		case ZFS_ERR_DISCARDING_CHECKPOINT:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			fatal(B_FALSE, "spa_vdev_remove() = %d", error);
 		}
 	} else {
@@ -3605,7 +3608,10 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc("spa_vdev_add");
 			break;
 		default:
-			fatal(B_FALSE, "spa_vdev_add() = %d", error);
+			if (ZTEST_HFE_ACTIVE())
+				break;
+			fatal(B_FALSE, "%s: spa_vdev_add() = %d", __func__,
+			    error);
 		}
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4031,9 +4031,11 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 		error = spa_vdev_detach(spa, oldguid, pguid, B_FALSE);
 		if (error != 0 && error != ENODEV && error != EBUSY &&
 		    error != ENOTSUP && error != ZFS_ERR_CHECKPOINT_EXISTS &&
-		    error != ZFS_ERR_DISCARDING_CHECKPOINT)
+		    error != ZFS_ERR_DISCARDING_CHECKPOINT &&
+		    !ZTEST_HFE_ACTIVE()) {
 			fatal(B_FALSE, "detach (%s) returned %d",
 			    oldpath, error);
+		}
 		goto out;
 	}
 
@@ -4148,7 +4150,8 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	    error == ZFS_ERR_REBUILD_IN_PROGRESS)
 		expected_error = error;
 
-	if (error != expected_error && expected_error != EBUSY) {
+	if (error != expected_error && expected_error != EBUSY &&
+	    !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE, "attach (%s %"PRIu64", %s %"PRIu64", %d) "
 		    "returned %d, expected %d",
 		    oldpath, oldsize, newpath,

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6830,7 +6830,7 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	int fd;
 	uint64_t offset;
 	uint64_t leaves;
@@ -6849,10 +6849,15 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 	boolean_t islog = B_FALSE;
 	boolean_t injected = B_FALSE;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	path0 = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 	pathrand = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 
 	mutex_enter(&ztest_vdev_lock);
+
+	spa = ztest_spa;
 
 	/*
 	 * Device removal is in progress, fault injection must be disabled
@@ -7126,6 +7131,7 @@ out:
 	umem_free(path0, MAXPATHLEN);
 	umem_free(pathrand, MAXPATHLEN);
 
+	mutex_exit(&ztest_hfe_lock);
 }
 
 static uint64_t

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3780,6 +3780,8 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		case 0:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			fatal(B_FALSE, "spa_vdev_add(%p) = %d", nvroot, error);
 		}
 		fnvlist_free(nvroot);
@@ -3801,6 +3803,8 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		case ZFS_ERR_DISCARDING_CHECKPOINT:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			if (error != ignore_err)
 				fatal(B_FALSE,
 				    "spa_vdev_remove(%"PRIu64") = %d",

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4724,8 +4724,10 @@ ztest_objset_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 	/*
 	 * Create the objects common to all ztest datasets.
 	 */
-	VERIFY0(zap_create_claim(os, ZTEST_DIROBJ,
-	    DMU_OT_ZAP_OTHER, DMU_OT_NONE, 0, tx));
+	int err = zap_create_claim(os, ZTEST_DIROBJ,
+	    DMU_OT_ZAP_OTHER, DMU_OT_NONE, 0, tx);
+	if (!ZTEST_HFE_ACTIVE())
+		VERIFY0(err);
 }
 
 static int
@@ -4808,9 +4810,16 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	/*
 	 * Verify that the dataset contains a directory object.
 	 */
-	VERIFY0(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE,
-	    B_TRUE, FTAG, &os));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE,
+	    B_TRUE, FTAG, &os);
+	if (error && ZTEST_HFE_ACTIVE())
+		return (error);
+	VERIFY0(error);
 	error = dmu_object_info(os, ZTEST_DIROBJ, &doi);
+	if (!(error == ENOENT || error == 0) && ZTEST_HFE_ACTIVE()) {
+		dmu_objset_disown(os, B_TRUE, FTAG);
+		return (EIO);
+	}
 	if (error != ENOENT) {
 		/* We could have crashed in the middle of destroying it */
 		ASSERT0(error);
@@ -4824,6 +4833,8 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	 */
 	if (strchr(name, '@') != NULL) {
 		error = dsl_destroy_snapshot(name, B_TRUE);
+		if (!(error == ECHRNG || error == 0) && ZTEST_HFE_ACTIVE())
+			return (EIO);
 		if (error != ECHRNG) {
 			/*
 			 * The program was executed, but encountered a runtime
@@ -4834,6 +4845,9 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 		}
 	} else {
 		error = dsl_destroy_head(name);
+		if (!(error == ENOSPC || error == EBUSY || error == 0) &&
+		    ZTEST_HFE_ACTIVE())
+			return (EIO);
 		if (error == ENOSPC) {
 			/* There could be checkpoint or insufficient slop */
 			ztest_record_enospc(FTAG);
@@ -4886,11 +4900,12 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd;
 	ztest_ds_t *zdtmp;
+	boolean_t zdtmp_inited = B_FALSE;
 	int iters;
 	int error;
-	objset_t *os, *os2;
+	objset_t *os = NULL, *os2;
 	char name[ZFS_MAX_DATASET_NAME_LEN];
-	zilog_t *zilog;
+	zilog_t *zilog = NULL;
 	int i;
 
 	zdtmp = umem_alloc(sizeof (ztest_ds_t), UMEM_NOFAIL);
@@ -4912,6 +4927,7 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 		zil_replay(os, zdtmp, ztest_replay_vector);
 		ztest_zd_fini(zdtmp);
 		dmu_objset_disown(os, B_TRUE, FTAG);
+		os = NULL;
 	}
 
 	/*
@@ -4919,8 +4935,10 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 * create lying around from a previous run.  If so, destroy it
 	 * and all of its snapshots.
 	 */
-	(void) dmu_objset_find(name, ztest_objset_destroy_cb, NULL,
+	error = dmu_objset_find(name, ztest_objset_destroy_cb, NULL,
 	    DS_FIND_CHILDREN | DS_FIND_SNAPSHOTS);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	/*
 	 * Verify that the destroyed dataset is no longer in the namespace.
@@ -4929,10 +4947,12 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE, B_TRUE,
 	    FTAG, &os);
 	if (error == 0) {
-		dmu_objset_disown(os, B_TRUE, FTAG);
 		ztest_record_enospc(FTAG);
 		goto out;
 	}
+	os = NULL;
+	if (error != ENOENT && ZTEST_HFE_ACTIVE())
+		goto out;
 	VERIFY3U(ENOENT, ==, error);
 
 	/*
@@ -4944,13 +4964,21 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", name, error);
 	}
 
-	VERIFY0(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
-	    FTAG, &os));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
+	    FTAG, &os);
+	if (error && ZTEST_HFE_ACTIVE()) {
+		os = NULL;
+		goto out;
+	}
+	VERIFY0(error);
 
 	ztest_zd_init(zdtmp, NULL, os);
+	zdtmp_inited = B_TRUE;
 
 	/*
 	 * Open the intent log for it.
@@ -4964,34 +4992,45 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	iters = ztest_random(5);
 	for (i = 0; i < iters; i++) {
 		ztest_dmu_object_alloc_free(zdtmp, id);
-		if (ztest_random(iters) == 0)
+		if (ztest_random(iters) == 0) {
 			(void) ztest_snapshot_create(name, i);
+		}
 	}
 
 	/*
 	 * Verify that we cannot create an existing dataset.
 	 */
-	VERIFY3U(EEXIST, ==,
-	    dmu_objset_create(name, DMU_OST_OTHER, 0, NULL, NULL, NULL));
+	error = dmu_objset_create(name, DMU_OST_OTHER, 0, NULL, NULL, NULL);
+	if (!(error == EEXIST) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3U(error, ==, EEXIST);
 
 	/*
 	 * Verify that we can hold an objset that is also owned.
 	 */
-	VERIFY0(dmu_objset_hold(name, FTAG, &os2));
+	error = dmu_objset_hold(name, FTAG, &os2);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	dmu_objset_rele(os2, FTAG);
 
 	/*
 	 * Verify that we cannot own an objset that is already owned.
 	 */
-	VERIFY3U(EBUSY, ==, ztest_dmu_objset_own(name, DMU_OST_OTHER,
-	    B_FALSE, B_TRUE, FTAG, &os2));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
+	    FTAG, &os2);
+	if (!(error == EBUSY) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3U(error, ==, EBUSY);
 
-	zil_close(zilog);
-	dmu_objset_disown(os, B_TRUE, FTAG);
-	ztest_zd_fini(zdtmp);
 out:
+	if (zilog)
+		zil_close(zilog);
+	if (os)
+		dmu_objset_disown(os, B_TRUE, FTAG);
+	if (zdtmp_inited)
+		ztest_zd_fini(zdtmp);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
-
 	umem_free(zdtmp, sizeof (ztest_ds_t));
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3669,8 +3669,10 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 
 	if (error == ENOSPC)
 		ztest_record_enospc("spa_vdev_add");
-	else if (error != 0)
-		fatal(B_FALSE, "spa_vdev_add() = %d", error);
+	else if (error != 0 && !ZTEST_HFE_ACTIVE()) {
+		fatal(B_FALSE, "%s: spa_vdev_add() = %d", __func__,
+		    error);
+	}
 
 	/*
 	 * 50% of the time allow small blocks in the special class
@@ -3681,7 +3683,8 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 			(void) printf("Enabling special VDEV small blocks\n");
 		error = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_SPECIAL_SMALL_BLOCKS, 32768, B_FALSE);
-		ASSERT(error == 0 || error == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == ENOSPC);
 	}
 
 	mutex_exit(&ztest_vdev_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2031,7 +2031,7 @@ ztest_log_create(ztest_ds_t *zd, dmu_tx_t *tx, lr_create_t *lr)
 	size_t namesize = strlen(name) + 1;
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_CREATE, sizeof (*lr) + namesize);
@@ -2048,7 +2048,7 @@ ztest_log_remove(ztest_ds_t *zd, dmu_tx_t *tx, lr_remove_t *lr, uint64_t object)
 	size_t namesize = strlen(name) + 1;
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_REMOVE, sizeof (*lr) + namesize);
@@ -2065,7 +2065,7 @@ ztest_log_write(ztest_ds_t *zd, dmu_tx_t *tx, lr_write_t *lr)
 	itx_t *itx;
 	itx_wr_state_t write_state = ztest_random(WR_NUM_STATES);
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	if (lr->lr_length > zil_max_log_data(zd->zd_zilog, sizeof (lr_write_t)))
@@ -2097,7 +2097,7 @@ ztest_log_truncate(ztest_ds_t *zd, dmu_tx_t *tx, lr_truncate_t *lr)
 {
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_TRUNCATE, sizeof (*lr));
@@ -2113,7 +2113,7 @@ ztest_log_setattr(ztest_ds_t *zd, dmu_tx_t *tx, lr_setattr_t *lr)
 {
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_SETATTR, sizeof (*lr));

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1690,11 +1690,8 @@ ztest_spa_prop_set_uint64(zpool_prop_t prop, uint64_t value)
 
 	fnvlist_free(props);
 
-	if (error == ENOSPC) {
+	if (error == ENOSPC)
 		ztest_record_enospc(FTAG);
-		return (error);
-	}
-	ASSERT0(error);
 
 	return (error);
 }
@@ -6623,13 +6620,18 @@ ztest_dsl_prop_get_set(ztest_ds_t *zd, uint64_t id)
 	for (int p = 0; p < sizeof (proplist) / sizeof (proplist[0]); p++) {
 		int error = ztest_dsl_prop_set_uint64(zd->zd_name, proplist[p],
 		    ztest_random_dsl_prop(proplist[p]), (int)ztest_random(2));
+		if (!(error == 0 || error == ENOSPC) && ZTEST_HFE_ACTIVE())
+			goto out;
 		ASSERT(error == 0 || error == ENOSPC);
 	}
 
 	int error = ztest_dsl_prop_set_uint64(zd->zd_name, ZFS_PROP_RECORDSIZE,
 	    ztest_random_blocksize(), (int)ztest_random(2));
+	if (!(error == 0 || error == ENOSPC) && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT(error == 0 || error == ENOSPC);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 
@@ -6637,19 +6639,29 @@ void
 ztest_spa_prop_get_set(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
+	nvlist_t *props = NULL;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
 
-	(void) ztest_spa_prop_set_uint64(ZPOOL_PROP_AUTOTRIM, ztest_random(2));
+	err = ztest_spa_prop_set_uint64(ZPOOL_PROP_AUTOTRIM, ztest_random(2));
+	if (!(err == 0 || err == ENOSPC) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY(err == 0 || err == ENOSPC);
 
-	nvlist_t *props = fnvlist_alloc();
+	props = fnvlist_alloc();
 
-	VERIFY0(spa_prop_get(ztest_spa, props));
+	err = spa_prop_get(ztest_spa, props);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	if (ztest_opts.zo_verbose >= 6)
 		dump_nvlist(props, 4);
 
-	fnvlist_free(props);
+out:
+	if (props)
+		fnvlist_free(props);
 
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1899,6 +1899,8 @@ ztest_tx_assign(dmu_tx_t *tx, dmu_tx_flag_t txg_how, const char *tag)
 	/*
 	 * Attempt to assign tx to some transaction group.
 	 */
+	if ((txg_how & DMU_TX_WAIT) && ztest_random(2) == 0)
+		txg_how |= DMU_TX_SUSPEND;
 	error = dmu_tx_assign(tx, txg_how);
 	if (error) {
 		if (error == ERESTART) {

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1645,7 +1645,8 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 
 	error = dsl_prop_set_int(osname, propname,
 	    (inherit ? ZPROP_SRC_NONE : ZPROP_SRC_LOCAL), value);
-
+	if (!(error == ENOSPC || error == 0) && ZTEST_HFE_ACTIVE())
+		return (EIO);
 	if (error == ENOSPC) {
 		ztest_record_enospc(FTAG);
 		return (error);
@@ -1653,7 +1654,9 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 	ASSERT0(error);
 
 	setpoint = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
-	VERIFY0(dsl_prop_get_integer(osname, propname, &curval, setpoint));
+	error = dsl_prop_get_integer(osname, propname, &curval, setpoint);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (ztest_opts.zo_verbose >= 6) {
 		int err;
@@ -1666,6 +1669,8 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 			(void) printf("%s %s = %s at '%s'\n",
 			    osname, propname, valname, setpoint);
 	}
+
+out:
 	umem_free(setpoint, MAXPATHLEN);
 
 	return (error);
@@ -2276,12 +2281,13 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	uint64_t offset, length;
 	ztest_block_tag_t *bt = (ztest_block_tag_t *)data;
 	ztest_block_tag_t *bbt;
-	uint64_t gen, txg, lrtxg, crtxg;
+	uint64_t gen, txg = 0, lrtxg, crtxg;
 	dmu_object_info_t doi;
 	dmu_tx_t *tx;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	arc_buf_t *abuf = NULL;
 	rl_t *rl;
+	int error = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2307,7 +2313,10 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	ztest_object_lock(zd, lr->lr_foid, ZTRL_READER);
 	rl = ztest_range_lock(zd, lr->lr_foid, offset, length, ZTRL_WRITER);
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	error = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	dmu_object_info_from_db(db, &doi);
 
@@ -2329,10 +2338,8 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	if (txg == 0) {
 		if (abuf != NULL)
 			dmu_return_arcbuf(abuf);
-		dmu_buf_rele(db, FTAG);
-		ztest_range_unlock(rl);
-		ztest_object_unlock(zd, lr->lr_foid);
-		return (ENOSPC);
+		error = ENOSPC;
+		goto out;
 	}
 
 	if (bt != NULL) {
@@ -2343,7 +2350,7 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 		 */
 		ASSERT(doi.doi_data_block_size);
 		ASSERT0(offset % doi.doi_data_block_size);
-		if (ztest_random(4) != 0) {
+		if (ztest_random(4) != 0 && !ZTEST_HFE_ACTIVE()) {
 			dmu_flags_t flags = ztest_random(2) ?
 			    DMU_READ_PREFETCH : DMU_READ_NO_PREFETCH;
 
@@ -2355,8 +2362,14 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 
 			ztest_block_tag_t rbt;
 
-			VERIFY0(dmu_read(os, lr->lr_foid, offset,
-			    sizeof (rbt), &rbt, flags));
+			error = dmu_read(os, lr->lr_foid, offset, sizeof (rbt),
+			    &rbt, flags);
+			if (error && ZTEST_HFE_ACTIVE()) {
+				if (abuf != NULL)
+					dmu_return_arcbuf(abuf);
+				goto out;
+			}
+			VERIFY0(error);
 			if (rbt.bt_magic == BT_MAGIC) {
 				ztest_bt_verify(&rbt, os, lr->lr_foid, 0,
 				    offset, gen, txg, crtxg);
@@ -2386,21 +2399,32 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	if (abuf == NULL) {
 		dmu_write(os, lr->lr_foid, offset, length, data, tx,
 		    DMU_READ_PREFETCH);
+		if (ZTEST_HFE_ACTIVE()) {
+			error = EIO;
+			goto out;
+		}
 	} else {
 		memcpy(abuf->b_data, data, length);
-		VERIFY0(dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx, 0));
+		error = dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx, 0);
+		if (error && ZTEST_HFE_ACTIVE()) {
+			dmu_return_arcbuf(abuf);
+			goto out;
+		}
+		VERIFY0(error);
 	}
 
 	(void) ztest_log_write(zd, tx, lr);
 
-	dmu_buf_rele(db, FTAG);
-
-	dmu_tx_commit(tx);
+out:
+	if (db != NULL)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_range_unlock(rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2412,6 +2436,7 @@ ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 	dmu_tx_t *tx;
 	uint64_t txg;
 	rl_t *rl;
+	int err = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2431,17 +2456,20 @@ ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 		return (ENOSPC);
 	}
 
-	VERIFY0(dmu_free_range(os, lr->lr_foid, lr->lr_offset,
-	    lr->lr_length, tx));
+	err = dmu_free_range(os, lr->lr_foid, lr->lr_offset,
+	    lr->lr_length, tx);
+	if (!ZTEST_HFE_ACTIVE())
+		VERIFY0(err);
 
-	(void) ztest_log_truncate(zd, tx, lr);
+	if (!err)
+		(void) ztest_log_truncate(zd, tx, lr);
 
 	dmu_tx_commit(tx);
 
 	ztest_range_unlock(rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (err);
 }
 
 static int
@@ -2451,25 +2479,28 @@ ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	lr_setattr_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	ztest_block_tag_t *bbt;
-	uint64_t txg, lrtxg, crtxg, dnodesize;
+	uint64_t txg = 0, lrtxg, crtxg, dnodesize;
+	int err = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
 
 	ztest_object_lock(zd, lr->lr_foid, ZTRL_WRITER);
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	err = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	tx = dmu_tx_create(os);
 	dmu_tx_hold_bonus(tx, lr->lr_foid);
 
 	txg = ztest_tx_assign(tx, DMU_TX_WAIT, FTAG);
 	if (txg == 0) {
-		dmu_buf_rele(db, FTAG);
-		ztest_object_unlock(zd, lr->lr_foid);
-		return (ENOSPC);
+		err = ENOSPC;
+		goto out;
 	}
 
 	bbt = ztest_bt_bonus(db);
@@ -2499,24 +2530,37 @@ ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	    MAX(txg, lrtxg), crtxg);
 
 	dmu_buf_will_dirty(db, tx);
+	if (ZTEST_HFE_ACTIVE()) {
+		err = EIO;
+		goto out;
+	}
 
 	ASSERT3U(lr->lr_size, >=, sizeof (*bbt));
 	ASSERT3U(lr->lr_size, <=, db->db_size);
-	VERIFY0(dmu_set_bonus(db, lr->lr_size, tx));
+	err = dmu_set_bonus(db, lr->lr_size, tx);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 	bbt = ztest_bt_bonus(db);
 
 	ztest_bt_generate(bbt, os, lr->lr_foid, dnodesize, -1ULL, lr->lr_mode,
 	    txg, crtxg);
 	ztest_fill_unused_bonus(db, bbt, lr->lr_foid, os, bbt->bt_gen);
 	dmu_buf_rele(db, FTAG);
+	db = NULL;
 
-	(void) ztest_log_setattr(zd, tx, lr);
+	if (!err)
+		(void) ztest_log_setattr(zd, tx, lr);
 
-	dmu_tx_commit(tx);
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (err);
 }
 
 static zil_replay_func_t *ztest_replay_vector[TX_MAX_TYPE] = {
@@ -2927,7 +2971,10 @@ ztest_io(ztest_ds_t *zd, uint64_t object, uint64_t offset)
 	if (ztest_random(4) == 0)
 		dmu_read_flags |= DMU_DIRECTIO;
 
-	VERIFY0(dmu_object_info(zd->zd_os, object, &doi));
+	err = dmu_object_info(zd->zd_os, object, &doi);
+	if (err && ZTEST_HFE_ACTIVE())
+		return;
+	VERIFY0(err);
 	blocksize = doi.doi_data_block_size;
 	data = umem_alloc(blocksize, UMEM_NOFAIL);
 
@@ -2982,16 +3029,21 @@ ztest_io(ztest_ds_t *zd, uint64_t object, uint64_t offset)
 		err = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_CHECKSUM, spa_dedup_checksum(ztest_spa),
 		    B_FALSE);
-		ASSERT(err == 0 || err == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(err == 0 || err == ENOSPC);
 		err = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_COMPRESSION,
 		    ztest_random_dsl_prop(ZFS_PROP_COMPRESSION),
 		    B_FALSE);
-		ASSERT(err == 0 || err == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(err == 0 || err == ENOSPC);
 		(void) pthread_rwlock_unlock(&ztest_name_lock);
 
-		VERIFY0(dmu_read(zd->zd_os, object, offset, blocksize, data,
-		    dmu_read_flags));
+		err = dmu_read(zd->zd_os, object, offset, blocksize, data,
+		    dmu_read_flags);
+		if (err && ZTEST_HFE_ACTIVE())
+			break;
+		VERIFY0(err);
 
 		(void) ztest_write(zd, object, offset, blocksize, data);
 		break;
@@ -5727,11 +5779,12 @@ ztest_dmu_write_parallel(ztest_ds_t *zd, uint64_t id)
 	ztest_od_init(od, ID_PARALLEL, FTAG, 0, DMU_OT_UINT64_OTHER, 0, 0, 0);
 
 	if (ztest_object_init(zd, od, sizeof (ztest_od_t), B_FALSE) != 0)
-		return;
+		goto out;
 
-	while (ztest_random(10) != 0)
+	while (ztest_random(10) != 0 && !ZTEST_HFE_ACTIVE())
 		ztest_io(zd, od->od_object, offset);
 
+out:
 	umem_free(od, sizeof (ztest_od_t));
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4697,7 +4697,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Make sure we were able to grow the vdev.
 	 */
-	if (new_ms_count <= old_ms_count) {
+	if (new_ms_count <= old_ms_count && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE,
 		    "LUN expansion failed: ms_count %"PRIu64" < %"PRIu64"\n",
 		    old_ms_count, new_ms_count);
@@ -4706,7 +4706,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Make sure we were able to grow the pool.
 	 */
-	if (new_class_space <= old_class_space) {
+	if (new_class_space <= old_class_space && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE,
 		    "LUN expansion failed: class_space %"PRIu64" < %"PRIu64"\n",
 		    old_class_space, new_class_space);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3453,6 +3453,8 @@ ztest_spa_checkpoint(spa_t *spa)
 		ztest_record_enospc(FTAG);
 		break;
 	default:
+		if (ZTEST_HFE_ACTIVE())
+			break;
 		fatal(B_FALSE, "spa_checkpoint(%s) = %d", spa->spa_name, error);
 	}
 }
@@ -3470,6 +3472,8 @@ ztest_spa_discard_checkpoint(spa_t *spa)
 	case ZFS_ERR_NO_CHECKPOINT:
 		break;
 	default:
+		if (ZTEST_HFE_ACTIVE())
+			break;
 		fatal(B_FALSE, "spa_discard_checkpoint(%s) = %d",
 		    spa->spa_name, error);
 	}

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2839,7 +2839,7 @@ ztest_create(ztest_ds_t *zd, ztest_od_t *od, int count)
 		lr->lr_gen = od->od_crgen;
 		lr->lr_crtime[0] = time(NULL);
 
-		if (ztest_replay_create(zd, lr, B_FALSE) != 0) {
+		if (ztest_replay_create(zd, lrc, B_FALSE) != 0) {
 			ASSERT0(missing);
 			od->od_object = 0;
 			missing++;
@@ -2851,7 +2851,7 @@ ztest_create(ztest_ds_t *zd, ztest_od_t *od, int count)
 			ASSERT3U(od->od_object, !=, 0);
 		}
 
-		ztest_lr_free(lr, sizeof (*lr), od->od_name);
+		ztest_lr_free(lrc, sizeof (*lrc), od->od_name);
 	}
 
 	return (missing);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2136,9 +2136,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	char *name = (char *)&lrc->lr_data[0];		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	ztest_block_tag_t *bbt;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	dmu_tx_t *tx;
-	uint64_t txg;
+	uint64_t txg = 0;
 	int error = 0;
 	int bonuslen;
 
@@ -2186,6 +2186,8 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 			    bonuslen, lr->lrz_dnodesize, tx);
 		}
 	}
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (error) {
 		ASSERT3U(error, ==, EEXIST);
@@ -2196,26 +2198,45 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 
 	ASSERT3U(lr->lr_foid, !=, 0);
 
-	if (lr->lrz_type != DMU_OT_ZAP_OTHER)
-		VERIFY0(dmu_object_set_blocksize(os, lr->lr_foid,
-		    lr->lrz_blocksize, lr->lrz_ibshift, tx));
+	if (lr->lrz_type != DMU_OT_ZAP_OTHER) {
+		error = dmu_object_set_blocksize(os, lr->lr_foid,
+		    lr->lrz_blocksize, lr->lrz_ibshift, tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
+	}
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	error = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	bbt = ztest_bt_bonus(db);
 	dmu_buf_will_dirty(db, tx);
+	if (ZTEST_HFE_ACTIVE()) {
+		error = EIO;
+		goto out;
+	}
 	ztest_bt_generate(bbt, os, lr->lr_foid, lr->lrz_dnodesize, -1ULL,
 	    lr->lr_gen, txg, txg);
 	ztest_fill_unused_bonus(db, bbt, lr->lr_foid, os, lr->lr_gen);
 	dmu_buf_rele(db, FTAG);
+	db = NULL;
 
-	VERIFY0(zap_add(os, lr->lr_doid, name, sizeof (uint64_t), 1,
-	    &lr->lr_foid, tx));
+	error = zap_add(os, lr->lr_doid, name, sizeof (uint64_t), 1,
+	    &lr->lr_foid, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	(void) ztest_log_create(zd, tx, lrc);
 
-	dmu_tx_commit(tx);
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2227,7 +2248,8 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 	objset_t *os = zd->zd_os;
 	dmu_object_info_t doi;
 	dmu_tx_t *tx;
-	uint64_t object, txg;
+	uint64_t object = 0, txg = 0;
+	int error = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2235,13 +2257,18 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 	ASSERT3U(lr->lr_doid, ==, ZTEST_DIROBJ);
 	ASSERT3S(name[0], !=, '\0');
 
-	VERIFY0(
-	    zap_lookup(os, lr->lr_doid, name, sizeof (object), 1, &object));
+	error = zap_lookup(os, lr->lr_doid, name, sizeof (object), 1, &object);
+	if (error && ZTEST_HFE_ACTIVE())
+		return (error);
+	VERIFY0(error);
 	ASSERT3U(object, !=, 0);
 
 	ztest_object_lock(zd, object, ZTRL_WRITER);
 
-	VERIFY0(dmu_object_info(os, object, &doi));
+	error = dmu_object_info(os, object, &doi);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	tx = dmu_tx_create(os);
 
@@ -2250,25 +2277,33 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 
 	txg = ztest_tx_assign(tx, DMU_TX_WAIT, FTAG);
 	if (txg == 0) {
-		ztest_object_unlock(zd, object);
-		return (ENOSPC);
+		error = ENOSPC;
+		goto out;
 	}
 
 	if (doi.doi_type == DMU_OT_ZAP_OTHER) {
-		VERIFY0(zap_destroy(os, object, tx));
+		error = zap_destroy(os, object, tx);
 	} else {
-		VERIFY0(dmu_object_free(os, object, tx));
+		error = dmu_object_free(os, object, tx);
 	}
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
-	VERIFY0(zap_remove(os, lr->lr_doid, name, tx));
+	error = zap_remove(os, lr->lr_doid, name, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	(void) ztest_log_remove(zd, tx, lr, object);
 
-	dmu_tx_commit(tx);
+out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_object_unlock(zd, object);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2658,7 +2693,8 @@ ztest_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 
 		error = dmu_read(os, object, offset, size, buf,
 		    DMU_READ_NO_PREFETCH | DMU_KEEP_CACHING);
-		ASSERT0(error);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT0(error);
 	} else {
 		ASSERT3P(zio, !=, NULL);
 		size = doi.doi_data_block_size;
@@ -3107,21 +3143,25 @@ ztest_zil_commit(ztest_ds_t *zd, uint64_t id)
 {
 	(void) id;
 	zilog_t *zilog = zd->zd_zilog;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&zd->zd_zilog_lock);
 
-	VERIFY0(zil_commit(zilog, ztest_random(ZTEST_OBJECTS)));
+	err = zil_commit(zilog, ztest_random(ZTEST_OBJECTS));
 
 	/*
 	 * Remember the committed values in zd, which is in parent/child
 	 * shared memory.  If we die, the next iteration of ztest_run()
 	 * will verify that the log really does contain this record.
 	 */
-	mutex_enter(&zilog->zl_lock);
-	ASSERT3P(zd->zd_shared, !=, NULL);
-	ASSERT3U(zd->zd_shared->zd_seq, <=, zilog->zl_commit_lr_seq);
-	zd->zd_shared->zd_seq = zilog->zl_commit_lr_seq;
-	mutex_exit(&zilog->zl_lock);
+	if (!err && !ZTEST_HFE_ACTIVE()) {
+		mutex_enter(&zilog->zl_lock);
+		ASSERT3P(zd->zd_shared, !=, NULL);
+		ASSERT3U(zd->zd_shared->zd_seq, <=, zilog->zl_commit_lr_seq);
+		if (zilog->zl_commit_lr_seq > zd->zd_shared->zd_seq)
+			zd->zd_shared->zd_seq = zilog->zl_commit_lr_seq;
+		mutex_exit(&zilog->zl_lock);
+	}
 
 	(void) pthread_rwlock_unlock(&zd->zd_zilog_lock);
 }
@@ -3136,6 +3176,7 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 {
 	(void) id;
 	objset_t *os = zd->zd_os;
+	zilog_t *ret;
 
 	/*
 	 * We hold the ztest_vdev_lock so we don't cause problems with
@@ -3154,11 +3195,17 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 
 	/* zfsvfs_teardown() */
 	zil_close(zd->zd_zilog);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
 
 	/* zfsvfs_setup() */
-	VERIFY3P(zil_open(os, ztest_get_data, NULL), ==, zd->zd_zilog);
+	ret = zil_open(os, ztest_get_data, NULL);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3P(ret, ==, zd->zd_zilog);
 	zil_replay(os, zd, ztest_replay_vector);
 
+out:
 	(void) pthread_rwlock_unlock(&zd->zd_zilog_lock);
 	mutex_exit(&zd->zd_dirobj_lock);
 	mutex_exit(&ztest_vdev_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3366,6 +3366,9 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	if (strcmp(ztest_opts.zo_raid_type, VDEV_TYPE_DRAID) == 0)
 		return;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	mutex_enter(&ztest_vdev_lock);
 	name = kmem_asprintf("%s_upgrade", ztest_opts.zo_pool);
 
@@ -3429,6 +3432,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 
 	kmem_strfree(name);
 	mutex_exit(&ztest_vdev_lock);
+	mutex_exit(&ztest_hfe_lock);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1906,7 +1906,7 @@ ztest_tx_assign(dmu_tx_t *tx, dmu_tx_flag_t txg_how, const char *tag)
 			dmu_tx_wait(tx);
 		} else if (error == ENOSPC) {
 			ztest_record_enospc(tag);
-		} else {
+		} else if (!ZTEST_HFE_ACTIVE()) {
 			ASSERT(error == EDQUOT || error == EIO);
 		}
 		dmu_tx_abort(tx);
@@ -2687,12 +2687,14 @@ ztest_lookup(ztest_ds_t *zd, ztest_od_t *od, int count)
 		od->od_object = 0;
 		error = zap_lookup(zd->zd_os, od->od_dir, od->od_name,
 		    sizeof (uint64_t), 1, &od->od_object);
+		if (!(error == 0 || error == ENOENT) && ZTEST_HFE_ACTIVE())
+			return (missing + 1);
 		if (error) {
 			ASSERT3S(error, ==, ENOENT);
 			ASSERT0(od->od_object);
 			missing++;
 		} else {
-			dmu_buf_t *db;
+			dmu_buf_t *db = NULL;
 			ztest_block_tag_t *bbt;
 			dmu_object_info_t doi;
 
@@ -2700,16 +2702,27 @@ ztest_lookup(ztest_ds_t *zd, ztest_od_t *od, int count)
 			ASSERT0(missing);	/* there should be no gaps */
 
 			ztest_object_lock(zd, od->od_object, ZTRL_READER);
-			VERIFY0(dmu_bonus_hold(zd->zd_os, od->od_object,
-			    FTAG, &db));
+			error = dmu_bonus_hold(zd->zd_os, od->od_object, FTAG,
+			    &db);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto errout;
+			VERIFY0(error);
 			dmu_object_info_from_db(db, &doi);
 			bbt = ztest_bt_bonus(db);
+			if (bbt->bt_magic != BT_MAGIC && ZTEST_HFE_ACTIVE())
+				goto errout;
 			ASSERT3U(bbt->bt_magic, ==, BT_MAGIC);
 			od->od_type = doi.doi_type;
 			od->od_blocksize = doi.doi_data_block_size;
 			od->od_gen = bbt->bt_gen;
 			dmu_buf_rele(db, FTAG);
 			ztest_object_unlock(zd, od->od_object);
+			continue;
+errout:
+			if (db)
+				dmu_buf_rele(db, FTAG);
+			ztest_object_unlock(zd, od->od_object);
+			return (missing + 1);
 		}
 	}
 
@@ -2790,7 +2803,8 @@ ztest_remove(ztest_ds_t *zd, ztest_od_t *od, int count)
 		lr->lr_doid = od->od_dir;
 
 		if ((error = ztest_replay_remove(zd, lr, B_FALSE)) != 0) {
-			ASSERT3U(error, ==, ENOSPC);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOSPC);
 			missing++;
 		} else {
 			od->od_object = 0;
@@ -5134,15 +5148,19 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	od = umem_alloc(size, UMEM_NOFAIL);
 	dmu_tx_t *tx;
 	int freeit, error;
-	uint64_t i, n, s, txg;
-	bufwad_t *packbuf, *bigbuf, *pack, *bigH, *bigT;
-	uint64_t packobj, packoff, packsize, bigobj, bigoff, bigsize;
+	uint64_t i, n, s, txg = 0;
+	bufwad_t *pack, *bigH, *bigT;
+	uint64_t packobj, packoff, bigobj, bigoff;
+	bufwad_t *packbuf = NULL, *bigbuf = NULL;
+	uint64_t packsize = 0, bigsize = 0;
 	uint64_t chunksize = (1000 + ztest_random(1000)) * sizeof (uint64_t);
 	uint64_t regions = 997;
 	uint64_t stride = 123456789ULL;
 	uint64_t width = 40;
 	int free_percent = 5;
 	dmu_flags_t dmu_read_flags = DMU_READ_PREFETCH;
+	void *packcheck = NULL;
+	void *bigcheck = NULL;
 
 	/*
 	 * We will randomly set when to do O_DIRECT on a read.
@@ -5181,10 +5199,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	ztest_od_init(od + 1, id, FTAG, 1, DMU_OT_UINT64_OTHER, 0, 0,
 	    chunksize);
 
-	if (ztest_object_init(zd, od, size, B_FALSE) != 0) {
-		umem_free(od, size);
-		return;
-	}
+	if (ztest_object_init(zd, od, size, B_FALSE) != 0)
+		goto out;
 
 	bigobj = od[0].od_object;
 	packobj = od[1].od_object;
@@ -5228,9 +5244,13 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 */
 	error = dmu_read(os, packobj, packoff, packsize, packbuf,
 	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 	error = dmu_read(os, bigobj, bigoff, bigsize, bigbuf,
 	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 
 	/*
@@ -5249,12 +5269,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	dmu_tx_hold_bonus(tx, bigobj);
 
 	txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
-	if (txg == 0) {
-		umem_free(packbuf, packsize);
-		umem_free(bigbuf, bigsize);
-		umem_free(od, size);
-		return;
-	}
+	if (txg == 0)
+		goto out;
 
 	enum zio_checksum cksum;
 	do {
@@ -5277,6 +5293,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 * with the new values we want to write out.
 	 */
 	for (i = 0; i < s; i++) {
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		/* LINTED */
 		pack = (bufwad_t *)((char *)packbuf + i * sizeof (bufwad_t));
 		/* LINTED */
@@ -5322,6 +5340,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 */
 	dmu_write(os, packobj, packoff, packsize, packbuf, tx,
 	    DMU_READ_PREFETCH);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (freeit) {
 		if (ztest_opts.zo_verbose >= 7) {
@@ -5329,7 +5349,10 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 			    " txg %"PRIx64"\n",
 			    bigoff, bigsize, txg);
 		}
-		VERIFY0(dmu_free_range(os, bigobj, bigoff, bigsize, tx));
+		error = dmu_free_range(os, bigobj, bigoff, bigsize, tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	} else {
 		if (ztest_opts.zo_verbose >= 7) {
 			(void) printf("writing offset %"PRIx64" size %"PRIx64""
@@ -5338,32 +5361,49 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 		}
 		dmu_write(os, bigobj, bigoff, bigsize, bigbuf, tx,
 		    DMU_READ_PREFETCH);
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 	}
 
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Sanity check the stuff we just wrote.
 	 */
-	{
-		void *packcheck = umem_alloc(packsize, UMEM_NOFAIL);
-		void *bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
+	packcheck = umem_alloc(packsize, UMEM_NOFAIL);
+	bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
 
-		VERIFY0(dmu_read(os, packobj, packoff,
-		    packsize, packcheck, dmu_read_flags));
-		VERIFY0(dmu_read(os, bigobj, bigoff,
-		    bigsize, bigcheck, dmu_read_flags));
+	error = dmu_read(os, packobj, packoff, packsize, packcheck,
+	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
+	error = dmu_read(os, bigobj, bigoff, bigsize, bigcheck,
+	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+
+	if (!ZTEST_HFE_ACTIVE()) {
 		ASSERT0(memcmp(packbuf, packcheck, packsize));
 		ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
-
-		umem_free(packcheck, packsize);
-		umem_free(bigcheck, bigsize);
 	}
 
-	umem_free(packbuf, packsize);
-	umem_free(bigbuf, bigsize);
-	umem_free(od, size);
+out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
+	if (bigcheck)
+		umem_free(bigcheck, bigsize);
+	if (packcheck)
+		umem_free(packcheck, packsize);
+	if (packbuf)
+		umem_free(packbuf, packsize);
+	if (bigbuf)
+		umem_free(bigbuf, bigsize);
+	if (od)
+		umem_free(od, size);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2164,9 +2164,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 
 	if (lr->lrz_type == DMU_OT_ZAP_OTHER) {
 		if (lr->lr_foid == 0) {
-			lr->lr_foid = zap_create_dnsize(os,
+			error = zap_create_dnsize(os,
 			    lr->lrz_type, lr->lrz_bonustype,
-			    bonuslen, lr->lrz_dnodesize, tx);
+			    bonuslen, lr->lrz_dnodesize, tx, &lr->lr_foid);
 		} else {
 			error = zap_create_claim_dnsize(os, lr->lr_foid,
 			    lr->lrz_type, lr->lrz_bonustype,
@@ -2174,9 +2174,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		}
 	} else {
 		if (lr->lr_foid == 0) {
-			lr->lr_foid = dmu_object_alloc_dnsize(os,
+			error = dmu_object_alloc_dnsize(os,
 			    lr->lrz_type, 0, lr->lrz_bonustype,
-			    bonuslen, lr->lrz_dnodesize, tx);
+			    bonuslen, lr->lrz_dnodesize, tx, &lr->lr_foid);
 		} else {
 			error = dmu_object_claim_dnsize(os, lr->lr_foid,
 			    lr->lrz_type, 0, lr->lrz_bonustype,

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4451,7 +4451,8 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	 */
 	error = spa_scan(spa, POOL_SCAN_SCRUB, 0);
 	if (error == 0) {
-		while (dsl_scan_scrubbing(spa_get_dsl(spa)))
+		while (dsl_scan_scrubbing(spa_get_dsl(spa)) &&
+		    !ZTEST_HFE_ACTIVE())
 			txg_wait_synced(spa_get_dsl(spa), 0);
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5567,23 +5567,27 @@ void
 ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 {
 	objset_t *os = zd->zd_os;
-	ztest_od_t *od;
+	ztest_od_t *od = NULL;
 	dmu_tx_t *tx;
-	uint64_t i;
+	uint64_t i, j;
 	int error;
 	int size;
-	uint64_t n, s, txg;
-	bufwad_t *packbuf, *bigbuf;
+	uint64_t n, s, txg = 0;
+	bufwad_t *packbuf = NULL, *bigbuf = NULL;
 	uint64_t packobj, packoff, packsize, bigobj, bigoff, bigsize;
 	uint64_t blocksize = ztest_random_blocksize();
 	uint64_t chunksize = blocksize;
 	uint64_t regions = 997;
 	uint64_t stride = 123456789ULL;
 	uint64_t width = 9;
-	dmu_buf_t *bonus_db;
-	arc_buf_t **bigbuf_arcbufs;
+	dmu_buf_t *bonus_db = NULL;
+	arc_buf_t **bigbuf_arcbufs = NULL;
+	boolean_t *arcs_to_return = NULL;
 	dmu_object_info_t doi;
 	uint32_t dmu_read_flags = DMU_READ_PREFETCH;
+	void *packcheck = NULL;
+	void *bigcheck = NULL;
+	dmu_buf_t *dbt = NULL;
 
 	/*
 	 * We will randomly set when to do O_DIRECT on a read.
@@ -5629,7 +5633,10 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	chunksize = blocksize;
 	ASSERT3U(chunksize, ==, od[1].od_gen);
 
-	VERIFY0(dmu_object_info(os, bigobj, &doi));
+	error = dmu_object_info(os, bigobj, &doi);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	VERIFY(ISP2(doi.doi_data_block_size));
 	VERIFY3U(chunksize, ==, doi.doi_data_block_size);
 	VERIFY3U(chunksize, >=, 2 * sizeof (bufwad_t));
@@ -5649,9 +5656,13 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	packbuf = umem_zalloc(packsize, UMEM_NOFAIL);
 	bigbuf = umem_zalloc(bigsize, UMEM_NOFAIL);
 
-	VERIFY0(dmu_bonus_hold(os, bigobj, FTAG, &bonus_db));
+	error = dmu_bonus_hold(os, bigobj, FTAG, &bonus_db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	bigbuf_arcbufs = umem_zalloc(2 * s * sizeof (arc_buf_t *), UMEM_NOFAIL);
+	arcs_to_return = umem_zalloc(2 * s * sizeof (boolean_t), UMEM_NOFAIL);
 
 	/*
 	 * Iteration 0 test zcopy for DB_UNCACHED dbufs.
@@ -5663,7 +5674,6 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	 * Iteration 6 one more zcopy write.
 	 */
 	for (i = 0; i < 7; i++) {
-		uint64_t j;
 		uint64_t off;
 
 		/*
@@ -5676,11 +5686,14 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
 				bigbuf_arcbufs[j] =
 				    dmu_request_arcbuf(bonus_db, chunksize);
+				arcs_to_return[j] = B_TRUE;
 			} else {
 				bigbuf_arcbufs[2 * j] =
 				    dmu_request_arcbuf(bonus_db, chunksize / 2);
+				arcs_to_return[2 * j] = B_TRUE;
 				bigbuf_arcbufs[2 * j + 1] =
 				    dmu_request_arcbuf(bonus_db, chunksize / 2);
+				arcs_to_return[2 * j + 1] = B_TRUE;
 			}
 		}
 
@@ -5693,25 +5706,8 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		dmu_tx_hold_write(tx, bigobj, bigoff, bigsize);
 
 		txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
-		if (txg == 0) {
-			umem_free(packbuf, packsize);
-			umem_free(bigbuf, bigsize);
-			for (j = 0; j < s; j++) {
-				if (i != 5 ||
-				    chunksize < (SPA_MINBLOCKSIZE * 2)) {
-					dmu_return_arcbuf(bigbuf_arcbufs[j]);
-				} else {
-					dmu_return_arcbuf(
-					    bigbuf_arcbufs[2 * j]);
-					dmu_return_arcbuf(
-					    bigbuf_arcbufs[2 * j + 1]);
-				}
-			}
-			umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
-			umem_free(od, size);
-			dmu_buf_rele(bonus_db, FTAG);
-			return;
-		}
+		if (txg == 0)
+			goto out;
 
 		/*
 		 * 50% of the time don't read objects in the 1st iteration to
@@ -5721,13 +5717,18 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		if (i != 0 || ztest_random(2) != 0) {
 			error = dmu_read(os, packobj, packoff,
 			    packsize, packbuf, dmu_read_flags);
-			ASSERT0(error);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 			error = dmu_read(os, bigobj, bigoff, bigsize,
 			    bigbuf, dmu_read_flags);
-			ASSERT0(error);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 		}
-		compare_and_update_pbbufs(s, packbuf, bigbuf, bigsize,
-		    n, chunksize, txg);
+		if (!ZTEST_HFE_ACTIVE())
+			compare_and_update_pbbufs(s, packbuf, bigbuf, bigsize,
+			    n, chunksize, txg);
 
 		/*
 		 * We've verified all the old bufwads, and made new ones.
@@ -5741,7 +5742,6 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			    bigoff, bigsize, txg);
 		}
 		for (off = bigoff, j = 0; j < s; j++, off += chunksize) {
-			dmu_buf_t *dbt;
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
 				memcpy(bigbuf_arcbufs[j]->b_data,
 				    (caddr_t)bigbuf + (off - bigoff),
@@ -5757,42 +5757,71 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			}
 
 			if (i == 1) {
-				VERIFY0(dmu_buf_hold(os, bigobj, off,
-				    FTAG, &dbt, DMU_READ_NO_PREFETCH));
+				error = dmu_buf_hold(os, bigobj, off,
+				    FTAG, &dbt, DMU_READ_NO_PREFETCH);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
 			}
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
-				    off, bigbuf_arcbufs[j], tx, 0));
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
+				    off, bigbuf_arcbufs[j], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[j] = B_FALSE;
 			} else {
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
-				    off, bigbuf_arcbufs[2 * j], tx, 0));
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
+				    off, bigbuf_arcbufs[2 * j], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[2 * j] = B_FALSE;
+
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
 				    off + chunksize / 2,
-				    bigbuf_arcbufs[2 * j + 1], tx, 0));
+				    bigbuf_arcbufs[2 * j + 1], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[2 * j + 1] = B_FALSE;
 			}
 			if (i == 1) {
 				dmu_buf_rele(dbt, FTAG);
+				dbt = NULL;
 			}
 		}
 		dmu_tx_commit(tx);
+		txg = 0;
 
 		/*
 		 * Sanity check the stuff we just wrote.
 		 */
 		{
-			void *packcheck = umem_alloc(packsize, UMEM_NOFAIL);
-			void *bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
+			packcheck = umem_alloc(packsize, UMEM_NOFAIL);
+			bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
 
-			VERIFY0(dmu_read(os, packobj, packoff,
-			    packsize, packcheck, dmu_read_flags));
-			VERIFY0(dmu_read(os, bigobj, bigoff,
-			    bigsize, bigcheck, dmu_read_flags));
+			error = dmu_read(os, packobj, packoff,
+			    packsize, packcheck, dmu_read_flags);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 
-			ASSERT0(memcmp(packbuf, packcheck, packsize));
-			ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
+			error = dmu_read(os, bigobj, bigoff,
+			    bigsize, bigcheck, dmu_read_flags);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
+
+			if (!ZTEST_HFE_ACTIVE()) {
+				ASSERT0(memcmp(packbuf, packcheck, packsize));
+				ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
+			}
 
 			umem_free(packcheck, packsize);
+			packcheck = NULL;
 			umem_free(bigcheck, bigsize);
+			bigcheck = NULL;
 		}
 		if (i == 2) {
 			txg_wait_open(dmu_objset_pool(os), 0, B_TRUE);
@@ -5801,11 +5830,31 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		}
 	}
 
-	dmu_buf_rele(bonus_db, FTAG);
-	umem_free(packbuf, packsize);
-	umem_free(bigbuf, bigsize);
-	umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
-	umem_free(od, size);
+out:
+	if (arcs_to_return)
+		for (j = 0; j < 2 * s; j++)
+			if (arcs_to_return[j])
+				dmu_return_arcbuf(bigbuf_arcbufs[j]);
+	if (dbt)
+		dmu_buf_rele(dbt, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
+	if (packcheck)
+		umem_free(packcheck, packsize);
+	if (bigcheck)
+		umem_free(bigcheck, bigsize);
+	if (bonus_db)
+		dmu_buf_rele(bonus_db, FTAG);
+	if (packbuf)
+		umem_free(packbuf, packsize);
+	if (bigbuf)
+		umem_free(bigbuf, bigsize);
+	if (arcs_to_return)
+		umem_free(arcs_to_return, 2 * s * sizeof (boolean_t));
+	if (bigbuf_arcbufs)
+		umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
+	if (od)
+		umem_free(od, size);
 }
 
 void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3076,7 +3076,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 *	an export concurrently.
 	 */
 	VERIFY0(spa_open(zo->zo_pool, &spa, FTAG));
-	int error = spa_destroy(zo->zo_pool);
+	int error = spa_destroy(zo->zo_pool, B_FALSE, B_FALSE);
 	if (error != EBUSY && error != ZFS_ERR_EXPORT_IN_PROGRESS) {
 		fatal(B_FALSE, "spa_destroy(%s) returned unexpected value %d",
 		    spa->spa_name, error);
@@ -3178,7 +3178,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Clean up from previous runs.
 	 */
-	(void) spa_destroy(name);
+	(void) spa_destroy(name, B_FALSE, B_FALSE);
 
 	raidz_children = ztest_get_raidz_children(ztest_spa);
 
@@ -3632,7 +3632,7 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 	}
 
 	/* clean up the old pool, if any */
-	(void) spa_destroy("splitp");
+	(void) spa_destroy("splitp", B_FALSE, B_FALSE);
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 
@@ -7472,7 +7472,7 @@ ztest_spa_import_export(char *oldname, char *newname)
 	/*
 	 * Clean up from previous runs.
 	 */
-	(void) spa_destroy(newname);
+	(void) spa_destroy(newname, B_FALSE, B_FALSE);
 
 	/*
 	 * Get the pool's configuration and guid.
@@ -8662,7 +8662,7 @@ ztest_init(ztest_shared_t *zs)
 	/*
 	 * Create the storage pool.
 	 */
-	(void) spa_destroy(ztest_opts.zo_pool);
+	(void) spa_destroy(ztest_opts.zo_pool, B_FALSE, B_FALSE);
 	ztest_shared->zs_vdev_next_leaf = 0;
 	zs->zs_splits = 0;
 	zs->zs_mirrors = ztest_opts.zo_mirrors;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6713,6 +6713,9 @@ ztest_dmu_snapshot_hold(ztest_ds_t *zd, uint64_t id)
 	char osname[ZFS_MAX_DATASET_NAME_LEN];
 	nvlist_t *holds;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
 
 	dmu_objset_name(os, osname);
@@ -6820,6 +6823,7 @@ ztest_dmu_snapshot_hold(ztest_ds_t *zd, uint64_t id)
 
 out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	mutex_exit(&ztest_hfe_lock);
 }
 
 /*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -9243,6 +9243,8 @@ ztest_run(ztest_shared_t *zs)
 		ASSERT3U(ztest_opts.zo_raidz_expand_test, ==,
 		    RAIDZ_EXPAND_NONE);
 
+		(void) spa_checkpoint_discard(spa->spa_name);
+
 		int d, ndatasets;
 		ndatasets = MIN(ztest_opts.zo_datasets, ztest_opts.zo_threads);
 		d = ztest_random(ndatasets);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -98,6 +98,8 @@
 #include <sys/dbuf.h>
 #include <sys/zap.h>
 #include <sys/dmu_objset.h>
+#include <sys/dmu_recv.h>
+#include <sys/dmu_send.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -486,6 +488,7 @@ ztest_func_t ztest_ddt_prune;
 ztest_func_t ztest_spa_log_flushall_start;
 ztest_func_t ztest_spa_log_flushall_cancel;
 ztest_func_t ztest_hardforced_export;
+ztest_func_t ztest_send_recv;
 
 static uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 static uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -546,6 +549,7 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_spa_log_flushall_start, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_cancel, 1, &zopt_rarely),
 	ZTI_INIT(ztest_hardforced_export, 1, &zopt_rarely),
+	ZTI_INIT(ztest_send_recv, 1, &zopt_sometimes),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
@@ -602,6 +606,12 @@ static kmutex_t ztest_vdev_lock;
 static boolean_t ztest_device_removal_active = B_FALSE;
 static boolean_t ztest_pool_scrubbed = B_FALSE;
 static kmutex_t ztest_checkpoint_lock;
+
+/* Send-recv test scenario state. */
+static kmutex_t ztest_sr_lock;
+static uint64_t ztest_sr_send0_guid;
+static uint64_t ztest_sr_bytes_sent;
+static char *ztest_sr_zstream_path;
 
 /* Hardforced export test scenario state. */
 enum {
@@ -7601,6 +7611,234 @@ ztest_hardforced_export(ztest_ds_t *zd, uint64_t id)
 	mutex_exit(&ztest_hfe_lock);
 }
 
+static int
+ztest_sr_dump_bytes(objset_t *os, void *buf, int len, void *arg)
+{
+	(void) os;
+	int fd = *(int *)arg;
+	char *p = buf;
+	ssize_t cnt;
+
+	while (len > 0) {
+		cnt = write(fd, p, len);
+		if (cnt < 0)
+			return (EIO);
+		ztest_sr_bytes_sent += cnt;
+		p += cnt;
+		len -= cnt;
+	}
+
+	return (0);
+}
+
+static void
+ztest_send(ztest_ds_t *zd, uint64_t id)
+{
+	(void) id;
+	objset_t *snap;
+	uint64_t tosnap;
+	char snapname[ZFS_MAX_DATASET_NAME_LEN];
+	int fd;
+	int err;
+
+	(void) snprintf(snapname, sizeof (snapname), "%s@%s",
+	    zd->zd_name, "send0");
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	err = dmu_objset_snapshot_one(zd->zd_name, "send0");
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	if (err == ENOSPC) {
+		ztest_record_enospc(FTAG);
+		goto out;
+	}
+	ASSERT0(err);
+
+	err = dmu_objset_hold(snapname, FTAG, &snap);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+	tosnap = dsl_get_objsetid(snap->os_dsl_dataset);
+	ztest_sr_send0_guid = dsl_get_guid(snap->os_dsl_dataset);
+	dmu_objset_rele(snap, FTAG);
+
+	if (ztest_sr_zstream_path != NULL)
+		umem_free(ztest_sr_zstream_path, MAXPATHLEN);
+	ztest_sr_zstream_path = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
+	(void) snprintf(ztest_sr_zstream_path, MAXPATHLEN,
+	    "%s/ztest.zstream", ztest_opts.zo_dir);
+	fd = open(ztest_sr_zstream_path,
+	    O_RDWR | O_CREAT | O_TRUNC, 0666);
+	ASSERT3S(fd, !=, -1);
+
+	ztest_sr_bytes_sent = 0;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: sending %s (tosnap=%lu)...\n", __func__,
+		    snapname, tosnap);
+
+	offset_t off = 0;
+	const boolean_t embedok = B_TRUE;
+	const boolean_t large_block_ok = B_TRUE;
+	const boolean_t compressok = B_TRUE;
+	const boolean_t rawok = B_FALSE;
+	const boolean_t savedok = B_FALSE;
+	dmu_send_outparams_t out = {
+		.dso_outfunc = ztest_sr_dump_bytes,
+		.dso_arg = &fd,
+		.dso_dryrun = B_FALSE,
+	};
+	err = dmu_send_obj(zd->zd_name, tosnap,
+	    0, embedok, large_block_ok, compressok,
+	    rawok, savedok, fd, &off, &out);
+	if (ztest_opts.zo_verbose >= 5)
+		printf("ztest_send: dmu_send_obj() err=%d\n", err);
+	(void) close(fd);
+	if (ZTEST_HFE_ACTIVE()) {
+		umem_free(ztest_sr_zstream_path, MAXPATHLEN);
+		ztest_sr_zstream_path = NULL;
+		goto out;
+	}
+	ASSERT0(err);
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+out:
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (bytes_sent=%lu, hfe=%d, err=%d)\n",
+		    __func__, ztest_sr_bytes_sent, ZTEST_HFE_ACTIVE(), err);
+}
+
+static void
+ztest_recv(ztest_ds_t *zd, uint64_t id)
+{
+	(void) id;
+	char tofs[ZFS_MAX_DATASET_NAME_LEN];
+	char snapname[ZFS_MAX_DATASET_NAME_LEN];
+	objset_t *snap;
+	const char *tosnap;
+	int fd = -1;
+	int err;
+
+	ASSERT(ztest_sr_zstream_path);
+
+	(void) snprintf(tofs, sizeof (tofs), "%s_recv", zd->zd_name);
+	tosnap = "recv0";
+	(void) snprintf(snapname, sizeof (snapname), "%s_recv@%s",
+	    zd->zd_name, "recv0");
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	err = dsl_destroy_head(tofs);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: receiving %s@%s...\n", __func__, tofs,
+		    tosnap);
+
+	fd = open(ztest_sr_zstream_path, O_RDONLY);
+	ASSERT3S(fd, !=, -1);
+	zfs_file_t input_fp = { .f_fd = fd };
+
+	offset_t off = 0;
+	dmu_replay_record_t drr;
+	memset(&drr, 0, sizeof (drr));
+	char *buf = (char *)&drr;
+	int total = 0;
+	while (total < sizeof (drr)) {
+		ssize_t n = read(input_fp.f_fd, buf + total,
+		    sizeof (drr) - total);
+		if (n <= 0)
+			break;
+		total += n;
+	}
+	ASSERT3S(total, ==, sizeof (drr));
+
+	dmu_recv_cookie_t drc;
+	err = dmu_recv_begin(tofs, tosnap, &drr, B_FALSE, B_FALSE,
+	    B_FALSE, NULL, NULL, NULL, &drc, &input_fp,
+	    &off);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+
+	err = dmu_recv_stream(&drc, &off);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+
+	err = dmu_recv_end(&drc, NULL);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+
+	/* Expect the same number of bytes received */
+	drc.drc_bytes_read += sizeof (drr);
+	ASSERT3U(drc.drc_bytes_read, ==, ztest_sr_bytes_sent);
+
+	/* Expect the same GUID of the replica */
+	err = dmu_objset_hold(snapname, FTAG, &snap);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+	ASSERT3U(ztest_sr_send0_guid, ==, dsl_get_guid(snap->os_dsl_dataset));
+	dmu_objset_rele(snap, FTAG);
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	err = dsl_destroy_head(tofs);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+out:
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (bytes_read=%lu, hfe=%d, err=%d)\n",
+		    __func__, drc.drc_bytes_read, ZTEST_HFE_ACTIVE(), err);
+	if (fd != -1)
+		close(fd);
+}
+
+void
+ztest_send_recv(ztest_ds_t *zd, uint64_t id)
+{
+	if (!mutex_tryenter(&ztest_sr_lock))
+		return;
+
+	/*
+	 * We want to stress recv more than send, as most of the potential
+	 * troubles are there. Thus, we create a zstream once and reuse it
+	 * during the same ztest pass.
+	 */
+	if (ztest_sr_zstream_path == NULL)
+		ztest_send(zd, id);
+	else
+		ztest_recv(zd, id);
+
+	mutex_exit(&ztest_sr_lock);
+}
+
 /*
  * By design ztest will never inject uncorrectable damage in to the pool.
  * Issue a scrub, wait for it to complete, and verify there is never any
@@ -9374,6 +9612,8 @@ ztest_run(ztest_shared_t *zs)
 	 */
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_sr_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	zs->zs_thread_start = gethrtime();
@@ -9558,6 +9798,8 @@ ztest_run(ztest_shared_t *zs)
 	list_destroy(&zcl.zcl_callbacks);
 	mutex_destroy(&zcl.zcl_callbacks_lock);
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_sr_lock);
+	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
 }
@@ -9621,9 +9863,10 @@ ztest_init(ztest_shared_t *zs)
 	nvlist_t *nvroot, *props;
 	int i;
 
-	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_sr_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	raidz_scratch_verify();
@@ -9695,9 +9938,10 @@ ztest_init(ztest_shared_t *zs)
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_sr_lock);
+	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
-	mutex_destroy(&ztest_hfe_lock);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8711,9 +8711,9 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	 * Kick off all the tests that run in parallel.
 	 */
 	for (i = 0; i < ztest_opts.zo_threads; i++) {
-		run_threads[i] = thread_create(NULL, 0, ztest_thread,
-		    (void *)(uintptr_t)i, 0, NULL, TS_RUN | TS_JOINABLE,
-		    defclsyspri);
+		run_threads[i] = thread_create_named("ztest_func", NULL, 0,
+		    ztest_thread, (void *)(uintptr_t)i, 0, NULL,
+		    TS_RUN | TS_JOINABLE, defclsyspri);
 	}
 
 	/*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6211,7 +6211,7 @@ ztest_commit_callback(void *arg, int error)
 	VERIFY(!data->zcd_called);
 
 	synced_txg = spa_last_synced_txg(data->zcd_spa);
-	if (data->zcd_txg > synced_txg)
+	if (data->zcd_txg > synced_txg && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE,
 		    "commit callback of txg %"PRIu64" called prematurely, "
 		    "last synced txg = %"PRIu64"\n",
@@ -6333,8 +6333,11 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Read existing data to make sure there isn't a future leak.
 	 */
-	VERIFY0(dmu_read(os, od->od_object, 0, sizeof (uint64_t),
-	    &old_txg, DMU_READ_PREFETCH));
+	error = dmu_read(os, od->od_object, 0, sizeof (uint64_t),
+	    &old_txg, DMU_READ_PREFETCH);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto txout;
+	VERIFY0(error);
 
 	if (old_txg > txg)
 		fatal(B_FALSE,
@@ -6343,7 +6346,10 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 
 	dmu_write(os, od->od_object, 0, sizeof (uint64_t), &txg, tx,
 	    DMU_READ_PREFETCH);
+	if (ZTEST_HFE_ACTIVE())
+		goto txout;
 
+txout:
 	(void) mutex_enter(&zcl.zcl_callbacks_lock);
 
 	/*
@@ -9072,7 +9078,7 @@ ztest_run(ztest_shared_t *zs)
 	}
 
 	/* Verify that at least one commit cb was called in a timely fashion */
-	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG)
+	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG && ZTEST_HFE_NEVER_RUN())
 		VERIFY0(zc_min_txg_delay);
 
 	spa_close(spa, (const void *)ztest_run);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -125,6 +125,7 @@
 #include <sys/dsl_userhold.h>
 #include <sys/abd.h>
 #include <sys/blake3.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -142,6 +143,27 @@
 #include <sys/backtrace.h>
 #include <libzpool.h>
 #include <libspl.h>
+
+#if defined(__linux__)
+#ifdef HAVE_GETTID
+#define	libspl_gettid()		gettid()
+#else
+#include <sys/syscall.h>
+#define	libspl_gettid()		((pid_t)syscall(__NR_gettid))
+#endif
+#elif defined(__FreeBSD__)
+#include <pthread_np.h>
+#define	libspl_gettid()		pthread_getthreadid_np()
+#elif defined(__APPLE__)
+static inline uint64_t
+libspl_gettid(void)
+{
+	uint64_t tid;
+	if (pthread_threadid_np(NULL, &tid) != 0)
+		tid = 0;
+	return (tid);
+}
+#endif
 
 static int ztest_fd_data = -1;
 
@@ -453,6 +475,7 @@ ztest_func_t ztest_pool_prefetch_ddt;
 ztest_func_t ztest_ddt_prune;
 ztest_func_t ztest_spa_log_flushall_start;
 ztest_func_t ztest_spa_log_flushall_cancel;
+ztest_func_t ztest_hardforced_export;
 
 static uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 static uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -512,9 +535,18 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_ddt_prune, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_start, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_cancel, 1, &zopt_rarely),
+	ZTI_INIT(ztest_hardforced_export, 1, &zopt_rarely),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
+
+static volatile uint64_t ztest_running_threads = 0;
+static struct {
+	const char *func;
+	pid_t pid;
+	uint64_t tid;
+	boolean_t onhold;
+} *ztest_threads;
 
 /*
  * The following struct is used to hold a list of uncalled commit callbacks.
@@ -560,6 +592,35 @@ static kmutex_t ztest_vdev_lock;
 static boolean_t ztest_device_removal_active = B_FALSE;
 static boolean_t ztest_pool_scrubbed = B_FALSE;
 static kmutex_t ztest_checkpoint_lock;
+
+/* Hardforced export test scenario state. */
+enum {
+	HFE_STAGE_DONE_ONCE,
+	HFE_STAGE_INACTIVE,
+	HFE_STAGE_STARTED,
+	HFE_STAGE_SUSPENDED,
+	HFE_STAGE_CANCELLING_IO,
+	HFE_STAGE_CLOSING_DATASETS,
+	HFE_STAGE_EXPORTING,
+	HFE_STAGE_REIMPORTING,
+};
+static atomic_uint ztest_hfe_stage = HFE_STAGE_INACTIVE;
+static uint64_t ztest_hfe_runs = 0;
+static kmutex_t ztest_hfe_lock;
+static volatile uint64_t ztest_hfe_reimport_waiters = 0;
+#define	ZTEST_HFE_SET_STAGE(stage) atomic_store(&ztest_hfe_stage, (stage))
+#define	ZTEST_HFE_STAGE() atomic_load(&ztest_hfe_stage)
+#define	ZTEST_HFE_ACTIVE() ((ZTEST_HFE_STAGE() >= HFE_STAGE_STARTED && \
+	ZTEST_HFE_STAGE() <= HFE_STAGE_EXPORTING) || \
+	vdev_file_constant_error != 0)
+#define	ZTEST_HFE_NEVER_RUN() (ZTEST_HFE_STAGE() == HFE_STAGE_INACTIVE && \
+	ztest_hfe_runs == 0)
+
+static int ztest_dataset_open(int);
+static void ztest_dataset_close(int);
+static void ztest_open_pool(ztest_shared_t *, spa_t **);
+static void ztest_get_zdb_bin(char *, int);
+static void ztest_run(ztest_shared_t *);
 
 /*
  * The ztest_name_lock protects the pool and dataset namespace used by
@@ -1223,6 +1284,17 @@ invalid:
 static void
 ztest_kill(ztest_shared_t *zs)
 {
+	/*
+	 * If the hardforced export scenario is running then spa is volatile.
+	 */
+	if (ZTEST_HFE_ACTIVE()) {
+		if (raidz_expand_pause_point != RAIDZ_EXPAND_PAUSE_NONE) {
+			raidz_expand_pause_point = RAIDZ_EXPAND_PAUSE_NONE;
+			return;
+		}
+		goto kill;
+	}
+
 	zs->zs_alloc = metaslab_class_get_alloc(spa_normal_class(ztest_spa));
 	zs->zs_space = metaslab_class_get_space(spa_normal_class(ztest_spa));
 
@@ -1254,6 +1326,7 @@ ztest_kill(ztest_shared_t *zs)
 		spa_namespace_exit(FTAG);
 	}
 
+kill:
 	(void) raise(SIGKILL);
 }
 
@@ -6732,6 +6805,216 @@ out:
 
 	umem_free(path0, MAXPATHLEN);
 	umem_free(pathrand, MAXPATHLEN);
+
+}
+
+static uint64_t
+ztest_zdb_latest_txg(vdev_t *vd)
+{
+	FILE *fp;
+	const size_t bin_len = MAXPATHLEN + MAXNAMELEN + 20;
+	const size_t cmd_len = MAXPATHLEN + MAXNAMELEN + 20;
+	const size_t buf_len = 1024;
+	char *bin;
+	char *cmd;
+	char *buf;
+	char *endp;
+	uint64_t txg = 0;
+
+	if (vd->vdev_ops == &vdev_file_ops) {
+		bin = umem_alloc(bin_len, UMEM_NOFAIL);
+		cmd = umem_alloc(cmd_len, UMEM_NOFAIL);
+		buf = umem_zalloc(buf_len, UMEM_NOFAIL);
+		ztest_get_zdb_bin(bin, bin_len);
+		snprintf(cmd, cmd_len, "sh -c '%s -llll %s | "
+		    "sed -En s/^\\ +txg:\\ +\\([0-9]+\\)$/\\\\1/p | "
+		    "sort -r | head -n1'", bin, vd->vdev_path);
+		fp = popen(cmd, "r");
+		if (fgets(buf, buf_len, fp) != NULL &&
+		    strlen(buf) > 0) {
+			txg = strtoull(buf, &endp, 0);
+			if (*endp != '\n')
+				txg = 0;
+		}
+		pclose(fp);
+		umem_free(buf, buf_len);
+		umem_free(cmd, cmd_len);
+		umem_free(bin, bin_len);
+	}
+
+	for (uint64_t i = 0; i < vd->vdev_children; i++) {
+		uint64_t child_txg = ztest_zdb_latest_txg(vd->vdev_child[i]);
+		if (child_txg > txg)
+			txg = child_txg;
+	}
+
+	return (txg);
+}
+
+/*
+ * Suspend the pool, forcibly export, re-import.
+ */
+void
+ztest_hardforced_export(ztest_ds_t *zd, uint64_t id)
+{
+	(void) zd, (void) id;
+	spa_t *spa;
+	uint64_t pool_guid;
+	uint64_t last_actually_synced_txg;
+	ztest_shared_t *zs = ztest_shared;
+	uint64_t failmode_orig;
+	int i;
+	const uint_t timeout_sec = 60 +
+	    (2 + ztest_opts.zo_threads / boot_ncpus) * zfs_txg_timeout;
+
+	/*
+	 * We must not be an uncounted reimport_waiter stuck down here,
+	 * waiting for the lock. If someone else has started the scenario then
+	 * let's quit and run other ztest.
+	 */
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
+	/*
+	 * Let ztest_resume_thread() do its job.
+	 */
+	spa = ztest_spa;
+	if (spa_suspended(spa)) {
+		mutex_exit(&ztest_hfe_lock);
+		return;
+	}
+
+	/*
+	 * Intentionally fault disks.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_STARTED);
+	failmode_orig = spa->spa_failmode;
+	spa->spa_failmode = ZIO_FAILURE_MODE_WAIT;
+	pool_guid = spa_guid(spa);
+	vdev_file_constant_error = EIO;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: started\n", __func__);
+
+	/*
+	 * Wait for suspension state.
+	 *
+	 * The read/write ztest funcs, always running in parallel, are
+	 * expected to trigger it very quickly.
+	 */
+	for (i = 0; i < timeout_sec; i++) {
+		sleep(1);
+		if (spa_suspended(spa))
+			break;
+	}
+	if (!spa_suspended(spa)) {
+		/*
+		 * We expect that activity of other test threads would trigger
+		 * suspension, but there is no guarantee for that. It's better
+		 * to avoid false positives then.
+		 */
+		if (ztest_opts.zo_verbose >= 5)
+			(void) printf("%s: decided to suspend manually\n",
+			    __func__);
+		zio_suspend(spa, NULL, ZIO_SUSPEND_IOERR);
+	}
+	VERIFY(spa_suspended(spa));
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_SUSPENDED);
+	last_actually_synced_txg = ztest_zdb_latest_txg(spa->spa_root_vdev);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: suspended (spa_last_synced_txg=%lu, "
+		    "last_actually_synced_txg=%lu, spa_guid=%lu)\n", __func__,
+		    spa_last_synced_txg(spa), last_actually_synced_txg,
+		    spa_guid(spa));
+
+	/*
+	 * Cancel suspended I/O.
+	 *
+	 * From this point we want other threads not to start new tests as we
+	 * plan to drop the exiting spa and its datasets.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_CANCELLING_IO);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: cancelling suspended I/O...\n", __func__);
+	spa_set_forced_exit_required(spa);
+	VERIFY(spa_exiting(spa));
+
+	/*
+	 * Pause testing activity.
+	 */
+	uint64_t expected = atomic_load_64(&ztest_running_threads) - 1;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: waiting for other test threads to become "
+		    "idle...\n", __func__);
+	for (i = 0; i < timeout_sec; i++) {
+		sleep(1);
+		expected = atomic_load_64(&ztest_running_threads) - 1;
+		if (atomic_load_64(&ztest_hfe_reimport_waiters) == expected)
+			break;
+	}
+	const uint64_t actual = atomic_load_64(&ztest_hfe_reimport_waiters);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: all other test threads to be idle: "
+		    "expected=%lu, actual=%lu\n", __func__, expected, actual);
+	for (int t = 0; t < ztest_opts.zo_threads; t++) {
+		if (t == id || ztest_threads[t].onhold)
+			continue;
+		(void) printf("%s: still active thread: id=%d, func=%s, "
+		    "pid=%d, tid=%lu\n", __func__, t, ztest_threads[t].func,
+		    ztest_threads[t].pid, ztest_threads[t].tid);
+	}
+	VERIFY3U(actual, ==, expected);
+
+	/*
+	 * Close the datasets.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_CLOSING_DATASETS);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: closing datasets...\n", __func__);
+	for (i = 0; i < ztest_opts.zo_threads; i++) {
+		if (i < ztest_opts.zo_datasets)
+			ztest_dataset_close(i);
+	}
+	txg_wait_synced(spa_get_dsl(spa), 0);
+	spa_close(spa, (const void *)ztest_run);
+
+	/*
+	 * Export with hardforce.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_EXPORTING);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: exporting with hardforce...\n", __func__);
+	VERIFY(spa_suspended(spa));
+	VERIFY0(spa_export(spa_name(spa), NULL, B_TRUE, B_TRUE));
+
+	/*
+	 * Import back.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_REIMPORTING);
+	vdev_file_constant_error = 0;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: re-importing...\n", __func__);
+	ztest_open_pool(zs, &spa);
+	VERIFY3U(pool_guid, ==, spa_guid(spa));
+	VERIFY3U(spa_first_txg(spa), >=, last_actually_synced_txg);
+	VERIFY3U(spa->spa_state, ==, POOL_STATE_ACTIVE);
+	for (i = 0; i < ztest_opts.zo_threads; i++) {
+		if (i < ztest_opts.zo_datasets)
+			VERIFY0(ztest_dataset_open(i));
+	}
+	spa->spa_failmode = failmode_orig;
+	ztest_spa = spa;
+
+	/*
+	 * Finish the scenario.
+	 */
+	ztest_hfe_runs++;
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_DONE_ONCE);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (spa_first_txg=%lu, "
+		    "spa_guid=%lu)\n", __func__, spa_first_txg(spa),
+		    spa_guid(spa));
+
+	mutex_exit(&ztest_hfe_lock);
 }
 
 /*
@@ -7565,9 +7848,23 @@ ztest_resume_thread(void *arg)
 		ddt_dump_prune_histogram = B_TRUE;
 
 	while (!ztest_exiting) {
-		if (spa_suspended(spa))
-			ztest_resume(spa);
 		(void) poll(NULL, 0, 100);
+
+		/*
+		 * Resume only if the hardforced export test scenario is not
+		 * running, otherwise suspension is expected.
+		 */
+		if (mutex_tryenter(&ztest_hfe_lock)) {
+			/*
+			 * The hardforced export test changes the spa ref.
+			 */
+			spa = ztest_spa;
+
+			if (spa_suspended(spa))
+				ztest_resume(spa);
+
+			mutex_exit(&ztest_hfe_lock);
+		}
 
 		/*
 		 * Periodically change the zfs_compressed_arc_enabled setting.
@@ -7606,18 +7903,45 @@ ztest_deadman_thread(void *arg)
 		}
 
 		/*
-		 * If the pool is suspended then fail immediately. Otherwise,
-		 * check to see if the pool is making any progress. If
-		 * vdev_deadman() discovers that there hasn't been any recent
-		 * I/Os then it will end up aborting the tests.
+		 * Do not conflict with the hardforced export test scenario.
 		 */
-		if (spa_suspended(spa) || spa->spa_root_vdev == NULL) {
-			fatal(B_FALSE,
-			    "aborting test after %llu seconds because "
-			    "pool has transitioned to a suspended state.",
-			    (u_longlong_t)zfs_deadman_synctime_ms / 1000);
+		if (mutex_tryenter(&ztest_hfe_lock)) {
+			/*
+			 * The hardforced export test changes the spa ref.
+			 */
+			spa = ztest_spa;
+
+			/*
+			 * If the pool is suspended then fail immediately.
+			 * Otherwise, check to see if the pool is making any
+			 * progress. If vdev_deadman() discovers that there
+			 * hasn't been any recent I/Os then it will end up
+			 * aborting the tests.
+			 */
+			if (spa_suspended(spa) || spa->spa_root_vdev == NULL) {
+				fatal(B_FALSE,
+				    "aborting test after %llu seconds because "
+				    "pool has transitioned to a suspended "
+				    "state.",
+				    (u_longlong_t)zfs_deadman_synctime_ms
+				    / 1000);
+			}
+			vdev_deadman(spa->spa_root_vdev, FTAG);
+
+			mutex_exit(&ztest_hfe_lock);
 		}
-		vdev_deadman(spa->spa_root_vdev, FTAG);
+
+		(void) printf("ztest has been running for %lld seconds\n",
+		    (gethrtime() - zs->zs_proc_start) / NANOSEC);
+
+		for (int t = 0; t < ztest_opts.zo_threads; t++) {
+			if (ztest_threads[t].onhold)
+				continue;
+			(void) printf("%s: active thread: id=%d, func=%s, "
+			    "pid=%d, tid=%lu\n", __func__, t,
+			    ztest_threads[t].func, ztest_threads[t].pid,
+			    ztest_threads[t].tid);
+		}
 
 		/*
 		 * If the process doesn't complete within a grace period of
@@ -7631,9 +7955,6 @@ ztest_deadman_thread(void *arg)
 			    "the process is overdue for termination.",
 			    (gethrtime() - zs->zs_proc_start) / NANOSEC);
 		}
-
-		(void) printf("ztest has been running for %lld seconds\n",
-		    (gethrtime() - zs->zs_proc_start) / NANOSEC);
 
 		last_run = gethrtime();
 		delay = MSEC2NSEC(zfs_deadman_checktime_ms);
@@ -7743,6 +8064,7 @@ ztest_thread(void *arg)
 	ztest_info_t *zi;
 	ztest_shared_callstate_t *zc;
 
+	atomic_inc_64(&ztest_running_threads);
 	while ((now = gethrtime()) < zs->zs_thread_stop) {
 		/*
 		 * See if it's time to force a crash.
@@ -7759,19 +8081,51 @@ ztest_thread(void *arg)
 			break;
 
 		/*
+		 * If hardforced export test scenario has reached the
+		 * pool suspended stage then it's time to stop running
+		 * anything, as the spa is going to be changed by exporting
+		 * and re-importing.
+		 */
+		if (ZTEST_HFE_STAGE() >= HFE_STAGE_SUSPENDED) {
+			atomic_inc_64(&ztest_hfe_reimport_waiters);
+			ztest_threads[id].onhold = B_TRUE;
+			mutex_enter(&ztest_hfe_lock);
+			atomic_dec_64(&ztest_hfe_reimport_waiters);
+			ztest_threads[id].onhold = B_FALSE;
+			mutex_exit(&ztest_hfe_lock);
+			continue;
+		}
+
+		/*
 		 * Pick a random function to execute.
 		 */
 		rand = ztest_random(ZTEST_FUNCS);
 		zi = &ztest_info[rand];
+		if (zi->zi_func == ztest_hardforced_export) {
+			/* all other threads have resumed, can repeat then */
+			if (atomic_load_64(&ztest_hfe_reimport_waiters) == 0)
+				ZTEST_HFE_SET_STAGE(HFE_STAGE_INACTIVE);
+			/* to soon to run another one */
+			if (ZTEST_HFE_STAGE() >= HFE_STAGE_STARTED)
+				continue;
+			/* we want other tests to resume first */
+			if (ZTEST_HFE_STAGE() == HFE_STAGE_DONE_ONCE)
+				continue;
+		}
 		zc = ZTEST_GET_SHARED_CALLSTATE(rand);
 		call_next = zc->zc_next;
 
 		if (now >= call_next &&
 		    atomic_cas_64(&zc->zc_next, call_next, call_next +
 		    ztest_random(2 * zi->zi_interval[0] + 1)) == call_next) {
+			ztest_threads[id].func = zi->zi_funcname;
+			ztest_threads[id].pid = getpid();
+			ztest_threads[id].tid = libspl_gettid();
 			ztest_execute(rand, zi, id);
 		}
 	}
+	atomic_dec_64(&ztest_running_threads);
+	ztest_threads[id].onhold = B_TRUE;
 
 	thread_exit();
 }
@@ -8339,6 +8693,8 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 
 	run_threads = umem_zalloc(ztest_opts.zo_threads * sizeof (kthread_t *),
 	    UMEM_NOFAIL);
+	ztest_threads = umem_zalloc(ztest_opts.zo_threads *
+	    sizeof (*ztest_threads), UMEM_NOFAIL);
 
 	/*
 	 * Actual number of datasets to be used.
@@ -8366,6 +8722,8 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	for (i = 0; i < ztest_opts.zo_threads; i++)
 		VERIFY0(thread_join(run_threads[i]));
 
+	spa = ztest_spa; /* hardforced export test re-imports the spa */
+
 	/*
 	 * Close all datasets. This must be done after all the threads
 	 * are joined so we can be sure none of the datasets are in-use
@@ -8379,7 +8737,25 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	zs->zs_alloc = metaslab_class_get_alloc(spa_normal_class(spa));
 	zs->zs_space = metaslab_class_get_space(spa_normal_class(spa));
 
+	umem_free(ztest_threads, ztest_opts.zo_threads *
+	    sizeof (*ztest_threads));
 	umem_free(run_threads, ztest_opts.zo_threads * sizeof (kthread_t *));
+}
+
+static void
+ztest_open_pool(ztest_shared_t *zs, spa_t **spap)
+{
+	int error;
+
+	error = spa_open(ztest_opts.zo_pool, spap, (const void *)ztest_run);
+	if (error) {
+		VERIFY3S(error, ==, ENOENT);
+		ztest_import_impl();
+		VERIFY0(spa_open(ztest_opts.zo_pool, spap,
+		    (const void *)ztest_run));
+		zs->zs_metaslab_sz = 1ULL << (*spap)->spa_root_vdev
+		    ->vdev_child[0]->vdev_ms_shift;
+	}
 }
 
 /*
@@ -8426,14 +8802,7 @@ ztest_run(ztest_shared_t *zs)
 	 */
 	raidz_scratch_verify();
 	kernel_init(SPA_MODE_READ | SPA_MODE_WRITE);
-	error = spa_open(ztest_opts.zo_pool, &spa, FTAG);
-	if (error) {
-		VERIFY3S(error, ==, ENOENT);
-		ztest_import_impl();
-		VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
-		zs->zs_metaslab_sz =
-		    1ULL << spa->spa_root_vdev->vdev_child[0]->vdev_ms_shift;
-	}
+	ztest_open_pool(zs, &spa);
 
 	metaslab_preload_limit = ztest_random(20) + 1;
 	ztest_spa = spa;
@@ -8548,6 +8917,7 @@ ztest_run(ztest_shared_t *zs)
 	ztest_exiting = B_TRUE;
 	VERIFY0(thread_join(resume_thread));
 	VERIFY0(thread_join(deadman_thread));
+	spa = ztest_spa; /* hardforced export test re-imports the spa */
 	ztest_resume(spa);
 
 	/*
@@ -8563,7 +8933,7 @@ ztest_run(ztest_shared_t *zs)
 	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG)
 		VERIFY0(zc_min_txg_delay);
 
-	spa_close(spa, FTAG);
+	spa_close(spa, (const void *)ztest_run);
 
 	/*
 	 * Verify that we can loop over all pools.
@@ -8654,6 +9024,7 @@ ztest_init(ztest_shared_t *zs)
 	nvlist_t *nvroot, *props;
 	int i;
 
+	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
@@ -8729,6 +9100,7 @@ ztest_init(ztest_shared_t *zs)
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
+	mutex_destroy(&ztest_hfe_lock);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7373,7 +7373,7 @@ ztest_scrub_impl(spa_t *spa)
 	if (error)
 		return (error);
 
-	while (dsl_scan_scrubbing(spa_get_dsl(spa)))
+	while (dsl_scan_scrubbing(spa_get_dsl(spa)) && !ZTEST_HFE_ACTIVE())
 		txg_wait_synced(spa_get_dsl(spa), 0);
 
 	if (spa_approx_errlog_size(spa) > 0)
@@ -7409,7 +7409,8 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 	error = ztest_scrub_impl(spa);
 	if (error == EBUSY)
 		error = 0;
-	ASSERT0(error);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(error);
 }
 
 /*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -9475,6 +9475,12 @@ main(int argc, char **argv)
 	 */
 	zfs_reconstruct_indirect_damage_fraction = 100;
 
+	/*
+	 * Ask zio_flush() to propagate errors. Required for zil testing
+	 * during the hardforced export scenario.
+	 */
+	zio_flush_err_propagation = B_TRUE;
+
 	action.sa_handler = sig_handler;
 	sigemptyset(&action.sa_mask);
 	action.sa_flags = 0;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7727,13 +7727,20 @@ ztest_pool_prefetch_ddt(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	spa_t *spa;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
-	VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
+
+	err = spa_open(ztest_opts.zo_pool, &spa, FTAG);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	ddt_prefetch_all(spa);
 
 	spa_close(spa, FTAG);
+
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7873,10 +7873,12 @@ void
 ztest_initialize(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	int error = 0;
 
 	mutex_enter(&ztest_vdev_lock);
+
+	spa = ztest_spa;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8044,7 +8044,7 @@ ztest_ddt_prune(ztest_ds_t *zd, uint64_t id)
  * Verify pool integrity by running zdb.
  */
 static void
-ztest_run_zdb(uint64_t guid)
+ztest_run_zdb(const char *pool_name)
 {
 	int status;
 	char *bin;
@@ -8068,13 +8068,13 @@ ztest_run_zdb(uint64_t guid)
 	free(set_gvars_args);
 
 	size_t would = snprintf(zdb, len,
-	    "%s -bcc%s%s -G -d -Y -e -y %s -p %s %"PRIu64,
+	    "%s -bcc%s%s -G -d -Y -e -y %s -p %s %s",
 	    bin,
 	    ztest_opts.zo_verbose >= 3 ? "s" : "",
 	    ztest_opts.zo_verbose >= 4 ? "v" : "",
 	    set_gvars_args_joined,
 	    ztest_opts.zo_dir,
-	    guid);
+	    pool_name);
 	ASSERT3U(would, <, len);
 
 	umem_free(set_gvars_args_joined, strlen(set_gvars_args_joined) + 1);
@@ -8817,9 +8817,9 @@ ztest_import(ztest_shared_t *zs)
 	kernel_fini();
 
 	if (!ztest_opts.zo_mmp_test) {
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(spa->spa_name);
 		ztest_freeze();
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(spa->spa_name);
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
@@ -9473,9 +9473,9 @@ ztest_init(ztest_shared_t *zs)
 	kernel_fini();
 
 	if (!ztest_opts.zo_mmp_test) {
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(ztest_opts.zo_pool);
 		ztest_freeze();
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(ztest_opts.zo_pool);
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
@@ -9910,7 +9910,7 @@ main(int argc, char **argv)
 		}
 
 		if (!ztest_opts.zo_mmp_test)
-			ztest_run_zdb(zs->zs_guid);
+			ztest_run_zdb(ztest_opts.zo_pool);
 		if (ztest_shared_opts->zo_raidz_expand_test ==
 		    RAIDZ_EXPAND_CHECKED)
 			break; /* raidz expand test complete */

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7975,7 +7975,8 @@ ztest_trim(ztest_ds_t *zd, uint64_t id)
 	spa_config_exit(spa, SCL_VDEV, FTAG);
 
 	uint64_t cmd = ztest_random(POOL_TRIM_FUNCS);
-	uint64_t rate = 1 << ztest_random(30);
+	/* Do not use very small rate not to slow the things down very much. */
+	uint64_t rate = (1 << 16) << ztest_random(30 - 16);
 	boolean_t partial = (ztest_random(5) > 0);
 	boolean_t secure = (ztest_random(5) > 0);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8574,7 +8574,7 @@ ztest_dataset_open(int d)
 
 	ztest_dataset_name(name, ztest_opts.zo_pool, d);
 
-	if (ztest_opts.zo_verbose >= 6)
+	if (ztest_opts.zo_verbose >= 3)
 		(void) printf("Opening %s\n", name);
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7427,15 +7427,15 @@ ztest_reguid(ztest_ds_t *zd, uint64_t id)
 	if (ztest_opts.zo_mmp_test)
 		return;
 
+	(void) pthread_rwlock_wrlock(&ztest_name_lock);
 	orig = spa_guid(spa);
 	load = spa_load_guid(spa);
-
-	(void) pthread_rwlock_wrlock(&ztest_name_lock);
 	error = spa_change_guid(spa, NULL);
-	zs->zs_guid = spa_guid(spa);
+	if (error == 0)
+		zs->zs_guid = spa_guid(spa);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 
-	if (error != 0)
+	if (error != 0 || ZTEST_HFE_ACTIVE())
 		return;
 
 	if (ztest_opts.zo_verbose >= 4) {

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -176,6 +176,7 @@ typedef struct ztest_shared_hdr {
 	uint64_t	zh_ds_size;
 	uint64_t	zh_ds_count;
 	uint64_t	zh_scratch_state_size;
+	uint64_t	zh_prng_state_size;
 } ztest_shared_hdr_t;
 
 static ztest_shared_hdr_t *ztest_shared_hdr;
@@ -228,6 +229,8 @@ typedef struct ztest_shared_opts {
 	int zo_mmp_test;
 	int zo_special_vdevs;
 	int zo_dump_dbgmsg;
+	int zo_fishing;
+	uint64_t zo_fishing_seed[4];
 	int zo_gvars_count;
 	char zo_gvars[ZO_GVARS_MAX_COUNT][ZO_GVARS_MAX_ARGLEN];
 } ztest_shared_opts_t;
@@ -320,6 +323,13 @@ typedef struct ztest_scratch_state {
 } ztest_shared_scratch_state_t;
 
 static ztest_shared_scratch_state_t *ztest_scratch_state;
+
+typedef struct ztest_prng_state {
+	uint64_t		zs_primary_seed[4];
+	volatile uint64_t	zs_jumps;
+} ztest_shared_prng_state_t;
+
+static ztest_shared_prng_state_t *ztest_prng_state;
 
 #define	BT_MAGIC	0x123456789abcdefULL
 #define	MAXFAULTS(zs) \
@@ -881,6 +891,9 @@ static ztest_option_t option_table[] = {
 	{ 'G',	"dump-debug-msg", NULL,
 	    "Dump zfs_dbgmsg buffer before exiting due to an error",
 	    NO_DEFAULT, NULL},
+	{ 'J',	"fishing", "seed",
+	    "Use repeatable random sequences",
+	    NO_DEFAULT, NULL},
 	{ 'V',	"verbose", NULL,
 	    "Verbose (use multiple times for ever more verbosity)",
 	    NO_DEFAULT, NULL},
@@ -964,18 +977,193 @@ usage(boolean_t requested)
 	exit(requested ? 0 : 1);
 }
 
+/*
+ * xoshiro256++ 1.0 PRNG by David Blackman and Sebastiano Vigna
+ *
+ * xoshiro256plusplus_* functions are copied and adopted from the following
+ * CC-0 licensed file:
+ *
+ * https://prng.di.unimi.it/xoshiro256plusplus.c
+ */
+
+static inline uint64_t xoshiro256plusplus_rotl(const uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+static uint64_t xoshiro256plusplus_next(uint64_t *s) {
+	const uint64_t result = xoshiro256plusplus_rotl(s[0] + s[3], 23) + s[0];
+
+	const uint64_t t = s[1] << 17;
+
+	s[2] ^= s[0];
+	s[3] ^= s[1];
+	s[1] ^= s[2];
+	s[0] ^= s[3];
+
+	s[2] ^= t;
+
+	s[3] = xoshiro256plusplus_rotl(s[3], 45);
+
+	return (result);
+}
+
+static void xoshiro256plusplus_jump(uint64_t *s) {
+	static const uint64_t JUMP[] = { 0x180ec6d33cfd0aba, 0xd5a61266f0c9392c,
+	    0xa9582618e03fc9aa, 0x39abdc4529b1661c };
+
+	uint64_t s0 = 0;
+	uint64_t s1 = 0;
+	uint64_t s2 = 0;
+	uint64_t s3 = 0;
+	for (int i = 0; i < sizeof (JUMP) / sizeof (*JUMP); i++)
+		for (int b = 0; b < 64; b++) {
+			if (JUMP[i] & UINT64_C(1) << b) {
+				s0 ^= s[0];
+				s1 ^= s[1];
+				s2 ^= s[2];
+				s3 ^= s[3];
+			}
+			xoshiro256plusplus_next(s);
+		}
+
+	s[0] = s0;
+	s[1] = s1;
+	s[2] = s2;
+	s[3] = s3;
+}
+
+static __thread volatile uint64_t seeded;
+static __thread uint64_t seed[4];
+
 static uint64_t
-ztest_random(uint64_t range)
+ztest_random_flags(uint64_t range, boolean_t fishing)
 {
 	uint64_t r;
 
 	if (range == 0)
 		return (0);
 
+	if (fishing)
+		goto fishing;
+
 	random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
+
+fishing:
+	if (atomic_load_64(&ztest_prng_state->zs_jumps) == 0) {
+		memcpy(ztest_prng_state->zs_primary_seed,
+		    ztest_opts.zo_fishing_seed,
+		    sizeof (ztest_opts.zo_fishing_seed));
+		if (ztest_prng_state->zs_primary_seed[0] == 0 &&
+		    ztest_prng_state->zs_primary_seed[1] == 0 &&
+		    ztest_prng_state->zs_primary_seed[2] == 0 &&
+		    ztest_prng_state->zs_primary_seed[3] == 0) {
+			random_force_pseudo(B_FALSE);
+			random_get_pseudo_bytes(
+			    (uint8_t *)ztest_prng_state->zs_primary_seed,
+			    sizeof (ztest_prng_state->zs_primary_seed));
+		}
+		printf("primary_prng_seed=%016lx%016lx%016lx%016lx\n",
+		    ztest_prng_state->zs_primary_seed[0],
+		    ztest_prng_state->zs_primary_seed[1],
+		    ztest_prng_state->zs_primary_seed[2],
+		    ztest_prng_state->zs_primary_seed[3]);
+	}
+	if (atomic_load_64(&seeded) == 0) {
+		memcpy(seed, ztest_prng_state->zs_primary_seed,
+		    sizeof (ztest_prng_state->zs_primary_seed));
+		uint64_t jumps = atomic_inc_64_nv(
+		    &ztest_prng_state->zs_jumps);
+		for (uint64_t i = 0; i < jumps; i++)
+			xoshiro256plusplus_jump(seed);
+		atomic_inc_64(&seeded);
+		if (ztest_opts.zo_verbose >= 5) {
+			printf("thread=%u prng_seed=%016lx%016lx%016lx%016lx\n",
+			    libspl_gettid(),
+			    seed[0], seed[1], seed[2], seed[3]);
+		}
+	}
+	r = xoshiro256plusplus_next(seed);
+
+	return (r % range);
 }
+
+static uint64_t
+ztest_random(uint64_t range)
+{
+	return (ztest_random_flags(range, ztest_opts.zo_fishing));
+}
+
+static void
+ztest_random_bytes(uint8_t *buf, size_t len)
+{
+	uint64_t rnd;
+	size_t cnt;
+
+	while (len > 0) {
+		rnd = ztest_random(UINT64_MAX);
+		cnt = (len > sizeof (rnd)) ? sizeof (rnd) : len;
+		memcpy(buf, &rnd, cnt);
+		buf += cnt;
+		len -= cnt;
+	}
+}
+
+typedef struct ztest_fishing_thread_arg {
+	void (*func)(void *);
+	void *arg;
+} ztest_fishing_thread_arg_t;
+
+static __attribute__((noreturn)) void
+ztest_fishing_thread(void *arg)
+{
+	(void) ztest_random(1); /* trigger seed lazy init for this thread */
+
+	ztest_fishing_thread_arg_t ftarg = *(ztest_fishing_thread_arg_t *)arg;
+	umem_free(arg, sizeof (ztest_fishing_thread_arg_t));
+
+	ftarg.func(ftarg.arg);
+
+	thread_exit();
+}
+
+static kthread_t *
+ztest_thread_create(const char *name,
+    void *stk, size_t stksize, void (*func)(void *), void *arg,
+    size_t len, proc_t *pp, int state, pri_t pri)
+{
+	(void) stk, (void) len, (void) pp, (void) pri;
+	kthread_t *result;
+	ztest_fishing_thread_arg_t *ftargp;
+	uint64_t jumps;
+
+	if (ztest_opts.zo_fishing)
+		goto fishing;
+
+	return (thread_create_named(name, stk, stksize, func, arg, len, pp,
+	    state, pri));
+
+fishing:
+	ftargp = umem_alloc(sizeof (ztest_fishing_thread_arg_t), UMEM_NOFAIL);
+	ftargp->func = func;
+	ftargp->arg = arg;
+
+	jumps = atomic_load_64(&ztest_prng_state->zs_jumps);
+	result = thread_create_named(name, stk, stksize,
+	    ztest_fishing_thread, ftargp, len, pp, state, pri);
+	while (atomic_load_64(&ztest_prng_state->zs_jumps) == jumps) {
+		/* let this thread initialize its seed */
+	}
+
+	return (result);
+}
+
+#define	_thread_create_named(name, stk, stksize, func, arg, len, \
+    pp, state, pri)	\
+	ztest_thread_create(name, stk, stksize, func, arg, len, pp, state, pri)
+#define	_thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
+	ztest_thread_create(#func, stk, stksize, func, arg, len, pp, state, pri)
 
 static void
 ztest_parse_name_value(const char *input, ztest_shared_opts_t *zo)
@@ -1160,6 +1348,32 @@ process_options(int argc, char **argv)
 		case 'G':
 			zo->zo_dump_dbgmsg = 1;
 			break;
+		case 'J':
+			zo->zo_fishing = 1;
+			if (strlen(optarg) == 0 || strcmp(optarg, "0") == 0) {
+				/* ok, no seed provided */
+				break;
+			} else if (strlen(optarg) != 64) {
+				(void) fprintf(stderr,
+				    "fishing seed must be 64 hex digits: %s\n",
+				    optarg);
+				usage(B_FALSE);
+			}
+			for (int i = 0; i < 4; i++) {
+				char s[17];
+				char *end = NULL;
+				memcpy(s, optarg + i * 16, 16);
+				s[16] = '\0';
+				errno = 0;
+				zo->zo_fishing_seed[i] = strtoull(s, &end, 16);
+				if (errno != 0 || end != s + 16) {
+					(void) fprintf(stderr,
+					    "invalid fishing seed: %s\n",
+					    optarg);
+					usage(B_FALSE);
+				}
+			}
+			break;
 		case 'h':
 			usage(B_TRUE);
 			break;
@@ -1183,7 +1397,7 @@ process_options(int argc, char **argv)
 	}
 
 	if (strcmp(raid_kind, "random") == 0) {
-		switch (ztest_random(3)) {
+		switch (ztest_random_flags(3, B_FALSE)) {
 		case 0:
 			raid_kind = "raidz";
 			break;
@@ -4367,7 +4581,7 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 	if (ztest_random(2) == 0 && expected_error == 0) {
 		raidz_expand_pause_point =
 		    ztest_random(RAIDZ_EXPAND_PAUSE_SCRATCH_POST_REFLOW_2) + 1;
-		scratch_thread = thread_create(NULL, 0, ztest_scratch_thread,
+		scratch_thread = _thread_create(NULL, 0, ztest_scratch_thread,
 		    ztest_shared, 0, NULL, TS_RUN | TS_JOINABLE, defclsyspri);
 	}
 
@@ -8902,7 +9116,7 @@ ztest_raidz_expand_run(ztest_shared_t *zs, spa_t *spa)
 	/* Setup a 1 MiB buffer of random data */
 	uint64_t bufsize = 1024 * 1024;
 	void *buffer = umem_alloc(bufsize, UMEM_NOFAIL);
-	random_get_pseudo_bytes((uint8_t *)buffer, bufsize);
+	ztest_random_bytes((uint8_t *)buffer, bufsize);
 
 	/*
 	 * Put some data in the pool and then attach a vdev to initiate
@@ -8934,7 +9148,7 @@ ztest_raidz_expand_run(ztest_shared_t *zs, spa_t *spa)
 		thread_args[t].rzx_buffer = buffer;
 		thread_args[t].rzx_alloc_max = alloc_goal;
 		thread_args[t].rzx_spa = spa;
-		run_threads[t] = thread_create(NULL, 0, ztest_rzx_thread,
+		run_threads[t] = _thread_create(NULL, 0, ztest_rzx_thread,
 		    &thread_args[t], 0, NULL, TS_RUN | TS_JOINABLE,
 		    defclsyspri);
 	}
@@ -9092,7 +9306,7 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	 * Kick off all the tests that run in parallel.
 	 */
 	for (i = 0; i < ztest_opts.zo_threads; i++) {
-		run_threads[i] = thread_create_named("ztest_func", NULL, 0,
+		run_threads[i] = _thread_create_named("ztest_func", NULL, 0,
 		    ztest_thread, (void *)(uintptr_t)i, 0, NULL,
 		    TS_RUN | TS_JOINABLE, defclsyspri);
 	}
@@ -9209,13 +9423,13 @@ ztest_run(ztest_shared_t *zs)
 	/*
 	 * Create a thread to periodically resume suspended I/O.
 	 */
-	resume_thread = thread_create(NULL, 0, ztest_resume_thread,
+	resume_thread = _thread_create(NULL, 0, ztest_resume_thread,
 	    spa, 0, NULL, TS_RUN | TS_JOINABLE, defclsyspri);
 
 	/*
 	 * Create a deadman thread and set to panic if we hang.
 	 */
-	deadman_thread = thread_create(NULL, 0, ztest_deadman_thread,
+	deadman_thread = _thread_create(NULL, 0, ztest_deadman_thread,
 	    zs, 0, NULL, TS_RUN | TS_JOINABLE, defclsyspri);
 
 	spa->spa_deadman_failmode = ZIO_FAILURE_MODE_PANIC;
@@ -9507,6 +9721,7 @@ shared_data_size(ztest_shared_hdr_t *hdr)
 	size += hdr->zh_stats_size * hdr->zh_stats_count;
 	size += hdr->zh_ds_size * hdr->zh_ds_count;
 	size += hdr->zh_scratch_state_size;
+	size += hdr->zh_prng_state_size;
 
 	return (size);
 }
@@ -9531,6 +9746,7 @@ setup_hdr(void)
 	hdr->zh_ds_size = sizeof (ztest_shared_ds_t);
 	hdr->zh_ds_count = ztest_opts.zo_datasets;
 	hdr->zh_scratch_state_size = sizeof (ztest_shared_scratch_state_t);
+	hdr->zh_prng_state_size = sizeof (ztest_shared_prng_state_t);
 
 	size = shared_data_size(hdr);
 	VERIFY0(ftruncate(ztest_fd_data, size));
@@ -9567,6 +9783,8 @@ setup_data(void)
 	ztest_shared_ds = (void *)&buf[offset];
 	offset += hdr->zh_ds_size * hdr->zh_ds_count;
 	ztest_scratch_state = (void *)&buf[offset];
+	offset += hdr->zh_scratch_state_size;
+	ztest_prng_state = (void *)&buf[offset];
 }
 
 static boolean_t

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7914,13 +7914,20 @@ ztest_pool_prefetch_ddt(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	spa_t *spa;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
-	VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
+
+	err = spa_open(ztest_opts.zo_pool, &spa, FTAG);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	ddt_prefetch_all(spa);
 
 	spa_close(spa, FTAG);
+
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5280,21 +5280,21 @@ ztest_dsl_dataset_cleanup(char *osname, uint64_t id)
 	    clone1name, id);
 
 	error = dsl_destroy_head(clone2name);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_head(%s) = %d", clone2name, error);
 	error = dsl_destroy_snapshot(snap3name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap3name, error);
 	error = dsl_destroy_snapshot(snap2name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap2name, error);
 	error = dsl_destroy_head(clone1name);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_head(%s) = %d", clone1name, error);
 	error = dsl_destroy_snapshot(snap1name, B_FALSE);
-	if (error && error != ENOENT)
+	if (error && error != ENOENT && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_destroy_snapshot(%s) = %d",
 		    snap1name, error);
 
@@ -5347,6 +5347,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_take_snapshot(%s) = %d", snap1name, error);
 	}
 
@@ -5356,6 +5358,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", clone1name, error);
 	}
 
@@ -5365,6 +5369,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_open_snapshot(%s) = %d", snap2name, error);
 	}
 
@@ -5374,6 +5380,8 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_open_snapshot(%s) = %d", snap3name, error);
 	}
 
@@ -5383,27 +5391,32 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", clone2name, error);
 	}
 
 	error = ztest_dmu_objset_own(snap2name, DMU_OST_ANY, B_TRUE, B_TRUE,
 	    FTAG, &os);
-	if (error)
+	if (error) {
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_own(%s) = %d", snap2name, error);
+	}
 	error = dsl_dataset_promote(clone2name, NULL);
 	if (error == ENOSPC) {
 		dmu_objset_disown(os, B_TRUE, FTAG);
 		ztest_record_enospc(FTAG);
 		goto out;
 	}
-	if (error != EBUSY)
+	if (error != EBUSY && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE, "dsl_dataset_promote(%s), %d, not EBUSY",
 		    clone2name, error);
 	dmu_objset_disown(os, B_TRUE, FTAG);
 
-out:
 	ztest_dsl_dataset_cleanup(osname, id);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 
 	umem_free(snap1name, ZFS_MAX_DATASET_NAME_LEN);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -9703,6 +9703,8 @@ ztest_run(ztest_shared_t *zs)
 		ASSERT3U(ztest_opts.zo_raidz_expand_test, ==,
 		    RAIDZ_EXPAND_NONE);
 
+		(void) spa_checkpoint_discard(spa->spa_name);
+
 		int d, ndatasets;
 		ndatasets = MIN(ztest_opts.zo_datasets, ztest_opts.zo_threads);
 		d = ztest_random(ndatasets);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5043,40 +5043,43 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	return (0);
 }
 
-static boolean_t
+static int
 ztest_snapshot_create(char *osname, uint64_t id)
 {
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];
-	int error;
+	int err = 0;
 
 	(void) snprintf(snapname, sizeof (snapname), "%"PRIu64"", id);
 
-	error = dmu_objset_snapshot_one(osname, snapname);
-	if (error == ENOSPC) {
+	err = dmu_objset_snapshot_one(osname, snapname);
+	if (err == ENOSPC) {
 		ztest_record_enospc(FTAG);
-		return (B_FALSE);
+		return (err);
 	}
-	if (error != 0 && error != EEXIST && error != ECHRNG) {
-		fatal(B_FALSE, "ztest_snapshot_create(%s@%s) = %d", osname,
-		    snapname, error);
+	if (err != 0 && err != EEXIST && err != ECHRNG) {
+		if (!ZTEST_HFE_ACTIVE())
+			fatal(B_FALSE, "ztest_snapshot_create(%s@%s) = %d",
+			    osname, snapname, err);
 	}
-	return (B_TRUE);
+	return (err);
 }
 
-static boolean_t
+static int
 ztest_snapshot_destroy(char *osname, uint64_t id)
 {
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];
-	int error;
+	int error = 0;
 
 	(void) snprintf(snapname, sizeof (snapname), "%s@%"PRIu64"",
 	    osname, id);
 
 	error = dsl_destroy_snapshot(snapname, B_FALSE);
-	if (error != 0 && error != ENOENT && error != ECHRNG)
-		fatal(B_FALSE, "ztest_snapshot_destroy(%s) = %d",
-		    snapname, error);
-	return (B_TRUE);
+	if (error != 0 && error != ENOENT && error != ECHRNG) {
+		if (!ZTEST_HFE_ACTIVE())
+			fatal(B_FALSE, "ztest_snapshot_destroy(%s) = %d",
+			    snapname, error);
+	}
+	return (error);
 }
 
 void
@@ -5224,9 +5227,12 @@ out:
 void
 ztest_dmu_snapshot_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
+	int err;
+
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
-	(void) ztest_snapshot_destroy(zd->zd_name, id);
-	(void) ztest_snapshot_create(zd->zd_name, id);
+	err = ztest_snapshot_destroy(zd->zd_name, id);
+	if (err == 0 || err == ENOENT)
+		err = ztest_snapshot_create(zd->zd_name, id);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6077,11 +6077,11 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	objset_t *os = zd->zd_os;
 	ztest_od_t *od;
 	uint64_t object;
-	uint64_t txg, last_txg;
+	uint64_t txg = 0, last_txg;
 	uint64_t value[ZTEST_ZAP_MAX_INTS];
 	uint64_t zl_ints, zl_intsize, prop;
 	int i, ints;
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
 	char propname[100], txgname[100];
 	int error;
 	const char *const hc[2] = { "s.acl.h", ".s.open.h.hyLZlg" };
@@ -6106,21 +6106,35 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 		goto out;
 	for (i = 0; i < 2; i++) {
 		value[i] = i;
-		VERIFY0(zap_add(os, object, hc[i], sizeof (uint64_t),
-		    1, &value[i], tx));
+		error = zap_add(os, object, hc[i], sizeof (uint64_t),
+		    1, &value[i], tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	}
 	for (i = 0; i < 2; i++) {
-		VERIFY3U(EEXIST, ==, zap_add(os, object, hc[i],
-		    sizeof (uint64_t), 1, &value[i], tx));
-		VERIFY0(
-		    zap_length(os, object, hc[i], &zl_intsize, &zl_ints));
+		error = zap_add(os, object, hc[i],
+		    sizeof (uint64_t), 1, &value[i], tx);
+		if (!(error == EEXIST) && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY3U(error, ==, EEXIST);
+
+		error = zap_length(os, object, hc[i], &zl_intsize, &zl_ints);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
+
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, 1);
 	}
 	for (i = 0; i < 2; i++) {
-		VERIFY0(zap_remove(os, object, hc[i], tx));
+		error = zap_remove(os, object, hc[i], tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	}
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Generate a bunch of random entries.
@@ -6141,22 +6155,33 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, 1);
 
-		VERIFY0(zap_lookup(os, object, txgname, zl_intsize,
-		    zl_ints, &last_txg));
+		error = zap_lookup(os, object, txgname, zl_intsize,
+		    zl_ints, &last_txg);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
-		VERIFY0(zap_length(os, object, propname, &zl_intsize,
-		    &zl_ints));
+		error = zap_length(os, object, propname, &zl_intsize,
+		    &zl_ints);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
 		ASSERT3U(zl_intsize, ==, sizeof (uint64_t));
 		ASSERT3U(zl_ints, ==, ints);
 
-		VERIFY0(zap_lookup(os, object, propname, zl_intsize,
-		    zl_ints, value));
+		error = zap_lookup(os, object, propname, zl_intsize,
+		    zl_ints, value);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 
 		for (i = 0; i < ints; i++) {
 			ASSERT3U(value[i], ==, last_txg + object + i);
 		}
 	} else {
+		if (!(error == ENOENT) && ZTEST_HFE_ACTIVE())
+			goto out;
 		ASSERT3U(error, ==, ENOENT);
 	}
 
@@ -6180,12 +6205,19 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	for (i = 0; i < ints; i++)
 		value[i] = txg + object + i;
 
-	VERIFY0(zap_update(os, object, txgname, sizeof (uint64_t),
-	    1, &txg, tx));
-	VERIFY0(zap_update(os, object, propname, sizeof (uint64_t),
-	    ints, value, tx));
+	error = zap_update(os, object, txgname, sizeof (uint64_t),
+	    1, &txg, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+	error = zap_update(os, object, propname, sizeof (uint64_t),
+	    ints, value, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Remove a random pair of entries.
@@ -6198,7 +6230,8 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 
 	if (error == ENOENT)
 		goto out;
-
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 
 	tx = dmu_tx_create(os);
@@ -6206,10 +6239,18 @@ ztest_zap(ztest_ds_t *zd, uint64_t id)
 	txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
 	if (txg == 0)
 		goto out;
-	VERIFY0(zap_remove(os, object, txgname, tx));
-	VERIFY0(zap_remove(os, object, propname, tx));
-	dmu_tx_commit(tx);
+	error = zap_remove(os, object, txgname, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+	error = zap_remove(os, object, propname, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+
 out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
 	umem_free(od, sizeof (ztest_od_t));
 }
 
@@ -6251,6 +6292,11 @@ ztest_fzap(ztest_ds_t *zd, uint64_t id)
 			goto out;
 		error = zap_add(os, object, name, sizeof (uint64_t), 1,
 		    &value, tx);
+		if (!(error == 0 || error == EEXIST) &&
+		    ZTEST_HFE_ACTIVE()) {
+			dmu_tx_commit(tx);
+			goto out;
+		}
 		ASSERT(error == 0 || error == EEXIST);
 		dmu_tx_commit(tx);
 	}
@@ -6265,7 +6311,7 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 	objset_t *os = zd->zd_os;
 	ztest_od_t *od;
 	uint64_t txg, object, count, wsize, wc, zl_wsize, zl_wc;
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
 	int i, namelen, error;
 	int micro = ztest_random(2);
 	char name[20], string_value[20];
@@ -6306,7 +6352,12 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 	}
 
 	count = -1ULL;
-	VERIFY0(zap_count(os, object, &count));
+	error = zap_count(os, object, &count);
+	if (error && ZTEST_HFE_ACTIVE()) {
+		umem_free(od, sizeof (ztest_od_t));
+		return;
+	}
+	VERIFY0(error);
 	ASSERT3S(count, !=, -1ULL);
 
 	/*
@@ -6337,7 +6388,8 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 			ASSERT3U(wsize, ==, zl_wsize);
 			ASSERT3U(wc, ==, zl_wc);
 		} else {
-			ASSERT3U(error, ==, ENOENT);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOENT);
 		}
 		break;
 
@@ -6349,22 +6401,27 @@ ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 				fatal(B_FALSE, "name '%s' != val '%s' len %d",
 				    name, (char *)data, namelen);
 		} else {
-			ASSERT3U(error, ==, ENOENT);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOENT);
 		}
 		break;
 
 	case 2:
 		error = zap_add(os, object, name, wsize, wc, data, tx);
-		ASSERT(error == 0 || error == EEXIST);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == EEXIST);
 		break;
 
 	case 3:
-		VERIFY0(zap_update(os, object, name, wsize, wc, data, tx));
+		error = zap_update(os, object, name, wsize, wc, data, tx);
+		if (!ZTEST_HFE_ACTIVE())
+			VERIFY0(error);
 		break;
 
 	case 4:
 		error = zap_remove(os, object, name, tx);
-		ASSERT(error == 0 || error == ENOENT);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == ENOENT);
 		break;
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8952,7 +8952,9 @@ ztest_run(ztest_shared_t *zs)
 		ASSERT3U(ztest_opts.zo_raidz_expand_test, ==,
 		    RAIDZ_EXPAND_NONE);
 
-		int d = ztest_random(ztest_opts.zo_datasets);
+		int d, ndatasets;
+		ndatasets = MIN(ztest_opts.zo_datasets, ztest_opts.zo_threads);
+		d = ztest_random(ndatasets);
 		ztest_dataset_destroy(d);
 		txg_wait_synced(spa_get_dsl(spa), 0);
 	}

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7017,7 +7017,7 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	int fd;
 	uint64_t offset;
 	uint64_t leaves;
@@ -7036,10 +7036,15 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 	boolean_t islog = B_FALSE;
 	boolean_t injected = B_FALSE;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	path0 = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 	pathrand = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 
 	mutex_enter(&ztest_vdev_lock);
+
+	spa = ztest_spa;
 
 	/*
 	 * Device removal is in progress, fault injection must be disabled
@@ -7313,6 +7318,7 @@ out:
 	umem_free(path0, MAXPATHLEN);
 	umem_free(pathrand, MAXPATHLEN);
 
+	mutex_exit(&ztest_hfe_lock);
 }
 
 static uint64_t

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2393,9 +2393,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 
 	if (lr->lrz_type == DMU_OT_ZAP_OTHER) {
 		if (lr->lr_foid == 0) {
-			lr->lr_foid = zap_create_dnsize(os,
+			error = zap_create_dnsize(os,
 			    lr->lrz_type, lr->lrz_bonustype,
-			    bonuslen, lr->lrz_dnodesize, tx);
+			    bonuslen, lr->lrz_dnodesize, tx, &lr->lr_foid);
 		} else {
 			error = zap_create_claim_dnsize(os, lr->lr_foid,
 			    lr->lrz_type, lr->lrz_bonustype,
@@ -2403,9 +2403,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		}
 	} else {
 		if (lr->lr_foid == 0) {
-			lr->lr_foid = dmu_object_alloc_dnsize(os,
+			error = dmu_object_alloc_dnsize(os,
 			    lr->lrz_type, 0, lr->lrz_bonustype,
-			    bonuslen, lr->lrz_dnodesize, tx);
+			    bonuslen, lr->lrz_dnodesize, tx, &lr->lr_foid);
 		} else {
 			error = dmu_object_claim_dnsize(os, lr->lr_foid,
 			    lr->lrz_type, 0, lr->lrz_bonustype,

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -117,6 +117,7 @@
 #include <sys/dsl_userhold.h>
 #include <sys/abd.h>
 #include <sys/blake3.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -134,6 +135,27 @@
 #include <sys/backtrace.h>
 #include <libzpool.h>
 #include <libspl.h>
+
+#if defined(__linux__)
+#ifdef HAVE_GETTID
+#define	libspl_gettid()		gettid()
+#else
+#include <sys/syscall.h>
+#define	libspl_gettid()		((pid_t)syscall(__NR_gettid))
+#endif
+#elif defined(__FreeBSD__)
+#include <pthread_np.h>
+#define	libspl_gettid()		pthread_getthreadid_np()
+#elif defined(__APPLE__)
+static inline uint64_t
+libspl_gettid(void)
+{
+	uint64_t tid;
+	if (pthread_threadid_np(NULL, &tid) != 0)
+		tid = 0;
+	return (tid);
+}
+#endif
 
 static int ztest_fd_data = -1;
 
@@ -455,6 +477,7 @@ ztest_func_t ztest_pool_prefetch_ddt;
 ztest_func_t ztest_ddt_prune;
 ztest_func_t ztest_spa_log_flushall_start;
 ztest_func_t ztest_spa_log_flushall_cancel;
+ztest_func_t ztest_hardforced_export;
 
 static uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 static uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -513,9 +536,18 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_ddt_prune, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_start, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_cancel, 1, &zopt_rarely),
+	ZTI_INIT(ztest_hardforced_export, 1, &zopt_rarely),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
+
+static volatile uint64_t ztest_running_threads = 0;
+static struct {
+	const char *func;
+	pid_t pid;
+	uint64_t tid;
+	boolean_t onhold;
+} *ztest_threads;
 
 /*
  * The following struct is used to hold a list of uncalled commit callbacks.
@@ -561,6 +593,35 @@ static kmutex_t ztest_vdev_lock;
 static boolean_t ztest_device_removal_active = B_FALSE;
 static boolean_t ztest_pool_scrubbed = B_FALSE;
 static kmutex_t ztest_checkpoint_lock;
+
+/* Hardforced export test scenario state. */
+enum {
+	HFE_STAGE_DONE_ONCE,
+	HFE_STAGE_INACTIVE,
+	HFE_STAGE_STARTED,
+	HFE_STAGE_SUSPENDED,
+	HFE_STAGE_CANCELLING_IO,
+	HFE_STAGE_CLOSING_DATASETS,
+	HFE_STAGE_EXPORTING,
+	HFE_STAGE_REIMPORTING,
+};
+static atomic_uint ztest_hfe_stage = HFE_STAGE_INACTIVE;
+static uint64_t ztest_hfe_runs = 0;
+static kmutex_t ztest_hfe_lock;
+static volatile uint64_t ztest_hfe_reimport_waiters = 0;
+#define	ZTEST_HFE_SET_STAGE(stage) atomic_store(&ztest_hfe_stage, (stage))
+#define	ZTEST_HFE_STAGE() atomic_load(&ztest_hfe_stage)
+#define	ZTEST_HFE_ACTIVE() ((ZTEST_HFE_STAGE() >= HFE_STAGE_STARTED && \
+	ZTEST_HFE_STAGE() <= HFE_STAGE_EXPORTING) || \
+	vdev_file_constant_error != 0)
+#define	ZTEST_HFE_NEVER_RUN() (ZTEST_HFE_STAGE() == HFE_STAGE_INACTIVE && \
+	ztest_hfe_runs == 0)
+
+static int ztest_dataset_open(int);
+static void ztest_dataset_close(int);
+static void ztest_open_pool(ztest_shared_t *, spa_t **);
+static void ztest_get_zdb_bin(char *, int);
+static void ztest_run(ztest_shared_t *);
 
 /*
  * The ztest_name_lock protects the pool and dataset namespace used by
@@ -1452,6 +1513,17 @@ invalid:
 static void
 ztest_kill(ztest_shared_t *zs)
 {
+	/*
+	 * If the hardforced export scenario is running then spa is volatile.
+	 */
+	if (ZTEST_HFE_ACTIVE()) {
+		if (raidz_expand_pause_point != RAIDZ_EXPAND_PAUSE_NONE) {
+			raidz_expand_pause_point = RAIDZ_EXPAND_PAUSE_NONE;
+			return;
+		}
+		goto kill;
+	}
+
 	zs->zs_alloc = metaslab_class_get_alloc(spa_normal_class(ztest_spa));
 	zs->zs_space = metaslab_class_get_space(spa_normal_class(ztest_spa));
 
@@ -1483,6 +1555,7 @@ ztest_kill(ztest_shared_t *zs)
 		spa_namespace_exit(FTAG);
 	}
 
+kill:
 	(void) raise(SIGKILL);
 }
 
@@ -6919,6 +6992,216 @@ out:
 
 	umem_free(path0, MAXPATHLEN);
 	umem_free(pathrand, MAXPATHLEN);
+
+}
+
+static uint64_t
+ztest_zdb_latest_txg(vdev_t *vd)
+{
+	FILE *fp;
+	const size_t bin_len = MAXPATHLEN + MAXNAMELEN + 20;
+	const size_t cmd_len = MAXPATHLEN + MAXNAMELEN + 20;
+	const size_t buf_len = 1024;
+	char *bin;
+	char *cmd;
+	char *buf;
+	char *endp;
+	uint64_t txg = 0;
+
+	if (vd->vdev_ops == &vdev_file_ops) {
+		bin = umem_alloc(bin_len, UMEM_NOFAIL);
+		cmd = umem_alloc(cmd_len, UMEM_NOFAIL);
+		buf = umem_zalloc(buf_len, UMEM_NOFAIL);
+		ztest_get_zdb_bin(bin, bin_len);
+		snprintf(cmd, cmd_len, "sh -c '%s -llll %s | "
+		    "sed -En s/^\\ +txg:\\ +\\([0-9]+\\)$/\\\\1/p | "
+		    "sort -r | head -n1'", bin, vd->vdev_path);
+		fp = popen(cmd, "r");
+		if (fgets(buf, buf_len, fp) != NULL &&
+		    strlen(buf) > 0) {
+			txg = strtoull(buf, &endp, 0);
+			if (*endp != '\n')
+				txg = 0;
+		}
+		pclose(fp);
+		umem_free(buf, buf_len);
+		umem_free(cmd, cmd_len);
+		umem_free(bin, bin_len);
+	}
+
+	for (uint64_t i = 0; i < vd->vdev_children; i++) {
+		uint64_t child_txg = ztest_zdb_latest_txg(vd->vdev_child[i]);
+		if (child_txg > txg)
+			txg = child_txg;
+	}
+
+	return (txg);
+}
+
+/*
+ * Suspend the pool, forcibly export, re-import.
+ */
+void
+ztest_hardforced_export(ztest_ds_t *zd, uint64_t id)
+{
+	(void) zd, (void) id;
+	spa_t *spa;
+	uint64_t pool_guid;
+	uint64_t last_actually_synced_txg;
+	ztest_shared_t *zs = ztest_shared;
+	uint64_t failmode_orig;
+	int i;
+	const uint_t timeout_sec = 60 +
+	    (2 + ztest_opts.zo_threads / boot_ncpus) * zfs_txg_timeout;
+
+	/*
+	 * We must not be an uncounted reimport_waiter stuck down here,
+	 * waiting for the lock. If someone else has started the scenario then
+	 * let's quit and run other ztest.
+	 */
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
+	/*
+	 * Let ztest_resume_thread() do its job.
+	 */
+	spa = ztest_spa;
+	if (spa_suspended(spa)) {
+		mutex_exit(&ztest_hfe_lock);
+		return;
+	}
+
+	/*
+	 * Intentionally fault disks.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_STARTED);
+	failmode_orig = spa->spa_failmode;
+	spa->spa_failmode = ZIO_FAILURE_MODE_WAIT;
+	pool_guid = spa_guid(spa);
+	vdev_file_constant_error = EIO;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: started\n", __func__);
+
+	/*
+	 * Wait for suspension state.
+	 *
+	 * The read/write ztest funcs, always running in parallel, are
+	 * expected to trigger it very quickly.
+	 */
+	for (i = 0; i < timeout_sec; i++) {
+		sleep(1);
+		if (spa_suspended(spa))
+			break;
+	}
+	if (!spa_suspended(spa)) {
+		/*
+		 * We expect that activity of other test threads would trigger
+		 * suspension, but there is no guarantee for that. It's better
+		 * to avoid false positives then.
+		 */
+		if (ztest_opts.zo_verbose >= 5)
+			(void) printf("%s: decided to suspend manually\n",
+			    __func__);
+		zio_suspend(spa, NULL, ZIO_SUSPEND_IOERR);
+	}
+	VERIFY(spa_suspended(spa));
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_SUSPENDED);
+	last_actually_synced_txg = ztest_zdb_latest_txg(spa->spa_root_vdev);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: suspended (spa_last_synced_txg=%lu, "
+		    "last_actually_synced_txg=%lu, spa_guid=%lu)\n", __func__,
+		    spa_last_synced_txg(spa), last_actually_synced_txg,
+		    spa_guid(spa));
+
+	/*
+	 * Cancel suspended I/O.
+	 *
+	 * From this point we want other threads not to start new tests as we
+	 * plan to drop the exiting spa and its datasets.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_CANCELLING_IO);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: cancelling suspended I/O...\n", __func__);
+	spa_set_forced_exit_required(spa);
+	VERIFY(spa_exiting(spa));
+
+	/*
+	 * Pause testing activity.
+	 */
+	uint64_t expected = atomic_load_64(&ztest_running_threads) - 1;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: waiting for other test threads to become "
+		    "idle...\n", __func__);
+	for (i = 0; i < timeout_sec; i++) {
+		sleep(1);
+		expected = atomic_load_64(&ztest_running_threads) - 1;
+		if (atomic_load_64(&ztest_hfe_reimport_waiters) == expected)
+			break;
+	}
+	const uint64_t actual = atomic_load_64(&ztest_hfe_reimport_waiters);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: all other test threads to be idle: "
+		    "expected=%lu, actual=%lu\n", __func__, expected, actual);
+	for (int t = 0; t < ztest_opts.zo_threads; t++) {
+		if (t == id || ztest_threads[t].onhold)
+			continue;
+		(void) printf("%s: still active thread: id=%d, func=%s, "
+		    "pid=%d, tid=%lu\n", __func__, t, ztest_threads[t].func,
+		    ztest_threads[t].pid, ztest_threads[t].tid);
+	}
+	VERIFY3U(actual, ==, expected);
+
+	/*
+	 * Close the datasets.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_CLOSING_DATASETS);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: closing datasets...\n", __func__);
+	for (i = 0; i < ztest_opts.zo_threads; i++) {
+		if (i < ztest_opts.zo_datasets)
+			ztest_dataset_close(i);
+	}
+	txg_wait_synced(spa_get_dsl(spa), 0);
+	spa_close(spa, (const void *)ztest_run);
+
+	/*
+	 * Export with hardforce.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_EXPORTING);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: exporting with hardforce...\n", __func__);
+	VERIFY(spa_suspended(spa));
+	VERIFY0(spa_export(spa_name(spa), NULL, B_TRUE, B_TRUE));
+
+	/*
+	 * Import back.
+	 */
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_REIMPORTING);
+	vdev_file_constant_error = 0;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: re-importing...\n", __func__);
+	ztest_open_pool(zs, &spa);
+	VERIFY3U(pool_guid, ==, spa_guid(spa));
+	VERIFY3U(spa->spa_state, ==, POOL_STATE_ACTIVE);
+	for (i = 0; i < ztest_opts.zo_threads; i++) {
+		if (i < ztest_opts.zo_datasets)
+			VERIFY0(ztest_dataset_open(i));
+	}
+	VERIFY3U(spa_last_synced_txg(spa), >=, last_actually_synced_txg);
+	spa->spa_failmode = failmode_orig;
+	ztest_spa = spa;
+
+	/*
+	 * Finish the scenario.
+	 */
+	ztest_hfe_runs++;
+	ZTEST_HFE_SET_STAGE(HFE_STAGE_DONE_ONCE);
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (spa_first_txg=%lu, "
+		    "spa_guid=%lu)\n", __func__, spa_first_txg(spa),
+		    spa_guid(spa));
+
+	mutex_exit(&ztest_hfe_lock);
 }
 
 /*
@@ -7753,9 +8036,23 @@ ztest_resume_thread(void *arg)
 		ddt_dump_prune_histogram = B_TRUE;
 
 	while (!ztest_exiting) {
-		if (spa_suspended(spa))
-			ztest_resume(spa);
 		(void) poll(NULL, 0, 100);
+
+		/*
+		 * Resume only if the hardforced export test scenario is not
+		 * running, otherwise suspension is expected.
+		 */
+		if (mutex_tryenter(&ztest_hfe_lock)) {
+			/*
+			 * The hardforced export test changes the spa ref.
+			 */
+			spa = ztest_spa;
+
+			if (spa_suspended(spa))
+				ztest_resume(spa);
+
+			mutex_exit(&ztest_hfe_lock);
+		}
 
 		/*
 		 * Periodically change the zfs_compressed_arc_enabled setting.
@@ -7794,18 +8091,45 @@ ztest_deadman_thread(void *arg)
 		}
 
 		/*
-		 * If the pool is suspended then fail immediately. Otherwise,
-		 * check to see if the pool is making any progress. If
-		 * vdev_deadman() discovers that there hasn't been any recent
-		 * I/Os then it will end up aborting the tests.
+		 * Do not conflict with the hardforced export test scenario.
 		 */
-		if (spa_suspended(spa) || spa->spa_root_vdev == NULL) {
-			fatal(B_FALSE,
-			    "aborting test after %llu seconds because "
-			    "pool has transitioned to a suspended state.",
-			    (u_longlong_t)zfs_deadman_synctime_ms / 1000);
+		if (mutex_tryenter(&ztest_hfe_lock)) {
+			/*
+			 * The hardforced export test changes the spa ref.
+			 */
+			spa = ztest_spa;
+
+			/*
+			 * If the pool is suspended then fail immediately.
+			 * Otherwise, check to see if the pool is making any
+			 * progress. If vdev_deadman() discovers that there
+			 * hasn't been any recent I/Os then it will end up
+			 * aborting the tests.
+			 */
+			if (spa_suspended(spa) || spa->spa_root_vdev == NULL) {
+				fatal(B_FALSE,
+				    "aborting test after %llu seconds because "
+				    "pool has transitioned to a suspended "
+				    "state.",
+				    (u_longlong_t)zfs_deadman_synctime_ms
+				    / 1000);
+			}
+			vdev_deadman(spa->spa_root_vdev, FTAG);
+
+			mutex_exit(&ztest_hfe_lock);
 		}
-		vdev_deadman(spa->spa_root_vdev, FTAG);
+
+		(void) printf("ztest has been running for %lld seconds\n",
+		    (gethrtime() - zs->zs_proc_start) / NANOSEC);
+
+		for (int t = 0; t < ztest_opts.zo_threads; t++) {
+			if (ztest_threads[t].onhold)
+				continue;
+			(void) printf("%s: active thread: id=%d, func=%s, "
+			    "pid=%d, tid=%lu\n", __func__, t,
+			    ztest_threads[t].func, ztest_threads[t].pid,
+			    ztest_threads[t].tid);
+		}
 
 		/*
 		 * If the process doesn't complete within a grace period of
@@ -7819,9 +8143,6 @@ ztest_deadman_thread(void *arg)
 			    "the process is overdue for termination.",
 			    (gethrtime() - zs->zs_proc_start) / NANOSEC);
 		}
-
-		(void) printf("ztest has been running for %lld seconds\n",
-		    (gethrtime() - zs->zs_proc_start) / NANOSEC);
 
 		last_run = gethrtime();
 		delay = MSEC2NSEC(zfs_deadman_checktime_ms);
@@ -7931,6 +8252,7 @@ ztest_thread(void *arg)
 	ztest_info_t *zi;
 	ztest_shared_callstate_t *zc;
 
+	atomic_inc_64(&ztest_running_threads);
 	while ((now = gethrtime()) < zs->zs_thread_stop) {
 		/*
 		 * See if it's time to force a crash.
@@ -7947,19 +8269,51 @@ ztest_thread(void *arg)
 			break;
 
 		/*
+		 * If hardforced export test scenario has reached the
+		 * pool suspended stage then it's time to stop running
+		 * anything, as the spa is going to be changed by exporting
+		 * and re-importing.
+		 */
+		if (ZTEST_HFE_STAGE() >= HFE_STAGE_SUSPENDED) {
+			atomic_inc_64(&ztest_hfe_reimport_waiters);
+			ztest_threads[id].onhold = B_TRUE;
+			mutex_enter(&ztest_hfe_lock);
+			atomic_dec_64(&ztest_hfe_reimport_waiters);
+			ztest_threads[id].onhold = B_FALSE;
+			mutex_exit(&ztest_hfe_lock);
+			continue;
+		}
+
+		/*
 		 * Pick a random function to execute.
 		 */
 		rand = ztest_random(ZTEST_FUNCS);
 		zi = &ztest_info[rand];
+		if (zi->zi_func == ztest_hardforced_export) {
+			/* all other threads have resumed, can repeat then */
+			if (atomic_load_64(&ztest_hfe_reimport_waiters) == 0)
+				ZTEST_HFE_SET_STAGE(HFE_STAGE_INACTIVE);
+			/* to soon to run another one */
+			if (ZTEST_HFE_STAGE() >= HFE_STAGE_STARTED)
+				continue;
+			/* we want other tests to resume first */
+			if (ZTEST_HFE_STAGE() == HFE_STAGE_DONE_ONCE)
+				continue;
+		}
 		zc = ZTEST_GET_SHARED_CALLSTATE(rand);
 		call_next = zc->zc_next;
 
 		if (now >= call_next &&
 		    atomic_cas_64(&zc->zc_next, call_next, call_next +
 		    ztest_random(2 * zi->zi_interval[0] + 1)) == call_next) {
+			ztest_threads[id].func = zi->zi_funcname;
+			ztest_threads[id].pid = getpid();
+			ztest_threads[id].tid = libspl_gettid();
 			ztest_execute(rand, zi, id);
 		}
 	}
+	atomic_dec_64(&ztest_running_threads);
+	ztest_threads[id].onhold = B_TRUE;
 
 	thread_exit();
 }
@@ -8798,6 +9152,8 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 
 	run_threads = umem_zalloc(ztest_opts.zo_threads * sizeof (kthread_t *),
 	    UMEM_NOFAIL);
+	ztest_threads = umem_zalloc(ztest_opts.zo_threads *
+	    sizeof (*ztest_threads), UMEM_NOFAIL);
 
 	/*
 	 * Actual number of datasets to be used.
@@ -8825,6 +9181,8 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	for (i = 0; i < ztest_opts.zo_threads; i++)
 		VERIFY0(thread_join(run_threads[i]));
 
+	spa = ztest_spa; /* hardforced export test re-imports the spa */
+
 	/*
 	 * Close all datasets. This must be done after all the threads
 	 * are joined so we can be sure none of the datasets are in-use
@@ -8838,7 +9196,25 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	zs->zs_alloc = metaslab_class_get_alloc(spa_normal_class(spa));
 	zs->zs_space = metaslab_class_get_space(spa_normal_class(spa));
 
+	umem_free(ztest_threads, ztest_opts.zo_threads *
+	    sizeof (*ztest_threads));
 	umem_free(run_threads, ztest_opts.zo_threads * sizeof (kthread_t *));
+}
+
+static void
+ztest_open_pool(ztest_shared_t *zs, spa_t **spap)
+{
+	int error;
+
+	error = spa_open(ztest_opts.zo_pool, spap, (const void *)ztest_run);
+	if (error) {
+		VERIFY3S(error, ==, ENOENT);
+		ztest_import_impl();
+		VERIFY0(spa_open(ztest_opts.zo_pool, spap,
+		    (const void *)ztest_run));
+		zs->zs_metaslab_sz = 1ULL << (*spap)->spa_root_vdev
+		    ->vdev_child[0]->vdev_ms_shift;
+	}
 }
 
 /*
@@ -8862,6 +9238,7 @@ ztest_run(ztest_shared_t *zs)
 	 */
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	zs->zs_thread_start = gethrtime();
@@ -8885,14 +9262,7 @@ ztest_run(ztest_shared_t *zs)
 	 */
 	raidz_scratch_verify();
 	kernel_init(SPA_MODE_READ | SPA_MODE_WRITE);
-	error = spa_open(ztest_opts.zo_pool, &spa, FTAG);
-	if (error) {
-		VERIFY3S(error, ==, ENOENT);
-		ztest_import_impl();
-		VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
-		zs->zs_metaslab_sz =
-		    1ULL << spa->spa_root_vdev->vdev_child[0]->vdev_ms_shift;
-	}
+	ztest_open_pool(zs, &spa);
 
 	metaslab_preload_limit = ztest_random(20) + 1;
 	ztest_spa = spa;
@@ -9007,6 +9377,7 @@ ztest_run(ztest_shared_t *zs)
 	ztest_exiting = B_TRUE;
 	VERIFY0(thread_join(resume_thread));
 	VERIFY0(thread_join(deadman_thread));
+	spa = ztest_spa; /* hardforced export test re-imports the spa */
 	ztest_resume(spa);
 
 	/*
@@ -9022,7 +9393,7 @@ ztest_run(ztest_shared_t *zs)
 	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG)
 		VERIFY0(zc_min_txg_delay);
 
-	spa_close(spa, FTAG);
+	spa_close(spa, (const void *)ztest_run);
 
 	/*
 	 * Verify that we can loop over all pools.
@@ -9050,6 +9421,7 @@ ztest_run(ztest_shared_t *zs)
 	list_destroy(&zcl.zcl_callbacks);
 	mutex_destroy(&zcl.zcl_callbacks_lock);
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
 }
@@ -9115,6 +9487,7 @@ ztest_init(ztest_shared_t *zs)
 
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	raidz_scratch_verify();
@@ -9200,6 +9573,7 @@ ztest_init(ztest_shared_t *zs)
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
 }

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6398,7 +6398,7 @@ ztest_commit_callback(void *arg, int error)
 	VERIFY(!data->zcd_called);
 
 	synced_txg = spa_last_synced_txg(data->zcd_spa);
-	if (data->zcd_txg > synced_txg)
+	if (data->zcd_txg > synced_txg && !ZTEST_HFE_ACTIVE())
 		fatal(B_FALSE,
 		    "commit callback of txg %"PRIu64" called prematurely, "
 		    "last synced txg = %"PRIu64"\n",
@@ -6520,8 +6520,11 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Read existing data to make sure there isn't a future leak.
 	 */
-	VERIFY0(dmu_read(os, od->od_object, 0, sizeof (uint64_t),
-	    &old_txg, DMU_READ_PREFETCH));
+	error = dmu_read(os, od->od_object, 0, sizeof (uint64_t),
+	    &old_txg, DMU_READ_PREFETCH);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto txout;
+	VERIFY0(error);
 
 	if (old_txg > txg)
 		fatal(B_FALSE,
@@ -6530,7 +6533,10 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 
 	dmu_write(os, od->od_object, 0, sizeof (uint64_t), &txg, tx,
 	    DMU_READ_PREFETCH);
+	if (ZTEST_HFE_ACTIVE())
+		goto txout;
 
+txout:
 	(void) mutex_enter(&zcl.zcl_callbacks_lock);
 
 	/*
@@ -9532,7 +9538,7 @@ ztest_run(ztest_shared_t *zs)
 	}
 
 	/* Verify that at least one commit cb was called in a timely fashion */
-	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG)
+	if (zc_cb_counter >= ZTEST_COMMIT_CB_MIN_REG && ZTEST_HFE_NEVER_RUN())
 		VERIFY0(zc_min_txg_delay);
 
 	spa_close(spa, (const void *)ztest_run);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -9170,9 +9170,9 @@ ztest_generic_run(ztest_shared_t *zs, spa_t *spa)
 	 * Kick off all the tests that run in parallel.
 	 */
 	for (i = 0; i < ztest_opts.zo_threads; i++) {
-		run_threads[i] = _thread_create(NULL, 0, ztest_thread,
-		    (void *)(uintptr_t)i, 0, NULL, TS_RUN | TS_JOINABLE,
-		    defclsyspri);
+		run_threads[i] = _thread_create_named("ztest_func", NULL, 0,
+		    ztest_thread, (void *)(uintptr_t)i, 0, NULL,
+		    TS_RUN | TS_JOINABLE, defclsyspri);
 	}
 
 	/*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1919,11 +1919,8 @@ ztest_spa_prop_set_uint64(zpool_prop_t prop, uint64_t value)
 
 	fnvlist_free(props);
 
-	if (error == ENOSPC) {
+	if (error == ENOSPC)
 		ztest_record_enospc(FTAG);
-		return (error);
-	}
-	ASSERT0(error);
 
 	return (error);
 }
@@ -6810,13 +6807,18 @@ ztest_dsl_prop_get_set(ztest_ds_t *zd, uint64_t id)
 	for (int p = 0; p < sizeof (proplist) / sizeof (proplist[0]); p++) {
 		int error = ztest_dsl_prop_set_uint64(zd->zd_name, proplist[p],
 		    ztest_random_dsl_prop(proplist[p]), (int)ztest_random(2));
+		if (!(error == 0 || error == ENOSPC) && ZTEST_HFE_ACTIVE())
+			goto out;
 		ASSERT(error == 0 || error == ENOSPC);
 	}
 
 	int error = ztest_dsl_prop_set_uint64(zd->zd_name, ZFS_PROP_RECORDSIZE,
 	    ztest_random_blocksize(), (int)ztest_random(2));
+	if (!(error == 0 || error == ENOSPC) && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT(error == 0 || error == ENOSPC);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 
@@ -6824,19 +6826,29 @@ void
 ztest_spa_prop_get_set(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
+	nvlist_t *props = NULL;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
 
-	(void) ztest_spa_prop_set_uint64(ZPOOL_PROP_AUTOTRIM, ztest_random(2));
+	err = ztest_spa_prop_set_uint64(ZPOOL_PROP_AUTOTRIM, ztest_random(2));
+	if (!(err == 0 || err == ENOSPC) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY(err == 0 || err == ENOSPC);
 
-	nvlist_t *props = fnvlist_alloc();
+	props = fnvlist_alloc();
 
-	VERIFY0(spa_prop_get(ztest_spa, props));
+	err = spa_prop_get(ztest_spa, props);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	if (ztest_opts.zo_verbose >= 6)
 		dump_nvlist(props, 4);
 
-	fnvlist_free(props);
+out:
+	if (props)
+		fnvlist_free(props);
 
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3959,6 +3959,8 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		case 0:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			fatal(B_FALSE, "spa_vdev_add(%p) = %d", nvroot, error);
 		}
 		fnvlist_free(nvroot);
@@ -3980,6 +3982,8 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		case ZFS_ERR_DISCARDING_CHECKPOINT:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			if (error != ignore_err)
 				fatal(B_FALSE,
 				    "spa_vdev_remove(%"PRIu64") = %d",

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7560,7 +7560,7 @@ ztest_scrub_impl(spa_t *spa)
 	if (error)
 		return (error);
 
-	while (dsl_scan_scrubbing(spa_get_dsl(spa)))
+	while (dsl_scan_scrubbing(spa_get_dsl(spa)) && !ZTEST_HFE_ACTIVE())
 		txg_wait_synced(spa_get_dsl(spa), 0);
 
 	if (spa_approx_errlog_size(spa) > 0)
@@ -7596,7 +7596,8 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 	error = ztest_scrub_impl(spa);
 	if (error == EBUSY)
 		error = 0;
-	ASSERT0(error);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(error);
 }
 
 /*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2135,7 +2135,7 @@ ztest_tx_assign(dmu_tx_t *tx, dmu_tx_flag_t txg_how, const char *tag)
 			dmu_tx_wait(tx);
 		} else if (error == ENOSPC) {
 			ztest_record_enospc(tag);
-		} else {
+		} else if (!ZTEST_HFE_ACTIVE()) {
 			ASSERT(error == EDQUOT || error == EIO);
 		}
 		dmu_tx_abort(tx);
@@ -2916,12 +2916,14 @@ ztest_lookup(ztest_ds_t *zd, ztest_od_t *od, int count)
 		od->od_object = 0;
 		error = zap_lookup(zd->zd_os, od->od_dir, od->od_name,
 		    sizeof (uint64_t), 1, &od->od_object);
+		if (!(error == 0 || error == ENOENT) && ZTEST_HFE_ACTIVE())
+			return (missing + 1);
 		if (error) {
 			ASSERT3S(error, ==, ENOENT);
 			ASSERT0(od->od_object);
 			missing++;
 		} else {
-			dmu_buf_t *db;
+			dmu_buf_t *db = NULL;
 			ztest_block_tag_t *bbt;
 			dmu_object_info_t doi;
 
@@ -2929,16 +2931,27 @@ ztest_lookup(ztest_ds_t *zd, ztest_od_t *od, int count)
 			ASSERT0(missing);	/* there should be no gaps */
 
 			ztest_object_lock(zd, od->od_object, ZTRL_READER);
-			VERIFY0(dmu_bonus_hold(zd->zd_os, od->od_object,
-			    FTAG, &db));
+			error = dmu_bonus_hold(zd->zd_os, od->od_object, FTAG,
+			    &db);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto errout;
+			VERIFY0(error);
 			dmu_object_info_from_db(db, &doi);
 			bbt = ztest_bt_bonus(db);
+			if (bbt->bt_magic != BT_MAGIC && ZTEST_HFE_ACTIVE())
+				goto errout;
 			ASSERT3U(bbt->bt_magic, ==, BT_MAGIC);
 			od->od_type = doi.doi_type;
 			od->od_blocksize = doi.doi_data_block_size;
 			od->od_gen = bbt->bt_gen;
 			dmu_buf_rele(db, FTAG);
 			ztest_object_unlock(zd, od->od_object);
+			continue;
+errout:
+			if (db)
+				dmu_buf_rele(db, FTAG);
+			ztest_object_unlock(zd, od->od_object);
+			return (missing + 1);
 		}
 	}
 
@@ -3019,7 +3032,8 @@ ztest_remove(ztest_ds_t *zd, ztest_od_t *od, int count)
 		lr->lr_doid = od->od_dir;
 
 		if ((error = ztest_replay_remove(zd, lr, B_FALSE)) != 0) {
-			ASSERT3U(error, ==, ENOSPC);
+			if (!ZTEST_HFE_ACTIVE())
+				ASSERT3U(error, ==, ENOSPC);
 			missing++;
 		} else {
 			od->od_object = 0;
@@ -5321,15 +5335,19 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	od = umem_alloc(size, UMEM_NOFAIL);
 	dmu_tx_t *tx;
 	int freeit, error;
-	uint64_t i, n, s, txg;
-	bufwad_t *packbuf, *bigbuf, *pack, *bigH, *bigT;
-	uint64_t packobj, packoff, packsize, bigobj, bigoff, bigsize;
+	uint64_t i, n, s, txg = 0;
+	bufwad_t *pack, *bigH, *bigT;
+	uint64_t packobj, packoff, bigobj, bigoff;
+	bufwad_t *packbuf = NULL, *bigbuf = NULL;
+	uint64_t packsize = 0, bigsize = 0;
 	uint64_t chunksize = (1000 + ztest_random(1000)) * sizeof (uint64_t);
 	uint64_t regions = 997;
 	uint64_t stride = 123456789ULL;
 	uint64_t width = 40;
 	int free_percent = 5;
 	dmu_flags_t dmu_read_flags = DMU_READ_PREFETCH;
+	void *packcheck = NULL;
+	void *bigcheck = NULL;
 
 	/*
 	 * We will randomly set when to do O_DIRECT on a read.
@@ -5368,10 +5386,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	ztest_od_init(od + 1, id, FTAG, 1, DMU_OT_UINT64_OTHER, 0, 0,
 	    chunksize);
 
-	if (ztest_object_init(zd, od, size, B_FALSE) != 0) {
-		umem_free(od, size);
-		return;
-	}
+	if (ztest_object_init(zd, od, size, B_FALSE) != 0)
+		goto out;
 
 	bigobj = od[0].od_object;
 	packobj = od[1].od_object;
@@ -5415,9 +5431,13 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 */
 	error = dmu_read(os, packobj, packoff, packsize, packbuf,
 	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 	error = dmu_read(os, bigobj, bigoff, bigsize, bigbuf,
 	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 	ASSERT0(error);
 
 	/*
@@ -5436,12 +5456,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	dmu_tx_hold_bonus(tx, bigobj);
 
 	txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
-	if (txg == 0) {
-		umem_free(packbuf, packsize);
-		umem_free(bigbuf, bigsize);
-		umem_free(od, size);
-		return;
-	}
+	if (txg == 0)
+		goto out;
 
 	enum zio_checksum cksum;
 	do {
@@ -5464,6 +5480,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 * with the new values we want to write out.
 	 */
 	for (i = 0; i < s; i++) {
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		/* LINTED */
 		pack = (bufwad_t *)((char *)packbuf + i * sizeof (bufwad_t));
 		/* LINTED */
@@ -5509,6 +5527,8 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 	 */
 	dmu_write(os, packobj, packoff, packsize, packbuf, tx,
 	    DMU_READ_PREFETCH);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (freeit) {
 		if (ztest_opts.zo_verbose >= 7) {
@@ -5516,7 +5536,10 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 			    " txg %"PRIx64"\n",
 			    bigoff, bigsize, txg);
 		}
-		VERIFY0(dmu_free_range(os, bigobj, bigoff, bigsize, tx));
+		error = dmu_free_range(os, bigobj, bigoff, bigsize, tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
 	} else {
 		if (ztest_opts.zo_verbose >= 7) {
 			(void) printf("writing offset %"PRIx64" size %"PRIx64""
@@ -5525,32 +5548,49 @@ ztest_dmu_read_write(ztest_ds_t *zd, uint64_t id)
 		}
 		dmu_write(os, bigobj, bigoff, bigsize, bigbuf, tx,
 		    DMU_READ_PREFETCH);
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 	}
 
 	dmu_tx_commit(tx);
+	txg = 0;
 
 	/*
 	 * Sanity check the stuff we just wrote.
 	 */
-	{
-		void *packcheck = umem_alloc(packsize, UMEM_NOFAIL);
-		void *bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
+	packcheck = umem_alloc(packsize, UMEM_NOFAIL);
+	bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
 
-		VERIFY0(dmu_read(os, packobj, packoff,
-		    packsize, packcheck, dmu_read_flags));
-		VERIFY0(dmu_read(os, bigobj, bigoff,
-		    bigsize, bigcheck, dmu_read_flags));
+	error = dmu_read(os, packobj, packoff, packsize, packcheck,
+	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
+	error = dmu_read(os, bigobj, bigoff, bigsize, bigcheck,
+	    dmu_read_flags);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
+
+	if (!ZTEST_HFE_ACTIVE()) {
 		ASSERT0(memcmp(packbuf, packcheck, packsize));
 		ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
-
-		umem_free(packcheck, packsize);
-		umem_free(bigcheck, bigsize);
 	}
 
-	umem_free(packbuf, packsize);
-	umem_free(bigbuf, bigsize);
-	umem_free(od, size);
+out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
+	if (bigcheck)
+		umem_free(bigcheck, bigsize);
+	if (packcheck)
+		umem_free(packcheck, packsize);
+	if (packbuf)
+		umem_free(packbuf, packsize);
+	if (bigbuf)
+		umem_free(bigbuf, bigsize);
+	if (od)
+		umem_free(od, size);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8060,10 +8060,12 @@ void
 ztest_initialize(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	int error = 0;
 
 	mutex_enter(&ztest_vdev_lock);
+
+	spa = ztest_spa;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8762,7 +8762,7 @@ ztest_dataset_open(int d)
 
 	ztest_dataset_name(name, ztest_opts.zo_pool, d);
 
-	if (ztest_opts.zo_verbose >= 6)
+	if (ztest_opts.zo_verbose >= 3)
 		(void) printf("Opening %s\n", name);
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1874,7 +1874,8 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 
 	error = dsl_prop_set_int(osname, propname,
 	    (inherit ? ZPROP_SRC_NONE : ZPROP_SRC_LOCAL), value);
-
+	if (!(error == ENOSPC || error == 0) && ZTEST_HFE_ACTIVE())
+		return (EIO);
 	if (error == ENOSPC) {
 		ztest_record_enospc(FTAG);
 		return (error);
@@ -1882,7 +1883,9 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 	ASSERT0(error);
 
 	setpoint = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
-	VERIFY0(dsl_prop_get_integer(osname, propname, &curval, setpoint));
+	error = dsl_prop_get_integer(osname, propname, &curval, setpoint);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (ztest_opts.zo_verbose >= 6) {
 		int err;
@@ -1895,6 +1898,8 @@ ztest_dsl_prop_set_uint64(char *osname, zfs_prop_t prop, uint64_t value,
 			(void) printf("%s %s = %s at '%s'\n",
 			    osname, propname, valname, setpoint);
 	}
+
+out:
 	umem_free(setpoint, MAXPATHLEN);
 
 	return (error);
@@ -2505,12 +2510,13 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	uint64_t offset, length;
 	ztest_block_tag_t *bt = (ztest_block_tag_t *)data;
 	ztest_block_tag_t *bbt;
-	uint64_t gen, txg, lrtxg, crtxg;
+	uint64_t gen, txg = 0, lrtxg, crtxg;
 	dmu_object_info_t doi;
 	dmu_tx_t *tx;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	arc_buf_t *abuf = NULL;
 	rl_t *rl;
+	int error = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2536,7 +2542,10 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	ztest_object_lock(zd, lr->lr_foid, ZTRL_READER);
 	rl = ztest_range_lock(zd, lr->lr_foid, offset, length, ZTRL_WRITER);
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	error = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	dmu_object_info_from_db(db, &doi);
 
@@ -2558,10 +2567,8 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	if (txg == 0) {
 		if (abuf != NULL)
 			dmu_return_arcbuf(abuf);
-		dmu_buf_rele(db, FTAG);
-		ztest_range_unlock(rl);
-		ztest_object_unlock(zd, lr->lr_foid);
-		return (ENOSPC);
+		error = ENOSPC;
+		goto out;
 	}
 
 	if (bt != NULL) {
@@ -2572,7 +2579,7 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 		 */
 		ASSERT(doi.doi_data_block_size);
 		ASSERT0(offset % doi.doi_data_block_size);
-		if (ztest_random(4) != 0) {
+		if (ztest_random(4) != 0 && !ZTEST_HFE_ACTIVE()) {
 			dmu_flags_t flags = ztest_random(2) ?
 			    DMU_READ_PREFETCH : DMU_READ_NO_PREFETCH;
 
@@ -2584,8 +2591,14 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 
 			ztest_block_tag_t rbt;
 
-			VERIFY0(dmu_read(os, lr->lr_foid, offset,
-			    sizeof (rbt), &rbt, flags));
+			error = dmu_read(os, lr->lr_foid, offset, sizeof (rbt),
+			    &rbt, flags);
+			if (error && ZTEST_HFE_ACTIVE()) {
+				if (abuf != NULL)
+					dmu_return_arcbuf(abuf);
+				goto out;
+			}
+			VERIFY0(error);
 			if (rbt.bt_magic == BT_MAGIC) {
 				ztest_bt_verify(&rbt, os, lr->lr_foid, 0,
 				    offset, gen, txg, crtxg);
@@ -2615,21 +2628,32 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	if (abuf == NULL) {
 		dmu_write(os, lr->lr_foid, offset, length, data, tx,
 		    DMU_READ_PREFETCH);
+		if (ZTEST_HFE_ACTIVE()) {
+			error = EIO;
+			goto out;
+		}
 	} else {
 		memcpy(abuf->b_data, data, length);
-		VERIFY0(dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx, 0));
+		error = dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx, 0);
+		if (error && ZTEST_HFE_ACTIVE()) {
+			dmu_return_arcbuf(abuf);
+			goto out;
+		}
+		VERIFY0(error);
 	}
 
 	(void) ztest_log_write(zd, tx, lr);
 
-	dmu_buf_rele(db, FTAG);
-
-	dmu_tx_commit(tx);
+out:
+	if (db != NULL)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_range_unlock(rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2641,6 +2665,7 @@ ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 	dmu_tx_t *tx;
 	uint64_t txg;
 	rl_t *rl;
+	int err = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2660,17 +2685,20 @@ ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 		return (ENOSPC);
 	}
 
-	VERIFY0(dmu_free_range(os, lr->lr_foid, lr->lr_offset,
-	    lr->lr_length, tx));
+	err = dmu_free_range(os, lr->lr_foid, lr->lr_offset,
+	    lr->lr_length, tx);
+	if (!ZTEST_HFE_ACTIVE())
+		VERIFY0(err);
 
-	(void) ztest_log_truncate(zd, tx, lr);
+	if (!err)
+		(void) ztest_log_truncate(zd, tx, lr);
 
 	dmu_tx_commit(tx);
 
 	ztest_range_unlock(rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (err);
 }
 
 static int
@@ -2680,25 +2708,28 @@ ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	lr_setattr_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	ztest_block_tag_t *bbt;
-	uint64_t txg, lrtxg, crtxg, dnodesize;
+	uint64_t txg = 0, lrtxg, crtxg, dnodesize;
+	int err = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
 
 	ztest_object_lock(zd, lr->lr_foid, ZTRL_WRITER);
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	err = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 
 	tx = dmu_tx_create(os);
 	dmu_tx_hold_bonus(tx, lr->lr_foid);
 
 	txg = ztest_tx_assign(tx, DMU_TX_WAIT, FTAG);
 	if (txg == 0) {
-		dmu_buf_rele(db, FTAG);
-		ztest_object_unlock(zd, lr->lr_foid);
-		return (ENOSPC);
+		err = ENOSPC;
+		goto out;
 	}
 
 	bbt = ztest_bt_bonus(db);
@@ -2728,24 +2759,37 @@ ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	    MAX(txg, lrtxg), crtxg);
 
 	dmu_buf_will_dirty(db, tx);
+	if (ZTEST_HFE_ACTIVE()) {
+		err = EIO;
+		goto out;
+	}
 
 	ASSERT3U(lr->lr_size, >=, sizeof (*bbt));
 	ASSERT3U(lr->lr_size, <=, db->db_size);
-	VERIFY0(dmu_set_bonus(db, lr->lr_size, tx));
+	err = dmu_set_bonus(db, lr->lr_size, tx);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 	bbt = ztest_bt_bonus(db);
 
 	ztest_bt_generate(bbt, os, lr->lr_foid, dnodesize, -1ULL, lr->lr_mode,
 	    txg, crtxg);
 	ztest_fill_unused_bonus(db, bbt, lr->lr_foid, os, bbt->bt_gen);
 	dmu_buf_rele(db, FTAG);
+	db = NULL;
 
-	(void) ztest_log_setattr(zd, tx, lr);
+	if (!err)
+		(void) ztest_log_setattr(zd, tx, lr);
 
-	dmu_tx_commit(tx);
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_object_unlock(zd, lr->lr_foid);
 
-	return (0);
+	return (err);
 }
 
 static zil_replay_func_t *ztest_replay_vector[TX_MAX_TYPE] = {
@@ -3156,7 +3200,10 @@ ztest_io(ztest_ds_t *zd, uint64_t object, uint64_t offset)
 	if (ztest_random(4) == 0)
 		dmu_read_flags |= DMU_DIRECTIO;
 
-	VERIFY0(dmu_object_info(zd->zd_os, object, &doi));
+	err = dmu_object_info(zd->zd_os, object, &doi);
+	if (err && ZTEST_HFE_ACTIVE())
+		return;
+	VERIFY0(err);
 	blocksize = doi.doi_data_block_size;
 	data = umem_alloc(blocksize, UMEM_NOFAIL);
 
@@ -3211,16 +3258,21 @@ ztest_io(ztest_ds_t *zd, uint64_t object, uint64_t offset)
 		err = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_CHECKSUM, spa_dedup_checksum(ztest_spa),
 		    B_FALSE);
-		ASSERT(err == 0 || err == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(err == 0 || err == ENOSPC);
 		err = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_COMPRESSION,
 		    ztest_random_dsl_prop(ZFS_PROP_COMPRESSION),
 		    B_FALSE);
-		ASSERT(err == 0 || err == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(err == 0 || err == ENOSPC);
 		(void) pthread_rwlock_unlock(&ztest_name_lock);
 
-		VERIFY0(dmu_read(zd->zd_os, object, offset, blocksize, data,
-		    dmu_read_flags));
+		err = dmu_read(zd->zd_os, object, offset, blocksize, data,
+		    dmu_read_flags);
+		if (err && ZTEST_HFE_ACTIVE())
+			break;
+		VERIFY0(err);
 
 		(void) ztest_write(zd, object, offset, blocksize, data);
 		break;
@@ -5914,11 +5966,12 @@ ztest_dmu_write_parallel(ztest_ds_t *zd, uint64_t id)
 	ztest_od_init(od, ID_PARALLEL, FTAG, 0, DMU_OT_UINT64_OTHER, 0, 0, 0);
 
 	if (ztest_object_init(zd, od, sizeof (ztest_od_t), B_FALSE) != 0)
-		return;
+		goto out;
 
-	while (ztest_random(10) != 0)
+	while (ztest_random(10) != 0 && !ZTEST_HFE_ACTIVE())
 		ztest_io(zd, od->od_object, offset);
 
+out:
 	umem_free(od, sizeof (ztest_od_t));
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2260,7 +2260,7 @@ ztest_log_create(ztest_ds_t *zd, dmu_tx_t *tx, lr_create_t *lr)
 	size_t namesize = strlen(name) + 1;
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_CREATE, sizeof (*lr) + namesize);
@@ -2277,7 +2277,7 @@ ztest_log_remove(ztest_ds_t *zd, dmu_tx_t *tx, lr_remove_t *lr, uint64_t object)
 	size_t namesize = strlen(name) + 1;
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_REMOVE, sizeof (*lr) + namesize);
@@ -2294,7 +2294,7 @@ ztest_log_write(ztest_ds_t *zd, dmu_tx_t *tx, lr_write_t *lr)
 	itx_t *itx;
 	itx_wr_state_t write_state = ztest_random(WR_NUM_STATES);
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	if (lr->lr_length > zil_max_log_data(zd->zd_zilog, sizeof (lr_write_t)))
@@ -2326,7 +2326,7 @@ ztest_log_truncate(ztest_ds_t *zd, dmu_tx_t *tx, lr_truncate_t *lr)
 {
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_TRUNCATE, sizeof (*lr));
@@ -2342,7 +2342,7 @@ ztest_log_setattr(ztest_ds_t *zd, dmu_tx_t *tx, lr_setattr_t *lr)
 {
 	itx_t *itx;
 
-	if (zil_replaying(zd->zd_zilog, tx))
+	if (zil_replaying(zd->zd_zilog, tx) || zd->zd_zilog->zl_suspending)
 		return;
 
 	itx = zil_itx_create(TX_SETATTR, sizeof (*lr));

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4210,9 +4210,11 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 		error = spa_vdev_detach(spa, oldguid, pguid, B_FALSE);
 		if (error != 0 && error != ENODEV && error != EBUSY &&
 		    error != ENOTSUP && error != ZFS_ERR_CHECKPOINT_EXISTS &&
-		    error != ZFS_ERR_DISCARDING_CHECKPOINT)
+		    error != ZFS_ERR_DISCARDING_CHECKPOINT &&
+		    !ZTEST_HFE_ACTIVE()) {
 			fatal(B_FALSE, "detach (%s) returned %d",
 			    oldpath, error);
+		}
 		goto out;
 	}
 
@@ -4327,7 +4329,8 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	    error == ZFS_ERR_REBUILD_IN_PROGRESS)
 		expected_error = error;
 
-	if (error != expected_error && expected_error != EBUSY) {
+	if (error != expected_error && expected_error != EBUSY &&
+	    !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE, "attach (%s %"PRIu64", %s %"PRIu64", %d) "
 		    "returned %d, expected %d",
 		    oldpath, oldsize, newpath,

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3305,7 +3305,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 *	an export concurrently.
 	 */
 	VERIFY0(spa_open(zo->zo_pool, &spa, FTAG));
-	int error = spa_destroy(zo->zo_pool);
+	int error = spa_destroy(zo->zo_pool, B_FALSE, B_FALSE);
 	if (error != EBUSY && error != ZFS_ERR_EXPORT_IN_PROGRESS) {
 		fatal(B_FALSE, "spa_destroy(%s) returned unexpected value %d",
 		    spa->spa_name, error);
@@ -3357,7 +3357,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Clean up from previous runs.
 	 */
-	(void) spa_destroy(name);
+	(void) spa_destroy(name, B_FALSE, B_FALSE);
 
 	raidz_children = ztest_get_raidz_children(ztest_spa);
 
@@ -3811,7 +3811,7 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 	}
 
 	/* clean up the old pool, if any */
-	(void) spa_destroy("splitp");
+	(void) spa_destroy("splitp", B_FALSE, B_FALSE);
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 
@@ -7660,7 +7660,7 @@ ztest_spa_import_export(char *oldname, char *newname)
 	/*
 	 * Clean up from previous runs.
 	 */
-	(void) spa_destroy(newname);
+	(void) spa_destroy(newname, B_FALSE, B_FALSE);
 
 	/*
 	 * Get the pool's configuration and guid.
@@ -9121,7 +9121,7 @@ ztest_init(ztest_shared_t *zs)
 	/*
 	 * Create the storage pool.
 	 */
-	(void) spa_destroy(ztest_opts.zo_pool);
+	(void) spa_destroy(ztest_opts.zo_pool, B_FALSE, B_FALSE);
 	ztest_shared->zs_vdev_next_leaf = 0;
 	zs->zs_splits = 0;
 	zs->zs_mirrors = ztest_opts.zo_mirrors;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2128,6 +2128,8 @@ ztest_tx_assign(dmu_tx_t *tx, dmu_tx_flag_t txg_how, const char *tag)
 	/*
 	 * Attempt to assign tx to some transaction group.
 	 */
+	if ((txg_how & DMU_TX_WAIT) && ztest_random(2) == 0)
+		txg_how |= DMU_TX_SUSPEND;
 	error = dmu_tx_assign(tx, txg_how);
 	if (error) {
 		if (error == ERESTART) {

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6900,6 +6900,9 @@ ztest_dmu_snapshot_hold(ztest_ds_t *zd, uint64_t id)
 	char osname[ZFS_MAX_DATASET_NAME_LEN];
 	nvlist_t *holds;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
 
 	dmu_objset_name(os, osname);
@@ -7007,6 +7010,7 @@ ztest_dmu_snapshot_hold(ztest_ds_t *zd, uint64_t id)
 
 out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	mutex_exit(&ztest_hfe_lock);
 }
 
 /*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4876,7 +4876,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Make sure we were able to grow the vdev.
 	 */
-	if (new_ms_count <= old_ms_count) {
+	if (new_ms_count <= old_ms_count && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE,
 		    "LUN expansion failed: ms_count %"PRIu64" < %"PRIu64"\n",
 		    old_ms_count, new_ms_count);
@@ -4885,7 +4885,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Make sure we were able to grow the pool.
 	 */
-	if (new_class_space <= old_class_space) {
+	if (new_class_space <= old_class_space && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE,
 		    "LUN expansion failed: class_space %"PRIu64" < %"PRIu64"\n",
 		    old_class_space, new_class_space);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3848,8 +3848,10 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 
 	if (error == ENOSPC)
 		ztest_record_enospc("spa_vdev_add");
-	else if (error != 0)
-		fatal(B_FALSE, "spa_vdev_add() = %d", error);
+	else if (error != 0 && !ZTEST_HFE_ACTIVE()) {
+		fatal(B_FALSE, "%s: spa_vdev_add() = %d", __func__,
+		    error);
+	}
 
 	/*
 	 * 50% of the time allow small blocks in the special class
@@ -3860,7 +3862,8 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 			(void) printf("Enabling special VDEV small blocks\n");
 		error = ztest_dsl_prop_set_uint64(zd->zd_name,
 		    ZFS_PROP_SPECIAL_SMALL_BLOCKS, 32768, B_FALSE);
-		ASSERT(error == 0 || error == ENOSPC);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT(error == 0 || error == ENOSPC);
 	}
 
 	mutex_exit(&ztest_vdev_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3545,6 +3545,9 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	if (strcmp(ztest_opts.zo_raid_type, VDEV_TYPE_DRAID) == 0)
 		return;
 
+	if (!mutex_tryenter(&ztest_hfe_lock))
+		return;
+
 	mutex_enter(&ztest_vdev_lock);
 	name = kmem_asprintf("%s_upgrade", ztest_opts.zo_pool);
 
@@ -3608,6 +3611,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 
 	kmem_strfree(name);
 	mutex_exit(&ztest_vdev_lock);
+	mutex_exit(&ztest_hfe_lock);
 }
 
 static void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4903,8 +4903,10 @@ ztest_objset_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 	/*
 	 * Create the objects common to all ztest datasets.
 	 */
-	VERIFY0(zap_create_claim(os, ZTEST_DIROBJ,
-	    DMU_OT_ZAP_OTHER, DMU_OT_NONE, 0, tx));
+	int err = zap_create_claim(os, ZTEST_DIROBJ,
+	    DMU_OT_ZAP_OTHER, DMU_OT_NONE, 0, tx);
+	if (!ZTEST_HFE_ACTIVE())
+		VERIFY0(err);
 }
 
 static int
@@ -4995,9 +4997,16 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	/*
 	 * Verify that the dataset contains a directory object.
 	 */
-	VERIFY0(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE,
-	    B_TRUE, FTAG, &os));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE,
+	    B_TRUE, FTAG, &os);
+	if (error && ZTEST_HFE_ACTIVE())
+		return (error);
+	VERIFY0(error);
 	error = dmu_object_info(os, ZTEST_DIROBJ, &doi);
+	if (!(error == ENOENT || error == 0) && ZTEST_HFE_ACTIVE()) {
+		dmu_objset_disown(os, B_TRUE, FTAG);
+		return (EIO);
+	}
 	if (error != ENOENT) {
 		/* We could have crashed in the middle of destroying it */
 		ASSERT0(error);
@@ -5011,6 +5020,8 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	 */
 	if (strchr(name, '@') != NULL) {
 		error = dsl_destroy_snapshot(name, B_TRUE);
+		if (!(error == ECHRNG || error == 0) && ZTEST_HFE_ACTIVE())
+			return (EIO);
 		if (error != ECHRNG) {
 			/*
 			 * The program was executed, but encountered a runtime
@@ -5021,6 +5032,9 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 		}
 	} else {
 		error = dsl_destroy_head(name);
+		if (!(error == ENOSPC || error == EBUSY || error == 0) &&
+		    ZTEST_HFE_ACTIVE())
+			return (EIO);
 		if (error == ENOSPC) {
 			/* There could be checkpoint or insufficient slop */
 			ztest_record_enospc(FTAG);
@@ -5073,11 +5087,12 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd;
 	ztest_ds_t *zdtmp;
+	boolean_t zdtmp_inited = B_FALSE;
 	int iters;
 	int error;
-	objset_t *os, *os2;
+	objset_t *os = NULL, *os2;
 	char name[ZFS_MAX_DATASET_NAME_LEN];
-	zilog_t *zilog;
+	zilog_t *zilog = NULL;
 	int i;
 
 	zdtmp = umem_alloc(sizeof (ztest_ds_t), UMEM_NOFAIL);
@@ -5099,6 +5114,7 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 		zil_replay(os, zdtmp, ztest_replay_vector);
 		ztest_zd_fini(zdtmp);
 		dmu_objset_disown(os, B_TRUE, FTAG);
+		os = NULL;
 	}
 
 	/*
@@ -5106,8 +5122,10 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 * create lying around from a previous run.  If so, destroy it
 	 * and all of its snapshots.
 	 */
-	(void) dmu_objset_find(name, ztest_objset_destroy_cb, NULL,
+	error = dmu_objset_find(name, ztest_objset_destroy_cb, NULL,
 	    DS_FIND_CHILDREN | DS_FIND_SNAPSHOTS);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	/*
 	 * Verify that the destroyed dataset is no longer in the namespace.
@@ -5116,10 +5134,12 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE, B_TRUE,
 	    FTAG, &os);
 	if (error == 0) {
-		dmu_objset_disown(os, B_TRUE, FTAG);
 		ztest_record_enospc(FTAG);
 		goto out;
 	}
+	os = NULL;
+	if (error != ENOENT && ZTEST_HFE_ACTIVE())
+		goto out;
 	VERIFY3U(ENOENT, ==, error);
 
 	/*
@@ -5131,13 +5151,21 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc(FTAG);
 			goto out;
 		}
+		if (ZTEST_HFE_ACTIVE())
+			goto out;
 		fatal(B_FALSE, "dmu_objset_create(%s) = %d", name, error);
 	}
 
-	VERIFY0(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
-	    FTAG, &os));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
+	    FTAG, &os);
+	if (error && ZTEST_HFE_ACTIVE()) {
+		os = NULL;
+		goto out;
+	}
+	VERIFY0(error);
 
 	ztest_zd_init(zdtmp, NULL, os);
+	zdtmp_inited = B_TRUE;
 
 	/*
 	 * Open the intent log for it.
@@ -5151,34 +5179,45 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	iters = ztest_random(5);
 	for (i = 0; i < iters; i++) {
 		ztest_dmu_object_alloc_free(zdtmp, id);
-		if (ztest_random(iters) == 0)
+		if (ztest_random(iters) == 0) {
 			(void) ztest_snapshot_create(name, i);
+		}
 	}
 
 	/*
 	 * Verify that we cannot create an existing dataset.
 	 */
-	VERIFY3U(EEXIST, ==,
-	    dmu_objset_create(name, DMU_OST_OTHER, 0, NULL, NULL, NULL));
+	error = dmu_objset_create(name, DMU_OST_OTHER, 0, NULL, NULL, NULL);
+	if (!(error == EEXIST) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3U(error, ==, EEXIST);
 
 	/*
 	 * Verify that we can hold an objset that is also owned.
 	 */
-	VERIFY0(dmu_objset_hold(name, FTAG, &os2));
+	error = dmu_objset_hold(name, FTAG, &os2);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	dmu_objset_rele(os2, FTAG);
 
 	/*
 	 * Verify that we cannot own an objset that is already owned.
 	 */
-	VERIFY3U(EBUSY, ==, ztest_dmu_objset_own(name, DMU_OST_OTHER,
-	    B_FALSE, B_TRUE, FTAG, &os2));
+	error = ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
+	    FTAG, &os2);
+	if (!(error == EBUSY) && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3U(error, ==, EBUSY);
 
-	zil_close(zilog);
-	dmu_objset_disown(os, B_TRUE, FTAG);
-	ztest_zd_fini(zdtmp);
 out:
+	if (zilog)
+		zil_close(zilog);
+	if (os)
+		dmu_objset_disown(os, B_TRUE, FTAG);
+	if (zdtmp_inited)
+		ztest_zd_fini(zdtmp);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
-
 	umem_free(zdtmp, sizeof (ztest_ds_t));
 }
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3448,9 +3448,12 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	ztest_shared_opts_t *zo = &ztest_opts;
 	spa_t *spa;
 	nvlist_t *nvroot;
+	int err;
 
 	if (zo->zo_mmp_test)
 		return;
+
+	mutex_enter(&ztest_vdev_lock);
 
 	/*
 	 * Attempt to create using a bad file.
@@ -3489,15 +3492,21 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 *	For the case that there is another ztest thread doing
 	 *	an export concurrently.
 	 */
-	VERIFY0(spa_open(zo->zo_pool, &spa, FTAG));
+	err = spa_open(zo->zo_pool, &spa, FTAG);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(err);
 	int error = spa_destroy(zo->zo_pool, B_FALSE, B_FALSE);
-	if (error != EBUSY && error != ZFS_ERR_EXPORT_IN_PROGRESS) {
+	if (error != EBUSY && error != EAGAIN &&
+	    error != ZFS_ERR_EXPORT_IN_PROGRESS && !ZTEST_HFE_ACTIVE()) {
 		fatal(B_FALSE, "spa_destroy(%s) returned unexpected value %d",
 		    spa->spa_name, error);
 	}
 	spa_close(spa, FTAG);
 
+out:
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	mutex_exit(&ztest_vdev_lock);
 }
 
 static int

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8163,7 +8163,8 @@ ztest_trim(ztest_ds_t *zd, uint64_t id)
 	spa_config_exit(spa, SCL_VDEV, FTAG);
 
 	uint64_t cmd = ztest_random(POOL_TRIM_FUNCS);
-	uint64_t rate = 1 << ztest_random(30);
+	/* Do not use very small rate not to slow the things down very much. */
+	uint64_t rate = (1 << 16) << ztest_random(30 - 16);
 	boolean_t partial = (ztest_random(5) > 0);
 	boolean_t secure = (ztest_random(5) > 0);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7614,15 +7614,15 @@ ztest_reguid(ztest_ds_t *zd, uint64_t id)
 	if (ztest_opts.zo_mmp_test)
 		return;
 
+	(void) pthread_rwlock_wrlock(&ztest_name_lock);
 	orig = spa_guid(spa);
 	load = spa_load_guid(spa);
-
-	(void) pthread_rwlock_wrlock(&ztest_name_lock);
 	error = spa_change_guid(spa, NULL);
-	zs->zs_guid = spa_guid(spa);
+	if (error == 0)
+		zs->zs_guid = spa_guid(spa);
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 
-	if (error != 0)
+	if (error != 0 || ZTEST_HFE_ACTIVE())
 		return;
 
 	if (ztest_opts.zo_verbose >= 4) {

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8232,7 +8232,7 @@ ztest_ddt_prune(ztest_ds_t *zd, uint64_t id)
  * Verify pool integrity by running zdb.
  */
 static void
-ztest_run_zdb(uint64_t guid)
+ztest_run_zdb(const char *pool_name)
 {
 	int status;
 	char *bin;
@@ -8256,13 +8256,13 @@ ztest_run_zdb(uint64_t guid)
 	free(set_gvars_args);
 
 	size_t would = snprintf(zdb, len,
-	    "%s -bcc%s%s -G -d -Y -e -y %s -p %s %"PRIu64,
+	    "%s -bcc%s%s -G -d -Y -e -y %s -p %s %s",
 	    bin,
 	    ztest_opts.zo_verbose >= 3 ? "s" : "",
 	    ztest_opts.zo_verbose >= 4 ? "v" : "",
 	    set_gvars_args_joined,
 	    ztest_opts.zo_dir,
-	    guid);
+	    pool_name);
 	ASSERT3U(would, <, len);
 
 	umem_free(set_gvars_args_joined, strlen(set_gvars_args_joined) + 1);
@@ -9276,9 +9276,9 @@ ztest_import(ztest_shared_t *zs)
 	kernel_fini();
 
 	if (!ztest_opts.zo_mmp_test) {
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(spa->spa_name);
 		ztest_freeze();
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(spa->spa_name);
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
@@ -9948,9 +9948,9 @@ ztest_init(ztest_shared_t *zs)
 	kernel_fini();
 
 	if (!ztest_opts.zo_mmp_test) {
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(ztest_opts.zo_pool);
 		ztest_freeze();
-		ztest_run_zdb(zs->zs_guid);
+		ztest_run_zdb(ztest_opts.zo_pool);
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
@@ -10409,7 +10409,7 @@ main(int argc, char **argv)
 		}
 
 		if (!ztest_opts.zo_mmp_test)
-			ztest_run_zdb(zs->zs_guid);
+			ztest_run_zdb(ztest_opts.zo_pool);
 		if (ztest_shared_opts->zo_raidz_expand_test ==
 		    RAIDZ_EXPAND_CHECKED)
 			break; /* raidz expand test complete */

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3704,7 +3704,7 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 {
 	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
-	spa_t *spa = ztest_spa;
+	spa_t *spa;
 	uint64_t leaves;
 	uint64_t guid;
 	uint64_t raidz_children;
@@ -3716,6 +3716,7 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		return;
 
 	mutex_enter(&ztest_vdev_lock);
+	spa = ztest_spa;
 	raidz_children = ztest_get_raidz_children(spa);
 	leaves = MAX(zs->zs_mirrors + zs->zs_splits, 1) * raidz_children;
 
@@ -3761,6 +3762,8 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		case ZFS_ERR_DISCARDING_CHECKPOINT:
 			break;
 		default:
+			if (ZTEST_HFE_ACTIVE())
+				break;
 			fatal(B_FALSE, "spa_vdev_remove() = %d", error);
 		}
 	} else {
@@ -3784,7 +3787,10 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 			ztest_record_enospc("spa_vdev_add");
 			break;
 		default:
-			fatal(B_FALSE, "spa_vdev_add() = %d", error);
+			if (ZTEST_HFE_ACTIVE())
+				break;
+			fatal(B_FALSE, "%s: spa_vdev_add() = %d", __func__,
+			    error);
 		}
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2365,9 +2365,9 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	char *name = (char *)&lrc->lr_data[0];		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	ztest_block_tag_t *bbt;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	dmu_tx_t *tx;
-	uint64_t txg;
+	uint64_t txg = 0;
 	int error = 0;
 	int bonuslen;
 
@@ -2415,6 +2415,8 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 			    bonuslen, lr->lrz_dnodesize, tx);
 		}
 	}
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
 
 	if (error) {
 		ASSERT3U(error, ==, EEXIST);
@@ -2425,26 +2427,45 @@ ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 
 	ASSERT3U(lr->lr_foid, !=, 0);
 
-	if (lr->lrz_type != DMU_OT_ZAP_OTHER)
-		VERIFY0(dmu_object_set_blocksize(os, lr->lr_foid,
-		    lr->lrz_blocksize, lr->lrz_ibshift, tx));
+	if (lr->lrz_type != DMU_OT_ZAP_OTHER) {
+		error = dmu_object_set_blocksize(os, lr->lr_foid,
+		    lr->lrz_blocksize, lr->lrz_ibshift, tx);
+		if (error && ZTEST_HFE_ACTIVE())
+			goto out;
+		VERIFY0(error);
+	}
 
-	VERIFY0(dmu_bonus_hold(os, lr->lr_foid, FTAG, &db));
+	error = dmu_bonus_hold(os, lr->lr_foid, FTAG, &db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	bbt = ztest_bt_bonus(db);
 	dmu_buf_will_dirty(db, tx);
+	if (ZTEST_HFE_ACTIVE()) {
+		error = EIO;
+		goto out;
+	}
 	ztest_bt_generate(bbt, os, lr->lr_foid, lr->lrz_dnodesize, -1ULL,
 	    lr->lr_gen, txg, txg);
 	ztest_fill_unused_bonus(db, bbt, lr->lr_foid, os, lr->lr_gen);
 	dmu_buf_rele(db, FTAG);
+	db = NULL;
 
-	VERIFY0(zap_add(os, lr->lr_doid, name, sizeof (uint64_t), 1,
-	    &lr->lr_foid, tx));
+	error = zap_add(os, lr->lr_doid, name, sizeof (uint64_t), 1,
+	    &lr->lr_foid, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	(void) ztest_log_create(zd, tx, lrc);
 
-	dmu_tx_commit(tx);
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2456,7 +2477,8 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 	objset_t *os = zd->zd_os;
 	dmu_object_info_t doi;
 	dmu_tx_t *tx;
-	uint64_t object, txg;
+	uint64_t object = 0, txg = 0;
+	int error = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -2464,13 +2486,18 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 	ASSERT3U(lr->lr_doid, ==, ZTEST_DIROBJ);
 	ASSERT3S(name[0], !=, '\0');
 
-	VERIFY0(
-	    zap_lookup(os, lr->lr_doid, name, sizeof (object), 1, &object));
+	error = zap_lookup(os, lr->lr_doid, name, sizeof (object), 1, &object);
+	if (error && ZTEST_HFE_ACTIVE())
+		return (error);
+	VERIFY0(error);
 	ASSERT3U(object, !=, 0);
 
 	ztest_object_lock(zd, object, ZTRL_WRITER);
 
-	VERIFY0(dmu_object_info(os, object, &doi));
+	error = dmu_object_info(os, object, &doi);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	tx = dmu_tx_create(os);
 
@@ -2479,25 +2506,33 @@ ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 
 	txg = ztest_tx_assign(tx, DMU_TX_WAIT, FTAG);
 	if (txg == 0) {
-		ztest_object_unlock(zd, object);
-		return (ENOSPC);
+		error = ENOSPC;
+		goto out;
 	}
 
 	if (doi.doi_type == DMU_OT_ZAP_OTHER) {
-		VERIFY0(zap_destroy(os, object, tx));
+		error = zap_destroy(os, object, tx);
 	} else {
-		VERIFY0(dmu_object_free(os, object, tx));
+		error = dmu_object_free(os, object, tx);
 	}
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
-	VERIFY0(zap_remove(os, lr->lr_doid, name, tx));
+	error = zap_remove(os, lr->lr_doid, name, tx);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	(void) ztest_log_remove(zd, tx, lr, object);
 
-	dmu_tx_commit(tx);
+out:
+	if (txg != 0)
+		dmu_tx_commit(tx);
 
 	ztest_object_unlock(zd, object);
 
-	return (0);
+	return (error);
 }
 
 static int
@@ -2887,7 +2922,8 @@ ztest_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 
 		error = dmu_read(os, object, offset, size, buf,
 		    DMU_READ_NO_PREFETCH | DMU_KEEP_CACHING);
-		ASSERT0(error);
+		if (!ZTEST_HFE_ACTIVE())
+			ASSERT0(error);
 	} else {
 		ASSERT3P(zio, !=, NULL);
 		size = doi.doi_data_block_size;
@@ -3336,21 +3372,25 @@ ztest_zil_commit(ztest_ds_t *zd, uint64_t id)
 {
 	(void) id;
 	zilog_t *zilog = zd->zd_zilog;
+	int err;
 
 	(void) pthread_rwlock_rdlock(&zd->zd_zilog_lock);
 
-	VERIFY0(zil_commit(zilog, ztest_random(ZTEST_OBJECTS)));
+	err = zil_commit(zilog, ztest_random(ZTEST_OBJECTS));
 
 	/*
 	 * Remember the committed values in zd, which is in parent/child
 	 * shared memory.  If we die, the next iteration of ztest_run()
 	 * will verify that the log really does contain this record.
 	 */
-	mutex_enter(&zilog->zl_lock);
-	ASSERT3P(zd->zd_shared, !=, NULL);
-	ASSERT3U(zd->zd_shared->zd_seq, <=, zilog->zl_commit_lr_seq);
-	zd->zd_shared->zd_seq = zilog->zl_commit_lr_seq;
-	mutex_exit(&zilog->zl_lock);
+	if (!err && !ZTEST_HFE_ACTIVE()) {
+		mutex_enter(&zilog->zl_lock);
+		ASSERT3P(zd->zd_shared, !=, NULL);
+		ASSERT3U(zd->zd_shared->zd_seq, <=, zilog->zl_commit_lr_seq);
+		if (zilog->zl_commit_lr_seq > zd->zd_shared->zd_seq)
+			zd->zd_shared->zd_seq = zilog->zl_commit_lr_seq;
+		mutex_exit(&zilog->zl_lock);
+	}
 
 	(void) pthread_rwlock_unlock(&zd->zd_zilog_lock);
 }
@@ -3365,6 +3405,7 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 {
 	(void) id;
 	objset_t *os = zd->zd_os;
+	zilog_t *ret;
 
 	/*
 	 * We hold the ztest_vdev_lock so we don't cause problems with
@@ -3383,11 +3424,17 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 
 	/* zfsvfs_teardown() */
 	zil_close(zd->zd_zilog);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
 
 	/* zfsvfs_setup() */
-	VERIFY3P(zil_open(os, ztest_get_data, NULL), ==, zd->zd_zilog);
+	ret = zil_open(os, ztest_get_data, NULL);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY3P(ret, ==, zd->zd_zilog);
 	zil_replay(os, zd, ztest_replay_vector);
 
+out:
 	(void) pthread_rwlock_unlock(&zd->zd_zilog_lock);
 	mutex_exit(&zd->zd_dirobj_lock);
 	mutex_exit(&ztest_vdev_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4630,7 +4630,8 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	 */
 	error = spa_scan(spa, POOL_SCAN_SCRUB, 0);
 	if (error == 0) {
-		while (dsl_scan_scrubbing(spa_get_dsl(spa)))
+		while (dsl_scan_scrubbing(spa_get_dsl(spa)) &&
+		    !ZTEST_HFE_ACTIVE())
 			txg_wait_synced(spa_get_dsl(spa), 0);
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3068,7 +3068,7 @@ ztest_create(ztest_ds_t *zd, ztest_od_t *od, int count)
 		lr->lr_gen = od->od_crgen;
 		lr->lr_crtime[0] = time(NULL);
 
-		if (ztest_replay_create(zd, lr, B_FALSE) != 0) {
+		if (ztest_replay_create(zd, lrc, B_FALSE) != 0) {
 			ASSERT0(missing);
 			od->od_object = 0;
 			missing++;
@@ -3080,7 +3080,7 @@ ztest_create(ztest_ds_t *zd, ztest_od_t *od, int count)
 			ASSERT3U(od->od_object, !=, 0);
 		}
 
-		ztest_lr_free(lr, sizeof (*lr), od->od_name);
+		ztest_lr_free(lrc, sizeof (*lrc), od->od_name);
 	}
 
 	return (missing);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -9954,6 +9954,12 @@ main(int argc, char **argv)
 	 */
 	zfs_reconstruct_indirect_damage_fraction = 100;
 
+	/*
+	 * Ask zio_flush() to propagate errors. Required for zil testing
+	 * during the hardforced export scenario.
+	 */
+	zio_flush_err_propagation = B_TRUE;
+
 	action.sa_handler = sig_handler;
 	sigemptyset(&action.sa_mask);
 	action.sa_flags = 0;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3632,6 +3632,8 @@ ztest_spa_checkpoint(spa_t *spa)
 		ztest_record_enospc(FTAG);
 		break;
 	default:
+		if (ZTEST_HFE_ACTIVE())
+			break;
 		fatal(B_FALSE, "spa_checkpoint(%s) = %d", spa->spa_name, error);
 	}
 }
@@ -3649,6 +3651,8 @@ ztest_spa_discard_checkpoint(spa_t *spa)
 	case ZFS_ERR_NO_CHECKPOINT:
 		break;
 	default:
+		if (ZTEST_HFE_ACTIVE())
+			break;
 		fatal(B_FALSE, "spa_discard_checkpoint(%s) = %d",
 		    spa->spa_name, error);
 	}

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5343,7 +5343,7 @@ ztest_dmu_object_alloc_free(ztest_ds_t *zd, uint64_t id)
 		return;
 	}
 
-	while (ztest_random(4 * batchsize) != 0)
+	while (ztest_random(4 * batchsize) != 0 && !ZTEST_HFE_ACTIVE())
 		ztest_io(zd, od[ztest_random(batchsize)].od_object,
 		    ztest_random(ZTEST_RANGE_LOCKS) << SPA_MAXBLOCKSHIFT);
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -88,6 +88,8 @@
 #include <sys/dbuf.h>
 #include <sys/zap.h>
 #include <sys/dmu_objset.h>
+#include <sys/dmu_recv.h>
+#include <sys/dmu_send.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
 #include <sys/systeminfo.h>
@@ -478,6 +480,7 @@ ztest_func_t ztest_ddt_prune;
 ztest_func_t ztest_spa_log_flushall_start;
 ztest_func_t ztest_spa_log_flushall_cancel;
 ztest_func_t ztest_hardforced_export;
+ztest_func_t ztest_send_recv;
 
 static uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 static uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -537,6 +540,7 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_spa_log_flushall_start, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_log_flushall_cancel, 1, &zopt_rarely),
 	ZTI_INIT(ztest_hardforced_export, 1, &zopt_rarely),
+	ZTI_INIT(ztest_send_recv, 1, &zopt_sometimes),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
@@ -593,6 +597,12 @@ static kmutex_t ztest_vdev_lock;
 static boolean_t ztest_device_removal_active = B_FALSE;
 static boolean_t ztest_pool_scrubbed = B_FALSE;
 static kmutex_t ztest_checkpoint_lock;
+
+/* Send-recv test scenario state. */
+static kmutex_t ztest_sr_lock;
+static uint64_t ztest_sr_send0_guid;
+static uint64_t ztest_sr_bytes_sent;
+static char *ztest_sr_zstream_path;
 
 /* Hardforced export test scenario state. */
 enum {
@@ -7574,6 +7584,234 @@ ztest_hardforced_export(ztest_ds_t *zd, uint64_t id)
 	mutex_exit(&ztest_hfe_lock);
 }
 
+static int
+ztest_sr_dump_bytes(objset_t *os, void *buf, int len, void *arg)
+{
+	(void) os;
+	int fd = *(int *)arg;
+	char *p = buf;
+	ssize_t cnt;
+
+	while (len > 0) {
+		cnt = write(fd, p, len);
+		if (cnt < 0)
+			return (EIO);
+		ztest_sr_bytes_sent += cnt;
+		p += cnt;
+		len -= cnt;
+	}
+
+	return (0);
+}
+
+static void
+ztest_send(ztest_ds_t *zd, uint64_t id)
+{
+	(void) id;
+	objset_t *snap;
+	uint64_t tosnap;
+	char snapname[ZFS_MAX_DATASET_NAME_LEN];
+	int fd;
+	int err;
+
+	(void) snprintf(snapname, sizeof (snapname), "%s@%s",
+	    zd->zd_name, "send0");
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	err = dmu_objset_snapshot_one(zd->zd_name, "send0");
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+	if (err == ENOSPC) {
+		ztest_record_enospc(FTAG);
+		goto out;
+	}
+	ASSERT0(err);
+
+	err = dmu_objset_hold(snapname, FTAG, &snap);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+	tosnap = dsl_get_objsetid(snap->os_dsl_dataset);
+	ztest_sr_send0_guid = dsl_get_guid(snap->os_dsl_dataset);
+	dmu_objset_rele(snap, FTAG);
+
+	if (ztest_sr_zstream_path != NULL)
+		umem_free(ztest_sr_zstream_path, MAXPATHLEN);
+	ztest_sr_zstream_path = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
+	(void) snprintf(ztest_sr_zstream_path, MAXPATHLEN,
+	    "%s/ztest.zstream", ztest_opts.zo_dir);
+	fd = open(ztest_sr_zstream_path,
+	    O_RDWR | O_CREAT | O_TRUNC, 0666);
+	ASSERT3S(fd, !=, -1);
+
+	ztest_sr_bytes_sent = 0;
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: sending %s (tosnap=%lu)...\n", __func__,
+		    snapname, tosnap);
+
+	offset_t off = 0;
+	const boolean_t embedok = B_TRUE;
+	const boolean_t large_block_ok = B_TRUE;
+	const boolean_t compressok = B_TRUE;
+	const boolean_t rawok = B_FALSE;
+	const boolean_t savedok = B_FALSE;
+	dmu_send_outparams_t out = {
+		.dso_outfunc = ztest_sr_dump_bytes,
+		.dso_arg = &fd,
+		.dso_dryrun = B_FALSE,
+	};
+	err = dmu_send_obj(zd->zd_name, tosnap,
+	    0, embedok, large_block_ok, compressok,
+	    rawok, savedok, fd, &off, &out);
+	if (ztest_opts.zo_verbose >= 5)
+		printf("ztest_send: dmu_send_obj() err=%d\n", err);
+	(void) close(fd);
+	if (ZTEST_HFE_ACTIVE()) {
+		umem_free(ztest_sr_zstream_path, MAXPATHLEN);
+		ztest_sr_zstream_path = NULL;
+		goto out;
+	}
+	ASSERT0(err);
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+out:
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (bytes_sent=%lu, hfe=%d, err=%d)\n",
+		    __func__, ztest_sr_bytes_sent, ZTEST_HFE_ACTIVE(), err);
+}
+
+static void
+ztest_recv(ztest_ds_t *zd, uint64_t id)
+{
+	(void) id;
+	char tofs[ZFS_MAX_DATASET_NAME_LEN];
+	char snapname[ZFS_MAX_DATASET_NAME_LEN];
+	objset_t *snap;
+	const char *tosnap;
+	int fd = -1;
+	int err;
+
+	ASSERT(ztest_sr_zstream_path);
+
+	(void) snprintf(tofs, sizeof (tofs), "%s_recv", zd->zd_name);
+	tosnap = "recv0";
+	(void) snprintf(snapname, sizeof (snapname), "%s_recv@%s",
+	    zd->zd_name, "recv0");
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	err = dsl_destroy_head(tofs);
+	if (ZTEST_HFE_ACTIVE()) {
+		(void) pthread_rwlock_unlock(&ztest_name_lock);
+		goto out;
+	}
+	ASSERT(err == 0 || err == ENOENT);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: receiving %s@%s...\n", __func__, tofs,
+		    tosnap);
+
+	fd = open(ztest_sr_zstream_path, O_RDONLY);
+	ASSERT3S(fd, !=, -1);
+	zfs_file_t input_fp = { .f_fd = fd };
+
+	offset_t off = 0;
+	dmu_replay_record_t drr;
+	memset(&drr, 0, sizeof (drr));
+	char *buf = (char *)&drr;
+	int total = 0;
+	while (total < sizeof (drr)) {
+		ssize_t n = read(input_fp.f_fd, buf + total,
+		    sizeof (drr) - total);
+		if (n <= 0)
+			break;
+		total += n;
+	}
+	ASSERT3S(total, ==, sizeof (drr));
+
+	dmu_recv_cookie_t drc;
+	err = dmu_recv_begin(tofs, tosnap, &drr, B_FALSE, B_FALSE,
+	    B_FALSE, NULL, NULL, NULL, &drc, &input_fp,
+	    &off);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+
+	err = dmu_recv_stream(&drc, &off);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+
+	err = dmu_recv_end(&drc, NULL);
+	if (ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+
+	/* Expect the same number of bytes received */
+	drc.drc_bytes_read += sizeof (drr);
+	ASSERT3U(drc.drc_bytes_read, ==, ztest_sr_bytes_sent);
+
+	/* Expect the same GUID of the replica */
+	err = dmu_objset_hold(snapname, FTAG, &snap);
+	if (err && ZTEST_HFE_ACTIVE())
+		goto out;
+	ASSERT0(err);
+	ASSERT3U(ztest_sr_send0_guid, ==, dsl_get_guid(snap->os_dsl_dataset));
+	dmu_objset_rele(snap, FTAG);
+
+	(void) pthread_rwlock_rdlock(&ztest_name_lock);
+	err = dsl_destroy_snapshot(snapname, B_FALSE);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	err = dsl_destroy_head(tofs);
+	if (!ZTEST_HFE_ACTIVE())
+		ASSERT0(err);
+	(void) pthread_rwlock_unlock(&ztest_name_lock);
+
+out:
+	if (ztest_opts.zo_verbose >= 5)
+		(void) printf("%s: finished (bytes_read=%lu, hfe=%d, err=%d)\n",
+		    __func__, drc.drc_bytes_read, ZTEST_HFE_ACTIVE(), err);
+	if (fd != -1)
+		close(fd);
+}
+
+void
+ztest_send_recv(ztest_ds_t *zd, uint64_t id)
+{
+	if (!mutex_tryenter(&ztest_sr_lock))
+		return;
+
+	/*
+	 * We want to stress recv more than send, as most of the potential
+	 * troubles are there. Thus, we create a zstream once and reuse it
+	 * during the same ztest pass.
+	 */
+	if (ztest_sr_zstream_path == NULL)
+		ztest_send(zd, id);
+	else
+		ztest_recv(zd, id);
+
+	mutex_exit(&ztest_sr_lock);
+}
+
 /*
  * By design ztest will never inject uncorrectable damage in to the pool.
  * Issue a scrub, wait for it to complete, and verify there is never any
@@ -9620,6 +9858,7 @@ ztest_run(ztest_shared_t *zs)
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_sr_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	zs->zs_thread_start = gethrtime();
@@ -9804,6 +10043,7 @@ ztest_run(ztest_shared_t *zs)
 	list_destroy(&zcl.zcl_callbacks);
 	mutex_destroy(&zcl.zcl_callbacks_lock);
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_sr_lock);
 	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
@@ -9871,6 +10111,7 @@ ztest_init(ztest_shared_t *zs)
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_hfe_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_sr_lock, NULL, MUTEX_DEFAULT, NULL);
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	raidz_scratch_verify();
@@ -9956,6 +10197,7 @@ ztest_init(ztest_shared_t *zs)
 	}
 
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_sr_lock);
 	mutex_destroy(&ztest_hfe_lock);
 	mutex_destroy(&ztest_vdev_lock);
 	mutex_destroy(&ztest_checkpoint_lock);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -5754,23 +5754,27 @@ void
 ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 {
 	objset_t *os = zd->zd_os;
-	ztest_od_t *od;
+	ztest_od_t *od = NULL;
 	dmu_tx_t *tx;
-	uint64_t i;
+	uint64_t i, j;
 	int error;
 	int size;
-	uint64_t n, s, txg;
-	bufwad_t *packbuf, *bigbuf;
+	uint64_t n, s, txg = 0;
+	bufwad_t *packbuf = NULL, *bigbuf = NULL;
 	uint64_t packobj, packoff, packsize, bigobj, bigoff, bigsize;
 	uint64_t blocksize = ztest_random_blocksize();
 	uint64_t chunksize = blocksize;
 	uint64_t regions = 997;
 	uint64_t stride = 123456789ULL;
 	uint64_t width = 9;
-	dmu_buf_t *bonus_db;
-	arc_buf_t **bigbuf_arcbufs;
+	dmu_buf_t *bonus_db = NULL;
+	arc_buf_t **bigbuf_arcbufs = NULL;
+	boolean_t *arcs_to_return = NULL;
 	dmu_object_info_t doi;
 	uint32_t dmu_read_flags = DMU_READ_PREFETCH;
+	void *packcheck = NULL;
+	void *bigcheck = NULL;
+	dmu_buf_t *dbt = NULL;
 
 	/*
 	 * We will randomly set when to do O_DIRECT on a read.
@@ -5816,7 +5820,10 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	chunksize = blocksize;
 	ASSERT3U(chunksize, ==, od[1].od_gen);
 
-	VERIFY0(dmu_object_info(os, bigobj, &doi));
+	error = dmu_object_info(os, bigobj, &doi);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 	VERIFY(ISP2(doi.doi_data_block_size));
 	VERIFY3U(chunksize, ==, doi.doi_data_block_size);
 	VERIFY3U(chunksize, >=, 2 * sizeof (bufwad_t));
@@ -5836,9 +5843,13 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	packbuf = umem_zalloc(packsize, UMEM_NOFAIL);
 	bigbuf = umem_zalloc(bigsize, UMEM_NOFAIL);
 
-	VERIFY0(dmu_bonus_hold(os, bigobj, FTAG, &bonus_db));
+	error = dmu_bonus_hold(os, bigobj, FTAG, &bonus_db);
+	if (error && ZTEST_HFE_ACTIVE())
+		goto out;
+	VERIFY0(error);
 
 	bigbuf_arcbufs = umem_zalloc(2 * s * sizeof (arc_buf_t *), UMEM_NOFAIL);
+	arcs_to_return = umem_zalloc(2 * s * sizeof (boolean_t), UMEM_NOFAIL);
 
 	/*
 	 * Iteration 0 test zcopy for DB_UNCACHED dbufs.
@@ -5850,7 +5861,6 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	 * Iteration 6 one more zcopy write.
 	 */
 	for (i = 0; i < 7; i++) {
-		uint64_t j;
 		uint64_t off;
 
 		/*
@@ -5863,11 +5873,14 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
 				bigbuf_arcbufs[j] =
 				    dmu_request_arcbuf(bonus_db, chunksize);
+				arcs_to_return[j] = B_TRUE;
 			} else {
 				bigbuf_arcbufs[2 * j] =
 				    dmu_request_arcbuf(bonus_db, chunksize / 2);
+				arcs_to_return[2 * j] = B_TRUE;
 				bigbuf_arcbufs[2 * j + 1] =
 				    dmu_request_arcbuf(bonus_db, chunksize / 2);
+				arcs_to_return[2 * j + 1] = B_TRUE;
 			}
 		}
 
@@ -5880,25 +5893,8 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		dmu_tx_hold_write(tx, bigobj, bigoff, bigsize);
 
 		txg = ztest_tx_assign(tx, DMU_TX_MIGHTWAIT, FTAG);
-		if (txg == 0) {
-			umem_free(packbuf, packsize);
-			umem_free(bigbuf, bigsize);
-			for (j = 0; j < s; j++) {
-				if (i != 5 ||
-				    chunksize < (SPA_MINBLOCKSIZE * 2)) {
-					dmu_return_arcbuf(bigbuf_arcbufs[j]);
-				} else {
-					dmu_return_arcbuf(
-					    bigbuf_arcbufs[2 * j]);
-					dmu_return_arcbuf(
-					    bigbuf_arcbufs[2 * j + 1]);
-				}
-			}
-			umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
-			umem_free(od, size);
-			dmu_buf_rele(bonus_db, FTAG);
-			return;
-		}
+		if (txg == 0)
+			goto out;
 
 		/*
 		 * 50% of the time don't read objects in the 1st iteration to
@@ -5908,13 +5904,18 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		if (i != 0 || ztest_random(2) != 0) {
 			error = dmu_read(os, packobj, packoff,
 			    packsize, packbuf, dmu_read_flags);
-			ASSERT0(error);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 			error = dmu_read(os, bigobj, bigoff, bigsize,
 			    bigbuf, dmu_read_flags);
-			ASSERT0(error);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 		}
-		compare_and_update_pbbufs(s, packbuf, bigbuf, bigsize,
-		    n, chunksize, txg);
+		if (!ZTEST_HFE_ACTIVE())
+			compare_and_update_pbbufs(s, packbuf, bigbuf, bigsize,
+			    n, chunksize, txg);
 
 		/*
 		 * We've verified all the old bufwads, and made new ones.
@@ -5928,7 +5929,6 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			    bigoff, bigsize, txg);
 		}
 		for (off = bigoff, j = 0; j < s; j++, off += chunksize) {
-			dmu_buf_t *dbt;
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
 				memcpy(bigbuf_arcbufs[j]->b_data,
 				    (caddr_t)bigbuf + (off - bigoff),
@@ -5944,42 +5944,71 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			}
 
 			if (i == 1) {
-				VERIFY0(dmu_buf_hold(os, bigobj, off,
-				    FTAG, &dbt, DMU_READ_NO_PREFETCH));
+				error = dmu_buf_hold(os, bigobj, off,
+				    FTAG, &dbt, DMU_READ_NO_PREFETCH);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
 			}
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
-				    off, bigbuf_arcbufs[j], tx, 0));
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
+				    off, bigbuf_arcbufs[j], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[j] = B_FALSE;
 			} else {
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
-				    off, bigbuf_arcbufs[2 * j], tx, 0));
-				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
+				    off, bigbuf_arcbufs[2 * j], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[2 * j] = B_FALSE;
+
+				error = dmu_assign_arcbuf_by_dbuf(bonus_db,
 				    off + chunksize / 2,
-				    bigbuf_arcbufs[2 * j + 1], tx, 0));
+				    bigbuf_arcbufs[2 * j + 1], tx, 0);
+				if (error && ZTEST_HFE_ACTIVE())
+					goto out;
+				VERIFY0(error);
+				arcs_to_return[2 * j + 1] = B_FALSE;
 			}
 			if (i == 1) {
 				dmu_buf_rele(dbt, FTAG);
+				dbt = NULL;
 			}
 		}
 		dmu_tx_commit(tx);
+		txg = 0;
 
 		/*
 		 * Sanity check the stuff we just wrote.
 		 */
 		{
-			void *packcheck = umem_alloc(packsize, UMEM_NOFAIL);
-			void *bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
+			packcheck = umem_alloc(packsize, UMEM_NOFAIL);
+			bigcheck = umem_alloc(bigsize, UMEM_NOFAIL);
 
-			VERIFY0(dmu_read(os, packobj, packoff,
-			    packsize, packcheck, dmu_read_flags));
-			VERIFY0(dmu_read(os, bigobj, bigoff,
-			    bigsize, bigcheck, dmu_read_flags));
+			error = dmu_read(os, packobj, packoff,
+			    packsize, packcheck, dmu_read_flags);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
 
-			ASSERT0(memcmp(packbuf, packcheck, packsize));
-			ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
+			error = dmu_read(os, bigobj, bigoff,
+			    bigsize, bigcheck, dmu_read_flags);
+			if (error && ZTEST_HFE_ACTIVE())
+				goto out;
+			VERIFY0(error);
+
+			if (!ZTEST_HFE_ACTIVE()) {
+				ASSERT0(memcmp(packbuf, packcheck, packsize));
+				ASSERT0(memcmp(bigbuf, bigcheck, bigsize));
+			}
 
 			umem_free(packcheck, packsize);
+			packcheck = NULL;
 			umem_free(bigcheck, bigsize);
+			bigcheck = NULL;
 		}
 		if (i == 2) {
 			txg_wait_open(dmu_objset_pool(os), 0, B_TRUE);
@@ -5988,11 +6017,31 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		}
 	}
 
-	dmu_buf_rele(bonus_db, FTAG);
-	umem_free(packbuf, packsize);
-	umem_free(bigbuf, bigsize);
-	umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
-	umem_free(od, size);
+out:
+	if (arcs_to_return)
+		for (j = 0; j < 2 * s; j++)
+			if (arcs_to_return[j])
+				dmu_return_arcbuf(bigbuf_arcbufs[j]);
+	if (dbt)
+		dmu_buf_rele(dbt, FTAG);
+	if (txg != 0)
+		dmu_tx_commit(tx);
+	if (packcheck)
+		umem_free(packcheck, packsize);
+	if (bigcheck)
+		umem_free(bigcheck, bigsize);
+	if (bonus_db)
+		dmu_buf_rele(bonus_db, FTAG);
+	if (packbuf)
+		umem_free(packbuf, packsize);
+	if (bigbuf)
+		umem_free(bigbuf, bigsize);
+	if (arcs_to_return)
+		umem_free(arcs_to_return, 2 * s * sizeof (boolean_t));
+	if (bigbuf_arcbufs)
+		umem_free(bigbuf_arcbufs, 2 * s * sizeof (arc_buf_t *));
+	if (od)
+		umem_free(od, size);
 }
 
 void

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6822,7 +6822,9 @@ ztest_verify_dnode_bt(ztest_ds_t *zd, uint64_t id)
 			ztest_bt_verify(bt, os, obj, doi.doi_dnodesize,
 			    bt->bt_offset, bt->bt_gen, bt->bt_txg,
 			    bt->bt_crtxg);
-			ztest_verify_unused_bonus(db, bt, obj, os, bt->bt_gen);
+			if (!ZTEST_HFE_ACTIVE())
+				ztest_verify_unused_bonus(db, bt, obj, os,
+				    bt->bt_gen);
 		}
 
 		dmu_buf_rele(db, FTAG);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -266,7 +266,8 @@ _LIBZFS_H boolean_t zpool_skip_pool(const char *);
  */
 _LIBZFS_H int zpool_create(libzfs_handle_t *, const char *, nvlist_t *,
     nvlist_t *, nvlist_t *);
-_LIBZFS_H int zpool_destroy(zpool_handle_t *, const char *);
+_LIBZFS_H int zpool_destroy(zpool_handle_t *, boolean_t, boolean_t,
+    const char *);
 _LIBZFS_H int zpool_add(zpool_handle_t *, nvlist_t *, boolean_t check_ashift);
 
 typedef struct splitflags {

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -246,6 +246,7 @@ _LIBZFS_H void libzfs_mnttab_remove(libzfs_handle_t *, const char *);
  */
 _LIBZFS_H zpool_handle_t *zpool_open(libzfs_handle_t *, const char *);
 _LIBZFS_H zpool_handle_t *zpool_open_canfail(libzfs_handle_t *, const char *);
+_LIBZFS_H zpool_handle_t *zpool_open_unchecked(libzfs_handle_t *, const char *);
 _LIBZFS_H void zpool_close(zpool_handle_t *);
 _LIBZFS_H const char *zpool_get_name(zpool_handle_t *);
 _LIBZFS_H int zpool_get_state(zpool_handle_t *);
@@ -476,6 +477,7 @@ _LIBZFS_H zpool_status_t zpool_get_status(zpool_handle_t *, const char **,
     zpool_errata_t *);
 _LIBZFS_H zpool_status_t zpool_import_status(nvlist_t *, const char **,
     zpool_errata_t *);
+_LIBZFS_H boolean_t zpool_suspended(zpool_status_t status);
 
 /*
  * Statistics and configuration functions.
@@ -499,6 +501,7 @@ _LIBZFS_H int zpool_import_props(libzfs_handle_t *, nvlist_t *, const char *,
     nvlist_t *, int);
 _LIBZFS_H void zpool_collect_unsup_feat(nvlist_t *config, char *buf,
     size_t size);
+_LIBZFS_H int zpool_set_forced_exit_required(zpool_handle_t *);
 
 /*
  * Miscellaneous pool functions
@@ -1067,8 +1070,9 @@ _LIBZFS_H int zfs_smb_acl_rename(libzfs_handle_t *, char *, char *, char *,
  */
 _LIBZFS_H int zpool_enable_datasets(zpool_handle_t *, const char *, int,
     uint_t);
-_LIBZFS_H int zpool_disable_datasets(zpool_handle_t *, boolean_t);
-_LIBZFS_H void zpool_disable_datasets_os(zpool_handle_t *, boolean_t);
+_LIBZFS_H int zpool_disable_datasets(zpool_handle_t *, boolean_t, boolean_t);
+_LIBZFS_H void zpool_disable_datasets_os(zpool_handle_t *, boolean_t,
+    boolean_t);
 _LIBZFS_H void zpool_disable_volume_os(const char *);
 
 /*

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -236,6 +236,7 @@ _LIBZFS_H void libzfs_mnttab_remove(libzfs_handle_t *, const char *);
  */
 _LIBZFS_H zpool_handle_t *zpool_open(libzfs_handle_t *, const char *);
 _LIBZFS_H zpool_handle_t *zpool_open_canfail(libzfs_handle_t *, const char *);
+_LIBZFS_H zpool_handle_t *zpool_open_unchecked(libzfs_handle_t *, const char *);
 _LIBZFS_H void zpool_close(zpool_handle_t *);
 _LIBZFS_H const char *zpool_get_name(zpool_handle_t *);
 _LIBZFS_H int zpool_get_state(zpool_handle_t *);
@@ -468,6 +469,7 @@ _LIBZFS_H zpool_status_t zpool_get_status(zpool_handle_t *, const char **,
     zpool_errata_t *);
 _LIBZFS_H zpool_status_t zpool_import_status(nvlist_t *, const char **,
     zpool_errata_t *);
+_LIBZFS_H boolean_t zpool_suspended(zpool_status_t status);
 
 /*
  * Statistics and configuration functions.
@@ -491,6 +493,7 @@ _LIBZFS_H int zpool_import_props(libzfs_handle_t *, nvlist_t *, const char *,
     nvlist_t *, int);
 _LIBZFS_H void zpool_collect_unsup_feat(nvlist_t *config, char *buf,
     size_t size);
+_LIBZFS_H int zpool_set_forced_exit_required(zpool_handle_t *);
 
 /*
  * Miscellaneous pool functions
@@ -1059,8 +1062,9 @@ _LIBZFS_H int zfs_smb_acl_rename(libzfs_handle_t *, char *, char *, char *,
  */
 _LIBZFS_H int zpool_enable_datasets(zpool_handle_t *, const char *, int,
     uint_t);
-_LIBZFS_H int zpool_disable_datasets(zpool_handle_t *, boolean_t);
-_LIBZFS_H void zpool_disable_datasets_os(zpool_handle_t *, boolean_t);
+_LIBZFS_H int zpool_disable_datasets(zpool_handle_t *, boolean_t, boolean_t);
+_LIBZFS_H void zpool_disable_datasets_os(zpool_handle_t *, boolean_t,
+    boolean_t);
 _LIBZFS_H void zpool_disable_volume_os(const char *);
 
 /*

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -256,7 +256,8 @@ _LIBZFS_H boolean_t zpool_skip_pool(const char *);
  */
 _LIBZFS_H int zpool_create(libzfs_handle_t *, const char *, nvlist_t *,
     nvlist_t *, nvlist_t *);
-_LIBZFS_H int zpool_destroy(zpool_handle_t *, const char *);
+_LIBZFS_H int zpool_destroy(zpool_handle_t *, boolean_t, boolean_t,
+    const char *);
 _LIBZFS_H int zpool_add(zpool_handle_t *, nvlist_t *, boolean_t check_ashift);
 
 typedef struct splitflags {

--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
@@ -36,6 +36,7 @@
 #include <sys/rrwlock.h>
 #include <sys/rmlock.h>
 #include <sys/zfs_ioctl.h>
+#include <sys/dmu_objset.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
@@ -26,6 +26,7 @@
 #include <sys/rrwlock.h>
 #include <sys/rmlock.h>
 #include <sys/zfs_ioctl.h>
+#include <sys/dmu_objset.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -136,6 +136,8 @@ zfs_enter(zfsvfs_t *zfsvfs, const char *tag)
 	return (0);
 }
 
+#define	zfs_enter_unmountingok	zfs_enter
+
 /* Must be called before exiting the vop */
 static inline void
 zfs_exit(zfsvfs_t *zfsvfs, const char *tag)

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -126,6 +126,8 @@ zfs_enter(zfsvfs_t *zfsvfs, const char *tag)
 	return (0);
 }
 
+#define	zfs_enter_unmountingok	zfs_enter
+
 /* Must be called before exiting the vop */
 static inline void
 zfs_exit(zfsvfs_t *zfsvfs, const char *tag)

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -39,6 +39,8 @@
 #include <sys/dsl_dataset.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/objlist.h>
+#include <sys/spa_impl.h>
+#include <sys/dmu_objset.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -228,6 +230,11 @@ typedef struct zfid_long {
 
 #define	SHORT_FID_LEN	(sizeof (zfid_short_t) - sizeof (uint16_t))
 #define	LONG_FID_LEN	(sizeof (zfid_long_t) - sizeof (uint16_t))
+
+#define	zfs_forcibly_unmounting(zfsvfs)				\
+	(((zfsvfs)->z_os && (zfsvfs)->z_os->os_spa)		\
+	? (zfsvfs)->z_os->os_spa->spa_forced_exit_required	\
+	: B_FALSE)
 
 extern void zfs_init(void);
 extern void zfs_fini(void);

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -29,6 +29,8 @@
 #include <sys/dsl_dataset.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/objlist.h>
+#include <sys/spa_impl.h>
+#include <sys/dmu_objset.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -218,6 +220,11 @@ typedef struct zfid_long {
 
 #define	SHORT_FID_LEN	(sizeof (zfid_short_t) - sizeof (uint16_t))
 #define	LONG_FID_LEN	(sizeof (zfid_long_t) - sizeof (uint16_t))
+
+#define	zfs_forcibly_unmounting(zfsvfs)				\
+	(((zfsvfs)->z_os && (zfsvfs)->z_os->os_spa)		\
+	? (zfsvfs)->z_os->os_spa->spa_forced_exit_required	\
+	: B_FALSE)
 
 extern void zfs_init(void);
 extern void zfs_fini(void);

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -92,7 +92,19 @@ static inline int
 zfs_enter(zfsvfs_t *zfsvfs, const char *tag)
 {
 	ZFS_TEARDOWN_ENTER_READ(zfsvfs, tag);
-	if (unlikely(zfsvfs->z_unmounted)) {
+	if (unlikely(zfsvfs->z_unmounted || zfs_forcibly_unmounting(zfsvfs))) {
+		ZFS_TEARDOWN_EXIT_READ(zfsvfs, tag);
+		return (SET_ERROR(EIO));
+	}
+	return (0);
+}
+
+/* zfs_enter() but ok with forced unmount having begun. */
+static inline int
+zfs_enter_unmountingok(zfsvfs_t *zfsvfs, const char *tag)
+{
+	ZFS_TEARDOWN_ENTER_READ(zfsvfs, tag);
+	if (unlikely(zfsvfs->z_unmounted == B_TRUE)) {
 		ZFS_TEARDOWN_EXIT_READ(zfsvfs, tag);
 		return (SET_ERROR(EIO));
 	}

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -82,7 +82,19 @@ static inline int
 zfs_enter(zfsvfs_t *zfsvfs, const char *tag)
 {
 	ZFS_TEARDOWN_ENTER_READ(zfsvfs, tag);
-	if (unlikely(zfsvfs->z_unmounted)) {
+	if (unlikely(zfsvfs->z_unmounted || zfs_forcibly_unmounting(zfsvfs))) {
+		ZFS_TEARDOWN_EXIT_READ(zfsvfs, tag);
+		return (SET_ERROR(EIO));
+	}
+	return (0);
+}
+
+/* zfs_enter() but ok with forced unmount having begun. */
+static inline int
+zfs_enter_unmountingok(zfsvfs_t *zfsvfs, const char *tag)
+{
+	ZFS_TEARDOWN_ENTER_READ(zfsvfs, tag);
+	if (unlikely(zfsvfs->z_unmounted == B_TRUE)) {
 		ZFS_TEARDOWN_EXIT_READ(zfsvfs, tag);
 		return (SET_ERROR(EIO));
 	}

--- a/include/sys/bpobj.h
+++ b/include/sys/bpobj.h
@@ -73,8 +73,9 @@ typedef struct bpobj {
 typedef int bpobj_itor_t(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx);
 
-uint64_t bpobj_alloc(objset_t *mos, int blocksize, dmu_tx_t *tx);
-uint64_t bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx);
+int bpobj_alloc(objset_t *mos, int blocksize, dmu_tx_t *tx, uint64_t *objectp);
+int bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx,
+    uint64_t *objectp);
 void bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
 void bpobj_decr_empty(objset_t *os, dmu_tx_t *tx);
 
@@ -87,7 +88,7 @@ int bpobj_iterate_nofree(bpobj_t *bpo, bpobj_itor_t func, void *, uint64_t *);
 int livelist_bpobj_iterate_from_nofree(bpobj_t *bpo, bpobj_itor_t func,
     void *arg, int64_t start);
 
-void bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx);
+int bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx);
 void bpobj_prefetch_subobj(bpobj_t *bpo, uint64_t subobj);
 void bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx);

--- a/include/sys/bpobj.h
+++ b/include/sys/bpobj.h
@@ -63,8 +63,9 @@ typedef struct bpobj {
 typedef int bpobj_itor_t(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx);
 
-uint64_t bpobj_alloc(objset_t *mos, int blocksize, dmu_tx_t *tx);
-uint64_t bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx);
+int bpobj_alloc(objset_t *mos, int blocksize, dmu_tx_t *tx, uint64_t *objectp);
+int bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx,
+    uint64_t *objectp);
 void bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
 void bpobj_decr_empty(objset_t *os, dmu_tx_t *tx);
 
@@ -77,7 +78,7 @@ int bpobj_iterate_nofree(bpobj_t *bpo, bpobj_itor_t func, void *, uint64_t *);
 int livelist_bpobj_iterate_from_nofree(bpobj_t *bpo, bpobj_itor_t func,
     void *arg, int64_t start);
 
-void bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx);
+int bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx);
 void bpobj_prefetch_subobj(bpobj_t *bpo, uint64_t subobj);
 void bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx);

--- a/include/sys/bptree.h
+++ b/include/sys/bptree.h
@@ -49,7 +49,7 @@ typedef struct bptree_entry_phys {
 
 typedef int bptree_itor_t(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 
-uint64_t bptree_alloc(objset_t *os, dmu_tx_t *tx);
+int bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 int bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
 boolean_t bptree_is_empty(objset_t *os, uint64_t obj);
 

--- a/include/sys/bptree.h
+++ b/include/sys/bptree.h
@@ -51,7 +51,7 @@ typedef int bptree_itor_t(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 
 int bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 int bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
-boolean_t bptree_is_empty(objset_t *os, uint64_t obj);
+int bptree_is_empty(objset_t *os, uint64_t obj, boolean_t *rv);
 
 void bptree_add(objset_t *os, uint64_t obj, blkptr_t *bp, uint64_t birth_txg,
     uint64_t bytes, uint64_t comp, uint64_t uncomp, dmu_tx_t *tx);

--- a/include/sys/bptree.h
+++ b/include/sys/bptree.h
@@ -41,7 +41,7 @@ typedef int bptree_itor_t(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 
 int bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 int bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
-boolean_t bptree_is_empty(objset_t *os, uint64_t obj);
+int bptree_is_empty(objset_t *os, uint64_t obj, boolean_t *rv);
 
 void bptree_add(objset_t *os, uint64_t obj, blkptr_t *bp, uint64_t birth_txg,
     uint64_t bytes, uint64_t comp, uint64_t uncomp, dmu_tx_t *tx);

--- a/include/sys/bptree.h
+++ b/include/sys/bptree.h
@@ -39,7 +39,7 @@ typedef struct bptree_entry_phys {
 
 typedef int bptree_itor_t(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 
-uint64_t bptree_alloc(objset_t *os, dmu_tx_t *tx);
+int bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 int bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx);
 boolean_t bptree_is_empty(objset_t *os, uint64_t obj);
 

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -402,7 +402,8 @@ void dmu_buf_redact(dmu_buf_t *dbuf, dmu_tx_t *tx);
 void dbuf_destroy(dmu_buf_impl_t *db);
 
 void dbuf_unoverride(dbuf_dirty_record_t *dr);
-void dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx);
+int dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx);
+void dbuf_drain_list(list_t *list, dmu_tx_t *tx);
 void dbuf_release_bp(dmu_buf_impl_t *db);
 db_lock_type_t dmu_buf_lock_parent(dmu_buf_impl_t *db, krw_t rw,
     const void *tag);

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -392,7 +392,8 @@ void dmu_buf_redact(dmu_buf_t *dbuf, dmu_tx_t *tx);
 void dbuf_destroy(dmu_buf_impl_t *db);
 
 void dbuf_unoverride(dbuf_dirty_record_t *dr);
-void dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx);
+int dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx);
+void dbuf_drain_list(list_t *list, dmu_tx_t *tx);
 void dbuf_release_bp(dmu_buf_impl_t *db);
 db_lock_type_t dmu_buf_lock_parent(dmu_buf_impl_t *db, krw_t rw,
     const void *tag);

--- a/include/sys/ddt_impl.h
+++ b/include/sys/ddt_impl.h
@@ -180,7 +180,7 @@ typedef struct {
 extern const ddt_ops_t ddt_zap_ops;
 
 /* Dedup log API */
-extern void ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx,
+extern int ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx,
     ddt_log_update_t *dlu);
 extern void ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *dde,
     ddt_log_update_t *dlu);

--- a/include/sys/ddt_impl.h
+++ b/include/sys/ddt_impl.h
@@ -172,7 +172,7 @@ extern const ddt_ops_t ddt_zap_ops;
 extern unsigned int ddt_zap_default_bs;
 
 /* Dedup log API */
-extern void ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx,
+extern int ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx,
     ddt_log_update_t *dlu);
 extern void ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *dde,
     ddt_log_update_t *dlu);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -433,18 +433,19 @@ typedef struct dmu_buf {
  *
  * Return 0 on success, or ENOSPC or EEXIST as specified above.
  */
-uint64_t dmu_object_alloc(objset_t *os, dmu_object_type_t ot,
-    int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
-    int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot,
+int dmu_object_alloc(objset_t *os, dmu_object_type_t ot,
+    int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx,
+    uint64_t *objectp);
+int dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
+    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
+    dmu_tx_t *tx, uint64_t *objectp);
+int dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot,
     int blocksize, dmu_object_type_t bonus_type, int bonus_len,
-    int dnodesize, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot,
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
+int dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot,
     int blocksize, int indirect_blockshift, dmu_object_type_t bonustype,
     int bonuslen, int dnodesize, dnode_t **allocated_dnode, const void *tag,
-    dmu_tx_t *tx);
+    dmu_tx_t *tx, uint64_t *objectp);
 int dmu_object_claim(objset_t *os, uint64_t object, dmu_object_type_t ot,
     int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx);
 int dmu_object_claim_dnsize(objset_t *os, uint64_t object, dmu_object_type_t ot,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -539,7 +539,7 @@ void dmu_object_set_compress(objset_t *os, uint64_t object, uint8_t compress,
 int dmu_object_cached_size(objset_t *os, uint64_t object,
     uint64_t *l1sz, uint64_t *l2sz);
 
-void dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
+int dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
     void *data, uint8_t etype, uint8_t comp, int uncompressed_size,
     int compressed_size, int byteorder, dmu_tx_t *tx);
 void dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -423,18 +423,19 @@ typedef struct dmu_buf {
  *
  * Return 0 on success, or ENOSPC or EEXIST as specified above.
  */
-uint64_t dmu_object_alloc(objset_t *os, dmu_object_type_t ot,
-    int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
-    int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot,
+int dmu_object_alloc(objset_t *os, dmu_object_type_t ot,
+    int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx,
+    uint64_t *objectp);
+int dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
+    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
+    dmu_tx_t *tx, uint64_t *objectp);
+int dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot,
     int blocksize, dmu_object_type_t bonus_type, int bonus_len,
-    int dnodesize, dmu_tx_t *tx);
-uint64_t dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot,
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
+int dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot,
     int blocksize, int indirect_blockshift, dmu_object_type_t bonustype,
     int bonuslen, int dnodesize, dnode_t **allocated_dnode, const void *tag,
-    dmu_tx_t *tx);
+    dmu_tx_t *tx, uint64_t *objectp);
 int dmu_object_claim(objset_t *os, uint64_t object, dmu_object_type_t ot,
     int blocksize, dmu_object_type_t bonus_type, int bonus_len, dmu_tx_t *tx);
 int dmu_object_claim_dnsize(objset_t *os, uint64_t object, dmu_object_type_t ot,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -529,7 +529,7 @@ void dmu_object_set_compress(objset_t *os, uint64_t object, uint8_t compress,
 int dmu_object_cached_size(objset_t *os, uint64_t object,
     uint64_t *l1sz, uint64_t *l2sz);
 
-void dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
+int dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
     void *data, uint8_t etype, uint8_t comp, int uncompressed_size,
     int compressed_size, int byteorder, dmu_tx_t *tx);
 void dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -479,7 +479,7 @@ int dsl_dataset_snap_lookup(dsl_dataset_t *ds, const char *name,
     uint64_t *value);
 int dsl_dataset_snap_remove(dsl_dataset_t *ds, const char *name, dmu_tx_t *tx,
     boolean_t adj_cnt);
-void dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
+int dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
     zprop_source_t source, uint64_t value, dmu_tx_t *tx);
 void dsl_dataset_zapify(dsl_dataset_t *ds, dmu_tx_t *tx);
 boolean_t dsl_dataset_is_zapified(dsl_dataset_t *ds);
@@ -493,8 +493,8 @@ int dsl_dataset_rollback(const char *fsname, const char *tosnap, void *owner,
 int dsl_dataset_rename_snapshot_check(void *arg, dmu_tx_t *tx);
 void dsl_dataset_rename_snapshot_sync(void *arg, dmu_tx_t *tx);
 
-uint64_t dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds);
-void dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
+int dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds, uint64_t *objectp);
+int dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
 boolean_t dsl_dataset_remap_deadlist_exists(dsl_dataset_t *ds);
 void dsl_dataset_destroy_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
 

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -362,11 +362,12 @@ boolean_t dsl_dataset_tryown(dsl_dataset_t *ds, const void *tag,
     boolean_t override);
 int dsl_dataset_namelen(dsl_dataset_t *ds);
 boolean_t dsl_dataset_has_owner(dsl_dataset_t *ds);
-uint64_t dsl_dataset_create_sync(dsl_dir_t *pds, const char *lastname,
+int dsl_dataset_create_sync(dsl_dir_t *pds, const char *lastname,
     dsl_dataset_t *origin, uint64_t flags, cred_t *,
-    struct dsl_crypto_params *, dmu_tx_t *);
-uint64_t dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
-    struct dsl_crypto_params *dcp, uint64_t flags, dmu_tx_t *tx);
+    struct dsl_crypto_params *, dmu_tx_t *, uint64_t *objectp);
+int dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
+    struct dsl_crypto_params *dcp, uint64_t flags, dmu_tx_t *tx,
+    uint64_t *objectp);
 void dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors);
@@ -467,7 +468,7 @@ void dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
     dsl_dataset_t *origin_head, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check_impl(dsl_dataset_t *ds, const char *snapname,
     dmu_tx_t *tx, boolean_t recv, uint64_t cnt, cred_t *cr);
-void dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
+int dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     uint64_t crtime, dmu_tx_t *tx);
 
 void dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -478,7 +478,7 @@ int dsl_dataset_snap_lookup(dsl_dataset_t *ds, const char *name,
     uint64_t *value);
 int dsl_dataset_snap_remove(dsl_dataset_t *ds, const char *name, dmu_tx_t *tx,
     boolean_t adj_cnt);
-void dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
+int dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
     zprop_source_t source, uint64_t value, dmu_tx_t *tx);
 void dsl_dataset_zapify(dsl_dataset_t *ds, dmu_tx_t *tx);
 boolean_t dsl_dataset_is_zapified(dsl_dataset_t *ds);
@@ -492,8 +492,8 @@ int dsl_dataset_rollback(const char *fsname, const char *tosnap, void *owner,
 int dsl_dataset_rename_snapshot_check(void *arg, dmu_tx_t *tx);
 void dsl_dataset_rename_snapshot_sync(void *arg, dmu_tx_t *tx);
 
-uint64_t dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds);
-void dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
+int dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds, uint64_t *objectp);
+int dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
 boolean_t dsl_dataset_remap_deadlist_exists(dsl_dataset_t *ds);
 void dsl_dataset_destroy_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx);
 

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -361,11 +361,12 @@ boolean_t dsl_dataset_tryown(dsl_dataset_t *ds, const void *tag,
     boolean_t override);
 int dsl_dataset_namelen(dsl_dataset_t *ds);
 boolean_t dsl_dataset_has_owner(dsl_dataset_t *ds);
-uint64_t dsl_dataset_create_sync(dsl_dir_t *pds, const char *lastname,
+int dsl_dataset_create_sync(dsl_dir_t *pds, const char *lastname,
     dsl_dataset_t *origin, uint64_t flags, cred_t *,
-    struct dsl_crypto_params *, dmu_tx_t *);
-uint64_t dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
-    struct dsl_crypto_params *dcp, uint64_t flags, dmu_tx_t *tx);
+    struct dsl_crypto_params *, dmu_tx_t *, uint64_t *objectp);
+int dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
+    struct dsl_crypto_params *dcp, uint64_t flags, dmu_tx_t *tx,
+    uint64_t *objectp);
 void dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors);
@@ -466,7 +467,7 @@ void dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
     dsl_dataset_t *origin_head, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check_impl(dsl_dataset_t *ds, const char *snapname,
     dmu_tx_t *tx, boolean_t recv, uint64_t cnt, cred_t *cr);
-void dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
+int dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     uint64_t crtime, dmu_tx_t *tx);
 
 void dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,

--- a/include/sys/dsl_deadlist.h
+++ b/include/sys/dsl_deadlist.h
@@ -93,9 +93,9 @@ typedef int deadlist_iter_t(void *args, dsl_deadlist_entry_t *dle);
 int dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object);
 void dsl_deadlist_close(dsl_deadlist_t *dl);
 void dsl_deadlist_iterate(dsl_deadlist_t *dl, deadlist_iter_t func, void *arg);
-uint64_t dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx);
+int dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 void dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx);
-void dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
+int dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
     boolean_t free, dmu_tx_t *tx);
 int dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 int dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
@@ -105,8 +105,8 @@ void dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
 dmu_tx_t *tx);
 dsl_deadlist_entry_t *dsl_deadlist_first(dsl_deadlist_t *dl);
 dsl_deadlist_entry_t *dsl_deadlist_last(dsl_deadlist_t *dl);
-uint64_t dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
-    uint64_t mrs_obj, dmu_tx_t *tx);
+int dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
+    uint64_t mrs_obj, dmu_tx_t *tx, uint64_t *objectp);
 void dsl_deadlist_space(dsl_deadlist_t *dl,
     uint64_t *usedp, uint64_t *compp, uint64_t *uncompp);
 void dsl_deadlist_space_range(dsl_deadlist_t *dl,

--- a/include/sys/dsl_deadlist.h
+++ b/include/sys/dsl_deadlist.h
@@ -99,9 +99,9 @@ int dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
     boolean_t free, dmu_tx_t *tx);
 int dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 int dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
-void dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
-void dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
-void dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
+int dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
+int dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
+int dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
 dmu_tx_t *tx);
 dsl_deadlist_entry_t *dsl_deadlist_first(dsl_deadlist_t *dl);
 dsl_deadlist_entry_t *dsl_deadlist_last(dsl_deadlist_t *dl);
@@ -112,8 +112,8 @@ void dsl_deadlist_space(dsl_deadlist_t *dl,
 void dsl_deadlist_space_range(dsl_deadlist_t *dl,
     uint64_t mintxg, uint64_t maxtxg,
     uint64_t *usedp, uint64_t *compp, uint64_t *uncompp);
-void dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx);
-void dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
+int dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx);
+int dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
     dmu_tx_t *tx);
 boolean_t dsl_deadlist_is_open(dsl_deadlist_t *dl);
 int dsl_process_sub_livelist(bpobj_t *bpobj, struct bplist *to_free,

--- a/include/sys/dsl_deadlist.h
+++ b/include/sys/dsl_deadlist.h
@@ -89,9 +89,9 @@ int dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
     boolean_t free, dmu_tx_t *tx);
 int dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 int dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
-void dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
-void dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
-void dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
+int dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
+int dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx);
+int dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
 dmu_tx_t *tx);
 dsl_deadlist_entry_t *dsl_deadlist_first(dsl_deadlist_t *dl);
 dsl_deadlist_entry_t *dsl_deadlist_last(dsl_deadlist_t *dl);
@@ -102,8 +102,8 @@ void dsl_deadlist_space(dsl_deadlist_t *dl,
 void dsl_deadlist_space_range(dsl_deadlist_t *dl,
     uint64_t mintxg, uint64_t maxtxg,
     uint64_t *usedp, uint64_t *compp, uint64_t *uncompp);
-void dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx);
-void dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
+int dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx);
+int dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
     dmu_tx_t *tx);
 boolean_t dsl_deadlist_is_open(dsl_deadlist_t *dl);
 int dsl_process_sub_livelist(bpobj_t *bpobj, struct bplist *to_free,

--- a/include/sys/dsl_deadlist.h
+++ b/include/sys/dsl_deadlist.h
@@ -83,9 +83,9 @@ typedef int deadlist_iter_t(void *args, dsl_deadlist_entry_t *dle);
 int dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object);
 void dsl_deadlist_close(dsl_deadlist_t *dl);
 void dsl_deadlist_iterate(dsl_deadlist_t *dl, deadlist_iter_t func, void *arg);
-uint64_t dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx);
+int dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp);
 void dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx);
-void dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
+int dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp,
     boolean_t free, dmu_tx_t *tx);
 int dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 int dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
@@ -95,8 +95,8 @@ void dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg,
 dmu_tx_t *tx);
 dsl_deadlist_entry_t *dsl_deadlist_first(dsl_deadlist_t *dl);
 dsl_deadlist_entry_t *dsl_deadlist_last(dsl_deadlist_t *dl);
-uint64_t dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
-    uint64_t mrs_obj, dmu_tx_t *tx);
+int dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
+    uint64_t mrs_obj, dmu_tx_t *tx, uint64_t *objectp);
 void dsl_deadlist_space(dsl_deadlist_t *dl,
     uint64_t *usedp, uint64_t *compp, uint64_t *uncompp);
 void dsl_deadlist_space_range(dsl_deadlist_t *dl,

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -146,8 +146,8 @@ int dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
     const char *tail, const void *tag, dsl_dir_t **);
 void dsl_dir_name(dsl_dir_t *dd, char *buf);
 int dsl_dir_namelen(dsl_dir_t *dd);
-uint64_t dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds,
-    const char *name, dmu_tx_t *tx);
+int dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds,
+    const char *name, dmu_tx_t *tx, uint64_t *objectp);
 
 uint64_t dsl_dir_get_used(dsl_dir_t *dd);
 uint64_t dsl_dir_get_compressed(dsl_dir_t *dd);

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -136,8 +136,8 @@ int dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
     const char *tail, const void *tag, dsl_dir_t **);
 void dsl_dir_name(dsl_dir_t *dd, char *buf);
 int dsl_dir_namelen(dsl_dir_t *dd);
-uint64_t dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds,
-    const char *name, dmu_tx_t *tx);
+int dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds,
+    const char *name, dmu_tx_t *tx, uint64_t *objectp);
 
 uint64_t dsl_dir_get_used(dsl_dir_t *dd);
 uint64_t dsl_dir_get_compressed(dsl_dir_t *dd);

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -174,7 +174,7 @@ void dsl_free_sync(zio_t *pio, dsl_pool_t *dp, uint64_t txg,
     const blkptr_t *bpp);
 void dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx);
-void dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx);
+int dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_mos_diduse_space(dsl_pool_t *dp,
     int64_t used, int64_t comp, int64_t uncomp);
 void dsl_pool_ckpoint_diduse_space(dsl_pool_t *dp,
@@ -198,7 +198,7 @@ int dsl_pool_open_special_dir(dsl_pool_t *dp, const char *name, dsl_dir_t **);
 int dsl_pool_hold(const char *name, const void *tag, dsl_pool_t **dp);
 void dsl_pool_rele(dsl_pool_t *dp, const void *tag);
 
-void dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
+int dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_destroy_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
 
 #ifdef	__cplusplus

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -171,7 +171,7 @@ void dsl_free_sync(zio_t *pio, dsl_pool_t *dp, uint64_t txg,
     const blkptr_t *bpp);
 void dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx);
-void dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx);
+int dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_mos_diduse_space(dsl_pool_t *dp,
     int64_t used, int64_t comp, int64_t uncomp);
 void dsl_pool_ckpoint_diduse_space(dsl_pool_t *dp,
@@ -195,7 +195,7 @@ int dsl_pool_open_special_dir(dsl_pool_t *dp, const char *name, dsl_dir_t **);
 int dsl_pool_hold(const char *name, const void *tag, dsl_pool_t **dp);
 void dsl_pool_rele(dsl_pool_t *dp, const void *tag);
 
-void dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
+int dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_destroy_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx);
 
 #ifdef	__cplusplus

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1607,7 +1607,7 @@ typedef enum {
  */
 typedef enum zfs_ioc {
 	/*
-	 * Core features - 89/128 numbers reserved.
+	 * Core features - 91/128 numbers reserved.
 	 */
 #ifdef __FreeBSD__
 	ZFS_IOC_FIRST =	0,
@@ -1706,6 +1706,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_PREFETCH,			/* 0x5a58 */
 	ZFS_IOC_DDT_PRUNE,			/* 0x5a59 */
 	ZFS_IOC_POOL_CONDENSE,			/* 0x5a5a */
+	ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED,	/* 0x5a5b */
 
 	/*
 	 * Per-platform (Optional) - 8/128 numbers reserved.

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1609,7 +1609,7 @@ typedef enum {
  */
 typedef enum zfs_ioc {
 	/*
-	 * Core features - 89/128 numbers reserved.
+	 * Core features - 91/128 numbers reserved.
 	 */
 #ifdef __FreeBSD__
 	ZFS_IOC_FIRST =	0,
@@ -1708,6 +1708,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_PREFETCH,			/* 0x5a58 */
 	ZFS_IOC_DDT_PRUNE,			/* 0x5a59 */
 	ZFS_IOC_POOL_CONDENSE,			/* 0x5a5a */
+	ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED,	/* 0x5a5b */
 
 	/*
 	 * Per-platform (Optional) - 8/128 numbers reserved.

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -52,7 +52,7 @@ int metaslab_init(metaslab_group_t *, uint64_t, uint64_t, uint64_t,
 void metaslab_fini(metaslab_t *);
 
 void metaslab_set_unflushed_dirty(metaslab_t *, boolean_t);
-void metaslab_set_unflushed_txg(metaslab_t *, uint64_t, dmu_tx_t *);
+int metaslab_set_unflushed_txg(metaslab_t *, uint64_t, dmu_tx_t *);
 void metaslab_set_estimated_condensed_size(metaslab_t *, uint64_t, dmu_tx_t *);
 boolean_t metaslab_unflushed_dirty(metaslab_t *);
 uint64_t metaslab_unflushed_txg(metaslab_t *);

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -42,7 +42,7 @@ int metaslab_init(metaslab_group_t *, uint64_t, uint64_t, uint64_t,
 void metaslab_fini(metaslab_t *);
 
 void metaslab_set_unflushed_dirty(metaslab_t *, boolean_t);
-void metaslab_set_unflushed_txg(metaslab_t *, uint64_t, dmu_tx_t *);
+int metaslab_set_unflushed_txg(metaslab_t *, uint64_t, dmu_tx_t *);
 void metaslab_set_estimated_condensed_size(metaslab_t *, uint64_t, dmu_tx_t *);
 boolean_t metaslab_unflushed_dirty(metaslab_t *);
 uint64_t metaslab_unflushed_txg(metaslab_t *);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -901,6 +901,7 @@ extern int spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv,
 
 /* Namespace manipulation */
 extern spa_t *spa_lookup(const char *name);
+extern spa_t *spa_lookup_lockless(const char *name);
 extern spa_t *spa_add(const char *name, nvlist_t *config, const char *altroot);
 extern void spa_remove(spa_t *spa);
 extern spa_t *spa_next(spa_t *prev);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1198,7 +1198,7 @@ extern uint64_t zfs_strtonum(const char *str, char **nptr);
 
 extern char *spa_his_ievent_table[];
 
-extern void spa_history_create_obj(spa_t *spa, dmu_tx_t *tx);
+extern int spa_history_create_obj(spa_t *spa, dmu_tx_t *tx);
 extern int spa_history_get(spa_t *spa, uint64_t *offset, uint64_t *len_read,
     char *his_buf);
 extern int spa_history_log(spa_t *spa, const char *his_buf);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -782,7 +782,7 @@ extern int spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 extern int spa_import(char *pool, nvlist_t *config, nvlist_t *props,
     uint64_t flags);
 extern nvlist_t *spa_tryimport(nvlist_t *tryconfig);
-extern int spa_destroy(const char *pool);
+extern int spa_destroy(const char *pool, boolean_t, boolean_t);
 extern int spa_checkpoint(const char *pool);
 extern int spa_checkpoint_discard(const char *pool);
 extern int spa_export(const char *pool, nvlist_t **oldconfig, boolean_t force,

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1120,6 +1120,10 @@ extern uint64_t spa_get_failmode(spa_t *spa);
 extern uint64_t spa_get_deadman_failmode(spa_t *spa);
 extern void spa_set_deadman_failmode(spa_t *spa, const char *failmode);
 extern boolean_t spa_suspended(spa_t *spa);
+extern void spa_initiate_forced_exit(spa_t *spa);
+extern void spa_set_forced_exit_required(spa_t *spa);
+extern boolean_t spa_exiting(spa_t *spa);
+#define	SPA_EXITING(spa) (unlikely(spa_exiting(spa)))
 extern uint64_t spa_bootfs(spa_t *spa);
 extern uint64_t spa_get_last_scrubbed_txg(spa_t *spa);
 extern uint64_t spa_delegation(spa_t *spa);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -787,6 +787,9 @@ extern int spa_checkpoint(const char *pool);
 extern int spa_checkpoint_discard(const char *pool);
 extern int spa_export(const char *pool, nvlist_t **oldconfig, boolean_t force,
     boolean_t hardforce);
+#ifdef ZFS_DEBUG
+extern uint64_t spa_exiting_guid;
+#endif
 extern int spa_reset(const char *pool);
 extern void spa_async_request(spa_t *spa, int flag);
 extern void spa_async_unrequest(spa_t *spa, int flag);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -778,6 +778,9 @@ extern int spa_checkpoint(const char *pool);
 extern int spa_checkpoint_discard(const char *pool);
 extern int spa_export(const char *pool, nvlist_t **oldconfig, boolean_t force,
     boolean_t hardforce);
+#ifdef ZFS_DEBUG
+extern uint64_t spa_exiting_guid;
+#endif
 extern int spa_reset(const char *pool);
 extern void spa_async_request(spa_t *spa, int flag);
 extern void spa_async_unrequest(spa_t *spa, int flag);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1112,6 +1112,10 @@ extern uint64_t spa_get_failmode(spa_t *spa);
 extern uint64_t spa_get_deadman_failmode(spa_t *spa);
 extern void spa_set_deadman_failmode(spa_t *spa, const char *failmode);
 extern boolean_t spa_suspended(spa_t *spa);
+extern void spa_initiate_forced_exit(spa_t *spa);
+extern void spa_set_forced_exit_required(spa_t *spa);
+extern boolean_t spa_exiting(spa_t *spa);
+#define	SPA_EXITING(spa) (unlikely(spa_exiting(spa)))
 extern uint64_t spa_bootfs(spa_t *spa);
 extern uint64_t spa_get_last_scrubbed_txg(spa_t *spa);
 extern uint64_t spa_delegation(spa_t *spa);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -773,7 +773,7 @@ extern int spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 extern int spa_import(char *pool, nvlist_t *config, nvlist_t *props,
     uint64_t flags);
 extern nvlist_t *spa_tryimport(nvlist_t *tryconfig);
-extern int spa_destroy(const char *pool);
+extern int spa_destroy(const char *pool, boolean_t, boolean_t);
 extern int spa_checkpoint(const char *pool);
 extern int spa_checkpoint_discard(const char *pool);
 extern int spa_export(const char *pool, nvlist_t **oldconfig, boolean_t force,

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -893,6 +893,7 @@ extern int spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv,
 
 /* Namespace manipulation */
 extern spa_t *spa_lookup(const char *name);
+extern spa_t *spa_lookup_lockless(const char *name);
 extern spa_t *spa_add(const char *name, nvlist_t *config, const char *altroot);
 extern void spa_remove(spa_t *spa);
 extern spa_t *spa_next(spa_t *prev);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1190,7 +1190,7 @@ extern uint64_t zfs_strtonum(const char *str, char **nptr);
 
 extern char *spa_his_ievent_table[];
 
-extern void spa_history_create_obj(spa_t *spa, dmu_tx_t *tx);
+extern int spa_history_create_obj(spa_t *spa, dmu_tx_t *tx);
 extern int spa_history_get(spa_t *spa, uint64_t *offset, uint64_t *len_read,
     char *his_buf);
 extern int spa_history_log(spa_t *spa, const char *his_buf);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -425,6 +425,8 @@ struct spa {
 	kmutex_t	spa_suspend_lock;	/* protects suspend_zio_root */
 	kcondvar_t	spa_suspend_cv;		/* notification of resume */
 	zio_suspend_reason_t	spa_suspended;	/* pool is suspended */
+	boolean_t	spa_forced_exit_required; /* allowed to inititate */
+	boolean_t	spa_forcibly_exiting;	/* by dropping dirty data etc */
 	uint8_t		spa_claiming;		/* pool is doing zil_claim() */
 	boolean_t	spa_is_root;		/* pool is root */
 	int		spa_minref;		/* num refs when first opened */

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -415,6 +415,8 @@ struct spa {
 	kmutex_t	spa_suspend_lock;	/* protects suspend_zio_root */
 	kcondvar_t	spa_suspend_cv;		/* notification of resume */
 	zio_suspend_reason_t	spa_suspended;	/* pool is suspended */
+	boolean_t	spa_forced_exit_required; /* allowed to inititate */
+	boolean_t	spa_forcibly_exiting;	/* by dropping dirty data etc */
 	uint8_t		spa_claiming;		/* pool is doing zil_claim() */
 	boolean_t	spa_is_root;		/* pool is root */
 	int		spa_minref;		/* num refs when first opened */

--- a/include/sys/spa_log_spacemap.h
+++ b/include/sys/spa_log_spacemap.h
@@ -68,7 +68,7 @@ typedef enum spa_log_flushall_mode {
 
 int spa_ld_log_spacemaps(spa_t *);
 
-void spa_generate_syncing_log_sm(spa_t *, dmu_tx_t *);
+int spa_generate_syncing_log_sm(spa_t *, dmu_tx_t *);
 void spa_flush_metaslabs(spa_t *, dmu_tx_t *);
 void spa_sync_close_syncing_log_sm(spa_t *);
 

--- a/include/sys/spa_log_spacemap.h
+++ b/include/sys/spa_log_spacemap.h
@@ -58,7 +58,7 @@ typedef enum spa_log_flushall_mode {
 
 int spa_ld_log_spacemaps(spa_t *);
 
-void spa_generate_syncing_log_sm(spa_t *, dmu_tx_t *);
+int spa_generate_syncing_log_sm(spa_t *, dmu_tx_t *);
 void spa_flush_metaslabs(spa_t *, dmu_tx_t *);
 void spa_sync_close_syncing_log_sm(spa_t *);
 

--- a/include/sys/space_map.h
+++ b/include/sys/space_map.h
@@ -232,7 +232,8 @@ void space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 uint64_t space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
     uint64_t vdev_id);
 void space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx);
-uint64_t space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx);
+int space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx,
+    uint64_t *objectp);
 void space_map_free(space_map_t *sm, dmu_tx_t *tx);
 void space_map_free_obj(objset_t *os, uint64_t smobj, dmu_tx_t *tx);
 

--- a/include/sys/space_map.h
+++ b/include/sys/space_map.h
@@ -222,7 +222,8 @@ void space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 uint64_t space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
     uint64_t vdev_id);
 void space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx);
-uint64_t space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx);
+int space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx,
+    uint64_t *objectp);
 void space_map_free(space_map_t *sm, dmu_tx_t *tx);
 void space_map_free_obj(objset_t *os, uint64_t smobj, dmu_tx_t *tx);
 

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -88,8 +88,9 @@ extern boolean_t vdev_resilver_needed(vdev_t *vd,
     uint64_t *minp, uint64_t *maxp);
 extern void vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj,
     dmu_tx_t *tx);
-extern uint64_t vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx);
-extern void vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx);
+extern int vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx,
+    uint64_t *objectp);
+extern int vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx);
 extern void vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx);
 extern void vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset,
     uint64_t size);

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -80,8 +80,9 @@ extern boolean_t vdev_resilver_needed(vdev_t *vd,
     uint64_t *minp, uint64_t *maxp);
 extern void vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj,
     dmu_tx_t *tx);
-extern uint64_t vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx);
-extern void vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx);
+extern int vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx,
+    uint64_t *objectp);
+extern int vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx);
 extern void vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx);
 extern void vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset,
     uint64_t size);

--- a/include/sys/vdev_file.h
+++ b/include/sys/vdev_file.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+extern volatile int vdev_file_constant_error;
+
 typedef struct vdev_file {
 	zfs_file_t	*vf_file;
 } vdev_file_t;

--- a/include/sys/vdev_file.h
+++ b/include/sys/vdev_file.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+extern volatile int vdev_file_constant_error;
+
 typedef struct vdev_file {
 	zfs_file_t	*vf_file;
 } vdev_file_t;

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -591,7 +591,7 @@ extern void vdev_remove_parent(vdev_t *cvd);
 extern boolean_t vdev_log_state_valid(vdev_t *vd);
 extern int vdev_load(vdev_t *vd);
 extern int vdev_dtl_load(vdev_t *vd);
-extern void vdev_sync(vdev_t *vd, uint64_t txg);
+extern int vdev_sync(vdev_t *vd, uint64_t txg);
 extern void vdev_sync_dispatch(vdev_t *vd, uint64_t txg);
 extern void vdev_sync_done(vdev_t *vd, uint64_t txg);
 extern void vdev_dirty(vdev_t *vd, int flags, void *arg, uint64_t txg);
@@ -634,9 +634,9 @@ extern int zfs_vdev_standard_sm_blksz;
 /*
  * Functions from vdev_indirect.c
  */
-extern void vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx);
+extern int vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx);
 extern boolean_t vdev_indirect_should_condense(vdev_t *vd);
-extern void spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx);
+extern int spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx);
 extern int vdev_obsolete_sm_object(vdev_t *vd, uint64_t *sm_obj);
 extern int vdev_obsolete_counts_are_precise(vdev_t *vd, boolean_t *are_precise);
 

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -603,7 +603,7 @@ extern void vdev_remove_parent(vdev_t *cvd);
 extern boolean_t vdev_log_state_valid(vdev_t *vd);
 extern int vdev_load(vdev_t *vd);
 extern int vdev_dtl_load(vdev_t *vd);
-extern void vdev_sync(vdev_t *vd, uint64_t txg);
+extern int vdev_sync(vdev_t *vd, uint64_t txg);
 extern void vdev_sync_dispatch(vdev_t *vd, uint64_t txg);
 extern void vdev_sync_done(vdev_t *vd, uint64_t txg);
 extern void vdev_dirty(vdev_t *vd, int flags, void *arg, uint64_t txg);
@@ -646,9 +646,9 @@ extern int zfs_vdev_standard_sm_blksz;
 /*
  * Functions from vdev_indirect.c
  */
-extern void vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx);
+extern int vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx);
 extern boolean_t vdev_indirect_should_condense(vdev_t *vd);
-extern void spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx);
+extern int spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx);
 extern int vdev_obsolete_sm_object(vdev_t *vd, uint64_t *sm_obj);
 extern int vdev_obsolete_counts_are_precise(vdev_t *vd, boolean_t *are_precise);
 

--- a/include/sys/vdev_indirect_births.h
+++ b/include/sys/vdev_indirect_births.h
@@ -58,7 +58,8 @@ extern vdev_indirect_births_t *vdev_indirect_births_open(objset_t *os,
     uint64_t object);
 extern void vdev_indirect_births_close(vdev_indirect_births_t *vib);
 extern boolean_t vdev_indirect_births_is_open(vdev_indirect_births_t *vib);
-extern uint64_t vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx);
+extern int vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx,
+    uint64_t *objectp);
 extern void vdev_indirect_births_free(objset_t *os, uint64_t object,
     dmu_tx_t *tx);
 

--- a/include/sys/vdev_indirect_births.h
+++ b/include/sys/vdev_indirect_births.h
@@ -54,8 +54,8 @@ typedef struct vdev_indirect_births {
 	vdev_indirect_birth_phys_t	*vib_phys;
 } vdev_indirect_births_t;
 
-extern vdev_indirect_births_t *vdev_indirect_births_open(objset_t *os,
-    uint64_t object);
+extern int vdev_indirect_births_open(objset_t *os,
+    uint64_t object, vdev_indirect_births_t **vibp);
 extern void vdev_indirect_births_close(vdev_indirect_births_t *vib);
 extern boolean_t vdev_indirect_births_is_open(vdev_indirect_births_t *vib);
 extern int vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx,

--- a/include/sys/vdev_indirect_births.h
+++ b/include/sys/vdev_indirect_births.h
@@ -50,8 +50,8 @@ typedef struct vdev_indirect_births {
 	vdev_indirect_birth_phys_t	*vib_phys;
 } vdev_indirect_births_t;
 
-extern vdev_indirect_births_t *vdev_indirect_births_open(objset_t *os,
-    uint64_t object);
+extern int vdev_indirect_births_open(objset_t *os,
+    uint64_t object, vdev_indirect_births_t **vibp);
 extern void vdev_indirect_births_close(vdev_indirect_births_t *vib);
 extern boolean_t vdev_indirect_births_is_open(vdev_indirect_births_t *vib);
 extern int vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx,

--- a/include/sys/vdev_indirect_births.h
+++ b/include/sys/vdev_indirect_births.h
@@ -54,7 +54,8 @@ extern vdev_indirect_births_t *vdev_indirect_births_open(objset_t *os,
     uint64_t object);
 extern void vdev_indirect_births_close(vdev_indirect_births_t *vib);
 extern boolean_t vdev_indirect_births_is_open(vdev_indirect_births_t *vib);
-extern uint64_t vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx);
+extern int vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx,
+    uint64_t *objectp);
 extern void vdev_indirect_births_free(objset_t *os, uint64_t object,
     dmu_tx_t *tx);
 

--- a/include/sys/vdev_indirect_mapping.h
+++ b/include/sys/vdev_indirect_mapping.h
@@ -95,8 +95,8 @@ typedef struct vdev_indirect_mapping {
 	vdev_indirect_mapping_phys_t	*vim_phys;
 } vdev_indirect_mapping_t;
 
-extern vdev_indirect_mapping_t *vdev_indirect_mapping_open(objset_t *os,
-    uint64_t object);
+extern int vdev_indirect_mapping_open(objset_t *os,
+    uint64_t object, vdev_indirect_mapping_t **vimp);
 extern void vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim);
 extern int vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx,
     uint64_t *objectp);

--- a/include/sys/vdev_indirect_mapping.h
+++ b/include/sys/vdev_indirect_mapping.h
@@ -98,7 +98,8 @@ typedef struct vdev_indirect_mapping {
 extern vdev_indirect_mapping_t *vdev_indirect_mapping_open(objset_t *os,
     uint64_t object);
 extern void vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim);
-extern uint64_t vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx);
+extern int vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx,
+    uint64_t *objectp);
 extern void vdev_indirect_mapping_free(objset_t *os, uint64_t obj,
     dmu_tx_t *tx);
 

--- a/include/sys/vdev_indirect_mapping.h
+++ b/include/sys/vdev_indirect_mapping.h
@@ -91,8 +91,8 @@ typedef struct vdev_indirect_mapping {
 	vdev_indirect_mapping_phys_t	*vim_phys;
 } vdev_indirect_mapping_t;
 
-extern vdev_indirect_mapping_t *vdev_indirect_mapping_open(objset_t *os,
-    uint64_t object);
+extern int vdev_indirect_mapping_open(objset_t *os,
+    uint64_t object, vdev_indirect_mapping_t **vimp);
 extern void vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim);
 extern int vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx,
     uint64_t *objectp);

--- a/include/sys/vdev_indirect_mapping.h
+++ b/include/sys/vdev_indirect_mapping.h
@@ -94,7 +94,8 @@ typedef struct vdev_indirect_mapping {
 extern vdev_indirect_mapping_t *vdev_indirect_mapping_open(objset_t *os,
     uint64_t object);
 extern void vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim);
-extern uint64_t vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx);
+extern int vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx,
+    uint64_t *objectp);
 extern void vdev_indirect_mapping_free(objset_t *os, uint64_t obj,
     dmu_tx_t *tx);
 

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -122,47 +122,51 @@ typedef enum zap_flags {
 /*
  * Create a new zapobj with no attributes and return its object number.
  */
-uint64_t zap_create(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx);
-uint64_t zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_norm_dnsize(objset_t *os, int normflags,
+int zap_create(objset_t *os, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp);
+int zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_norm_dnsize(objset_t *os, int normflags,
     dmu_object_type_t ot, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dmu_tx_t *tx);
-uint64_t zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_flags_dnsize(objset_t *os, int normflags,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx,
+    uint64_t *objectp);
+int zap_create_flags_dnsize(objset_t *os, int normflags,
     zap_flags_t flags, dmu_object_type_t ot, int leaf_blockshift,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dmu_tx_t *tx);
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
 
 /*
  * Create a zap object and return a pointer to the newly allocated dnode via
  * the allocated_dnode argument.  The returned dnode will be held and the
  * caller is responsible for releasing the hold by calling dnode_rele().
  */
-uint64_t zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
+int zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx);
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp);
 
 /*
  * Create a new zapobj with no attributes, and add an entry to an existing
  * zapobj with the given name as key and the object number of the new zapobj as
  * the value. Returns the object number of the new zapobj.
  */
-uint64_t zap_create_link(objset_t *os, dmu_object_type_t ot,
-    uint64_t parent_obj, const char *name, dmu_tx_t *tx);
-uint64_t zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot,
-    uint64_t parent_obj, const char *name, int dnodesize, dmu_tx_t *tx);
+int zap_create_link(objset_t *os, dmu_object_type_t ot,
+    uint64_t parent_obj, const char *name, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot,
+    uint64_t parent_obj, const char *name, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp);
 
 /*
  * Initialize an already-allocated object.
  */
-void mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags,
+int mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags,
     dmu_tx_t *tx);
 
 /*

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -112,47 +112,51 @@ typedef enum zap_flags {
 /*
  * Create a new zapobj with no attributes and return its object number.
  */
-uint64_t zap_create(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx);
-uint64_t zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_norm_dnsize(objset_t *os, int normflags,
+int zap_create(objset_t *os, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp);
+int zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_norm_dnsize(objset_t *os, int normflags,
     dmu_object_type_t ot, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dmu_tx_t *tx);
-uint64_t zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx);
-uint64_t zap_create_flags_dnsize(objset_t *os, int normflags,
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx,
+    uint64_t *objectp);
+int zap_create_flags_dnsize(objset_t *os, int normflags,
     zap_flags_t flags, dmu_object_type_t ot, int leaf_blockshift,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dmu_tx_t *tx);
+    int dnodesize, dmu_tx_t *tx, uint64_t *objectp);
 
 /*
  * Create a zap object and return a pointer to the newly allocated dnode via
  * the allocated_dnode argument.  The returned dnode will be held and the
  * caller is responsible for releasing the hold by calling dnode_rele().
  */
-uint64_t zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
+int zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx);
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp);
 
 /*
  * Create a new zapobj with no attributes, and add an entry to an existing
  * zapobj with the given name as key and the object number of the new zapobj as
  * the value. Returns the object number of the new zapobj.
  */
-uint64_t zap_create_link(objset_t *os, dmu_object_type_t ot,
-    uint64_t parent_obj, const char *name, dmu_tx_t *tx);
-uint64_t zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot,
-    uint64_t parent_obj, const char *name, int dnodesize, dmu_tx_t *tx);
+int zap_create_link(objset_t *os, dmu_object_type_t ot,
+    uint64_t parent_obj, const char *name, dmu_tx_t *tx, uint64_t *objectp);
+int zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot,
+    uint64_t parent_obj, const char *name, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp);
 
 /*
  * Initialize an already-allocated object.
  */
-void mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags,
+int mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags,
     dmu_tx_t *tx);
 
 /*

--- a/include/sys/zfs_fuid.h
+++ b/include/sys/zfs_fuid.h
@@ -112,7 +112,7 @@ extern void zfs_fuid_map_ids(struct znode *zp, cred_t *cr,
 extern zfs_fuid_info_t *zfs_fuid_info_alloc(void);
 extern void zfs_fuid_info_free(zfs_fuid_info_t *);
 extern boolean_t zfs_groupmember(zfsvfs_t *, uint64_t, cred_t *);
-void zfs_fuid_sync(zfsvfs_t *, dmu_tx_t *);
+int zfs_fuid_sync(zfsvfs_t *, dmu_tx_t *);
 extern const char *zfs_fuid_find_by_idx(zfsvfs_t *zfsvfs, uint32_t idx);
 extern void zfs_fuid_txhold(zfsvfs_t *zfsvfs, dmu_tx_t *tx);
 extern int zfs_id_to_fuidstr(zfsvfs_t *zfsvfs, const char *domain, uid_t rid,

--- a/include/sys/zfs_fuid.h
+++ b/include/sys/zfs_fuid.h
@@ -102,7 +102,7 @@ extern void zfs_fuid_map_ids(struct znode *zp, cred_t *cr,
 extern zfs_fuid_info_t *zfs_fuid_info_alloc(void);
 extern void zfs_fuid_info_free(zfs_fuid_info_t *);
 extern boolean_t zfs_groupmember(zfsvfs_t *, uint64_t, cred_t *);
-void zfs_fuid_sync(zfsvfs_t *, dmu_tx_t *);
+int zfs_fuid_sync(zfsvfs_t *, dmu_tx_t *);
 extern const char *zfs_fuid_find_by_idx(zfsvfs_t *zfsvfs, uint32_t idx);
 extern void zfs_fuid_txhold(zfsvfs_t *zfsvfs, dmu_tx_t *tx);
 extern int zfs_id_to_fuidstr(zfsvfs_t *zfsvfs, const char *domain, uid_t rid,

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -29,6 +29,26 @@
 
 #ifdef _KERNEL
 #include <sys/zfs_vfsops_os.h>
+
+/*
+ * Regardless of what happens inside ZFS a success code must never be returned
+ * by mistake for critical operations like fsync() in case of forced exit.
+ * Hence, zfsvfs' state must be re-checked on ZPL level as the final line of
+ * defense.
+ */
+static inline int
+zfsvfs_error(zfsvfs_t *zfsvfs)
+{
+	if (unlikely(zfsvfs == NULL ||
+	    zfsvfs->z_os == NULL ||
+	    zfsvfs->z_os->os_spa == NULL))
+		return (SET_ERROR(EIO));
+
+	if (SPA_EXITING(zfsvfs->z_os->os_spa))
+		return (SET_ERROR(EIO));
+
+	return (0);
+}
 #endif
 
 extern void zfsvfs_update_fromname(const char *, const char *);

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -19,6 +19,26 @@
 
 #ifdef _KERNEL
 #include <sys/zfs_vfsops_os.h>
+
+/*
+ * Regardless of what happens inside ZFS a success code must never be returned
+ * by mistake for critical operations like fsync() in case of forced exit.
+ * Hence, zfsvfs' state must be re-checked on ZPL level as the final line of
+ * defense.
+ */
+static inline int
+zfsvfs_error(zfsvfs_t *zfsvfs)
+{
+	if (unlikely(zfsvfs == NULL ||
+	    zfsvfs->z_os == NULL ||
+	    zfsvfs->z_os->os_spa == NULL))
+		return (SET_ERROR(EIO));
+
+	if (SPA_EXITING(zfsvfs->z_os->os_spa))
+		return (SET_ERROR(EIO));
+
+	return (0);
+}
 #endif
 
 extern void zfsvfs_update_fromname(const char *, const char *);

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -267,6 +267,20 @@ zfs_enter_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
 	return (0);
 }
 
+/* zfs_enter_unmountingok and zfs_verify_zp together */
+static inline int
+zfs_enter_unmountingok_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
+{
+	int error;
+	if ((error = zfs_enter_unmountingok(zfsvfs, tag)) != 0)
+		return (error);
+	if ((error = zfs_verify_zp(zp)) != 0) {
+		zfs_exit(zfsvfs, tag);
+		return (error);
+	}
+	return (0);
+}
+
 typedef struct znode_hold {
 	uint64_t	zh_obj;		/* object id */
 	avl_node_t	zh_node;	/* avl tree linkage */

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -257,6 +257,20 @@ zfs_enter_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
 	return (0);
 }
 
+/* zfs_enter_unmountingok and zfs_verify_zp together */
+static inline int
+zfs_enter_unmountingok_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
+{
+	int error;
+	if ((error = zfs_enter_unmountingok(zfsvfs, tag)) != 0)
+		return (error);
+	if ((error = zfs_verify_zp(zp)) != 0) {
+		zfs_exit(zfsvfs, tag);
+		return (error);
+	}
+	return (0);
+}
+
 typedef struct znode_hold {
 	uint64_t	zh_obj;		/* object id */
 	avl_node_t	zh_node;	/* avl tree linkage */

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -128,6 +128,7 @@ typedef struct lwb {
 	list_node_t	lwb_node;	/* zilog->zl_lwb_list linkage */
 	list_node_t	lwb_issue_node;	/* linkage of lwbs ready for issue */
 	list_t		lwb_itxs;	/* list of itx's */
+	uint64_t	lwb_max_lr_seq;	/* highest committed lr seq in lwb */
 	list_t		lwb_waiters;	/* list of zil_commit_waiter's */
 	avl_tree_t	lwb_vdev_tree;	/* vdevs to flush after lwb write */
 	kmutex_t	lwb_lock;	/* protects lwb_vdev_tree and size */

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -118,6 +118,7 @@ typedef struct lwb {
 	list_node_t	lwb_node;	/* zilog->zl_lwb_list linkage */
 	list_node_t	lwb_issue_node;	/* linkage of lwbs ready for issue */
 	list_t		lwb_itxs;	/* list of itx's */
+	uint64_t	lwb_max_lr_seq;	/* highest committed lr seq in lwb */
 	list_t		lwb_waiters;	/* list of zil_commit_waiter's */
 	avl_tree_t	lwb_vdev_tree;	/* vdevs to flush after lwb write */
 	kmutex_t	lwb_lock;	/* protects lwb_vdev_tree and size */

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -448,6 +448,7 @@ typedef zio_t *zio_pipe_stage_t(zio_t *zio);
 #define	ZIO_POST_REEXECUTE	(1 << 0)
 #define	ZIO_POST_SUSPEND	(1 << 1)
 #define	ZIO_POST_DIO_CHKSUM_ERR	(1 << 2)
+#define	ZIO_POST_CANCELLED	(1 << 3)
 
 /*
  * The io_trim flags are used to specify the type of TRIM to perform.  They
@@ -697,6 +698,7 @@ extern uint8_t zio_complevel_select(spa_t *spa, enum zio_compress compress,
 extern void zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t);
 extern int zio_resume(spa_t *spa);
 extern void zio_resume_wait(spa_t *spa);
+extern void zio_resume_but_keep_suspended(spa_t *spa);
 
 extern int zfs_blkptr_verify(spa_t *spa, const blkptr_t *bp,
     enum blk_config_flag blk_config, enum blk_verify_flag blk_verify);

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -438,6 +438,7 @@ typedef zio_t *zio_pipe_stage_t(zio_t *zio);
 #define	ZIO_POST_REEXECUTE	(1 << 0)
 #define	ZIO_POST_SUSPEND	(1 << 1)
 #define	ZIO_POST_DIO_CHKSUM_ERR	(1 << 2)
+#define	ZIO_POST_CANCELLED	(1 << 3)
 
 /*
  * The io_trim flags are used to specify the type of TRIM to perform.  They
@@ -687,6 +688,7 @@ extern uint8_t zio_complevel_select(spa_t *spa, enum zio_compress compress,
 extern void zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t);
 extern int zio_resume(spa_t *spa);
 extern void zio_resume_wait(spa_t *spa);
+extern void zio_resume_but_keep_suspended(spa_t *spa);
 
 extern int zfs_blkptr_verify(spa_t *spa, const blkptr_t *bp,
     enum blk_config_flag blk_config, enum blk_verify_flag blk_verify);

--- a/include/sys/zio_impl.h
+++ b/include/sys/zio_impl.h
@@ -285,6 +285,10 @@ enum zio_stage {
 extern void zio_inject_init(void);
 extern void zio_inject_fini(void);
 
+#ifndef _KERNEL
+extern boolean_t zio_flush_err_propagation;
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/zio_impl.h
+++ b/include/sys/zio_impl.h
@@ -275,6 +275,10 @@ enum zio_stage {
 extern void zio_inject_init(void);
 extern void zio_inject_fini(void);
 
+#ifndef _KERNEL
+extern boolean_t zio_flush_err_propagation;
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1396,7 +1396,8 @@ mountpoint_compare(const void *a, const void *b)
  * and gather all the filesystems that are currently mounted.
  */
 int
-zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
 	int used, alloc;
 	FILE *mnttab;
@@ -1406,7 +1407,38 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	int i;
 	int ret = -1;
-	int flags = (force ? MS_FORCE : 0);
+	int flags;
+	zpool_status_t status;
+
+	force = hardforce || force;
+	flags = force ? MS_FORCE : 0;
+
+	if (!hardforce) {
+		/*
+		 * It is important not to inquire about the pool's status on
+		 * the hardforce path, as it might end up sleeping for
+		 * spa_namespace_lock held by someone else, without forced exit
+		 * actually being initiated.
+		 */
+		status = zpool_get_status(zhp, NULL, NULL);
+		if (zpool_suspended(status)) {
+			(void) fprintf(stderr, gettext("cannot disable datasets"
+			    " of suspended pool '%s'\n"), zhp->zpool_name);
+			return (EAGAIN);
+		}
+	}
+
+	/*
+	 * We say that this pool is allowed to automatically switch to
+	 * the spa_forcibly_exiting state if it finds itself suspended.
+	 * If it is already suspended, then initiate exiting right now.
+	 * Once a forced exit is initiated, there is no way back to the
+	 * normal state, as some dirty data may have already been
+	 * dropped. The initiation is required before unmounting as zil_close
+	 * can be the first one to call txg_wait_synced().
+	 */
+	if (hardforce)
+		zpool_set_forced_exit_required(zhp);
 
 	namelen = strlen(zhp->zpool_name);
 
@@ -1488,8 +1520,15 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	 */
 	for (i = 0; i < used; i++) {
 		if (unmount_one(sets[i].dataset, sets[i].mountpoint,
-		    flags) != 0)
+		    flags) != 0) {
+			if (hardforce) {
+				(void) fprintf(stderr, gettext("cannot unmount"
+				    " '%s' of pool '%s', close the files and"
+				    " repeat\n"), sets[i].mountpoint,
+				    zhp->zpool_name);
+			}
 			goto out;
+		}
 	}
 
 	for (i = 0; i < used; i++) {
@@ -1497,7 +1536,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 			remove_mountpoint(sets[i].dataset);
 	}
 
-	zpool_disable_datasets_os(zhp, force);
+	zpool_disable_datasets_os(zhp, force, hardforce);
 
 	ret = 0;
 out:

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1386,7 +1386,8 @@ mountpoint_compare(const void *a, const void *b)
  * and gather all the filesystems that are currently mounted.
  */
 int
-zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
 	int used, alloc;
 	FILE *mnttab;
@@ -1396,7 +1397,38 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	int i;
 	int ret = -1;
-	int flags = (force ? MS_FORCE : 0);
+	int flags;
+	zpool_status_t status;
+
+	force = hardforce || force;
+	flags = force ? MS_FORCE : 0;
+
+	if (!hardforce) {
+		/*
+		 * It is important not to inquire about the pool's status on
+		 * the hardforce path, as it might end up sleeping for
+		 * spa_namespace_lock held by someone else, without forced exit
+		 * actually being initiated.
+		 */
+		status = zpool_get_status(zhp, NULL, NULL);
+		if (zpool_suspended(status)) {
+			(void) fprintf(stderr, gettext("cannot disable datasets"
+			    " of suspended pool '%s'\n"), zhp->zpool_name);
+			return (EAGAIN);
+		}
+	}
+
+	/*
+	 * We say that this pool is allowed to automatically switch to
+	 * the spa_forcibly_exiting state if it finds itself suspended.
+	 * If it is already suspended, then initiate exiting right now.
+	 * Once a forced exit is initiated, there is no way back to the
+	 * normal state, as some dirty data may have already been
+	 * dropped. The initiation is required before unmounting as zil_close
+	 * can be the first one to call txg_wait_synced().
+	 */
+	if (hardforce)
+		zpool_set_forced_exit_required(zhp);
 
 	namelen = strlen(zhp->zpool_name);
 
@@ -1478,8 +1510,15 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	 */
 	for (i = 0; i < used; i++) {
 		if (unmount_one(sets[i].dataset, sets[i].mountpoint,
-		    flags) != 0)
+		    flags) != 0) {
+			if (hardforce) {
+				(void) fprintf(stderr, gettext("cannot unmount"
+				    " '%s' of pool '%s', close the files and"
+				    " repeat\n"), sets[i].mountpoint,
+				    zhp->zpool_name);
+			}
 			goto out;
+		}
 	}
 
 	for (i = 0; i < used; i++) {
@@ -1487,7 +1526,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 			remove_mountpoint(sets[i].dataset);
 	}
 
-	zpool_disable_datasets_os(zhp, force);
+	zpool_disable_datasets_os(zhp, force, hardforce);
 
 	ret = 0;
 out:

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -250,6 +250,14 @@ zpool_pool_state_to_name(pool_state_t state)
 	return (gettext("UNKNOWN"));
 }
 
+boolean_t
+zpool_suspended(zpool_status_t status)
+{
+	return (status == ZPOOL_STATUS_IO_FAILURE_WAIT ||
+	    status == ZPOOL_STATUS_IO_FAILURE_CONTINUE ||
+	    status == ZPOOL_STATUS_IO_FAILURE_MMP);
+}
+
 /*
  * Given a pool handle, return the pool health string ("ONLINE", "DEGRADED",
  * "SUSPENDED", etc).
@@ -265,9 +273,7 @@ zpool_get_state_str(zpool_handle_t *zhp)
 
 	if (zpool_get_state(zhp) == POOL_STATE_UNAVAIL) {
 		str = gettext("FAULTED");
-	} else if (status == ZPOOL_STATUS_IO_FAILURE_WAIT ||
-	    status == ZPOOL_STATUS_IO_FAILURE_CONTINUE ||
-	    status == ZPOOL_STATUS_IO_FAILURE_MMP) {
+	} else if (zpool_suspended(status)) {
 		str = gettext("SUSPENDED");
 	} else {
 		nvlist_t *nvroot = fnvlist_lookup_nvlist(
@@ -1430,6 +1436,36 @@ zpool_open_silent(libzfs_handle_t *hdl, const char *pool, zpool_handle_t **ret)
 }
 
 /*
+ * Similar to zpool_open_canfail(), but does not communicate with the kernel
+ * module regarding the actual pool details.
+ * It is designed to be used for very specific cases like hardforce export,
+ * when it is important to break through sleeping lock holders.
+ * It must not be used for normal operations.
+ */
+zpool_handle_t *
+zpool_open_unchecked(libzfs_handle_t *hdl, const char *pool)
+{
+	zpool_handle_t *zhp;
+
+	/*
+	 * Make sure the pool name is valid.
+	 */
+	if (!zpool_name_valid(hdl, B_TRUE, pool)) {
+		(void) zfs_error_fmt(hdl, EZFS_INVALIDNAME,
+		    dgettext(TEXT_DOMAIN, "cannot open '%s'"),
+		    pool);
+		return (NULL);
+	}
+
+	zhp = zfs_alloc(hdl, sizeof (zpool_handle_t));
+
+	zhp->zpool_hdl = hdl;
+	(void) strlcpy(zhp->zpool_name, pool, sizeof (zhp->zpool_name));
+
+	return (zhp);
+}
+
+/*
  * Similar to zpool_open_canfail(), but refuses to open pools in the faulted
  * state.
  */
@@ -2051,6 +2087,16 @@ int
 zpool_export_force(zpool_handle_t *zhp, const char *log_str)
 {
 	return (zpool_export_common(zhp, B_TRUE, B_TRUE, log_str));
+}
+
+int
+zpool_set_forced_exit_required(zpool_handle_t *zhp)
+{
+	zfs_cmd_t zc = {"\0"};
+
+	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	return (zfs_ioctl(zhp->zpool_hdl,
+	    ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED, &zc));
 }
 
 static void

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1815,18 +1815,22 @@ create_failed:
  * datasets left in the pool.
  */
 int
-zpool_destroy(zpool_handle_t *zhp, const char *log_str)
+zpool_destroy(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
+    const char *log_str)
 {
 	zfs_cmd_t zc = {"\0"};
 	zfs_handle_t *zfp = NULL;
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	char errbuf[ERRBUFLEN];
 
-	if (zhp->zpool_state == POOL_STATE_ACTIVE &&
+	/* The hardforce path should avoid extra locking. */
+	if (!hardforce && zhp->zpool_state == POOL_STATE_ACTIVE &&
 	    (zfp = zfs_open(hdl, zhp->zpool_name, ZFS_TYPE_FILESYSTEM)) == NULL)
 		return (-1);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	zc.zc_cookie = force;
+	zc.zc_guid = hardforce;
 	zc.zc_history = (uint64_t)(uintptr_t)log_str;
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -240,6 +240,14 @@ zpool_pool_state_to_name(pool_state_t state)
 	return (gettext("UNKNOWN"));
 }
 
+boolean_t
+zpool_suspended(zpool_status_t status)
+{
+	return (status == ZPOOL_STATUS_IO_FAILURE_WAIT ||
+	    status == ZPOOL_STATUS_IO_FAILURE_CONTINUE ||
+	    status == ZPOOL_STATUS_IO_FAILURE_MMP);
+}
+
 /*
  * Given a pool handle, return the pool health string ("ONLINE", "DEGRADED",
  * "SUSPENDED", etc).
@@ -255,9 +263,7 @@ zpool_get_state_str(zpool_handle_t *zhp)
 
 	if (zpool_get_state(zhp) == POOL_STATE_UNAVAIL) {
 		str = gettext("FAULTED");
-	} else if (status == ZPOOL_STATUS_IO_FAILURE_WAIT ||
-	    status == ZPOOL_STATUS_IO_FAILURE_CONTINUE ||
-	    status == ZPOOL_STATUS_IO_FAILURE_MMP) {
+	} else if (zpool_suspended(status)) {
 		str = gettext("SUSPENDED");
 	} else {
 		nvlist_t *nvroot = fnvlist_lookup_nvlist(
@@ -1420,6 +1426,36 @@ zpool_open_silent(libzfs_handle_t *hdl, const char *pool, zpool_handle_t **ret)
 }
 
 /*
+ * Similar to zpool_open_canfail(), but does not communicate with the kernel
+ * module regarding the actual pool details.
+ * It is designed to be used for very specific cases like hardforce export,
+ * when it is important to break through sleeping lock holders.
+ * It must not be used for normal operations.
+ */
+zpool_handle_t *
+zpool_open_unchecked(libzfs_handle_t *hdl, const char *pool)
+{
+	zpool_handle_t *zhp;
+
+	/*
+	 * Make sure the pool name is valid.
+	 */
+	if (!zpool_name_valid(hdl, B_TRUE, pool)) {
+		(void) zfs_error_fmt(hdl, EZFS_INVALIDNAME,
+		    dgettext(TEXT_DOMAIN, "cannot open '%s'"),
+		    pool);
+		return (NULL);
+	}
+
+	zhp = zfs_alloc(hdl, sizeof (zpool_handle_t));
+
+	zhp->zpool_hdl = hdl;
+	(void) strlcpy(zhp->zpool_name, pool, sizeof (zhp->zpool_name));
+
+	return (zhp);
+}
+
+/*
  * Similar to zpool_open_canfail(), but refuses to open pools in the faulted
  * state.
  */
@@ -2041,6 +2077,16 @@ int
 zpool_export_force(zpool_handle_t *zhp, const char *log_str)
 {
 	return (zpool_export_common(zhp, B_TRUE, B_TRUE, log_str));
+}
+
+int
+zpool_set_forced_exit_required(zpool_handle_t *zhp)
+{
+	zfs_cmd_t zc = {"\0"};
+
+	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	return (zfs_ioctl(zhp->zpool_hdl,
+	    ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED, &zc));
 }
 
 static void

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1805,18 +1805,22 @@ create_failed:
  * datasets left in the pool.
  */
 int
-zpool_destroy(zpool_handle_t *zhp, const char *log_str)
+zpool_destroy(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
+    const char *log_str)
 {
 	zfs_cmd_t zc = {"\0"};
 	zfs_handle_t *zfp = NULL;
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	char errbuf[ERRBUFLEN];
 
-	if (zhp->zpool_state == POOL_STATE_ACTIVE &&
+	/* The hardforce path should avoid extra locking. */
+	if (!hardforce && zhp->zpool_state == POOL_STATE_ACTIVE &&
 	    (zfp = zfs_open(hdl, zhp->zpool_name, ZFS_TYPE_FILESYSTEM)) == NULL)
 		return (-1);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	zc.zc_cookie = force;
+	zc.zc_guid = hardforce;
 	zc.zc_history = (uint64_t)(uintptr_t)log_str;
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -142,9 +142,10 @@ zfs_mount_delegation_check(void)
 
 /* Called from the tail end of zpool_disable_datasets() */
 void
-zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
-	(void) zhp, (void) force;
+	(void) zhp, (void) force, (void) hardforce;
 }
 
 /* Called from the tail end of zfs_unmount() */

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -571,9 +571,10 @@ zfs_mount_delegation_check(void)
 
 /* Called from the tail end of zpool_disable_datasets() */
 void
-zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
-	(void) zhp, (void) force;
+	(void) zhp, (void) force, (void) hardforce;
 }
 
 /* Called from the tail end of zfs_unmount() */

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -561,9 +561,10 @@ zfs_mount_delegation_check(void)
 
 /* Called from the tail end of zpool_disable_datasets() */
 void
-zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
-	(void) zhp, (void) force;
+	(void) zhp, (void) force, (void) hardforce;
 }
 
 /* Called from the tail end of zfs_unmount() */

--- a/man/man8/zpool-destroy.8
+++ b/man/man8/zpool-destroy.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd July 11, 2022
+.Dd May 12, 2025
 .Dt ZPOOL-DESTROY 8
 .Os
 .
@@ -38,6 +38,7 @@
 .Nm zpool
 .Cm destroy
 .Op Fl f
+.Op Fl F
 .Ar pool
 .
 .Sh DESCRIPTION
@@ -46,6 +47,20 @@ This command tries to unmount any active datasets before destroying the pool.
 .Bl -tag -width Ds
 .It Fl f
 Forcefully unmount all active datasets.
+.It Fl F
+Implies and extends -f flag by forcibly destroying a suspended pool.
+It will cause data not already synced to the underlying storage to be lost.
+.Pp
+It must be used only as the last resort, and it is critical to avoid
+other operations over any pool in parallel such as create, import, export,
+destroy, etc.
+.Pp
+Once a pool is requested for forced destruction there is no way back to the
+normal state as some dirty data may have already been dropped.
+The destruction process must be finished, if there are obstacles such as
+operating system inability to unmount the related file systems, then destroy
+command with this hardforce flag must be repeated after unmounting issue
+resolution.
 .El
 .
 .Sh EXAMPLES

--- a/man/man8/zpool-destroy.8
+++ b/man/man8/zpool-destroy.8
@@ -17,7 +17,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd July 11, 2022
+.Dd May 12, 2025
 .Dt ZPOOL-DESTROY 8
 .Os
 .
@@ -28,6 +28,7 @@
 .Nm zpool
 .Cm destroy
 .Op Fl f
+.Op Fl F
 .Ar pool
 .
 .Sh DESCRIPTION
@@ -36,6 +37,20 @@ This command tries to unmount any active datasets before destroying the pool.
 .Bl -tag -width Ds
 .It Fl f
 Forcefully unmount all active datasets.
+.It Fl F
+Implies and extends -f flag by forcibly destroying a suspended pool.
+It will cause data not already synced to the underlying storage to be lost.
+.Pp
+It must be used only as the last resort, and it is critical to avoid
+other operations over any pool in parallel such as create, import, export,
+destroy, etc.
+.Pp
+Once a pool is requested for forced destruction there is no way back to the
+normal state as some dirty data may have already been dropped.
+The destruction process must be finished, if there are obstacles such as
+operating system inability to unmount the related file systems, then destroy
+command with this hardforce flag must be repeated after unmounting issue
+resolution.
 .El
 .
 .Sh EXAMPLES

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd July 11, 2022
+.Dd April 14, 2025
 .Dt ZPOOL-EXPORT 8
 .Os
 .
@@ -38,6 +38,7 @@
 .Nm zpool
 .Cm export
 .Op Fl f
+.Op Fl F
 .Fl a Ns | Ns Ar pool Ns …
 .
 .Sh DESCRIPTION
@@ -68,6 +69,21 @@ spares.
 This command will forcefully export the pool even if it has a shared spare that
 is currently being used.
 This may lead to potential data corruption.
+.It Fl F
+Implies and extends -f flag by forcibly exporting a suspended pool.
+It will cause data not already synced to the underlying storage to be lost.
+.Pp
+It must be used only as the last resort, and it is critical to avoid
+other operations over any pool in parallel such as create, import, export,
+destroy, etc.
+.Pp
+Once a pool is requested for forced export there is no way back to the normal
+state as some dirty data may have already been dropped.
+The export process must be completed.
+If there are obstacles, such as the
+operating system's inability to unmount the related file systems, then export
+command with the hardforce flag must be repeated after the unmounting issue is
+resolved.
 .El
 .
 .Sh EXAMPLES

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -17,7 +17,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd July 11, 2022
+.Dd April 14, 2025
 .Dt ZPOOL-EXPORT 8
 .Os
 .
@@ -28,6 +28,7 @@
 .Nm zpool
 .Cm export
 .Op Fl f
+.Op Fl F
 .Fl a Ns | Ns Ar pool Ns …
 .
 .Sh DESCRIPTION
@@ -58,6 +59,21 @@ spares.
 This command will forcefully export the pool even if it has a shared spare that
 is currently being used.
 This may lead to potential data corruption.
+.It Fl F
+Implies and extends -f flag by forcibly exporting a suspended pool.
+It will cause data not already synced to the underlying storage to be lost.
+.Pp
+It must be used only as the last resort, and it is critical to avoid
+other operations over any pool in parallel such as create, import, export,
+destroy, etc.
+.Pp
+Once a pool is requested for forced export there is no way back to the normal
+state as some dirty data may have already been dropped.
+The export process must be completed.
+If there are obstacles, such as the
+operating system's inability to unmount the related file systems, then export
+command with the hardforce flag must be repeated after the unmounting issue is
+resolved.
 .El
 .
 .Sh EXAMPLES

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1247,12 +1247,14 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 				aoid = 0;
 			}
 			if (aoid == 0) {
-				aoid = dmu_object_alloc(zfsvfs->z_os,
+				error = dmu_object_alloc(zfsvfs->z_os,
 				    otype, aclp->z_acl_bytes,
 				    otype == DMU_OT_ACL ?
 				    DMU_OT_SYSACL : DMU_OT_NONE,
 				    otype == DMU_OT_ACL ?
-				    DN_OLD_MAX_BONUSLEN : 0, tx);
+				    DN_OLD_MAX_BONUSLEN : 0, tx, &aoid);
+				if (error)
+					return (error);
 			} else {
 				(void) dmu_object_set_blocksize(zfsvfs->z_os,
 				    aoid, aclp->z_acl_bytes, 0, tx);

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1237,12 +1237,14 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 				aoid = 0;
 			}
 			if (aoid == 0) {
-				aoid = dmu_object_alloc(zfsvfs->z_os,
+				error = dmu_object_alloc(zfsvfs->z_os,
 				    otype, aclp->z_acl_bytes,
 				    otype == DMU_OT_ACL ?
 				    DMU_OT_SYSACL : DMU_OT_NONE,
 				    otype == DMU_OT_ACL ?
-				    DN_OLD_MAX_BONUSLEN : 0, tx);
+				    DN_OLD_MAX_BONUSLEN : 0, tx, &aoid);
+				if (error)
+					return (error);
 			} else {
 				(void) dmu_object_set_blocksize(zfsvfs->z_os,
 				    aoid, aclp->z_acl_bytes, 0, tx);

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -2332,9 +2332,16 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
-		ASSERT0(error);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
-		VERIFY0(sa_set_sa_object(os, sa_obj));
+		error = sa_set_sa_object(os, sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 		sa_register_update_callback(os, zfs_sa_upgrade);
 	}
 

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -2323,8 +2323,12 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -2313,8 +2313,12 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -2322,9 +2322,16 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
-		ASSERT0(error);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
-		VERIFY0(sa_set_sa_object(os, sa_obj));
+		error = sa_set_sa_object(os, sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 		sa_register_update_callback(os, zfs_sa_upgrade);
 	}
 

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -625,9 +625,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = zap_create_norm_dnsize(zfsvfs->z_os,
+			VERIFY0(zap_create_norm_dnsize(zfsvfs->z_os,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	} else {
 		if (zfsvfs->z_replay) {
@@ -635,9 +635,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = dmu_object_alloc_dnsize(zfsvfs->z_os,
+			VERIFY0(dmu_object_alloc_dnsize(zfsvfs->z_os,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	}
 
@@ -1803,8 +1803,8 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	 */
 
 	if (version >= ZPL_VERSION_SA) {
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj));
 		error = zap_add(os, moid, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
 		ASSERT0(error);
 	} else {
@@ -1813,7 +1813,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	/*
 	 * Create a delete queue.
 	 */
-	obj = zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx, &obj));
 
 	error = zap_add(os, moid, ZFS_UNLINKED_SET, 8, 1, &obj, tx);
 	ASSERT0(error);

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -615,9 +615,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = zap_create_norm_dnsize(zfsvfs->z_os,
+			VERIFY0(zap_create_norm_dnsize(zfsvfs->z_os,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	} else {
 		if (zfsvfs->z_replay) {
@@ -625,9 +625,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = dmu_object_alloc_dnsize(zfsvfs->z_os,
+			VERIFY0(dmu_object_alloc_dnsize(zfsvfs->z_os,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	}
 
@@ -1799,8 +1799,8 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	 */
 
 	if (version >= ZPL_VERSION_SA) {
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj));
 		error = zap_add(os, moid, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
 		ASSERT0(error);
 	} else {
@@ -1809,7 +1809,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	/*
 	 * Create a delete queue.
 	 */
-	obj = zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx, &obj));
 
 	error = zap_add(os, moid, ZFS_UNLINKED_SET, 8, 1, &obj, tx);
 	ASSERT0(error);

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -1432,12 +1432,14 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 				aoid = 0;
 			}
 			if (aoid == 0) {
-				aoid = dmu_object_alloc(zfsvfs->z_os,
+				error = dmu_object_alloc(zfsvfs->z_os,
 				    otype, aclp->z_acl_bytes,
 				    otype == DMU_OT_ACL ?
 				    DMU_OT_SYSACL : DMU_OT_NONE,
 				    otype == DMU_OT_ACL ?
-				    DN_OLD_MAX_BONUSLEN : 0, tx);
+				    DN_OLD_MAX_BONUSLEN : 0, tx, &aoid);
+				if (error)
+					return (error);
 			} else {
 				(void) dmu_object_set_blocksize(zfsvfs->z_os,
 				    aoid, aclp->z_acl_bytes, 0, tx);

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -1422,12 +1422,14 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 				aoid = 0;
 			}
 			if (aoid == 0) {
-				aoid = dmu_object_alloc(zfsvfs->z_os,
+				error = dmu_object_alloc(zfsvfs->z_os,
 				    otype, aclp->z_acl_bytes,
 				    otype == DMU_OT_ACL ?
 				    DMU_OT_SYSACL : DMU_OT_NONE,
 				    otype == DMU_OT_ACL ?
-				    DN_OLD_MAX_BONUSLEN : 0, tx);
+				    DN_OLD_MAX_BONUSLEN : 0, tx, &aoid);
+				if (error)
+					return (error);
 			} else {
 				(void) dmu_object_set_blocksize(zfsvfs->z_os,
 				    aoid, aclp->z_acl_bytes, 0, tx);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -987,7 +987,7 @@ zfs_statvfs(struct inode *ip, struct kstatfs *statp)
 	uint64_t refdbytes, availbytes, usedobjs, availobjs;
 	int err = 0;
 
-	if ((err = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+	if ((err = zfs_enter_unmountingok_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (err);
 
 	dmu_objset_space(zfsvfs->z_os,
@@ -1058,7 +1058,7 @@ zfs_root(zfsvfs_t *zfsvfs, struct inode **ipp)
 	znode_t *rootzp;
 	int error;
 
-	if ((error = zfs_enter(zfsvfs, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok(zfsvfs, FTAG)) != 0)
 		return (error);
 
 	error = zfs_zget(zfsvfs, zfsvfs->z_root, &rootzp);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1940,8 +1940,12 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1940,18 +1940,17 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx, &sa_obj);
-		if (error) {
+		if ((error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj)))
+			goto onerror;
+		if ((error = zap_add(os, MASTER_NODE_OBJ,
+		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx)))
+			goto onerror;
+		if ((error = sa_set_sa_object(os, sa_obj))) {
+onerror:
 			dmu_tx_commit(tx);
 			return (error);
 		}
-
-		error = zap_add(os, MASTER_NODE_OBJ,
-		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
-		ASSERT0(error);
-
-		VERIFY0(sa_set_sa_object(os, sa_obj));
 		sa_register_update_callback(os, zfs_sa_upgrade);
 	}
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1924,8 +1924,12 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj);
+		if (error) {
+			dmu_tx_commit(tx);
+			return (error);
+		}
 
 		error = zap_add(os, MASTER_NODE_OBJ,
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -977,7 +977,7 @@ zfs_statvfs(struct inode *ip, struct kstatfs *statp)
 	uint64_t refdbytes, availbytes, usedobjs, availobjs;
 	int err = 0;
 
-	if ((err = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+	if ((err = zfs_enter_unmountingok_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (err);
 
 	dmu_objset_space(zfsvfs->z_os,
@@ -1048,7 +1048,7 @@ zfs_root(zfsvfs_t *zfsvfs, struct inode **ipp)
 	znode_t *rootzp;
 	int error;
 
-	if ((error = zfs_enter(zfsvfs, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok(zfsvfs, FTAG)) != 0)
 		return (error);
 
 	error = zfs_zget(zfsvfs, zfsvfs->z_root, &rootzp);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1924,18 +1924,17 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 
 		ASSERT3U(spa_version(dmu_objset_spa(zfsvfs->z_os)), >=,
 		    SPA_VERSION_SA);
-		error = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx, &sa_obj);
-		if (error) {
+		if ((error = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj)))
+			goto onerror;
+		if ((error = zap_add(os, MASTER_NODE_OBJ,
+		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx)))
+			goto onerror;
+		if ((error = sa_set_sa_object(os, sa_obj))) {
+onerror:
 			dmu_tx_commit(tx);
 			return (error);
 		}
-
-		error = zap_add(os, MASTER_NODE_OBJ,
-		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
-		ASSERT0(error);
-
-		VERIFY0(sa_set_sa_object(os, sa_obj));
 		sa_register_update_callback(os, zfs_sa_upgrade);
 	}
 

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -220,7 +220,7 @@ zfs_close(struct inode *ip, int flag, cred_t *cr)
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	int error;
 
-	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (error);
 
 	/* Decrement the synchronous opens in the znode */

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -210,7 +210,7 @@ zfs_close(struct inode *ip, int flag, cred_t *cr)
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	int error;
 
-	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (error);
 
 	/* Decrement the synchronous opens in the znode */

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -734,9 +734,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = zap_create_norm_dnsize(zfsvfs->z_os,
+			VERIFY0(zap_create_norm_dnsize(zfsvfs->z_os,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	} else {
 		if (zfsvfs->z_replay) {
@@ -744,9 +744,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = dmu_object_alloc_dnsize(zfsvfs->z_os,
+			VERIFY0(dmu_object_alloc_dnsize(zfsvfs->z_os,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	}
 
@@ -1909,8 +1909,8 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	 */
 
 	if (version >= ZPL_VERSION_SA) {
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj));
 		error = zap_add(os, moid, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
 		ASSERT0(error);
 	} else {
@@ -1919,7 +1919,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	/*
 	 * Create a delete queue.
 	 */
-	obj = zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx, &obj));
 
 	error = zap_add(os, moid, ZFS_UNLINKED_SET, 8, 1, &obj, tx);
 	ASSERT0(error);

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -727,9 +727,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = zap_create_norm_dnsize(zfsvfs->z_os,
+			VERIFY0(zap_create_norm_dnsize(zfsvfs->z_os,
 			    zfsvfs->z_norm, DMU_OT_DIRECTORY_CONTENTS,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	} else {
 		if (zfsvfs->z_replay) {
@@ -737,9 +737,9 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
 			    obj_type, bonuslen, dnodesize, tx));
 		} else {
-			obj = dmu_object_alloc_dnsize(zfsvfs->z_os,
+			VERIFY0(dmu_object_alloc_dnsize(zfsvfs->z_os,
 			    DMU_OT_PLAIN_FILE_CONTENTS, 0,
-			    obj_type, bonuslen, dnodesize, tx);
+			    obj_type, bonuslen, dnodesize, tx, &obj));
 		}
 	}
 
@@ -1923,8 +1923,8 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	 */
 
 	if (version >= ZPL_VERSION_SA) {
-		sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    DMU_OT_NONE, 0, tx, &sa_obj));
 		error = zap_add(os, moid, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
 		ASSERT0(error);
 	} else {
@@ -1933,7 +1933,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	/*
 	 * Create a delete queue.
 	 */
-	obj = zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(os, DMU_OT_UNLINKED_SET, DMU_OT_NONE, 0, tx, &obj));
 
 	error = zap_add(os, moid, ZFS_UNLINKED_SET, 8, 1, &obj, tx);
 	ASSERT0(error);

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -231,6 +231,7 @@ zpl_iter_read(struct kiocb *kiocb, struct iov_iter *to)
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
+	ret = ret ? ret : -zfsvfs_error(ITOZSB(filp->f_mapping->host));
 	if (ret < 0)
 		return (ret);
 
@@ -281,6 +282,7 @@ zpl_iter_write(struct kiocb *kiocb, struct iov_iter *from)
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
+	ret = ret ? ret : -zfsvfs_error(ITOZSB(ip));
 	if (ret < 0)
 		return (ret);
 
@@ -664,7 +666,7 @@ zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 		wbc->sync_mode = sync_mode;
 		result = zpl_write_cache_pages(mapping, wbc, &for_sync);
 	}
-	return (result);
+	return (result ? result : -zfsvfs_error(zfsvfs));
 }
 
 #ifdef HAVE_VFS_WRITEPAGE
@@ -682,7 +684,9 @@ zpl_writepage(struct page *pp, struct writeback_control *wbc)
 
 	boolean_t for_sync = (wbc->sync_mode == WB_SYNC_ALL);
 
-	return (zpl_putpage(pp, wbc, &for_sync));
+	zfsvfs_t *zfsvfs = ITOZSB(pp->mapping->host);
+	int error = zpl_putpage(pp, wbc, &for_sync);
+	return (error ? error : -zfsvfs_error(zfsvfs));
 }
 #endif
 

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -221,6 +221,7 @@ zpl_iter_read(struct kiocb *kiocb, struct iov_iter *to)
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
+	ret = ret ? ret : -zfsvfs_error(ITOZSB(filp->f_mapping->host));
 	if (ret < 0)
 		return (ret);
 
@@ -271,6 +272,7 @@ zpl_iter_write(struct kiocb *kiocb, struct iov_iter *from)
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
+	ret = ret ? ret : -zfsvfs_error(ITOZSB(ip));
 	if (ret < 0)
 		return (ret);
 
@@ -654,7 +656,7 @@ zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 		wbc->sync_mode = sync_mode;
 		result = zpl_write_cache_pages(mapping, wbc, &for_sync);
 	}
-	return (result);
+	return (result ? result : -zfsvfs_error(zfsvfs));
 }
 
 #ifdef HAVE_VFS_WRITEPAGE
@@ -672,7 +674,9 @@ zpl_writepage(struct page *pp, struct writeback_control *wbc)
 
 	boolean_t for_sync = (wbc->sync_mode == WB_SYNC_ALL);
 
-	return (zpl_putpage(pp, wbc, &for_sync));
+	zfsvfs_t *zfsvfs = ITOZSB(pp->mapping->host);
+	int error = zpl_putpage(pp, wbc, &for_sync);
+	return (error ? error : -zfsvfs_error(zfsvfs));
 }
 #endif
 

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -1107,3 +1107,7 @@ ZFS_MODULE_PARAM(zfs, zfs_, delete_inode, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, delete_dentry, INT, ZMOD_RW,
 	"Delete dentries from dentry cache as soon as the last reference is "
 	"released.");
+
+ZFS_MODULE_PARAM(zfs, zfs_, forced_unmount_level, UINT, ZMOD_RW,
+	"Enables extra help in addition to the standard Linux forced umount"
+	" facility");

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -271,7 +271,7 @@ static int
 __zpl_show_devname(struct seq_file *seq, zfsvfs_t *zfsvfs)
 {
 	int error;
-	if ((error = zpl_enter(zfsvfs, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok(zfsvfs, FTAG)) != 0)
 		return (error);
 
 	char *fsname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -33,11 +33,19 @@
 #include <sys/zfs_vnops.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
+#include <sys/dmu_objset.h>
+#include <sys/dsl_dir.h>
 #include <linux/iversion.h>
 #include <linux/version.h>
 #include <linux/vfs_compat.h>
 #include <linux/fs_context.h>
 #include <linux/fs_parser.h>
+
+enum {
+	ZFS_FORCED_UNMOUNT_DEFAULT,
+	ZFS_FORCED_UNMOUNT_DRAIN_IO,
+};
+uint_t zfs_forced_unmount_level = ZFS_FORCED_UNMOUNT_DRAIN_IO;
 
 /*
  * What to do when the last reference to an inode is released. If 0, the kernel
@@ -146,6 +154,33 @@ zpl_evict_inode(struct inode *ip)
 	clear_inode(ip);
 	zfs_inactive(ip);
 	spl_fstrans_unmark(cookie);
+}
+
+static void
+zpl_umount_begin(struct super_block *sb)
+{
+	zfsvfs_t *zfsvfs = sb->s_fs_info;
+	const uint_t level = zfs_forced_unmount_level;
+
+	if (zfsvfs == NULL)
+		return;
+	if (!zfs_forcibly_unmounting(zfsvfs))
+		return;
+
+	if (level >= ZFS_FORCED_UNMOUNT_DRAIN_IO) {
+		/*
+		 * Flush out all POSIX I/Os.  Notify all waiters that they
+		 * must end, then wait for all users to drop their holds on
+		 * z_teardown_*_lock, and evict buffers.
+		 */
+		rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+		rw_enter(&zfsvfs->z_teardown_inactive_lock, RW_WRITER);
+		rw_exit(&zfsvfs->z_teardown_inactive_lock);
+		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+
+		dmu_objset_evict_dbufs(zfsvfs->z_os);
+		dsl_dir_cancel_waiters(zfsvfs->z_os->os_dsl_dataset->ds_dir);
+	}
 }
 
 static void
@@ -1053,6 +1088,7 @@ const struct super_operations zpl_super_operations = {
 	.drop_inode		= zpl_drop_inode,
 	.evict_inode		= zpl_evict_inode,
 	.put_super		= zpl_put_super,
+	.umount_begin		= zpl_umount_begin,
 	.sync_fs		= zpl_sync_fs,
 	.statfs			= zpl_statfs,
 	.show_devname		= zpl_show_devname,

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -23,11 +23,19 @@
 #include <sys/zfs_vnops.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
+#include <sys/dmu_objset.h>
+#include <sys/dsl_dir.h>
 #include <linux/iversion.h>
 #include <linux/version.h>
 #include <linux/vfs_compat.h>
 #include <linux/fs_context.h>
 #include <linux/fs_parser.h>
+
+enum {
+	ZFS_FORCED_UNMOUNT_DEFAULT,
+	ZFS_FORCED_UNMOUNT_DRAIN_IO,
+};
+uint_t zfs_forced_unmount_level = ZFS_FORCED_UNMOUNT_DRAIN_IO;
 
 /*
  * What to do when the last reference to an inode is released. If 0, the kernel
@@ -136,6 +144,33 @@ zpl_evict_inode(struct inode *ip)
 	clear_inode(ip);
 	zfs_inactive(ip);
 	spl_fstrans_unmark(cookie);
+}
+
+static void
+zpl_umount_begin(struct super_block *sb)
+{
+	zfsvfs_t *zfsvfs = sb->s_fs_info;
+	const uint_t level = zfs_forced_unmount_level;
+
+	if (zfsvfs == NULL)
+		return;
+	if (!zfs_forcibly_unmounting(zfsvfs))
+		return;
+
+	if (level >= ZFS_FORCED_UNMOUNT_DRAIN_IO) {
+		/*
+		 * Flush out all POSIX I/Os.  Notify all waiters that they
+		 * must end, then wait for all users to drop their holds on
+		 * z_teardown_*_lock, and evict buffers.
+		 */
+		rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+		rw_enter(&zfsvfs->z_teardown_inactive_lock, RW_WRITER);
+		rw_exit(&zfsvfs->z_teardown_inactive_lock);
+		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+
+		dmu_objset_evict_dbufs(zfsvfs->z_os);
+		dsl_dir_cancel_waiters(zfsvfs->z_os->os_dsl_dataset->ds_dir);
+	}
 }
 
 static void
@@ -1046,6 +1081,7 @@ const struct super_operations zpl_super_operations = {
 	.drop_inode		= zpl_drop_inode,
 	.evict_inode		= zpl_evict_inode,
 	.put_super		= zpl_put_super,
+	.umount_begin		= zpl_umount_begin,
 	.sync_fs		= zpl_sync_fs,
 	.statfs			= zpl_statfs,
 	.show_devname		= zpl_show_devname,

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -261,7 +261,7 @@ static int
 __zpl_show_devname(struct seq_file *seq, zfsvfs_t *zfsvfs)
 {
 	int error;
-	if ((error = zpl_enter(zfsvfs, FTAG)) != 0)
+	if ((error = zfs_enter_unmountingok(zfsvfs, FTAG)) != 0)
 		return (error);
 
 	char *fsname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -1100,3 +1100,7 @@ ZFS_MODULE_PARAM(zfs, zfs_, delete_inode, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, delete_dentry, INT, ZMOD_RW,
 	"Delete dentries from dentry cache as soon as the last reference is "
 	"released.");
+
+ZFS_MODULE_PARAM(zfs, zfs_, forced_unmount_level, UINT, ZMOD_RW,
+	"Enables extra help in addition to the standard Linux forced umount"
+	" facility");

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1501,8 +1501,10 @@ arc_cksum_verify(arc_buf_t *buf)
 	}
 
 	fletcher_2_native(buf->b_data, arc_buf_size(buf), NULL, &zc);
-	if (!ZIO_CHECKSUM_EQUAL(*hdr->b_l1hdr.b_freeze_cksum, zc))
-		panic("buffer modified while frozen!");
+	if (!ZIO_CHECKSUM_EQUAL(*hdr->b_l1hdr.b_freeze_cksum, zc)) {
+		if (hdr->b_spa != spa_exiting_guid) /* if !spa_exiting() */
+			panic("buffer modified while frozen!");
+	}
 	mutex_exit(&hdr->b_l1hdr.b_freeze_lock);
 #endif
 }
@@ -7004,6 +7006,12 @@ arc_write_done(zio_t *zio)
 
 	ASSERT0P(hdr->b_l1hdr.b_acb);
 
+	if (spa_exiting(zio->io_spa)) {
+		arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
+		VERIFY3S(remove_reference(hdr, hdr), >, 0);
+		goto finish;
+	}
+
 	if (zio->io_error == 0) {
 		arc_hdr_verify(hdr, zio->io_bp);
 
@@ -7075,6 +7083,7 @@ arc_write_done(zio_t *zio)
 		VERIFY3S(remove_reference(hdr, hdr), >, 0);
 	}
 
+finish:
 	callback->awcb_done(zio, buf, callback->awcb_private);
 
 	abd_free(zio->io_abd);
@@ -7096,7 +7105,7 @@ arc_write(zio_t *pio, spa_t *spa, uint64_t txg,
 
 	ASSERT3P(ready, !=, NULL);
 	ASSERT3P(done, !=, NULL);
-	ASSERT(!HDR_IO_ERROR(hdr));
+	ASSERT(!HDR_IO_ERROR(hdr) || SPA_EXITING(spa));
 	ASSERT(!HDR_IO_IN_PROGRESS(hdr));
 	ASSERT0P(hdr->b_l1hdr.b_acb);
 	ASSERT3P(hdr->b_l1hdr.b_buf, !=, NULL);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1492,8 +1492,10 @@ arc_cksum_verify(arc_buf_t *buf)
 	}
 
 	fletcher_2_native(buf->b_data, arc_buf_size(buf), NULL, &zc);
-	if (!ZIO_CHECKSUM_EQUAL(*hdr->b_l1hdr.b_freeze_cksum, zc))
-		panic("buffer modified while frozen!");
+	if (!ZIO_CHECKSUM_EQUAL(*hdr->b_l1hdr.b_freeze_cksum, zc)) {
+		if (hdr->b_spa != spa_exiting_guid) /* if !spa_exiting() */
+			panic("buffer modified while frozen!");
+	}
 	mutex_exit(&hdr->b_l1hdr.b_freeze_lock);
 #endif
 }
@@ -7018,6 +7020,12 @@ arc_write_done(zio_t *zio)
 
 	ASSERT0P(hdr->b_l1hdr.b_acb);
 
+	if (spa_exiting(zio->io_spa)) {
+		arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
+		VERIFY3S(remove_reference(hdr, hdr), >, 0);
+		goto finish;
+	}
+
 	if (zio->io_error == 0) {
 		arc_hdr_verify(hdr, zio->io_bp);
 
@@ -7089,6 +7097,7 @@ arc_write_done(zio_t *zio)
 		VERIFY3S(remove_reference(hdr, hdr), >, 0);
 	}
 
+finish:
 	callback->awcb_done(zio, buf, callback->awcb_private);
 
 	abd_free(zio->io_abd);
@@ -7110,7 +7119,7 @@ arc_write(zio_t *pio, spa_t *spa, uint64_t txg,
 
 	ASSERT3P(ready, !=, NULL);
 	ASSERT3P(done, !=, NULL);
-	ASSERT(!HDR_IO_ERROR(hdr));
+	ASSERT(!HDR_IO_ERROR(hdr) || SPA_EXITING(spa));
 	ASSERT(!HDR_IO_IN_PROGRESS(hdr));
 	ASSERT0P(hdr->b_l1hdr.b_acb);
 	ASSERT3P(hdr->b_l1hdr.b_buf, !=, NULL);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -28,6 +28,7 @@
 #include <sys/bpobj.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_refcount.h>
+#include <sys/dmu_objset.h>
 #include <sys/dsl_pool.h>
 #include <sys/zfeature.h>
 #include <sys/zap.h>
@@ -35,27 +36,35 @@
 /*
  * Return an empty bpobj, preferably the empty dummy one (dp_empty_bpobj).
  */
-uint64_t
-bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = dmu_objset_spa(os);
 	dsl_pool_t *dp = dmu_objset_pool(os);
+	int err = 0;
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_EMPTY_BPOBJ)) {
 		if (!spa_feature_is_active(spa, SPA_FEATURE_EMPTY_BPOBJ)) {
 			ASSERT0(dp->dp_empty_bpobj);
-			dp->dp_empty_bpobj =
-			    bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx);
-			VERIFY(zap_add(os,
+			err = bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx,
+			    &dp->dp_empty_bpobj);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
+			err = zap_add(os,
 			    DMU_POOL_DIRECTORY_OBJECT,
 			    DMU_POOL_EMPTY_BPOBJ, sizeof (uint64_t), 1,
-			    &dp->dp_empty_bpobj, tx) == 0);
+			    &dp->dp_empty_bpobj, tx);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
 		}
 		spa_feature_incr(spa, SPA_FEATURE_EMPTY_BPOBJ, tx);
 		ASSERT(dp->dp_empty_bpobj != 0);
-		return (dp->dp_empty_bpobj);
+		*objectp = dp->dp_empty_bpobj;
+		return (err);
 	} else {
-		return (bpobj_alloc(os, blocksize, tx));
+		return (bpobj_alloc(os, blocksize, tx, objectp));
 	}
 }
 
@@ -75,8 +84,8 @@ bpobj_decr_empty(objset_t *os, dmu_tx_t *tx)
 	}
 }
 
-uint64_t
-bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	int size;
 
@@ -91,7 +100,7 @@ bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
 		size = sizeof (bpobj_phys_t);
 
 	return (dmu_object_alloc(os, DMU_OT_BPOBJ, blocksize,
-	    DMU_OT_BPOBJ_HDR, size, tx));
+	    DMU_OT_BPOBJ_HDR, size, tx, objectp));
 }
 
 void
@@ -669,13 +678,15 @@ livelist_bpobj_iterate_from_nofree(bpobj_t *bpo, bpobj_itor_t func, void *arg,
  * | bp | bp | bp | bp |   ...   | bp |
  * +----+----+----+----+---------+----+
  */
-void
+int
 bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 {
+	spa_t *spa = bpo->bpo_os->os_spa;
 	bpobj_t subbpo;
 	uint64_t used, comp, uncomp, subsubobjs;
 	boolean_t copy_subsub = B_TRUE;
 	boolean_t copy_bps = B_TRUE;
+	int err = 0;
 
 	ASSERT(bpobj_is_open(bpo));
 	ASSERT(subobj != 0);
@@ -685,26 +696,39 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 
 	if (subobj == dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj) {
 		bpobj_decr_empty(bpo->bpo_os, tx);
-		return;
+		return (err);
 	}
 
-	VERIFY3U(0, ==, bpobj_open(&subbpo, bpo->bpo_os, subobj));
+	err = bpobj_open(&subbpo, bpo->bpo_os, subobj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (bpobj_is_empty(&subbpo)) {
 		/* No point in having an empty subobj. */
 		bpobj_close(&subbpo);
 		bpobj_free(bpo->bpo_os, subobj, tx);
-		return;
+		return (err);
 	}
-	VERIFY3U(0, ==, bpobj_space(&subbpo, &used, &comp, &uncomp));
+	err = bpobj_space(&subbpo, &used, &comp, &uncomp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	mutex_enter(&bpo->bpo_lock);
 	dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	dmu_object_info_t doi;
 
 	if (bpo->bpo_phys->bpo_subobjs != 0) {
-		ASSERT0(dmu_object_info(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
-		    &doi));
+		err = dmu_object_info(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
+		    &doi);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT3U(doi.doi_type, ==, DMU_OT_BPOBJ_SUBOBJ);
 	}
 
@@ -715,7 +739,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	 */
 	subsubobjs = subbpo.bpo_phys->bpo_subobjs;
 	if (subsubobjs != 0) {
-		VERIFY0(dmu_object_info(bpo->bpo_os, subsubobjs, &doi));
+		err = dmu_object_info(bpo->bpo_os, subsubobjs, &doi);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		if (doi.doi_max_offset > doi.doi_data_block_size) {
 			copy_subsub = B_FALSE;
 		}
@@ -727,7 +754,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	 * directly. This reduces recursion in bpobj_iterate due to nested
 	 * subobjs.
 	 */
-	VERIFY3U(0, ==, dmu_object_info(bpo->bpo_os, subobj, &doi));
+	err = dmu_object_info(bpo->bpo_os, subobj, &doi);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (doi.doi_max_offset > doi.doi_data_block_size || !copy_subsub) {
 		copy_bps = B_FALSE;
 	}
@@ -736,8 +766,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		dmu_buf_t *subdb;
 		uint64_t numsubsub = subbpo.bpo_phys->bpo_num_subobjs;
 
-		VERIFY0(dmu_buf_hold(bpo->bpo_os, subsubobjs,
-		    0, FTAG, &subdb, 0));
+		err = dmu_buf_hold(bpo->bpo_os, subsubobjs, 0, FTAG, &subdb, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		/*
 		 * Make sure that we are not asking dmu_write()
 		 * to write more data than we have in our buffer.
@@ -745,10 +777,14 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		VERIFY3U(subdb->db_size, >=,
 		    numsubsub * sizeof (subobj));
 		if (bpo->bpo_phys->bpo_subobjs == 0) {
-			bpo->bpo_phys->bpo_subobjs =
-			    dmu_object_alloc(bpo->bpo_os,
+			err = dmu_object_alloc(bpo->bpo_os,
 			    DMU_OT_BPOBJ_SUBOBJ, SPA_OLD_MAXBLOCKSIZE,
-			    DMU_OT_NONE, 0, tx);
+			    DMU_OT_NONE, 0, tx, &bpo->bpo_phys->bpo_subobjs);
+			if (err && SPA_EXITING(spa)) {
+				dmu_buf_rele(subdb, FTAG);
+				goto out;
+			}
+			VERIFY0(err);
 		}
 		dmu_write(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
 		    bpo->bpo_phys->bpo_num_subobjs * sizeof (subobj),
@@ -758,8 +794,15 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		bpo->bpo_phys->bpo_num_subobjs += numsubsub;
 
 		dmu_buf_will_dirty(subbpo.bpo_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		subbpo.bpo_phys->bpo_subobjs = 0;
-		VERIFY0(dmu_object_free(bpo->bpo_os, subsubobjs, tx));
+		err = dmu_object_free(bpo->bpo_os, subsubobjs, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	if (copy_bps) {
@@ -767,8 +810,11 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		uint64_t numbps = subbpo.bpo_phys->bpo_num_blkptrs;
 
 		ASSERT(copy_subsub);
-		VERIFY0(dmu_buf_hold(bpo->bpo_os, subobj,
-		    0, FTAG, &bps, 0));
+		err = dmu_buf_hold(bpo->bpo_os, subobj,
+		    0, FTAG, &bps, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		/*
 		 * Make sure that we are not asking dmu_write()
@@ -783,14 +829,19 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		bpo->bpo_phys->bpo_num_blkptrs += numbps;
 
 		bpobj_close(&subbpo);
-		VERIFY0(dmu_object_free(bpo->bpo_os, subobj, tx));
+		err = dmu_object_free(bpo->bpo_os, subobj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	} else {
 		bpobj_close(&subbpo);
 		if (bpo->bpo_phys->bpo_subobjs == 0) {
-			bpo->bpo_phys->bpo_subobjs =
-			    dmu_object_alloc(bpo->bpo_os,
+			err = dmu_object_alloc(bpo->bpo_os,
 			    DMU_OT_BPOBJ_SUBOBJ, SPA_OLD_MAXBLOCKSIZE,
-			    DMU_OT_NONE, 0, tx);
+			    DMU_OT_NONE, 0, tx, &bpo->bpo_phys->bpo_subobjs);
+			if (err && SPA_EXITING(spa))
+				goto out;
+			VERIFY0(err);
 		}
 
 		dmu_write(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
@@ -802,8 +853,11 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	bpo->bpo_phys->bpo_bytes += used;
 	bpo->bpo_phys->bpo_comp += comp;
 	bpo->bpo_phys->bpo_uncomp += uncomp;
+
+out:
 	mutex_exit(&bpo->bpo_lock);
 
+	return (err);
 }
 
 /*

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -72,14 +72,20 @@ void
 bpobj_decr_empty(objset_t *os, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dmu_objset_pool(os);
+	spa_t *spa = os->os_spa;
+	int err;
 
 	spa_feature_decr(dmu_objset_spa(os), SPA_FEATURE_EMPTY_BPOBJ, tx);
 	if (!spa_feature_is_active(dmu_objset_spa(os),
 	    SPA_FEATURE_EMPTY_BPOBJ)) {
-		VERIFY3U(0, ==, zap_remove(dp->dp_meta_objset,
+		err = zap_remove(dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_EMPTY_BPOBJ, tx));
-		VERIFY3U(0, ==, dmu_object_free(os, dp->dp_empty_bpobj, tx));
+		    DMU_POOL_EMPTY_BPOBJ, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = dmu_object_free(os, dp->dp_empty_bpobj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dp->dp_empty_bpobj = 0;
 	}
 }
@@ -106,21 +112,28 @@ bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 void
 bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	int64_t i;
 	bpobj_t bpo;
 	dmu_object_info_t doi;
-	int epb;
+	int epb, err;
 	dmu_buf_t *dbuf = NULL;
 
 	ASSERT(obj != dmu_objset_pool(os)->dp_empty_bpobj);
-	VERIFY3U(0, ==, bpobj_open(&bpo, os, obj));
+	err = bpobj_open(&bpo, os, obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	mutex_enter(&bpo.bpo_lock);
 
 	if (!bpo.bpo_havesubobj || bpo.bpo_phys->bpo_subobjs == 0)
 		goto out;
 
-	VERIFY3U(0, ==, dmu_object_info(os, bpo.bpo_phys->bpo_subobjs, &doi));
+	err = dmu_object_info(os, bpo.bpo_phys->bpo_subobjs, &doi);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	epb = doi.doi_data_block_size / sizeof (uint64_t);
 
 	for (i = bpo.bpo_phys->bpo_num_subobjs - 1; i >= 0; i--) {
@@ -133,8 +146,11 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 		if (dbuf == NULL || dbuf->db_offset > offset) {
 			if (dbuf)
 				dmu_buf_rele(dbuf, FTAG);
-			VERIFY3U(0, ==, dmu_buf_hold(os,
-			    bpo.bpo_phys->bpo_subobjs, offset, FTAG, &dbuf, 0));
+			err = dmu_buf_hold(os,
+			    bpo.bpo_phys->bpo_subobjs, offset, FTAG, &dbuf, 0);
+			if (err && SPA_EXITING(spa))
+				break;
+			VERIFY0(err);
 		}
 
 		ASSERT3U(offset, >=, dbuf->db_offset);
@@ -147,13 +163,17 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 		dmu_buf_rele(dbuf, FTAG);
 		dbuf = NULL;
 	}
-	VERIFY3U(0, ==, dmu_object_free(os, bpo.bpo_phys->bpo_subobjs, tx));
+	err = dmu_object_free(os, bpo.bpo_phys->bpo_subobjs, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 out:
 	mutex_exit(&bpo.bpo_lock);
 	bpobj_close(&bpo);
 
-	VERIFY3U(0, ==, dmu_object_free(os, obj, tx));
+	err = dmu_object_free(os, obj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 int
@@ -167,7 +187,6 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 		return (err);
 
 	memset(bpo, 0, sizeof (*bpo));
-	mutex_init(&bpo->bpo_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	ASSERT0P(bpo->bpo_dbuf);
 	ASSERT0P(bpo->bpo_phys);
@@ -179,6 +198,7 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 	if (err)
 		return (err);
 
+	mutex_init(&bpo->bpo_lock, NULL, MUTEX_DEFAULT, NULL);
 	bpo->bpo_os = os;
 	bpo->bpo_object = object;
 	bpo->bpo_epb = doi.doi_data_block_size >> SPA_BLKPTRSHIFT;
@@ -202,7 +222,8 @@ bpobj_close(bpobj_t *bpo)
 	if (bpo->bpo_object == 0)
 		return;
 
-	dmu_buf_rele(bpo->bpo_dbuf, bpo);
+	if (bpo->bpo_dbuf != NULL)
+		dmu_buf_rele(bpo->bpo_dbuf, bpo);
 	if (bpo->bpo_cached_dbuf != NULL)
 		dmu_buf_rele(bpo->bpo_cached_dbuf, bpo);
 	bpo->bpo_dbuf = NULL;
@@ -354,10 +375,12 @@ bpobj_iterate_blkptrs(bpobj_info_t *bpi, bpobj_itor_t func, void *arg,
 	if (free) {
 		propagate_space_reduction(bpi, freed, comp_freed,
 		    uncomp_freed, tx);
-		VERIFY0(dmu_free_range(bpo->bpo_os,
+		int error = dmu_free_range(bpo->bpo_os,
 		    bpo->bpo_object,
 		    bpo->bpo_phys->bpo_num_blkptrs * sizeof (blkptr_t),
-		    DMU_OBJECT_END, tx));
+		    DMU_OBJECT_END, tx);
+		if (!SPA_EXITING(dmu_objset_spa(bpo->bpo_os)))
+			VERIFY0(error);
 	}
 	if (dbuf) {
 		dmu_buf_rele(dbuf, FTAG);
@@ -403,8 +426,13 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 		ASSERT(MUTEX_HELD(&bpo->bpo_lock));
 		ASSERT(bpobj_is_open(bpo));
 
-		if (free)
+		if (free) {
 			dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+			if (SPA_EXITING(dmu_objset_spa(initial_bpo->bpo_os))) {
+				err = SET_ERROR(EIO);
+				break;
+			}
+		}
 
 		if (bpi->bpi_visited == B_FALSE) {
 			err = bpobj_iterate_blkptrs(bpi, func, arg, 0, tx,
@@ -424,7 +452,8 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 			 * If there are no entries, there should
 			 * be no bytes.
 			 */
-			if (bpobj_is_empty_impl(bpo)) {
+			if (bpobj_is_empty_impl(bpo) &&
+			    !SPA_EXITING(dmu_objset_spa(initial_bpo->bpo_os))) {
 				ASSERT0(bpo->bpo_phys->bpo_bytes);
 				ASSERT0(bpo->bpo_phys->bpo_comp);
 				ASSERT0(bpo->bpo_phys->bpo_uncomp);
@@ -445,10 +474,14 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 
 					p->bpo_phys->bpo_num_subobjs--;
 
-					VERIFY0(dmu_free_range(p->bpo_os,
+					err = dmu_free_range(p->bpo_os,
 					    p->bpo_phys->bpo_subobjs,
 					    bpi->bpi_index * sizeof (uint64_t),
-					    sizeof (uint64_t), tx));
+					    sizeof (uint64_t), tx);
+					if (err && SPA_EXITING(dmu_objset_spa(
+					    initial_bpo->bpo_os)))
+						break;
+					VERIFY0(err);
 
 					/* eliminate the empty subobj list */
 					if (bpo->bpo_havesubobj &&
@@ -710,8 +743,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		return (err);
 	}
 	err = bpobj_space(&subbpo, &used, &comp, &uncomp);
-	if (err && SPA_EXITING(spa))
+	if (err && SPA_EXITING(spa)) {
+		bpobj_close(&subbpo);
 		return (err);
+	}
 	VERIFY0(err);
 
 	mutex_enter(&bpo->bpo_lock);
@@ -855,6 +890,8 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	bpo->bpo_phys->bpo_uncomp += uncomp;
 
 out:
+	if (bpobj_is_open(&subbpo))
+		bpobj_close(&subbpo);
 	mutex_exit(&bpo->bpo_lock);
 
 	return (err);
@@ -928,7 +965,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 {
 	blkptr_t stored_bp = *bp;
 	uint64_t offset;
-	int blkoff;
+	int blkoff, err;
 	blkptr_t *bparray;
 
 	ASSERT(bpobj_is_open(bpo));
@@ -969,16 +1006,23 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 	    bpo->bpo_cached_dbuf->db_size) {
 		if (bpo->bpo_cached_dbuf)
 			dmu_buf_rele(bpo->bpo_cached_dbuf, bpo);
-		VERIFY3U(0, ==, dmu_buf_hold(bpo->bpo_os, bpo->bpo_object,
-		    offset, bpo, &bpo->bpo_cached_dbuf, 0));
+		err = dmu_buf_hold(bpo->bpo_os, bpo->bpo_object,
+		    offset, bpo, &bpo->bpo_cached_dbuf, 0);
+		if (err && SPA_EXITING(bpo->bpo_os->os_spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT3P(bpo->bpo_cached_dbuf, !=, NULL);
 	}
 
 	dmu_buf_will_dirty(bpo->bpo_cached_dbuf, tx);
+	if (SPA_EXITING(bpo->bpo_os->os_spa))
+		goto out;
 	bparray = bpo->bpo_cached_dbuf->db_data;
 	bparray[blkoff] = stored_bp;
 
 	dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+	if (SPA_EXITING(bpo->bpo_os->os_spa))
+		goto out;
 	bpo->bpo_phys->bpo_num_blkptrs++;
 	int sign = bp_freed ? -1 : +1;
 	bpo->bpo_phys->bpo_bytes += sign *
@@ -991,6 +1035,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 		ASSERT(bpo->bpo_havefreed);
 		bpo->bpo_phys->bpo_num_freed++;
 	}
+out:
 	mutex_exit(&bpo->bpo_lock);
 }
 

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -18,6 +18,7 @@
 #include <sys/bpobj.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_refcount.h>
+#include <sys/dmu_objset.h>
 #include <sys/dsl_pool.h>
 #include <sys/zfeature.h>
 #include <sys/zap.h>
@@ -25,27 +26,35 @@
 /*
  * Return an empty bpobj, preferably the empty dummy one (dp_empty_bpobj).
  */
-uint64_t
-bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = dmu_objset_spa(os);
 	dsl_pool_t *dp = dmu_objset_pool(os);
+	int err = 0;
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_EMPTY_BPOBJ)) {
 		if (!spa_feature_is_active(spa, SPA_FEATURE_EMPTY_BPOBJ)) {
 			ASSERT0(dp->dp_empty_bpobj);
-			dp->dp_empty_bpobj =
-			    bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx);
-			VERIFY(zap_add(os,
+			err = bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx,
+			    &dp->dp_empty_bpobj);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
+			err = zap_add(os,
 			    DMU_POOL_DIRECTORY_OBJECT,
 			    DMU_POOL_EMPTY_BPOBJ, sizeof (uint64_t), 1,
-			    &dp->dp_empty_bpobj, tx) == 0);
+			    &dp->dp_empty_bpobj, tx);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
 		}
 		spa_feature_incr(spa, SPA_FEATURE_EMPTY_BPOBJ, tx);
 		ASSERT(dp->dp_empty_bpobj != 0);
-		return (dp->dp_empty_bpobj);
+		*objectp = dp->dp_empty_bpobj;
+		return (err);
 	} else {
-		return (bpobj_alloc(os, blocksize, tx));
+		return (bpobj_alloc(os, blocksize, tx, objectp));
 	}
 }
 
@@ -65,8 +74,8 @@ bpobj_decr_empty(objset_t *os, dmu_tx_t *tx)
 	}
 }
 
-uint64_t
-bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	int size;
 
@@ -81,7 +90,7 @@ bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
 		size = sizeof (bpobj_phys_t);
 
 	return (dmu_object_alloc(os, DMU_OT_BPOBJ, blocksize,
-	    DMU_OT_BPOBJ_HDR, size, tx));
+	    DMU_OT_BPOBJ_HDR, size, tx, objectp));
 }
 
 void
@@ -659,13 +668,15 @@ livelist_bpobj_iterate_from_nofree(bpobj_t *bpo, bpobj_itor_t func, void *arg,
  * | bp | bp | bp | bp |   ...   | bp |
  * +----+----+----+----+---------+----+
  */
-void
+int
 bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 {
+	spa_t *spa = bpo->bpo_os->os_spa;
 	bpobj_t subbpo;
 	uint64_t used, comp, uncomp, subsubobjs;
 	boolean_t copy_subsub = B_TRUE;
 	boolean_t copy_bps = B_TRUE;
+	int err = 0;
 
 	ASSERT(bpobj_is_open(bpo));
 	ASSERT(subobj != 0);
@@ -675,26 +686,39 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 
 	if (subobj == dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj) {
 		bpobj_decr_empty(bpo->bpo_os, tx);
-		return;
+		return (err);
 	}
 
-	VERIFY3U(0, ==, bpobj_open(&subbpo, bpo->bpo_os, subobj));
+	err = bpobj_open(&subbpo, bpo->bpo_os, subobj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (bpobj_is_empty(&subbpo)) {
 		/* No point in having an empty subobj. */
 		bpobj_close(&subbpo);
 		bpobj_free(bpo->bpo_os, subobj, tx);
-		return;
+		return (err);
 	}
-	VERIFY3U(0, ==, bpobj_space(&subbpo, &used, &comp, &uncomp));
+	err = bpobj_space(&subbpo, &used, &comp, &uncomp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	mutex_enter(&bpo->bpo_lock);
 	dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	dmu_object_info_t doi;
 
 	if (bpo->bpo_phys->bpo_subobjs != 0) {
-		ASSERT0(dmu_object_info(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
-		    &doi));
+		err = dmu_object_info(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
+		    &doi);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT3U(doi.doi_type, ==, DMU_OT_BPOBJ_SUBOBJ);
 	}
 
@@ -705,7 +729,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	 */
 	subsubobjs = subbpo.bpo_phys->bpo_subobjs;
 	if (subsubobjs != 0) {
-		VERIFY0(dmu_object_info(bpo->bpo_os, subsubobjs, &doi));
+		err = dmu_object_info(bpo->bpo_os, subsubobjs, &doi);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		if (doi.doi_max_offset > doi.doi_data_block_size) {
 			copy_subsub = B_FALSE;
 		}
@@ -717,7 +744,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	 * directly. This reduces recursion in bpobj_iterate due to nested
 	 * subobjs.
 	 */
-	VERIFY3U(0, ==, dmu_object_info(bpo->bpo_os, subobj, &doi));
+	err = dmu_object_info(bpo->bpo_os, subobj, &doi);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (doi.doi_max_offset > doi.doi_data_block_size || !copy_subsub) {
 		copy_bps = B_FALSE;
 	}
@@ -726,8 +756,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		dmu_buf_t *subdb;
 		uint64_t numsubsub = subbpo.bpo_phys->bpo_num_subobjs;
 
-		VERIFY0(dmu_buf_hold(bpo->bpo_os, subsubobjs,
-		    0, FTAG, &subdb, 0));
+		err = dmu_buf_hold(bpo->bpo_os, subsubobjs, 0, FTAG, &subdb, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		/*
 		 * Make sure that we are not asking dmu_write()
 		 * to write more data than we have in our buffer.
@@ -735,10 +767,14 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		VERIFY3U(subdb->db_size, >=,
 		    numsubsub * sizeof (subobj));
 		if (bpo->bpo_phys->bpo_subobjs == 0) {
-			bpo->bpo_phys->bpo_subobjs =
-			    dmu_object_alloc(bpo->bpo_os,
+			err = dmu_object_alloc(bpo->bpo_os,
 			    DMU_OT_BPOBJ_SUBOBJ, SPA_OLD_MAXBLOCKSIZE,
-			    DMU_OT_NONE, 0, tx);
+			    DMU_OT_NONE, 0, tx, &bpo->bpo_phys->bpo_subobjs);
+			if (err && SPA_EXITING(spa)) {
+				dmu_buf_rele(subdb, FTAG);
+				goto out;
+			}
+			VERIFY0(err);
 		}
 		dmu_write(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
 		    bpo->bpo_phys->bpo_num_subobjs * sizeof (subobj),
@@ -748,8 +784,15 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		bpo->bpo_phys->bpo_num_subobjs += numsubsub;
 
 		dmu_buf_will_dirty(subbpo.bpo_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		subbpo.bpo_phys->bpo_subobjs = 0;
-		VERIFY0(dmu_object_free(bpo->bpo_os, subsubobjs, tx));
+		err = dmu_object_free(bpo->bpo_os, subsubobjs, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	if (copy_bps) {
@@ -757,8 +800,11 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		uint64_t numbps = subbpo.bpo_phys->bpo_num_blkptrs;
 
 		ASSERT(copy_subsub);
-		VERIFY0(dmu_buf_hold(bpo->bpo_os, subobj,
-		    0, FTAG, &bps, 0));
+		err = dmu_buf_hold(bpo->bpo_os, subobj,
+		    0, FTAG, &bps, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		/*
 		 * Make sure that we are not asking dmu_write()
@@ -773,14 +819,19 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		bpo->bpo_phys->bpo_num_blkptrs += numbps;
 
 		bpobj_close(&subbpo);
-		VERIFY0(dmu_object_free(bpo->bpo_os, subobj, tx));
+		err = dmu_object_free(bpo->bpo_os, subobj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	} else {
 		bpobj_close(&subbpo);
 		if (bpo->bpo_phys->bpo_subobjs == 0) {
-			bpo->bpo_phys->bpo_subobjs =
-			    dmu_object_alloc(bpo->bpo_os,
+			err = dmu_object_alloc(bpo->bpo_os,
 			    DMU_OT_BPOBJ_SUBOBJ, SPA_OLD_MAXBLOCKSIZE,
-			    DMU_OT_NONE, 0, tx);
+			    DMU_OT_NONE, 0, tx, &bpo->bpo_phys->bpo_subobjs);
+			if (err && SPA_EXITING(spa))
+				goto out;
+			VERIFY0(err);
 		}
 
 		dmu_write(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
@@ -792,8 +843,11 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	bpo->bpo_phys->bpo_bytes += used;
 	bpo->bpo_phys->bpo_comp += comp;
 	bpo->bpo_phys->bpo_uncomp += uncomp;
+
+out:
 	mutex_exit(&bpo->bpo_lock);
 
+	return (err);
 }
 
 /*

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -62,14 +62,20 @@ void
 bpobj_decr_empty(objset_t *os, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dmu_objset_pool(os);
+	spa_t *spa = os->os_spa;
+	int err;
 
 	spa_feature_decr(dmu_objset_spa(os), SPA_FEATURE_EMPTY_BPOBJ, tx);
 	if (!spa_feature_is_active(dmu_objset_spa(os),
 	    SPA_FEATURE_EMPTY_BPOBJ)) {
-		VERIFY3U(0, ==, zap_remove(dp->dp_meta_objset,
+		err = zap_remove(dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_EMPTY_BPOBJ, tx));
-		VERIFY3U(0, ==, dmu_object_free(os, dp->dp_empty_bpobj, tx));
+		    DMU_POOL_EMPTY_BPOBJ, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = dmu_object_free(os, dp->dp_empty_bpobj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dp->dp_empty_bpobj = 0;
 	}
 }
@@ -96,21 +102,28 @@ bpobj_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 void
 bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	int64_t i;
 	bpobj_t bpo;
 	dmu_object_info_t doi;
-	int epb;
+	int epb, err;
 	dmu_buf_t *dbuf = NULL;
 
 	ASSERT(obj != dmu_objset_pool(os)->dp_empty_bpobj);
-	VERIFY3U(0, ==, bpobj_open(&bpo, os, obj));
+	err = bpobj_open(&bpo, os, obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	mutex_enter(&bpo.bpo_lock);
 
 	if (!bpo.bpo_havesubobj || bpo.bpo_phys->bpo_subobjs == 0)
 		goto out;
 
-	VERIFY3U(0, ==, dmu_object_info(os, bpo.bpo_phys->bpo_subobjs, &doi));
+	err = dmu_object_info(os, bpo.bpo_phys->bpo_subobjs, &doi);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	epb = doi.doi_data_block_size / sizeof (uint64_t);
 
 	for (i = bpo.bpo_phys->bpo_num_subobjs - 1; i >= 0; i--) {
@@ -123,8 +136,11 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 		if (dbuf == NULL || dbuf->db_offset > offset) {
 			if (dbuf)
 				dmu_buf_rele(dbuf, FTAG);
-			VERIFY3U(0, ==, dmu_buf_hold(os,
-			    bpo.bpo_phys->bpo_subobjs, offset, FTAG, &dbuf, 0));
+			err = dmu_buf_hold(os,
+			    bpo.bpo_phys->bpo_subobjs, offset, FTAG, &dbuf, 0);
+			if (err && SPA_EXITING(spa))
+				break;
+			VERIFY0(err);
 		}
 
 		ASSERT3U(offset, >=, dbuf->db_offset);
@@ -137,13 +153,17 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 		dmu_buf_rele(dbuf, FTAG);
 		dbuf = NULL;
 	}
-	VERIFY3U(0, ==, dmu_object_free(os, bpo.bpo_phys->bpo_subobjs, tx));
+	err = dmu_object_free(os, bpo.bpo_phys->bpo_subobjs, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 out:
 	mutex_exit(&bpo.bpo_lock);
 	bpobj_close(&bpo);
 
-	VERIFY3U(0, ==, dmu_object_free(os, obj, tx));
+	err = dmu_object_free(os, obj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 int
@@ -157,7 +177,6 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 		return (err);
 
 	memset(bpo, 0, sizeof (*bpo));
-	mutex_init(&bpo->bpo_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	ASSERT0P(bpo->bpo_dbuf);
 	ASSERT0P(bpo->bpo_phys);
@@ -169,6 +188,7 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 	if (err)
 		return (err);
 
+	mutex_init(&bpo->bpo_lock, NULL, MUTEX_DEFAULT, NULL);
 	bpo->bpo_os = os;
 	bpo->bpo_object = object;
 	bpo->bpo_epb = doi.doi_data_block_size >> SPA_BLKPTRSHIFT;
@@ -192,7 +212,8 @@ bpobj_close(bpobj_t *bpo)
 	if (bpo->bpo_object == 0)
 		return;
 
-	dmu_buf_rele(bpo->bpo_dbuf, bpo);
+	if (bpo->bpo_dbuf != NULL)
+		dmu_buf_rele(bpo->bpo_dbuf, bpo);
 	if (bpo->bpo_cached_dbuf != NULL)
 		dmu_buf_rele(bpo->bpo_cached_dbuf, bpo);
 	bpo->bpo_dbuf = NULL;
@@ -344,10 +365,12 @@ bpobj_iterate_blkptrs(bpobj_info_t *bpi, bpobj_itor_t func, void *arg,
 	if (free) {
 		propagate_space_reduction(bpi, freed, comp_freed,
 		    uncomp_freed, tx);
-		VERIFY0(dmu_free_range(bpo->bpo_os,
+		int error = dmu_free_range(bpo->bpo_os,
 		    bpo->bpo_object,
 		    bpo->bpo_phys->bpo_num_blkptrs * sizeof (blkptr_t),
-		    DMU_OBJECT_END, tx));
+		    DMU_OBJECT_END, tx);
+		if (!SPA_EXITING(dmu_objset_spa(bpo->bpo_os)))
+			VERIFY0(error);
 	}
 	if (dbuf) {
 		dmu_buf_rele(dbuf, FTAG);
@@ -393,8 +416,13 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 		ASSERT(MUTEX_HELD(&bpo->bpo_lock));
 		ASSERT(bpobj_is_open(bpo));
 
-		if (free)
+		if (free) {
 			dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+			if (SPA_EXITING(dmu_objset_spa(initial_bpo->bpo_os))) {
+				err = SET_ERROR(EIO);
+				break;
+			}
+		}
 
 		if (bpi->bpi_visited == B_FALSE) {
 			err = bpobj_iterate_blkptrs(bpi, func, arg, 0, tx,
@@ -414,7 +442,8 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 			 * If there are no entries, there should
 			 * be no bytes.
 			 */
-			if (bpobj_is_empty_impl(bpo)) {
+			if (bpobj_is_empty_impl(bpo) &&
+			    !SPA_EXITING(dmu_objset_spa(initial_bpo->bpo_os))) {
 				ASSERT0(bpo->bpo_phys->bpo_bytes);
 				ASSERT0(bpo->bpo_phys->bpo_comp);
 				ASSERT0(bpo->bpo_phys->bpo_uncomp);
@@ -435,10 +464,14 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 
 					p->bpo_phys->bpo_num_subobjs--;
 
-					VERIFY0(dmu_free_range(p->bpo_os,
+					err = dmu_free_range(p->bpo_os,
 					    p->bpo_phys->bpo_subobjs,
 					    bpi->bpi_index * sizeof (uint64_t),
-					    sizeof (uint64_t), tx));
+					    sizeof (uint64_t), tx);
+					if (err && SPA_EXITING(dmu_objset_spa(
+					    initial_bpo->bpo_os)))
+						break;
+					VERIFY0(err);
 
 					/* eliminate the empty subobj list */
 					if (bpo->bpo_havesubobj &&
@@ -700,8 +733,10 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		return (err);
 	}
 	err = bpobj_space(&subbpo, &used, &comp, &uncomp);
-	if (err && SPA_EXITING(spa))
+	if (err && SPA_EXITING(spa)) {
+		bpobj_close(&subbpo);
 		return (err);
+	}
 	VERIFY0(err);
 
 	mutex_enter(&bpo->bpo_lock);
@@ -845,6 +880,8 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	bpo->bpo_phys->bpo_uncomp += uncomp;
 
 out:
+	if (bpobj_is_open(&subbpo))
+		bpobj_close(&subbpo);
 	mutex_exit(&bpo->bpo_lock);
 
 	return (err);
@@ -918,7 +955,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 {
 	blkptr_t stored_bp = *bp;
 	uint64_t offset;
-	int blkoff;
+	int blkoff, err;
 	blkptr_t *bparray;
 
 	ASSERT(bpobj_is_open(bpo));
@@ -959,16 +996,23 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 	    bpo->bpo_cached_dbuf->db_size) {
 		if (bpo->bpo_cached_dbuf)
 			dmu_buf_rele(bpo->bpo_cached_dbuf, bpo);
-		VERIFY3U(0, ==, dmu_buf_hold(bpo->bpo_os, bpo->bpo_object,
-		    offset, bpo, &bpo->bpo_cached_dbuf, 0));
+		err = dmu_buf_hold(bpo->bpo_os, bpo->bpo_object,
+		    offset, bpo, &bpo->bpo_cached_dbuf, 0);
+		if (err && SPA_EXITING(bpo->bpo_os->os_spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT3P(bpo->bpo_cached_dbuf, !=, NULL);
 	}
 
 	dmu_buf_will_dirty(bpo->bpo_cached_dbuf, tx);
+	if (SPA_EXITING(bpo->bpo_os->os_spa))
+		goto out;
 	bparray = bpo->bpo_cached_dbuf->db_data;
 	bparray[blkoff] = stored_bp;
 
 	dmu_buf_will_dirty(bpo->bpo_dbuf, tx);
+	if (SPA_EXITING(bpo->bpo_os->os_spa))
+		goto out;
 	bpo->bpo_phys->bpo_num_blkptrs++;
 	int sign = bp_freed ? -1 : +1;
 	bpo->bpo_phys->bpo_bytes += sign *
@@ -981,6 +1025,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 		ASSERT(bpo->bpo_havefreed);
 		bpo->bpo_phys->bpo_num_freed++;
 	}
+out:
 	mutex_exit(&bpo->bpo_lock);
 }
 

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -82,7 +82,7 @@ bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
 	if (SPA_EXITING(spa)) {
-		err = SET_ERROR(err);
+		err = SET_ERROR(EIO);
 		goto out;
 	}
 	bt = db->db_data;
@@ -103,8 +103,12 @@ bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
+	int err;
 
-	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, obj, FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (SET_ERROR(EIO));
+	VERIFY0(err);
 	bt = db->db_data;
 	ASSERT3U(bt->bt_begin, ==, bt->bt_end);
 	ASSERT0(bt->bt_bytes);
@@ -115,18 +119,21 @@ bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 	return (dmu_object_free(os, obj, tx));
 }
 
-boolean_t
-bptree_is_empty(objset_t *os, uint64_t obj)
+int
+bptree_is_empty(objset_t *os, uint64_t obj, boolean_t *rv)
 {
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
-	boolean_t rv;
+	int err = 0;
 
-	VERIFY0(dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, obj, FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
 	bt = db->db_data;
-	rv = (bt->bt_begin == bt->bt_end);
+	*rv = (bt->bt_begin == bt->bt_end);
 	dmu_buf_rele(db, FTAG);
-	return (rv);
+	return (err);
 }
 
 void

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -57,32 +57,45 @@ struct bptree_args {
 	dmu_tx_t *ba_tx;	/* caller supplied tx, NULL if not freeing */
 } bptree_args_t;
 
-uint64_t
-bptree_alloc(objset_t *os, dmu_tx_t *tx)
+int
+bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t obj;
+	spa_t *spa = os->os_spa;
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
+	int err = 0;
 
-	obj = dmu_object_alloc(os, DMU_OTN_UINT64_METADATA,
+	err = dmu_object_alloc(os, DMU_OTN_UINT64_METADATA,
 	    SPA_OLD_MAXBLOCKSIZE, DMU_OTN_UINT64_METADATA,
-	    sizeof (bptree_phys_t), tx);
+	    sizeof (bptree_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * Bonus buffer contents are already initialized to 0, but for
 	 * readability we make it explicit.
 	 */
-	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, *objectp, FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(err);
+		goto out;
+	}
 	bt = db->db_data;
 	bt->bt_begin = 0;
 	bt->bt_end = 0;
 	bt->bt_bytes = 0;
 	bt->bt_comp = 0;
 	bt->bt_uncomp = 0;
+
+out:
 	dmu_buf_rele(db, FTAG);
 
-	return (obj);
+	return (err);
 }
 
 int

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -72,7 +72,7 @@ bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
 	if (SPA_EXITING(spa)) {
-		err = SET_ERROR(err);
+		err = SET_ERROR(EIO);
 		goto out;
 	}
 	bt = db->db_data;
@@ -93,8 +93,12 @@ bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
+	int err;
 
-	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, obj, FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (SET_ERROR(EIO));
+	VERIFY0(err);
 	bt = db->db_data;
 	ASSERT3U(bt->bt_begin, ==, bt->bt_end);
 	ASSERT0(bt->bt_bytes);
@@ -105,18 +109,21 @@ bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 	return (dmu_object_free(os, obj, tx));
 }
 
-boolean_t
-bptree_is_empty(objset_t *os, uint64_t obj)
+int
+bptree_is_empty(objset_t *os, uint64_t obj, boolean_t *rv)
 {
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
-	boolean_t rv;
+	int err = 0;
 
-	VERIFY0(dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, obj, FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
 	bt = db->db_data;
-	rv = (bt->bt_begin == bt->bt_end);
+	*rv = (bt->bt_begin == bt->bt_end);
 	dmu_buf_rele(db, FTAG);
-	return (rv);
+	return (err);
 }
 
 void

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -47,32 +47,45 @@ struct bptree_args {
 	dmu_tx_t *ba_tx;	/* caller supplied tx, NULL if not freeing */
 } bptree_args_t;
 
-uint64_t
-bptree_alloc(objset_t *os, dmu_tx_t *tx)
+int
+bptree_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t obj;
+	spa_t *spa = os->os_spa;
 	dmu_buf_t *db;
 	bptree_phys_t *bt;
+	int err = 0;
 
-	obj = dmu_object_alloc(os, DMU_OTN_UINT64_METADATA,
+	err = dmu_object_alloc(os, DMU_OTN_UINT64_METADATA,
 	    SPA_OLD_MAXBLOCKSIZE, DMU_OTN_UINT64_METADATA,
-	    sizeof (bptree_phys_t), tx);
+	    sizeof (bptree_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * Bonus buffer contents are already initialized to 0, but for
 	 * readability we make it explicit.
 	 */
-	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
+	err = dmu_bonus_hold(os, *objectp, FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(err);
+		goto out;
+	}
 	bt = db->db_data;
 	bt->bt_begin = 0;
 	bt->bt_end = 0;
 	bt->bt_bytes = 0;
 	bt->bt_comp = 0;
 	bt->bt_uncomp = 0;
+
+out:
 	dmu_buf_rele(db, FTAG);
 
-	return (obj);
+	return (err);
 }
 
 int

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -33,6 +33,7 @@
 #include <sys/ddt.h>
 #include <sys/bitmap.h>
 #include <sys/zap.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/arc.h>
 #include <sys/dsl_pool.h>
@@ -439,22 +440,32 @@ brt_vdev(spa_t *spa, uint64_t vdevid, boolean_t alloc)
 	return (brtvd);
 }
 
-static void
+static int
 brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
 	char name[64];
+	int err = 0;
 
 	ASSERT(brtvd->bv_initiated);
 	ASSERT0(brtvd->bv_mos_brtvdev);
 	ASSERT0(brtvd->bv_mos_entries);
 
-	uint64_t mos_entries = zap_create_flags(spa->spa_meta_objset, 0,
+	uint64_t mos_entries;
+	err = zap_create_flags(spa->spa_meta_objset, 0,
 	    ZAP_FLAG_HASH64 | ZAP_FLAG_UINT64_KEY, DMU_OTN_ZAP_METADATA,
-	    brt_zap_default_bs, brt_zap_default_ibs, DMU_OT_NONE, 0, tx);
+	    brt_zap_default_bs, brt_zap_default_ibs, DMU_OT_NONE, 0, tx,
+	    &mos_entries);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	VERIFY(mos_entries != 0);
-	VERIFY0(dnode_hold(spa->spa_meta_objset, mos_entries, brtvd,
-	    &brtvd->bv_mos_entries_dnode));
+	err = dnode_hold(spa->spa_meta_objset, mos_entries, brtvd,
+	    &brtvd->bv_mos_entries_dnode);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dnode_set_storage_type(brtvd->bv_mos_entries_dnode, DMU_OT_DDT_ZAP);
+
 	rw_enter(&brtvd->bv_mos_entries_lock, RW_WRITER);
 	brtvd->bv_mos_entries = mos_entries;
 	rw_exit(&brtvd->bv_mos_entries_lock);
@@ -466,17 +477,28 @@ brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	 * We will keep array size (bv_size) and cummulative count for all
 	 * bv_entcount[]s (bv_totalcount) in the bonus buffer.
 	 */
-	brtvd->bv_mos_brtvdev = dmu_object_alloc(spa->spa_meta_objset,
+	err = dmu_object_alloc(spa->spa_meta_objset,
 	    DMU_OTN_UINT64_METADATA, BRT_BLOCKSIZE,
-	    DMU_OTN_UINT64_METADATA, sizeof (brt_vdev_phys_t), tx);
+	    DMU_OTN_UINT64_METADATA, sizeof (brt_vdev_phys_t), tx,
+	    &brtvd->bv_mos_brtvdev);
+	if (err && SPA_EXITING(spa)) {
+		dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
+		return (err);
+	}
+	VERIFY0(err);
 	VERIFY(brtvd->bv_mos_brtvdev != 0);
 	BRT_DEBUG("MOS BRT VDEV created, object=%llu",
 	    (u_longlong_t)brtvd->bv_mos_brtvdev);
 
 	snprintf(name, sizeof (name), "%s%llu", BRT_OBJECT_VDEV_PREFIX,
 	    (u_longlong_t)brtvd->bv_vdevid);
-	VERIFY0(zap_add(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT, name,
-	    sizeof (uint64_t), 1, &brtvd->bv_mos_brtvdev, tx));
+	err = zap_add(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT, name,
+	    sizeof (uint64_t), 1, &brtvd->bv_mos_brtvdev, tx);
+	if (err && SPA_EXITING(spa)) {
+		dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
+		return (err);
+	}
+	VERIFY0(err);
 	BRT_DEBUG("Pool directory object created, object=%s", name);
 
 	/*
@@ -492,6 +514,8 @@ brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	}
 
 	spa_feature_incr(spa, SPA_FEATURE_BLOCK_CLONING, tx);
+
+	return (err);
 }
 
 static void
@@ -626,11 +650,12 @@ brt_vdev_dealloc(brt_vdev_t *brtvd)
 	BRT_DEBUG("BRT VDEV %llu deallocated.", (u_longlong_t)brtvd->bv_vdevid);
 }
 
-static void
+static int
 brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
 	char name[64];
 	uint64_t count;
+	int err = 0;
 
 	ASSERT(brtvd->bv_initiated);
 	ASSERT(brtvd->bv_mos_brtvdev != 0);
@@ -645,14 +670,21 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	rw_exit(&brtvd->bv_mos_entries_lock);
 	dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
 	brtvd->bv_mos_entries_dnode = NULL;
-	ASSERT0(zap_count(spa->spa_meta_objset, mos_entries, &count));
-	ASSERT0(count);
-	VERIFY0(zap_destroy(spa->spa_meta_objset, mos_entries, tx));
+	err = zap_count(spa->spa_meta_objset, mos_entries, &count);
+	if (!SPA_EXITING(spa)) {
+		ASSERT0(err);
+		ASSERT0(count);
+	}
+	err = zap_destroy(spa->spa_meta_objset, mos_entries, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("MOS entries destroyed, object=%llu",
 	    (u_longlong_t)mos_entries);
 
-	VERIFY0(dmu_object_free(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
-	    tx));
+	err = dmu_object_free(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
+	    tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("MOS BRT VDEV destroyed, object=%llu",
 	    (u_longlong_t)brtvd->bv_mos_brtvdev);
 	brtvd->bv_mos_brtvdev = 0;
@@ -660,8 +692,10 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 
 	snprintf(name, sizeof (name), "%s%llu", BRT_OBJECT_VDEV_PREFIX,
 	    (u_longlong_t)brtvd->bv_vdevid);
-	VERIFY0(zap_remove(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    name, tx));
+	err = zap_remove(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    name, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("Pool directory object removed, object=%s", name);
 
 	brtvd->bv_meta_dirty = FALSE;
@@ -673,6 +707,8 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	spa_feature_decr(spa, SPA_FEATURE_BLOCK_CLONING, tx);
 	if (spa_feature_is_active(spa, SPA_FEATURE_BLOCK_CLONING_ENDIAN))
 		spa_feature_decr(spa, SPA_FEATURE_BLOCK_CLONING_ENDIAN, tx);
+
+	return (err);
 }
 
 static void
@@ -791,18 +827,22 @@ brt_vdev_decref(spa_t *spa, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	BT_SET(brtvd->bv_bitmap, idx);
 }
 
-static void
+static int
 brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	brt_vdev_phys_t *bvphys;
+	int err = 0;
 
 	ASSERT(brtvd->bv_meta_dirty);
 	ASSERT(brtvd->bv_mos_brtvdev != 0);
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dmu_bonus_hold(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
-	    FTAG, &db));
+	err = dmu_bonus_hold(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
+	    FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	if (brtvd->bv_entcount_dirty) {
 		/*
@@ -817,6 +857,10 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	}
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	bvphys = db->db_data;
 	bvphys->bvp_mos_entries = brtvd->bv_mos_entries;
 	bvphys->bvp_size = brtvd->bv_size;
@@ -829,9 +873,16 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	bvphys->bvp_rangesize = spa->spa_brt_rangesize;
 	bvphys->bvp_usedspace = brtvd->bv_usedspace;
 	bvphys->bvp_savedspace = brtvd->bv_savedspace;
-	dmu_buf_rele(db, FTAG);
+
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (SPA_EXITING(spa))
+		brtvd->bv_entcount_dirty = FALSE;
 
 	brtvd->bv_meta_dirty = FALSE;
+
+	return (err);
 }
 
 static void
@@ -1361,34 +1412,44 @@ brt_pending_apply(spa_t *spa, uint64_t txg)
 	brt_unlock(spa);
 }
 
-static void
+static int
 brt_sync_entry(spa_t *spa, dnode_t *dn, brt_entry_t *bre, dmu_tx_t *tx)
 {
 	uint64_t off = BRE_OFFSET(bre);
+	int error = 0;
 
 	if (bre->bre_pcount == 0) {
 		/* The net change is zero, nothing to do in ZAP. */
 	} else if (bre->bre_count == 0) {
-		int error = zap_remove_uint64_by_dnode(dn, &off,
+		error = zap_remove_uint64_by_dnode(dn, &off,
 		    BRT_KEY_WORDS, tx);
+		if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+			return (error);
 		VERIFY(error == 0 || error == ENOENT);
 	} else {
 		if (brt_has_endian_fixed(spa)) {
-			VERIFY0(zap_update_uint64_by_dnode(dn, &off,
+			error = zap_update_uint64_by_dnode(dn, &off,
 			    BRT_KEY_WORDS, sizeof (bre->bre_count), 1,
-			    &bre->bre_count, tx));
+			    &bre->bre_count, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		} else {
-			VERIFY0(zap_update_uint64_by_dnode(dn, &off,
+			error = zap_update_uint64_by_dnode(dn, &off,
 			    BRT_KEY_WORDS, 1, sizeof (bre->bre_count),
-			    &bre->bre_count, tx));
+			    &bre->bre_count, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		}
 	}
+
+	return (error);
 }
 
 static void
 brt_sync_table(spa_t *spa, dmu_tx_t *tx)
 {
 	brt_entry_t *bre;
+	int err;
 
 	brt_rlock(spa);
 	for (uint64_t vdevid = 0; vdevid < spa->spa_brt_nvdevs; vdevid++) {
@@ -1405,13 +1466,19 @@ brt_sync_table(spa_t *spa, dmu_tx_t *tx)
 		ASSERT(!brtvd->bv_entcount_dirty ||
 		    avl_numnodes(&brtvd->bv_tree) != 0);
 
-		if (brtvd->bv_mos_brtvdev == 0)
-			brt_vdev_create(spa, brtvd, tx);
+		if (brtvd->bv_mos_brtvdev == 0) {
+			err = brt_vdev_create(spa, brtvd, tx);
+			if (err && SPA_EXITING(spa)) {
+				brt_rlock(spa);
+				continue;
+			}
+			VERIFY0(err);
+		}
 
 		void *c = NULL;
 		while ((bre = avl_destroy_nodes(&brtvd->bv_tree, &c)) != NULL) {
-			brt_sync_entry(spa, brtvd->bv_mos_entries_dnode, bre,
-			    tx);
+			(void) brt_sync_entry(spa, brtvd->bv_mos_entries_dnode,
+			    bre, tx);
 			kmem_cache_free(brt_entry_cache, bre);
 		}
 

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -23,6 +23,7 @@
 #include <sys/ddt.h>
 #include <sys/bitmap.h>
 #include <sys/zap.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/arc.h>
 #include <sys/dsl_pool.h>
@@ -432,22 +433,32 @@ brt_vdev(spa_t *spa, uint64_t vdevid, boolean_t alloc)
 	return (brtvd);
 }
 
-static void
+static int
 brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
 	char name[64];
+	int err = 0;
 
 	ASSERT(brtvd->bv_initiated);
 	ASSERT0(brtvd->bv_mos_brtvdev);
 	ASSERT0(brtvd->bv_mos_entries);
 
-	uint64_t mos_entries = zap_create_flags(spa->spa_meta_objset, 0,
+	uint64_t mos_entries;
+	err = zap_create_flags(spa->spa_meta_objset, 0,
 	    ZAP_FLAG_HASH64 | ZAP_FLAG_UINT64_KEY, DMU_OTN_ZAP_METADATA,
-	    brt_zap_default_bs, brt_zap_default_ibs, DMU_OT_NONE, 0, tx);
+	    brt_zap_default_bs, brt_zap_default_ibs, DMU_OT_NONE, 0, tx,
+	    &mos_entries);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	VERIFY(mos_entries != 0);
-	VERIFY0(dnode_hold(spa->spa_meta_objset, mos_entries, brtvd,
-	    &brtvd->bv_mos_entries_dnode));
+	err = dnode_hold(spa->spa_meta_objset, mos_entries, brtvd,
+	    &brtvd->bv_mos_entries_dnode);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dnode_set_storage_type(brtvd->bv_mos_entries_dnode, DMU_OT_DDT_ZAP);
+
 	rw_enter(&brtvd->bv_mos_entries_lock, RW_WRITER);
 	brtvd->bv_mos_entries = mos_entries;
 	rw_exit(&brtvd->bv_mos_entries_lock);
@@ -459,17 +470,28 @@ brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	 * We will keep array size (bv_size) and cummulative count for all
 	 * bv_entcount[]s (bv_totalcount) in the bonus buffer.
 	 */
-	brtvd->bv_mos_brtvdev = dmu_object_alloc(spa->spa_meta_objset,
+	err = dmu_object_alloc(spa->spa_meta_objset,
 	    DMU_OTN_UINT64_METADATA, BRT_BLOCKSIZE,
-	    DMU_OTN_UINT64_METADATA, sizeof (brt_vdev_phys_t), tx);
+	    DMU_OTN_UINT64_METADATA, sizeof (brt_vdev_phys_t), tx,
+	    &brtvd->bv_mos_brtvdev);
+	if (err && SPA_EXITING(spa)) {
+		dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
+		return (err);
+	}
+	VERIFY0(err);
 	VERIFY(brtvd->bv_mos_brtvdev != 0);
 	BRT_DEBUG("MOS BRT VDEV created, object=%llu",
 	    (u_longlong_t)brtvd->bv_mos_brtvdev);
 
 	snprintf(name, sizeof (name), "%s%llu", BRT_OBJECT_VDEV_PREFIX,
 	    (u_longlong_t)brtvd->bv_vdevid);
-	VERIFY0(zap_add(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT, name,
-	    sizeof (uint64_t), 1, &brtvd->bv_mos_brtvdev, tx));
+	err = zap_add(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT, name,
+	    sizeof (uint64_t), 1, &brtvd->bv_mos_brtvdev, tx);
+	if (err && SPA_EXITING(spa)) {
+		dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
+		return (err);
+	}
+	VERIFY0(err);
 	BRT_DEBUG("Pool directory object created, object=%s", name);
 
 	/*
@@ -485,6 +507,8 @@ brt_vdev_create(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	}
 
 	spa_feature_incr(spa, SPA_FEATURE_BLOCK_CLONING, tx);
+
+	return (err);
 }
 
 static void
@@ -621,11 +645,12 @@ brt_vdev_dealloc(brt_vdev_t *brtvd)
 	BRT_DEBUG("BRT VDEV %llu deallocated.", (u_longlong_t)brtvd->bv_vdevid);
 }
 
-static void
+static int
 brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
 	char name[64];
 	uint64_t count;
+	int err = 0;
 
 	ASSERT(brtvd->bv_initiated);
 	ASSERT(brtvd->bv_mos_brtvdev != 0);
@@ -640,14 +665,21 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	rw_exit(&brtvd->bv_mos_entries_lock);
 	dnode_rele(brtvd->bv_mos_entries_dnode, brtvd);
 	brtvd->bv_mos_entries_dnode = NULL;
-	ASSERT0(zap_count(spa->spa_meta_objset, mos_entries, &count));
-	ASSERT0(count);
-	VERIFY0(zap_destroy(spa->spa_meta_objset, mos_entries, tx));
+	err = zap_count(spa->spa_meta_objset, mos_entries, &count);
+	if (!SPA_EXITING(spa)) {
+		ASSERT0(err);
+		ASSERT0(count);
+	}
+	err = zap_destroy(spa->spa_meta_objset, mos_entries, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("MOS entries destroyed, object=%llu",
 	    (u_longlong_t)mos_entries);
 
-	VERIFY0(dmu_object_free(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
-	    tx));
+	err = dmu_object_free(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
+	    tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("MOS BRT VDEV destroyed, object=%llu",
 	    (u_longlong_t)brtvd->bv_mos_brtvdev);
 	brtvd->bv_mos_brtvdev = 0;
@@ -655,8 +687,10 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 
 	snprintf(name, sizeof (name), "%s%llu", BRT_OBJECT_VDEV_PREFIX,
 	    (u_longlong_t)brtvd->bv_vdevid);
-	VERIFY0(zap_remove(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    name, tx));
+	err = zap_remove(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    name, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	BRT_DEBUG("Pool directory object removed, object=%s", name);
 
 	brtvd->bv_meta_dirty = FALSE;
@@ -668,6 +702,8 @@ brt_vdev_destroy(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	spa_feature_decr(spa, SPA_FEATURE_BLOCK_CLONING, tx);
 	if (spa_feature_is_active(spa, SPA_FEATURE_BLOCK_CLONING_ENDIAN))
 		spa_feature_decr(spa, SPA_FEATURE_BLOCK_CLONING_ENDIAN, tx);
+
+	return (err);
 }
 
 static void
@@ -784,18 +820,22 @@ brt_vdev_decref(spa_t *spa, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	BT_SET(brtvd->bv_bitmap, idx / (BRT_BLOCKSIZE / sizeof (uint16_t)));
 }
 
-static void
+static int
 brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 {
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	brt_vdev_phys_t *bvphys;
+	int err = 0;
 
 	ASSERT(brtvd->bv_meta_dirty);
 	ASSERT(brtvd->bv_mos_brtvdev != 0);
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dmu_bonus_hold(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
-	    FTAG, &db));
+	err = dmu_bonus_hold(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
+	    FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	if (brtvd->bv_entcount_dirty) {
 		uint64_t nblocks = BRT_RANGESIZE_TO_NBLOCKS(brtvd->bv_size);
@@ -818,6 +858,10 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	}
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	bvphys = db->db_data;
 	bvphys->bvp_mos_entries = brtvd->bv_mos_entries;
 	bvphys->bvp_size = brtvd->bv_size;
@@ -830,9 +874,16 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	bvphys->bvp_rangesize = spa->spa_brt_rangesize;
 	bvphys->bvp_usedspace = brtvd->bv_usedspace;
 	bvphys->bvp_savedspace = brtvd->bv_savedspace;
-	dmu_buf_rele(db, FTAG);
+
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
+	if (SPA_EXITING(spa))
+		brtvd->bv_entcount_dirty = FALSE;
 
 	brtvd->bv_meta_dirty = FALSE;
+
+	return (err);
 }
 
 static void
@@ -1522,34 +1573,44 @@ brt_pending_apply(spa_t *spa, uint64_t txg)
 	kmem_free(bpva, sizeof (*bpva) * nvdevs);
 }
 
-static void
+static int
 brt_sync_entry(spa_t *spa, dnode_t *dn, brt_entry_t *bre, dmu_tx_t *tx)
 {
 	uint64_t off = BRE_OFFSET(bre);
+	int error = 0;
 
 	if (bre->bre_pcount == 0) {
 		/* The net change is zero, nothing to do in ZAP. */
 	} else if (bre->bre_count == 0) {
-		int error = zap_remove_uint64_by_dnode(dn, &off,
+		error = zap_remove_uint64_by_dnode(dn, &off,
 		    BRT_KEY_WORDS, tx);
+		if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+			return (error);
 		VERIFY(error == 0 || error == ENOENT);
 	} else {
 		if (brt_has_endian_fixed(spa)) {
-			VERIFY0(zap_update_uint64_by_dnode(dn, &off,
+			error = zap_update_uint64_by_dnode(dn, &off,
 			    BRT_KEY_WORDS, sizeof (bre->bre_count), 1,
-			    &bre->bre_count, tx));
+			    &bre->bre_count, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		} else {
-			VERIFY0(zap_update_uint64_by_dnode(dn, &off,
+			error = zap_update_uint64_by_dnode(dn, &off,
 			    BRT_KEY_WORDS, 1, sizeof (bre->bre_count),
-			    &bre->bre_count, tx));
+			    &bre->bre_count, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		}
 	}
+
+	return (error);
 }
 
 static void
 brt_sync_table(spa_t *spa, dmu_tx_t *tx)
 {
 	brt_entry_t *bre;
+	int err;
 
 	brt_rlock(spa);
 	for (uint64_t vdevid = 0; vdevid < spa->spa_brt_nvdevs; vdevid++) {
@@ -1566,13 +1627,19 @@ brt_sync_table(spa_t *spa, dmu_tx_t *tx)
 		ASSERT(!brtvd->bv_entcount_dirty ||
 		    avl_numnodes(&brtvd->bv_tree) != 0);
 
-		if (brtvd->bv_mos_brtvdev == 0)
-			brt_vdev_create(spa, brtvd, tx);
+		if (brtvd->bv_mos_brtvdev == 0) {
+			err = brt_vdev_create(spa, brtvd, tx);
+			if (err && SPA_EXITING(spa)) {
+				brt_rlock(spa);
+				continue;
+			}
+			VERIFY0(err);
+		}
 
 		void *c = NULL;
 		while ((bre = avl_destroy_nodes(&brtvd->bv_tree, &c)) != NULL) {
-			brt_sync_entry(spa, brtvd->bv_mos_entries_dnode, bre,
-			    tx);
+			(void) brt_sync_entry(spa, brtvd->bv_mos_entries_dnode,
+			    bre, tx);
 			kmem_cache_free(brt_entry_cache, bre);
 		}
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1122,11 +1122,12 @@ dbuf_verify(dmu_buf_impl_t *db)
 	uint32_t txg_prev;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
+	ASSERT(db->db_objset != NULL);
 
-	if (!(zfs_flags & ZFS_DEBUG_DBUF_VERIFY))
+	if (!(zfs_flags & ZFS_DEBUG_DBUF_VERIFY) ||
+	    SPA_EXITING(db->db_objset->os_spa))
 		return;
 
-	ASSERT(db->db_objset != NULL);
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
 	if (dn == NULL) {
@@ -2711,6 +2712,7 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 	boolean_t undirty = B_FALSE;
+	int err;
 
 	ASSERT(tx->tx_txg != 0);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));
@@ -2759,11 +2761,15 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 	 * not the uderlying block that is being replaced. dbuf_undirty() will
 	 * do brt_pending_remove() before removing the dirty record.
 	 */
-	(void) dbuf_read(db, NULL, flags | DB_RF_MUST_SUCCEED);
+	err = dbuf_read(db, NULL, flags | DB_RF_MUST_SUCCEED);
+	if (err && SPA_EXITING(db->db_objset->os_spa))
+		return;
 	if (undirty) {
 		mutex_enter(&db->db_mtx);
 		VERIFY(!dbuf_undirty(db, tx));
 		mutex_exit(&db->db_mtx);
+		if (SPA_EXITING(db->db_objset->os_spa))
+			return;
 	}
 	(void) dbuf_dirty(db, tx);
 }
@@ -4445,19 +4451,19 @@ dmu_buf_get_objset(dmu_buf_t *db)
 	return (dbi->db_objset);
 }
 
-static void
+static int
 dbuf_check_blkptr(dnode_t *dn, dmu_buf_impl_t *db)
 {
 	/* ASSERT(dmu_tx_is_syncing(tx) */
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 
 	if (db->db_blkptr != NULL)
-		return;
+		return (0);
 
 	if (db->db_blkid == DMU_SPILL_BLKID) {
 		db->db_blkptr = DN_SPILL_BLKPTR(dn->dn_phys);
 		BP_ZERO(db->db_blkptr);
-		return;
+		return (0);
 	}
 	if (db->db_level == dn->dn_phys->dn_nlevels-1) {
 		/*
@@ -4482,12 +4488,18 @@ dbuf_check_blkptr(dnode_t *dn, dmu_buf_impl_t *db)
 			    db->db_blkid >> epbs, db);
 			rw_exit(&dn->dn_struct_rwlock);
 			mutex_enter(&db->db_mtx);
+			if (parent == NULL &&
+			    SPA_EXITING(dn->dn_objset->os_spa))
+				return (SET_ERROR(EIO));
+			VERIFY(parent);
 			db->db_parent = parent;
 		}
 		db->db_blkptr = (blkptr_t *)parent->db.db_data +
 		    (db->db_blkid & ((1ULL << epbs) - 1));
 		DBUF_VERIFY(db);
 	}
+
+	return (0);
 }
 
 static void
@@ -4559,11 +4571,12 @@ dbuf_prepare_encrypted_dnode_leaf(dbuf_dirty_record_t *dr)
  * is critical the we not allow the compiler to inline this function in to
  * dbuf_sync_list() thereby drastically bloating the stack usage.
  */
-noinline static void
+noinline static int
 dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 	dnode_t *dn = dr->dr_dnode;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -4577,7 +4590,10 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	/* Read the block if it hasn't been read yet. */
 	if (db->db_buf == NULL) {
 		mutex_exit(&db->db_mtx);
-		(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		if (err && SPA_EXITING(dn->dn_objset->os_spa))
+			return (err);
+		VERIFY0(err);
 		mutex_enter(&db->db_mtx);
 	}
 	ASSERT3U(db->db_state, ==, DB_CACHED);
@@ -4585,7 +4601,12 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 
 	/* Indirect block size must match what the dnode thinks it is. */
 	ASSERT3U(db->db.db_size, ==, 1<<dn->dn_phys->dn_indblkshift);
-	dbuf_check_blkptr(dn, db);
+	err = dbuf_check_blkptr(dn, db);
+	if (err && SPA_EXITING(dn->dn_objset->os_spa)) {
+		mutex_exit(&db->db_mtx);
+		return (err);
+	}
+	VERIFY0(err);
 
 	/* Provide the pending dirty record to child dbufs */
 	db->db_data_pending = dr;
@@ -4596,10 +4617,12 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 
 	zio_t *zio = dr->dr_zio;
 	mutex_enter(&dr->dt.di.dr_mtx);
-	dbuf_sync_list(&dr->dt.di.dr_children, db->db_level - 1, tx);
+	err = dbuf_sync_list(&dr->dt.di.dr_children, db->db_level - 1, tx);
 	ASSERT(list_head(&dr->dt.di.dr_children) == NULL);
 	mutex_exit(&dr->dt.di.dr_mtx);
 	zio_nowait(zio);
+
+	return (err);
 }
 
 /*
@@ -4710,10 +4733,13 @@ dbuf_lightweight_done(zio_t *zio)
 {
 	dbuf_dirty_record_t *dr = zio->io_private;
 
-	VERIFY0(zio->io_error);
-
 	objset_t *os = dr->dr_dnode->dn_objset;
 	dmu_tx_t *tx = os->os_synctx;
+
+	if (zio->io_error && SPA_EXITING(zio->io_spa))
+		goto skip;
+
+	VERIFY0(zio->io_error);
 
 	if (zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)) {
 		ASSERT(BP_EQUAL(zio->io_bp, &zio->io_bp_orig));
@@ -4723,6 +4749,7 @@ dbuf_lightweight_done(zio_t *zio)
 		dsl_dataset_block_born(ds, zio->io_bp, tx);
 	}
 
+skip:
 	dsl_pool_undirty_space(dmu_objset_pool(os), dr->dr_accounted,
 	    zio->io_txg);
 
@@ -4769,7 +4796,7 @@ dbuf_sync_lightweight(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
  * critical the we not allow the compiler to inline this function in to
  * dbuf_sync_list() thereby drastically bloating the stack usage.
  */
-noinline static void
+noinline static int
 dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 {
 	arc_buf_t **datap = &dr->dt.dl.dr_data;
@@ -4777,6 +4804,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	dnode_t *dn = dr->dr_dnode;
 	objset_t *os;
 	uint64_t txg = tx->tx_txg;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -4846,7 +4874,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	if (db->db_blkid == DMU_BONUS_BLKID) {
 		ASSERT(dr->dr_dbuf == db);
 		dbuf_sync_bonus(dr, tx);
-		return;
+		return (0);
 	}
 
 	os = dn->dn_objset;
@@ -4857,7 +4885,12 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	 * don't check the dr_override_state until we have returned from
 	 * dbuf_check_blkptr.
 	 */
-	dbuf_check_blkptr(dn, db);
+	err = dbuf_check_blkptr(dn, db);
+	if (err && SPA_EXITING(os->os_spa)) {
+		mutex_exit(&db->db_mtx);
+		return (err);
+	}
+	VERIFY0(err);
 
 	/*
 	 * If this buffer is in the middle of an immediate write, wait for the
@@ -4931,18 +4964,21 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	} else {
 		zio_nowait(dr->dr_zio);
 	}
+
+	return (0);
 }
 
 /*
  * Syncs out a range of dirty records for indirect or leaf dbufs.  May be
  * called recursively from dbuf_sync_indirect().
  */
-void
+int
 dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx)
 {
 	dbuf_dirty_record_t *dr;
+	int err = 0;
 
-	while ((dr = list_head(list))) {
+	while (!err && (dr = list_head(list))) {
 		if (dr->dr_zio != NULL) {
 			/*
 			 * If we find an already initialized zio then we
@@ -4964,9 +5000,56 @@ dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx)
 				VERIFY3U(dr->dr_dbuf->db_level, ==, level);
 			}
 			if (dr->dr_dbuf->db_level > 0)
-				dbuf_sync_indirect(dr, tx);
+				err = dbuf_sync_indirect(dr, tx);
 			else
-				dbuf_sync_leaf(dr, tx);
+				err = dbuf_sync_leaf(dr, tx);
+		}
+		if (err)
+			list_insert_head(list, dr);
+	}
+
+	return (err);
+}
+
+static void
+dbuf_write_done(zio_t *, arc_buf_t *, void *);
+
+void
+dbuf_drain_list(list_t *list, dmu_tx_t *tx)
+{
+	dbuf_dirty_record_t *dr;
+
+	while ((dr = list_head(list))) {
+		list_remove(list, dr);
+		if (dr->dr_dbuf == NULL) {
+			/* dbuf_sync_lightweight() path */
+			dsl_pool_undirty_space(dmu_tx_pool(tx),
+			    dr->dr_accounted, dmu_tx_get_txg(tx));
+			abd_free(dr->dt.dll.dr_abd);
+			kmem_free(dr, sizeof (*dr));
+		} else if (dr->dr_dbuf->db_level > 0) {
+			/* dbuf_sync_indirect() path */
+			mutex_enter(&dr->dt.di.dr_mtx);
+			dbuf_drain_list(&dr->dt.di.dr_children, tx);
+			ASSERT(list_head(&dr->dt.di.dr_children) == NULL);
+			mutex_exit(&dr->dt.di.dr_mtx);
+
+			dbuf_write_done(NULL, NULL, dr->dr_dbuf);
+		} else {
+			/* dbuf_sync_leaf path */
+			dmu_buf_impl_t *db = dr->dr_dbuf;
+			mutex_enter(&db->db_mtx);
+			if (db->db_blkid == DMU_BONUS_BLKID) {
+				dbuf_sync_bonus(dr, tx);
+				continue;
+			}
+			while (dr->dt.dl.dr_override_state == DR_IN_DMU_SYNC)
+				cv_wait(&db->db_changed, &db->db_mtx);
+			mutex_exit(&db->db_mtx);
+
+			dbuf_write_done(NULL, NULL, db);
+
+			ASSERT(!list_link_active(&dr->dr_dirty_node));
 		}
 	}
 }
@@ -5126,10 +5209,12 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 {
 	(void) buf;
 	dmu_buf_impl_t *db = vdb;
-	blkptr_t *bp_orig = &zio->io_bp_orig;
 	blkptr_t *bp = db->db_blkptr;
 	objset_t *os = db->db_objset;
 	dmu_tx_t *tx = os->os_synctx;
+
+	if ((zio->io_error && SPA_EXITING(os->os_spa)) || zio == NULL)
+		goto cleanup;
 
 	ASSERT0(zio->io_error);
 	ASSERT(db->db_blkptr == bp);
@@ -5138,6 +5223,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 	 * For nopwrites and rewrites we ensure that the bp matches our
 	 * original and bypass all the accounting.
 	 */
+	blkptr_t *bp_orig = &zio->io_bp_orig;
 	if (zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)) {
 		ASSERT(BP_EQUAL(bp, bp_orig));
 	} else {
@@ -5146,6 +5232,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 		dsl_dataset_block_born(ds, bp, tx);
 	}
 
+cleanup:
 	mutex_enter(&db->db_mtx);
 
 	DBUF_VERIFY(db);
@@ -5198,7 +5285,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 	dbuf_rele_and_unlock(db, (void *)(uintptr_t)tx->tx_txg, B_FALSE);
 
 	dsl_pool_undirty_space(dmu_objset_pool(os), dr->dr_accounted,
-	    zio->io_txg);
+	    zio ? zio->io_txg : tx->tx_txg);
 
 	kmem_cache_free(dbuf_dirty_kmem_cache, dr);
 }

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1112,11 +1112,12 @@ dbuf_verify(dmu_buf_impl_t *db)
 	uint32_t txg_prev;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
+	ASSERT(db->db_objset != NULL);
 
-	if (!(zfs_flags & ZFS_DEBUG_DBUF_VERIFY))
+	if (!(zfs_flags & ZFS_DEBUG_DBUF_VERIFY) ||
+	    SPA_EXITING(db->db_objset->os_spa))
 		return;
 
-	ASSERT(db->db_objset != NULL);
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
 	if (dn == NULL) {
@@ -2709,6 +2710,7 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 	boolean_t undirty = B_FALSE;
+	int err;
 
 	ASSERT(tx->tx_txg != 0);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));
@@ -2757,11 +2759,15 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 	 * not the uderlying block that is being replaced. dbuf_undirty() will
 	 * do brt_pending_remove() before removing the dirty record.
 	 */
-	(void) dbuf_read(db, NULL, flags | DB_RF_MUST_SUCCEED);
+	err = dbuf_read(db, NULL, flags | DB_RF_MUST_SUCCEED);
+	if (err && SPA_EXITING(db->db_objset->os_spa))
+		return;
 	if (undirty) {
 		mutex_enter(&db->db_mtx);
 		VERIFY(!dbuf_undirty(db, tx));
 		mutex_exit(&db->db_mtx);
+		if (SPA_EXITING(db->db_objset->os_spa))
+			return;
 	}
 	(void) dbuf_dirty(db, tx);
 }
@@ -4443,19 +4449,19 @@ dmu_buf_get_objset(dmu_buf_t *db)
 	return (dbi->db_objset);
 }
 
-static void
+static int
 dbuf_check_blkptr(dnode_t *dn, dmu_buf_impl_t *db)
 {
 	/* ASSERT(dmu_tx_is_syncing(tx) */
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 
 	if (db->db_blkptr != NULL)
-		return;
+		return (0);
 
 	if (db->db_blkid == DMU_SPILL_BLKID) {
 		db->db_blkptr = DN_SPILL_BLKPTR(dn->dn_phys);
 		BP_ZERO(db->db_blkptr);
-		return;
+		return (0);
 	}
 	if (db->db_level == dn->dn_phys->dn_nlevels-1) {
 		/*
@@ -4480,12 +4486,18 @@ dbuf_check_blkptr(dnode_t *dn, dmu_buf_impl_t *db)
 			    db->db_blkid >> epbs, db);
 			rw_exit(&dn->dn_struct_rwlock);
 			mutex_enter(&db->db_mtx);
+			if (parent == NULL &&
+			    SPA_EXITING(dn->dn_objset->os_spa))
+				return (SET_ERROR(EIO));
+			VERIFY(parent);
 			db->db_parent = parent;
 		}
 		db->db_blkptr = (blkptr_t *)parent->db.db_data +
 		    (db->db_blkid & ((1ULL << epbs) - 1));
 		DBUF_VERIFY(db);
 	}
+
+	return (0);
 }
 
 static void
@@ -4557,11 +4569,12 @@ dbuf_prepare_encrypted_dnode_leaf(dbuf_dirty_record_t *dr)
  * is critical the we not allow the compiler to inline this function in to
  * dbuf_sync_list() thereby drastically bloating the stack usage.
  */
-noinline static void
+noinline static int
 dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 	dnode_t *dn = dr->dr_dnode;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -4575,7 +4588,10 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	/* Read the block if it hasn't been read yet. */
 	if (db->db_buf == NULL) {
 		mutex_exit(&db->db_mtx);
-		(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		if (err && SPA_EXITING(dn->dn_objset->os_spa))
+			return (err);
+		VERIFY0(err);
 		mutex_enter(&db->db_mtx);
 	}
 	ASSERT3U(db->db_state, ==, DB_CACHED);
@@ -4583,7 +4599,12 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 
 	/* Indirect block size must match what the dnode thinks it is. */
 	ASSERT3U(db->db.db_size, ==, 1<<dn->dn_phys->dn_indblkshift);
-	dbuf_check_blkptr(dn, db);
+	err = dbuf_check_blkptr(dn, db);
+	if (err && SPA_EXITING(dn->dn_objset->os_spa)) {
+		mutex_exit(&db->db_mtx);
+		return (err);
+	}
+	VERIFY0(err);
 
 	/* Provide the pending dirty record to child dbufs */
 	db->db_data_pending = dr;
@@ -4594,10 +4615,12 @@ dbuf_sync_indirect(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 
 	zio_t *zio = dr->dr_zio;
 	mutex_enter(&dr->dt.di.dr_mtx);
-	dbuf_sync_list(&dr->dt.di.dr_children, db->db_level - 1, tx);
+	err = dbuf_sync_list(&dr->dt.di.dr_children, db->db_level - 1, tx);
 	ASSERT(list_head(&dr->dt.di.dr_children) == NULL);
 	mutex_exit(&dr->dt.di.dr_mtx);
 	zio_nowait(zio);
+
+	return (err);
 }
 
 /*
@@ -4708,10 +4731,13 @@ dbuf_lightweight_done(zio_t *zio)
 {
 	dbuf_dirty_record_t *dr = zio->io_private;
 
-	VERIFY0(zio->io_error);
-
 	objset_t *os = dr->dr_dnode->dn_objset;
 	dmu_tx_t *tx = os->os_synctx;
+
+	if (zio->io_error && SPA_EXITING(zio->io_spa))
+		goto skip;
+
+	VERIFY0(zio->io_error);
 
 	if (zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)) {
 		ASSERT(BP_EQUAL(zio->io_bp, &zio->io_bp_orig));
@@ -4721,6 +4747,7 @@ dbuf_lightweight_done(zio_t *zio)
 		dsl_dataset_block_born(ds, zio->io_bp, tx);
 	}
 
+skip:
 	dsl_pool_undirty_space(dmu_objset_pool(os), dr->dr_accounted,
 	    zio->io_txg);
 
@@ -4767,7 +4794,7 @@ dbuf_sync_lightweight(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
  * critical the we not allow the compiler to inline this function in to
  * dbuf_sync_list() thereby drastically bloating the stack usage.
  */
-noinline static void
+noinline static int
 dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 {
 	arc_buf_t **datap = &dr->dt.dl.dr_data;
@@ -4775,6 +4802,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	dnode_t *dn = dr->dr_dnode;
 	objset_t *os;
 	uint64_t txg = tx->tx_txg;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -4844,7 +4872,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	if (db->db_blkid == DMU_BONUS_BLKID) {
 		ASSERT(dr->dr_dbuf == db);
 		dbuf_sync_bonus(dr, tx);
-		return;
+		return (0);
 	}
 
 	os = dn->dn_objset;
@@ -4855,7 +4883,12 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	 * don't check the dr_override_state until we have returned from
 	 * dbuf_check_blkptr.
 	 */
-	dbuf_check_blkptr(dn, db);
+	err = dbuf_check_blkptr(dn, db);
+	if (err && SPA_EXITING(os->os_spa)) {
+		mutex_exit(&db->db_mtx);
+		return (err);
+	}
+	VERIFY0(err);
 
 	/*
 	 * If this buffer is in the middle of an immediate write, wait for the
@@ -4929,18 +4962,21 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	} else {
 		zio_nowait(dr->dr_zio);
 	}
+
+	return (0);
 }
 
 /*
  * Syncs out a range of dirty records for indirect or leaf dbufs.  May be
  * called recursively from dbuf_sync_indirect().
  */
-void
+int
 dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx)
 {
 	dbuf_dirty_record_t *dr;
+	int err = 0;
 
-	while ((dr = list_head(list))) {
+	while (!err && (dr = list_head(list))) {
 		if (dr->dr_zio != NULL) {
 			/*
 			 * If we find an already initialized zio then we
@@ -4962,9 +4998,56 @@ dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx)
 				VERIFY3U(dr->dr_dbuf->db_level, ==, level);
 			}
 			if (dr->dr_dbuf->db_level > 0)
-				dbuf_sync_indirect(dr, tx);
+				err = dbuf_sync_indirect(dr, tx);
 			else
-				dbuf_sync_leaf(dr, tx);
+				err = dbuf_sync_leaf(dr, tx);
+		}
+		if (err)
+			list_insert_head(list, dr);
+	}
+
+	return (err);
+}
+
+static void
+dbuf_write_done(zio_t *, arc_buf_t *, void *);
+
+void
+dbuf_drain_list(list_t *list, dmu_tx_t *tx)
+{
+	dbuf_dirty_record_t *dr;
+
+	while ((dr = list_head(list))) {
+		list_remove(list, dr);
+		if (dr->dr_dbuf == NULL) {
+			/* dbuf_sync_lightweight() path */
+			dsl_pool_undirty_space(dmu_tx_pool(tx),
+			    dr->dr_accounted, dmu_tx_get_txg(tx));
+			abd_free(dr->dt.dll.dr_abd);
+			kmem_free(dr, sizeof (*dr));
+		} else if (dr->dr_dbuf->db_level > 0) {
+			/* dbuf_sync_indirect() path */
+			mutex_enter(&dr->dt.di.dr_mtx);
+			dbuf_drain_list(&dr->dt.di.dr_children, tx);
+			ASSERT(list_head(&dr->dt.di.dr_children) == NULL);
+			mutex_exit(&dr->dt.di.dr_mtx);
+
+			dbuf_write_done(NULL, NULL, dr->dr_dbuf);
+		} else {
+			/* dbuf_sync_leaf path */
+			dmu_buf_impl_t *db = dr->dr_dbuf;
+			mutex_enter(&db->db_mtx);
+			if (db->db_blkid == DMU_BONUS_BLKID) {
+				dbuf_sync_bonus(dr, tx);
+				continue;
+			}
+			while (dr->dt.dl.dr_override_state == DR_IN_DMU_SYNC)
+				cv_wait(&db->db_changed, &db->db_mtx);
+			mutex_exit(&db->db_mtx);
+
+			dbuf_write_done(NULL, NULL, db);
+
+			ASSERT(!list_link_active(&dr->dr_dirty_node));
 		}
 	}
 }
@@ -5124,10 +5207,12 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 {
 	(void) buf;
 	dmu_buf_impl_t *db = vdb;
-	blkptr_t *bp_orig = &zio->io_bp_orig;
 	blkptr_t *bp = db->db_blkptr;
 	objset_t *os = db->db_objset;
 	dmu_tx_t *tx = os->os_synctx;
+
+	if ((zio->io_error && SPA_EXITING(os->os_spa)) || zio == NULL)
+		goto cleanup;
 
 	ASSERT0(zio->io_error);
 	ASSERT(db->db_blkptr == bp);
@@ -5136,6 +5221,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 	 * For nopwrites and rewrites we ensure that the bp matches our
 	 * original and bypass all the accounting.
 	 */
+	blkptr_t *bp_orig = &zio->io_bp_orig;
 	if (zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)) {
 		ASSERT(BP_EQUAL(bp, bp_orig));
 	} else {
@@ -5144,6 +5230,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 		dsl_dataset_block_born(ds, bp, tx);
 	}
 
+cleanup:
 	mutex_enter(&db->db_mtx);
 
 	DBUF_VERIFY(db);
@@ -5196,7 +5283,7 @@ dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 	dbuf_rele_and_unlock(db, (void *)(uintptr_t)tx->tx_txg, B_FALSE);
 
 	dsl_pool_undirty_space(dmu_objset_pool(os), dr->dr_accounted,
-	    zio->io_txg);
+	    zio ? zio->io_txg : tx->tx_txg);
 
 	kmem_cache_free(dbuf_dirty_kmem_cache, dr);
 }

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -388,7 +388,7 @@ static const ddt_kstats_t ddt_kstats_template = {
 #endif /* _KERNEL */
 
 
-static void
+static int
 ddt_object_create(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
@@ -398,36 +398,56 @@ ddt_object_create(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 	boolean_t prehash = zio_checksum_table[ddt->ddt_checksum].ci_flags &
 	    ZCHECKSUM_FLAG_DEDUP;
 	char name[DDT_NAMELEN];
+	int err = 0;
 
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 
 	ddt_object_name(ddt, type, class, name);
 
 	ASSERT0(*objectp);
-	VERIFY0(ddt_ops[type]->ddt_op_create(os, objectp, tx, prehash));
+	err = ddt_ops[type]->ddt_op_create(os, objectp, tx, prehash);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(*objectp, !=, 0);
 
-	VERIFY0(dnode_hold(os, *objectp, ddt,
-	    &ddt->ddt_object_dnode[type][class]));
+	err = dnode_hold(os, *objectp, ddt,
+	    &ddt->ddt_object_dnode[type][class]);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ASSERT3U(ddt->ddt_version, !=, DDT_VERSION_UNCONFIGURED);
 
-	VERIFY0(zap_add(os, ddt->ddt_dir_object, name, sizeof (uint64_t), 1,
-	    objectp, tx));
+	err = zap_add(os, ddt->ddt_dir_object, name, sizeof (uint64_t), 1,
+	    objectp, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(os, spa->spa_ddt_stat_object, name,
+	err = zap_add(os, spa->spa_ddt_stat_object, name,
 	    sizeof (uint64_t), sizeof (ddt_histogram_t) / sizeof (uint64_t),
-	    &ddt->ddt_histogram[type][class], tx));
+	    &ddt->ddt_histogram[type][class], tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
-static void
+static int
 ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
 	spa_t *spa = ddt->ddt_spa;
 	objset_t *os = ddt->ddt_os;
+	uint64_t object;
 	uint64_t count;
 	char name[DDT_NAMELEN];
+	int err = 0;
+
+	if (SPA_EXITING(spa))
+		goto out;
 
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 
@@ -437,10 +457,19 @@ ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 	ASSERT(ddt_histogram_empty(&ddt->ddt_histogram[type][class]));
 	VERIFY0(ddt_object_count(ddt, type, class, &count));
 	VERIFY0(count);
-	VERIFY0(zap_remove(os, ddt->ddt_dir_object, name, tx));
-	VERIFY0(zap_remove(os, spa->spa_ddt_stat_object, name, tx));
 
-	uint64_t object = ddt->ddt_object[type][class];
+	err = zap_remove(os, ddt->ddt_dir_object, name, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_remove(os, spa->spa_ddt_stat_object, name, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	object = ddt->ddt_object[type][class];
 	dnode_t *dn = ddt->ddt_object_dnode[type][class];
 	rw_enter(&ddt->ddt_objects_lock, RW_WRITER);
 	ddt->ddt_object[type][class] = 0;
@@ -449,8 +478,12 @@ ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 
 	if (dn != NULL)
 		dnode_rele(dn, ddt);
-	VERIFY0(ddt_ops[type]->ddt_op_destroy(os, object, tx));
+	err = ddt_ops[type]->ddt_op_destroy(os, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	memset(&ddt->ddt_object_stats[type][class], 0, sizeof (ddt_object_t));
+
+	return (err);
 }
 
 static int
@@ -512,30 +545,43 @@ error:
 	return (error);
 }
 
-static void
+static int
 ddt_object_sync(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
 	ddt_object_t *ddo = &ddt->ddt_object_stats[type][class];
 	dmu_object_info_t doi;
 	uint64_t count;
 	char name[DDT_NAMELEN];
+	int err = 0;
 
 	ddt_object_name(ddt, type, class, name);
 
-	VERIFY0(zap_update(ddt->ddt_os, ddt->ddt_spa->spa_ddt_stat_object, name,
+	err = zap_update(ddt->ddt_os, spa->spa_ddt_stat_object, name,
 	    sizeof (uint64_t), sizeof (ddt_histogram_t) / sizeof (uint64_t),
-	    &ddt->ddt_histogram[type][class], tx));
+	    &ddt->ddt_histogram[type][class], tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * Cache DDT statistics; this is the only time they'll change.
 	 */
-	VERIFY0(ddt_object_info(ddt, type, class, &doi));
-	VERIFY0(ddt_object_count(ddt, type, class, &count));
+	err = ddt_object_info(ddt, type, class, &doi);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = ddt_object_count(ddt, type, class, &count);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ddo->ddo_count = count;
 	ddo->ddo_dspace = doi.doi_physical_blocks_512 << 9;
 	ddo->ddo_mspace = doi.doi_fill_count * doi.doi_data_block_size;
+
+	return (err);
 }
 
 static boolean_t
@@ -1245,7 +1291,10 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 		 * This is the first use of this DDT since the pool was
 		 * created; finish getting it ready for use.
 		 */
-		VERIFY0(ddt_configure(ddt, B_TRUE));
+		error = ddt_configure(ddt, B_TRUE);
+		if (error && SPA_EXITING(spa))
+			return (NULL);
+		VERIFY0(error);
 		ASSERT3U(ddt->ddt_version, !=, DDT_VERSION_UNCONFIGURED);
 	}
 
@@ -1356,7 +1405,8 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 		for (class = 0; class < DDT_CLASSES; class++) {
 			error = ddt_object_lookup(ddt, type, class, dde);
 			if (error != ENOENT) {
-				ASSERT0(error);
+				if (!SPA_EXITING(spa))
+					ASSERT0(error);
 				break;
 			}
 		}
@@ -1365,6 +1415,17 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 	}
 
 	ddt_enter(ddt);
+
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa)) {
+		if (dde->dde_waiters == 0) {
+			avl_remove(&ddt->ddt_tree, dde);
+			ddt_free(ddt, dde);
+		} else {
+			dde->dde_flags |= DDE_FLAG_LOADED | DDE_FLAG_OVERQUOTA;
+			cv_broadcast(&dde->dde_cv);
+		}
+		return (NULL);
+	}
 
 	ASSERT(!(dde->dde_flags & DDE_FLAG_LOADED));
 
@@ -1485,9 +1546,12 @@ ddt_key_compare(const void *x1, const void *x2)
 }
 
 /* Create the containing dir for this DDT and bump the feature count */
-static void
+static int
 ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT0(ddt->ddt_dir_object);
 	ASSERT3U(ddt->ddt_version, ==, DDT_VERSION_FDT);
 
@@ -1495,22 +1559,37 @@ ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 	snprintf(name, DDT_NAMELEN, DMU_POOL_DDT_DIR,
 	    zio_checksum_table[ddt->ddt_checksum].ci_name);
 
-	VERIFY0(zap_create_link(ddt->ddt_os,
+	err = zap_create_link(ddt->ddt_os,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx,
-	    &ddt->ddt_dir_object));
+	    &ddt->ddt_dir_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
-	    sizeof (uint64_t), 1, &ddt->ddt_version, tx));
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS,
-	    sizeof (uint64_t), 1, &ddt->ddt_flags, tx));
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
+	    sizeof (uint64_t), 1, &ddt->ddt_version, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS,
+	    sizeof (uint64_t), 1, &ddt->ddt_flags, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	spa_feature_incr(ddt->ddt_spa, SPA_FEATURE_FAST_DEDUP, tx);
+
+	return (err);
 }
 
 /* Destroy the containing dir and deactivate the feature */
-static void
+static int
 ddt_destroy_dir(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT3U(ddt->ddt_dir_object, !=, 0);
 	ASSERT3U(ddt->ddt_dir_object, !=, DMU_POOL_DIRECTORY_OBJECT);
 	ASSERT3U(ddt->ddt_version, ==, DDT_VERSION_FDT);
@@ -1528,18 +1607,40 @@ ddt_destroy_dir(ddt_t *ddt, dmu_tx_t *tx)
 	ddt_log_destroy(ddt, tx);
 
 	uint64_t count;
-	ASSERT0(zap_count(ddt->ddt_os, ddt->ddt_dir_object, &count));
-	ASSERT0(zap_contains(ddt->ddt_os, ddt->ddt_dir_object,
-	    DDT_DIR_VERSION));
-	ASSERT0(zap_contains(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS));
+
+	err = zap_count(ddt->ddt_os, ddt->ddt_dir_object, &count);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
+	err = zap_contains(ddt->ddt_os, ddt->ddt_dir_object,
+	    DDT_DIR_VERSION);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
+	err = zap_contains(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
 	ASSERT3U(count, ==, 2);
 
-	VERIFY0(zap_remove(ddt->ddt_os, DMU_POOL_DIRECTORY_OBJECT, name, tx));
-	VERIFY0(zap_destroy(ddt->ddt_os, ddt->ddt_dir_object, tx));
+	err = zap_remove(ddt->ddt_os, DMU_POOL_DIRECTORY_OBJECT, name, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_destroy(ddt->ddt_os, ddt->ddt_dir_object, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ddt->ddt_dir_object = 0;
 
 	spa_feature_decr(ddt->ddt_spa, SPA_FEATURE_FAST_DEDUP, tx);
+
+	return (err);
 }
 
 /*
@@ -1960,6 +2061,8 @@ ddt_repair_done(ddt_t *ddt, ddt_entry_t *dde)
 static void
 ddt_repair_entry_done(zio_t *zio)
 {
+	if (SPA_EXITING(zio->io_spa))
+		return;
 	ddt_t *ddt = ddt_select(zio->io_spa, zio->io_bp);
 	ddt_entry_t *rdde = zio->io_private;
 
@@ -2036,6 +2139,9 @@ ddt_repair_table(ddt_t *ddt, zio_t *rio)
 static void
 ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err;
+
 	/*
 	 * Count all the entries stored for each type/class, and updates the
 	 * stats within (ddt_object_sync()). If there's no entries for the
@@ -2048,15 +2154,24 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 		uint64_t add, tcount = 0;
 		for (ddt_class_t class = 0; class < DDT_CLASSES; class++) {
 			if (ddt_object_exists(ddt, type, class)) {
-				ddt_object_sync(ddt, type, class, tx);
-				VERIFY0(ddt_object_count(ddt, type, class,
-				    &add));
-				tcount += add;
+				err = ddt_object_sync(ddt, type, class, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+				err = ddt_object_count(ddt, type, class,
+				    &add);
+				if (!SPA_EXITING(spa)) {
+					VERIFY0(err);
+					tcount += add;
+				}
 			}
 		}
 		for (ddt_class_t class = 0; class < DDT_CLASSES; class++) {
-			if (tcount == 0 && ddt_object_exists(ddt, type, class))
-				ddt_object_destroy(ddt, type, class, tx);
+			if (tcount == 0 &&
+			    ddt_object_exists(ddt, type, class)) {
+				err = ddt_object_destroy(ddt, type, class, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+			}
 		}
 		count += tcount;
 	}
@@ -2067,15 +2182,18 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 		count += avl_numnodes(&ddt->ddt_log_flushing->ddl_tree);
 	}
 
-	if (count == 0) {
+	if (count == 0 && !SPA_EXITING(spa)) {
 		/*
 		 * No entries left on the DDT, so reset the version for next
 		 * time. This allows us to handle the feature being changed
 		 * since the DDT was originally created. New entries should get
 		 * whatever the feature currently demands.
 		 */
-		if (ddt->ddt_version == DDT_VERSION_FDT)
-			ddt_destroy_dir(ddt, tx);
+		if (ddt->ddt_version == DDT_VERSION_FDT) {
+			err = ddt_destroy_dir(ddt, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+		}
 
 		ddt->ddt_version = DDT_VERSION_UNCONFIGURED;
 		ddt->ddt_flags = 0;
@@ -2083,8 +2201,8 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 
 	memcpy(&ddt->ddt_histogram_cache, ddt->ddt_histogram,
 	    sizeof (ddt->ddt_histogram));
-	ddt->ddt_spa->spa_dedup_dspace = ~0ULL;
-	ddt->ddt_spa->spa_dedup_dsize = ~0ULL;
+	spa->spa_dedup_dspace = ~0ULL;
+	spa->spa_dedup_dsize = ~0ULL;
 }
 
 static void
@@ -2123,9 +2241,14 @@ static void
 ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
     ddt_type_t otype, ddt_class_t oclass, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
 	ddt_key_t *ddk = &ddlwe->ddlwe_key;
 	ddt_type_t ntype = DDT_TYPE_DEFAULT;
 	uint64_t refcnt = 0;
+	int err;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Compute the total refcnt. Along the way, issue frees for any DVAs
@@ -2137,7 +2260,8 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 		uint64_t phys_refcnt = ddt_phys_refcnt(ddp, v);
 
 		if (ddt_phys_birth(ddp, v) == 0) {
-			ASSERT0(phys_refcnt);
+			if (!SPA_EXITING(spa))
+				ASSERT0(phys_refcnt);
 			continue;
 		}
 		if (DDT_PHYS_IS_DITTO(ddt, p)) {
@@ -2165,7 +2289,10 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 	 */
 	if (otype != DDT_TYPES &&
 	    (otype != ntype || oclass != nclass || refcnt == 0)) {
-		VERIFY0(ddt_object_remove(ddt, otype, oclass, ddk, tx));
+		err = ddt_object_remove(ddt, otype, oclass, ddk, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		ASSERT(ddt_object_contains(ddt, otype, oclass, ddk) == ENOENT);
 	}
 
@@ -2178,9 +2305,16 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 
 		ddt_histogram_add_entry(ddt, ddh, ddlwe);
 
-		if (!ddt_object_exists(ddt, ntype, nclass))
-			ddt_object_create(ddt, ntype, nclass, tx);
-		VERIFY0(ddt_object_update(ddt, ntype, nclass, ddlwe, tx));
+		if (!ddt_object_exists(ddt, ntype, nclass)) {
+			err = ddt_object_create(ddt, ntype, nclass, tx);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
+		}
+		err = ddt_object_update(ddt, ntype, nclass, ddlwe, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -2419,11 +2553,8 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 	if (count > 0) {
 		ddt_log_update_t dlu = {0};
 		err = ddt_log_begin(ddt, count, tx, &dlu);
-		if (err && SPA_EXITING(ddt->ddt_spa)) {
-			dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp, &dlu);
-			dnode_rele(dlu.dlu_dn, &dlu);
-			return (err);
-		}
+		if (!SPA_EXITING(ddt->ddt_spa))
+			VERIFY0(err);
 
 		ddt_entry_t *dde;
 		void *cookie = NULL;
@@ -2445,12 +2576,22 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 				    ddt_class_start();
 			}
 
-			ddt_log_entry(ddt, &ddlwe, &dlu);
-			ddt_sync_scan_entry(ddt, &ddlwe, tx);
+			if (!err) {
+				ddt_log_entry(ddt, &ddlwe, &dlu);
+				ddt_sync_scan_entry(ddt, &ddlwe, tx);
+			}
 			ddt_free(ddt, dde);
 		}
 
-		ddt_log_commit(ddt, &dlu);
+		if (err) {
+			if (dlu.dlu_dbp)
+				dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp,
+				    &dlu);
+			if (dlu.dlu_dn)
+				dnode_rele(dlu.dlu_dn, &dlu);
+		} else {
+			ddt_log_commit(ddt, &dlu);
+		}
 
 		DDT_KSTAT_SET(ddt, dds_log_active_entries,
 		    avl_numnodes(&ddt->ddt_log_active->ddl_tree));
@@ -2531,6 +2672,7 @@ static void
 ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 {
 	spa_t *spa = ddt->ddt_spa;
+	int err;
 
 	if (ddt->ddt_version == UINT64_MAX)
 		return;
@@ -2541,13 +2683,15 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_ddt_stat_object == 0) {
-		VERIFY0(zap_create_link(ddt->ddt_os,
+		err = zap_create_link(ddt->ddt_os,
 		    DMU_OT_DDT_STATS, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object));
+		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (ddt->ddt_version == DDT_VERSION_FDT && ddt->ddt_dir_object == 0)
-		ddt_create_dir(ddt, tx);
+		(void) ddt_create_dir(ddt, tx);
 
 	if (ddt->ddt_flags & DDT_FLAG_LOG)
 		ddt_sync_table_log(ddt, tx);
@@ -2852,7 +2996,7 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 		ddt_t *ddt = spa->spa_ddt[ddb.ddb_checksum];
 		VERIFY(ddt);
 
-		if (spa_shutting_down(spa) || issig())
+		if (spa_shutting_down(spa) || issig() || SPA_EXITING(spa))
 			break;
 
 		ASSERT(ddt->ddt_flags & DDT_FLAG_FLAT);
@@ -2872,9 +3016,12 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 		if (pruning && class_start < cutoff) {
 			if (candidates++ >= zfs_ddt_prunes_per_txg) {
 				/* sync prune candidates in batches */
-				VERIFY0(dsl_sync_task(spa_name(spa),
+				error = dsl_sync_task(spa_name(spa),
 				    NULL, prune_candidates_sync,
-				    &dpi, 0, ZFS_SPACE_CHECK_NONE));
+				    &dpi, 0, ZFS_SPACE_CHECK_NONE);
+				if (error && SPA_EXITING(spa))
+					break;
+				VERIFY0(error);
 				candidates = 1;
 			}
 			ddt_prune_entry(&dpi.dpi_candidates, ddt,
@@ -2895,9 +3042,11 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 	if (pruning && valid > 0) {
 		if (!list_is_empty(&dpi.dpi_candidates)) {
 			/* sync out final batch of prune candidates */
-			VERIFY0(dsl_sync_task(spa_name(spa), NULL,
+			error = dsl_sync_task(spa_name(spa), NULL,
 			    prune_candidates_sync, &dpi, 0,
-			    ZFS_SPACE_CHECK_NONE));
+			    ZFS_SPACE_CHECK_NONE);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		}
 		list_destroy(&dpi.dpi_candidates);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -1495,8 +1495,9 @@ ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 	snprintf(name, DDT_NAMELEN, DMU_POOL_DDT_DIR,
 	    zio_checksum_table[ddt->ddt_checksum].ci_name);
 
-	ddt->ddt_dir_object = zap_create_link(ddt->ddt_os,
-	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx);
+	VERIFY0(zap_create_link(ddt->ddt_os,
+	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx,
+	    &ddt->ddt_dir_object));
 
 	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
 	    sizeof (uint64_t), 1, &ddt->ddt_version, tx));
@@ -2408,14 +2409,21 @@ housekeeping:
 	}
 }
 
-static void
+static int
 ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	uint64_t count = avl_numnodes(&ddt->ddt_tree);
 
 	if (count > 0) {
 		ddt_log_update_t dlu = {0};
-		ddt_log_begin(ddt, count, tx, &dlu);
+		err = ddt_log_begin(ddt, count, tx, &dlu);
+		if (err && SPA_EXITING(ddt->ddt_spa)) {
+			dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp, &dlu);
+			dnode_rele(dlu.dlu_dn, &dlu);
+			return (err);
+		}
 
 		ddt_entry_t *dde;
 		void *cookie = NULL;
@@ -2481,6 +2489,8 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 		DDT_KSTAT_SET(ddt, dds_log_ingest_rate,
 		    ddt->ddt_log_ingest_rate);
 	}
+
+	return (err);
 }
 
 static void
@@ -2531,9 +2541,9 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_ddt_stat_object == 0) {
-		spa->spa_ddt_stat_object = zap_create_link(ddt->ddt_os,
+		VERIFY0(zap_create_link(ddt->ddt_os,
 		    DMU_OT_DDT_STATS, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DDT_STATS, tx);
+		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object));
 	}
 
 	if (ddt->ddt_version == DDT_VERSION_FDT && ddt->ddt_dir_object == 0)

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -381,7 +381,7 @@ static const ddt_kstats_t ddt_kstats_template = {
 #endif /* _KERNEL */
 
 
-static void
+static int
 ddt_object_create(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
@@ -391,36 +391,56 @@ ddt_object_create(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 	boolean_t prehash = zio_checksum_table[ddt->ddt_checksum].ci_flags &
 	    ZCHECKSUM_FLAG_DEDUP;
 	char name[DDT_NAMELEN];
+	int err = 0;
 
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 
 	ddt_object_name(ddt, type, class, name);
 
 	ASSERT0(*objectp);
-	VERIFY0(ddt_ops[type]->ddt_op_create(os, objectp, tx, prehash));
+	err = ddt_ops[type]->ddt_op_create(os, objectp, tx, prehash);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(*objectp, !=, 0);
 
-	VERIFY0(dnode_hold(os, *objectp, ddt,
-	    &ddt->ddt_object_dnode[type][class]));
+	err = dnode_hold(os, *objectp, ddt,
+	    &ddt->ddt_object_dnode[type][class]);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ASSERT3U(ddt->ddt_version, !=, DDT_VERSION_UNCONFIGURED);
 
-	VERIFY0(zap_add(os, ddt->ddt_dir_object, name, sizeof (uint64_t), 1,
-	    objectp, tx));
+	err = zap_add(os, ddt->ddt_dir_object, name, sizeof (uint64_t), 1,
+	    objectp, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(os, spa->spa_ddt_stat_object, name,
+	err = zap_add(os, spa->spa_ddt_stat_object, name,
 	    sizeof (uint64_t), sizeof (ddt_histogram_t) / sizeof (uint64_t),
-	    &ddt->ddt_histogram[type][class], tx));
+	    &ddt->ddt_histogram[type][class], tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
-static void
+static int
 ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
 	spa_t *spa = ddt->ddt_spa;
 	objset_t *os = ddt->ddt_os;
+	uint64_t object;
 	uint64_t count;
 	char name[DDT_NAMELEN];
+	int err = 0;
+
+	if (SPA_EXITING(spa))
+		goto out;
 
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 
@@ -430,10 +450,19 @@ ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 	ASSERT(ddt_histogram_empty(&ddt->ddt_histogram[type][class]));
 	VERIFY0(ddt_object_count(ddt, type, class, &count));
 	VERIFY0(count);
-	VERIFY0(zap_remove(os, ddt->ddt_dir_object, name, tx));
-	VERIFY0(zap_remove(os, spa->spa_ddt_stat_object, name, tx));
 
-	uint64_t object = ddt->ddt_object[type][class];
+	err = zap_remove(os, ddt->ddt_dir_object, name, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_remove(os, spa->spa_ddt_stat_object, name, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	object = ddt->ddt_object[type][class];
 	dnode_t *dn = ddt->ddt_object_dnode[type][class];
 	rw_enter(&ddt->ddt_objects_lock, RW_WRITER);
 	ddt->ddt_object[type][class] = 0;
@@ -442,8 +471,12 @@ ddt_object_destroy(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
 
 	if (dn != NULL)
 		dnode_rele(dn, ddt);
-	VERIFY0(ddt_ops[type]->ddt_op_destroy(os, object, tx));
+	err = ddt_ops[type]->ddt_op_destroy(os, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	memset(&ddt->ddt_object_stats[type][class], 0, sizeof (ddt_object_t));
+
+	return (err);
 }
 
 static int
@@ -505,30 +538,43 @@ error:
 	return (error);
 }
 
-static void
+static int
 ddt_object_sync(ddt_t *ddt, ddt_type_t type, ddt_class_t class,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
 	ddt_object_t *ddo = &ddt->ddt_object_stats[type][class];
 	dmu_object_info_t doi;
 	uint64_t count;
 	char name[DDT_NAMELEN];
+	int err = 0;
 
 	ddt_object_name(ddt, type, class, name);
 
-	VERIFY0(zap_update(ddt->ddt_os, ddt->ddt_spa->spa_ddt_stat_object, name,
+	err = zap_update(ddt->ddt_os, spa->spa_ddt_stat_object, name,
 	    sizeof (uint64_t), sizeof (ddt_histogram_t) / sizeof (uint64_t),
-	    &ddt->ddt_histogram[type][class], tx));
+	    &ddt->ddt_histogram[type][class], tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * Cache DDT statistics; this is the only time they'll change.
 	 */
-	VERIFY0(ddt_object_info(ddt, type, class, &doi));
-	VERIFY0(ddt_object_count(ddt, type, class, &count));
+	err = ddt_object_info(ddt, type, class, &doi);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = ddt_object_count(ddt, type, class, &count);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ddo->ddo_count = count;
 	ddo->ddo_dspace = doi.doi_physical_blocks_512 << 9;
 	ddo->ddo_mspace = doi.doi_fill_count * doi.doi_data_block_size;
+
+	return (err);
 }
 
 static boolean_t
@@ -1225,7 +1271,10 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 		 * This is the first use of this DDT since the pool was
 		 * created; finish getting it ready for use.
 		 */
-		VERIFY0(ddt_configure(ddt, B_TRUE));
+		error = ddt_configure(ddt, B_TRUE);
+		if (error && SPA_EXITING(spa))
+			return (NULL);
+		VERIFY0(error);
 		ASSERT3U(ddt->ddt_version, !=, DDT_VERSION_UNCONFIGURED);
 	}
 
@@ -1336,7 +1385,8 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 		for (class = 0; class < DDT_CLASSES; class++) {
 			error = ddt_object_lookup(ddt, type, class, dde);
 			if (error != ENOENT) {
-				ASSERT0(error);
+				if (!SPA_EXITING(spa))
+					ASSERT0(error);
 				break;
 			}
 		}
@@ -1345,6 +1395,17 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t verify)
 	}
 
 	ddt_enter(ddt);
+
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa)) {
+		if (dde->dde_waiters == 0) {
+			avl_remove(&ddt->ddt_tree, dde);
+			ddt_free(ddt, dde);
+		} else {
+			dde->dde_flags |= DDE_FLAG_LOADED | DDE_FLAG_OVERQUOTA;
+			cv_broadcast(&dde->dde_cv);
+		}
+		return (NULL);
+	}
 
 	ASSERT(!(dde->dde_flags & DDE_FLAG_LOADED));
 
@@ -1479,9 +1540,12 @@ ddt_sync_dirty_est(spa_t *spa)
 }
 
 /* Create the containing dir for this DDT and bump the feature count */
-static void
+static int
 ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT0(ddt->ddt_dir_object);
 	ASSERT3U(ddt->ddt_version, ==, DDT_VERSION_FDT);
 
@@ -1489,22 +1553,37 @@ ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 	snprintf(name, DDT_NAMELEN, DMU_POOL_DDT_DIR,
 	    zio_checksum_table[ddt->ddt_checksum].ci_name);
 
-	VERIFY0(zap_create_link(ddt->ddt_os,
+	err = zap_create_link(ddt->ddt_os,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx,
-	    &ddt->ddt_dir_object));
+	    &ddt->ddt_dir_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
-	    sizeof (uint64_t), 1, &ddt->ddt_version, tx));
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS,
-	    sizeof (uint64_t), 1, &ddt->ddt_flags, tx));
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
+	    sizeof (uint64_t), 1, &ddt->ddt_version, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS,
+	    sizeof (uint64_t), 1, &ddt->ddt_flags, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	spa_feature_incr(ddt->ddt_spa, SPA_FEATURE_FAST_DEDUP, tx);
+
+	return (err);
 }
 
 /* Destroy the containing dir and deactivate the feature */
-static void
+static int
 ddt_destroy_dir(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT3U(ddt->ddt_dir_object, !=, 0);
 	ASSERT3U(ddt->ddt_dir_object, !=, DMU_POOL_DIRECTORY_OBJECT);
 	ASSERT3U(ddt->ddt_version, ==, DDT_VERSION_FDT);
@@ -1522,18 +1601,40 @@ ddt_destroy_dir(ddt_t *ddt, dmu_tx_t *tx)
 	ddt_log_destroy(ddt, tx);
 
 	uint64_t count;
-	ASSERT0(zap_count(ddt->ddt_os, ddt->ddt_dir_object, &count));
-	ASSERT0(zap_contains(ddt->ddt_os, ddt->ddt_dir_object,
-	    DDT_DIR_VERSION));
-	ASSERT0(zap_contains(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS));
+
+	err = zap_count(ddt->ddt_os, ddt->ddt_dir_object, &count);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
+	err = zap_contains(ddt->ddt_os, ddt->ddt_dir_object,
+	    DDT_DIR_VERSION);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
+	err = zap_contains(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_FLAGS);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
+
 	ASSERT3U(count, ==, 2);
 
-	VERIFY0(zap_remove(ddt->ddt_os, DMU_POOL_DIRECTORY_OBJECT, name, tx));
-	VERIFY0(zap_destroy(ddt->ddt_os, ddt->ddt_dir_object, tx));
+	err = zap_remove(ddt->ddt_os, DMU_POOL_DIRECTORY_OBJECT, name, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_destroy(ddt->ddt_os, ddt->ddt_dir_object, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ddt->ddt_dir_object = 0;
 
 	spa_feature_decr(ddt->ddt_spa, SPA_FEATURE_FAST_DEDUP, tx);
+
+	return (err);
 }
 
 /*
@@ -1954,6 +2055,8 @@ ddt_repair_done(ddt_t *ddt, ddt_entry_t *dde)
 static void
 ddt_repair_entry_done(zio_t *zio)
 {
+	if (SPA_EXITING(zio->io_spa))
+		return;
 	ddt_t *ddt = ddt_select(zio->io_spa, zio->io_bp);
 	ddt_entry_t *rdde = zio->io_private;
 
@@ -2030,6 +2133,9 @@ ddt_repair_table(ddt_t *ddt, zio_t *rio)
 static void
 ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err;
+
 	/*
 	 * Count all the entries stored for each type/class, and updates the
 	 * stats within (ddt_object_sync()). If there's no entries for the
@@ -2042,15 +2148,24 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 		uint64_t add, tcount = 0;
 		for (ddt_class_t class = 0; class < DDT_CLASSES; class++) {
 			if (ddt_object_exists(ddt, type, class)) {
-				ddt_object_sync(ddt, type, class, tx);
-				VERIFY0(ddt_object_count(ddt, type, class,
-				    &add));
-				tcount += add;
+				err = ddt_object_sync(ddt, type, class, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+				err = ddt_object_count(ddt, type, class,
+				    &add);
+				if (!SPA_EXITING(spa)) {
+					VERIFY0(err);
+					tcount += add;
+				}
 			}
 		}
 		for (ddt_class_t class = 0; class < DDT_CLASSES; class++) {
-			if (tcount == 0 && ddt_object_exists(ddt, type, class))
-				ddt_object_destroy(ddt, type, class, tx);
+			if (tcount == 0 &&
+			    ddt_object_exists(ddt, type, class)) {
+				err = ddt_object_destroy(ddt, type, class, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+			}
 		}
 		count += tcount;
 	}
@@ -2061,15 +2176,18 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 		count += avl_numnodes(&ddt->ddt_log_flushing->ddl_tree);
 	}
 
-	if (count == 0) {
+	if (count == 0 && !SPA_EXITING(spa)) {
 		/*
 		 * No entries left on the DDT, so reset the version for next
 		 * time. This allows us to handle the feature being changed
 		 * since the DDT was originally created. New entries should get
 		 * whatever the feature currently demands.
 		 */
-		if (ddt->ddt_version == DDT_VERSION_FDT)
-			ddt_destroy_dir(ddt, tx);
+		if (ddt->ddt_version == DDT_VERSION_FDT) {
+			err = ddt_destroy_dir(ddt, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+		}
 
 		ddt->ddt_version = DDT_VERSION_UNCONFIGURED;
 		ddt->ddt_flags = 0;
@@ -2077,8 +2195,8 @@ ddt_sync_update_stats(ddt_t *ddt, dmu_tx_t *tx)
 
 	memcpy(&ddt->ddt_histogram_cache, ddt->ddt_histogram,
 	    sizeof (ddt->ddt_histogram));
-	ddt->ddt_spa->spa_dedup_dspace = ~0ULL;
-	ddt->ddt_spa->spa_dedup_dsize = ~0ULL;
+	spa->spa_dedup_dspace = ~0ULL;
+	spa->spa_dedup_dsize = ~0ULL;
 }
 
 static void
@@ -2117,9 +2235,14 @@ static void
 ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
     ddt_type_t otype, ddt_class_t oclass, dmu_tx_t *tx)
 {
+	spa_t *spa = ddt->ddt_spa;
 	ddt_key_t *ddk = &ddlwe->ddlwe_key;
 	ddt_type_t ntype = DDT_TYPE_DEFAULT;
 	uint64_t refcnt = 0;
+	int err;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Compute the total refcnt. Along the way, issue frees for any DVAs
@@ -2131,7 +2254,8 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 		uint64_t phys_refcnt = ddt_phys_refcnt(ddp, v);
 
 		if (ddt_phys_birth(ddp, v) == 0) {
-			ASSERT0(phys_refcnt);
+			if (!SPA_EXITING(spa))
+				ASSERT0(phys_refcnt);
 			continue;
 		}
 		if (DDT_PHYS_IS_DITTO(ddt, p)) {
@@ -2159,7 +2283,10 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 	 */
 	if (otype != DDT_TYPES &&
 	    (otype != ntype || oclass != nclass || refcnt == 0)) {
-		VERIFY0(ddt_object_remove(ddt, otype, oclass, ddk, tx));
+		err = ddt_object_remove(ddt, otype, oclass, ddk, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		ASSERT(ddt_object_contains(ddt, otype, oclass, ddk) == ENOENT);
 	}
 
@@ -2172,9 +2299,16 @@ ddt_sync_flush_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe,
 
 		ddt_histogram_add_entry(ddt, ddh, ddlwe);
 
-		if (!ddt_object_exists(ddt, ntype, nclass))
-			ddt_object_create(ddt, ntype, nclass, tx);
-		VERIFY0(ddt_object_update(ddt, ntype, nclass, ddlwe, tx));
+		if (!ddt_object_exists(ddt, ntype, nclass)) {
+			err = ddt_object_create(ddt, ntype, nclass, tx);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
+		}
+		err = ddt_object_update(ddt, ntype, nclass, ddlwe, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -2413,11 +2547,8 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 	if (count > 0) {
 		ddt_log_update_t dlu = {0};
 		err = ddt_log_begin(ddt, count, tx, &dlu);
-		if (err && SPA_EXITING(ddt->ddt_spa)) {
-			dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp, &dlu);
-			dnode_rele(dlu.dlu_dn, &dlu);
-			return (err);
-		}
+		if (!SPA_EXITING(ddt->ddt_spa))
+			VERIFY0(err);
 
 		ddt_entry_t *dde;
 		void *cookie = NULL;
@@ -2439,12 +2570,22 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 				    ddt_class_start();
 			}
 
-			ddt_log_entry(ddt, &ddlwe, &dlu);
-			ddt_sync_scan_entry(ddt, &ddlwe, tx);
+			if (!err) {
+				ddt_log_entry(ddt, &ddlwe, &dlu);
+				ddt_sync_scan_entry(ddt, &ddlwe, tx);
+			}
 			ddt_free(ddt, dde);
 		}
 
-		ddt_log_commit(ddt, &dlu);
+		if (err) {
+			if (dlu.dlu_dbp)
+				dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp,
+				    &dlu);
+			if (dlu.dlu_dn)
+				dnode_rele(dlu.dlu_dn, &dlu);
+		} else {
+			ddt_log_commit(ddt, &dlu);
+		}
 
 		DDT_KSTAT_SET(ddt, dds_log_active_entries,
 		    avl_numnodes(&ddt->ddt_log_active->ddl_tree));
@@ -2525,6 +2666,7 @@ static void
 ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 {
 	spa_t *spa = ddt->ddt_spa;
+	int err;
 
 	if (ddt->ddt_version == UINT64_MAX)
 		return;
@@ -2535,13 +2677,15 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_ddt_stat_object == 0) {
-		VERIFY0(zap_create_link(ddt->ddt_os,
+		err = zap_create_link(ddt->ddt_os,
 		    DMU_OT_DDT_STATS, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object));
+		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (ddt->ddt_version == DDT_VERSION_FDT && ddt->ddt_dir_object == 0)
-		ddt_create_dir(ddt, tx);
+		(void) ddt_create_dir(ddt, tx);
 
 	if (ddt->ddt_flags & DDT_FLAG_LOG)
 		ddt_sync_table_log(ddt, tx);
@@ -2853,7 +2997,7 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 		ddt_t *ddt = spa->spa_ddt[ddb.ddb_checksum];
 		VERIFY(ddt);
 
-		if (spa_shutting_down(spa) || issig())
+		if (spa_shutting_down(spa) || issig() || SPA_EXITING(spa))
 			break;
 
 		ASSERT(ddt->ddt_flags & DDT_FLAG_FLAT);
@@ -2866,9 +3010,12 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 		if (pruning && class_start < cutoff) {
 			if (candidates++ >= zfs_ddt_prunes_per_txg) {
 				/* sync prune candidates in batches */
-				VERIFY0(dsl_sync_task(spa_name(spa),
+				error = dsl_sync_task(spa_name(spa),
 				    NULL, prune_candidates_sync,
-				    &dpi, 0, ZFS_SPACE_CHECK_NONE));
+				    &dpi, 0, ZFS_SPACE_CHECK_NONE);
+				if (error && SPA_EXITING(spa))
+					break;
+				VERIFY0(error);
 				candidates = 1;
 			}
 			ddt_prune_entry(&dpi.dpi_candidates, ddt,
@@ -2890,9 +3037,11 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 	if (pruning) {
 		if (!list_is_empty(&dpi.dpi_candidates)) {
 			/* sync out final batch of prune candidates */
-			VERIFY0(dsl_sync_task(spa_name(spa), NULL,
+			error = dsl_sync_task(spa_name(spa), NULL,
 			    prune_candidates_sync, &dpi, 0,
-			    ZFS_SPACE_CHECK_NONE));
+			    ZFS_SPACE_CHECK_NONE);
+			if (!SPA_EXITING(spa))
+				VERIFY0(error);
 		}
 		list_destroy(&dpi.dpi_candidates);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -1489,8 +1489,9 @@ ddt_create_dir(ddt_t *ddt, dmu_tx_t *tx)
 	snprintf(name, DDT_NAMELEN, DMU_POOL_DDT_DIR,
 	    zio_checksum_table[ddt->ddt_checksum].ci_name);
 
-	ddt->ddt_dir_object = zap_create_link(ddt->ddt_os,
-	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx);
+	VERIFY0(zap_create_link(ddt->ddt_os,
+	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT, name, tx,
+	    &ddt->ddt_dir_object));
 
 	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, DDT_DIR_VERSION,
 	    sizeof (uint64_t), 1, &ddt->ddt_version, tx));
@@ -2402,14 +2403,21 @@ housekeeping:
 	}
 }
 
-static void
+static int
 ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	uint64_t count = avl_numnodes(&ddt->ddt_tree);
 
 	if (count > 0) {
 		ddt_log_update_t dlu = {0};
-		ddt_log_begin(ddt, count, tx, &dlu);
+		err = ddt_log_begin(ddt, count, tx, &dlu);
+		if (err && SPA_EXITING(ddt->ddt_spa)) {
+			dmu_buf_rele_array(dlu.dlu_dbp, dlu.dlu_ndbp, &dlu);
+			dnode_rele(dlu.dlu_dn, &dlu);
+			return (err);
+		}
 
 		ddt_entry_t *dde;
 		void *cookie = NULL;
@@ -2475,6 +2483,8 @@ ddt_sync_table_log(ddt_t *ddt, dmu_tx_t *tx)
 		DDT_KSTAT_SET(ddt, dds_log_ingest_rate,
 		    ddt->ddt_log_ingest_rate);
 	}
+
+	return (err);
 }
 
 static void
@@ -2525,9 +2535,9 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_ddt_stat_object == 0) {
-		spa->spa_ddt_stat_object = zap_create_link(ddt->ddt_os,
+		VERIFY0(zap_create_link(ddt->ddt_os,
 		    DMU_OT_DDT_STATS, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DDT_STATS, tx);
+		    DMU_POOL_DDT_STATS, tx, &spa->spa_ddt_stat_object));
 	}
 
 	if (ddt->ddt_version == DDT_VERSION_FDT && ddt->ddt_dir_object == 0)

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -100,8 +100,15 @@ static void
 ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
-	VERIFY0(dmu_bonus_hold(ddt->ddt_os, ddl->ddl_object, FTAG, &db));
+	int err;
+
+	err = dmu_bonus_hold(ddt->ddt_os, ddl->ddl_object, FTAG, &db);
+	if (err && SPA_EXITING(ddt->ddt_spa))
+		return;
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(ddt->ddt_spa))
+		goto out;
 
 	ddt_log_header_t *hdr = (ddt_log_header_t *)db->db_data;
 	DLH_SET_VERSION(hdr, 1);
@@ -110,6 +117,7 @@ ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 	hdr->dlh_first_txg = ddl->ddl_first_txg;
 	hdr->dlh_checkpoint = ddl->ddl_checkpoint;
 
+out:
 	dmu_buf_rele(db, FTAG);
 }
 
@@ -259,6 +267,7 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 
 	dlu->dlu_tx = tx;
 	dlu->dlu_block = dlu->dlu_offset = 0;
+
 	return (err);
 }
 

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -27,6 +27,7 @@
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/ddt.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dmu.h>
 #include <sys/ddt_impl.h>
@@ -112,30 +113,49 @@ ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 	dmu_buf_rele(db, FTAG);
 }
 
-static void
+static int
 ddt_log_create_one(ddt_t *ddt, ddt_log_t *ddl, uint_t n, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 	ASSERT0(ddl->ddl_object);
 
 	char name[DDT_NAMELEN];
 	ddt_log_name(ddt, name, n);
 
-	ddl->ddl_object = dmu_object_alloc(ddt->ddt_os,
+	err = dmu_object_alloc(ddt->ddt_os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
-	    DMU_OTN_UINT64_METADATA, sizeof (ddt_log_header_t), tx);
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, name,
-	    sizeof (uint64_t), 1, &ddl->ddl_object, tx));
+	    DMU_OTN_UINT64_METADATA, sizeof (ddt_log_header_t), tx,
+	    &ddl->ddl_object);
+	if (err && SPA_EXITING(ddt->ddt_os->os_spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, name,
+	    sizeof (uint64_t), 1, &ddl->ddl_object, tx);
+	if (err && SPA_EXITING(ddt->ddt_os->os_spa))
+		return (err);
+	VERIFY0(err);
 	ddl->ddl_length = 0;
 	ddl->ddl_first_txg = tx->tx_txg;
 	ddt_log_update_header(ddt, ddl, tx);
+
+	return (err);
 }
 
-static void
+static int
 ddt_log_create(ddt_t *ddt, dmu_tx_t *tx)
 {
-	ddt_log_create_one(ddt, ddt->ddt_log_active, 0, tx);
-	ddt_log_create_one(ddt, ddt->ddt_log_flushing, 1, tx);
+	int err = 0;
+
+	err = ddt_log_create_one(ddt, ddt->ddt_log_active, 0, tx);
+	if (err)
+		return (err);
+
+	err = ddt_log_create_one(ddt, ddt->ddt_log_flushing, 1, tx);
+
+	return (err);
 }
 
 static void
@@ -192,14 +212,21 @@ ddt_log_update_stats(ddt_t *ddt)
 	ddo->ddo_dspace = nblocks << 9;
 }
 
-void
+int
 ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT3U(nentries, >, 0);
 	ASSERT0P(dlu->dlu_dbp);
 
-	if (ddt->ddt_log_active->ddl_object == 0)
-		ddt_log_create(ddt, tx);
+	if (ddt->ddt_log_active->ddl_object == 0) {
+		err = ddt_log_create(ddt, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+	}
 
 	/*
 	 * We want to store as many entries as we can in a block, but never
@@ -211,8 +238,11 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 	ASSERT3U(reclen, <=, UINT16_MAX);
 	dlu->dlu_reclen = reclen;
 
-	VERIFY0(dnode_hold(ddt->ddt_os, ddt->ddt_log_active->ddl_object, dlu,
-	    &dlu->dlu_dn));
+	err = dnode_hold(ddt->ddt_os, ddt->ddt_log_active->ddl_object, dlu,
+	    &dlu->dlu_dn);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dnode_set_storage_type(dlu->dlu_dn, DMU_OT_DDT_ZAP);
 
 	uint64_t nblocks = howmany(nentries,
@@ -220,12 +250,16 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 	uint64_t offset = ddt->ddt_log_active->ddl_length;
 	uint64_t length = nblocks * dlu->dlu_dn->dn_datablksz;
 
-	VERIFY0(dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
+	err = dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
 	    B_FALSE, dlu, &dlu->dlu_ndbp, &dlu->dlu_dbp,
-	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO));
+	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dlu->dlu_tx = tx;
 	dlu->dlu_block = dlu->dlu_offset = 0;
+	return (err);
 }
 
 static ddt_log_entry_t *

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -90,8 +90,15 @@ static void
 ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
-	VERIFY0(dmu_bonus_hold(ddt->ddt_os, ddl->ddl_object, FTAG, &db));
+	int err;
+
+	err = dmu_bonus_hold(ddt->ddt_os, ddl->ddl_object, FTAG, &db);
+	if (err && SPA_EXITING(ddt->ddt_spa))
+		return;
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(ddt->ddt_spa))
+		goto out;
 
 	ddt_log_header_t *hdr = (ddt_log_header_t *)db->db_data;
 	DLH_SET_VERSION(hdr, 1);
@@ -100,6 +107,7 @@ ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 	hdr->dlh_first_txg = ddl->ddl_first_txg;
 	hdr->dlh_checkpoint = ddl->ddl_checkpoint;
 
+out:
 	dmu_buf_rele(db, FTAG);
 }
 
@@ -249,6 +257,7 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 
 	dlu->dlu_tx = tx;
 	dlu->dlu_block = dlu->dlu_offset = 0;
+
 	return (err);
 }
 

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -17,6 +17,7 @@
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/ddt.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dmu.h>
 #include <sys/ddt_impl.h>
@@ -102,30 +103,49 @@ ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 	dmu_buf_rele(db, FTAG);
 }
 
-static void
+static int
 ddt_log_create_one(ddt_t *ddt, ddt_log_t *ddl, uint_t n, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT3U(ddt->ddt_dir_object, >, 0);
 	ASSERT0(ddl->ddl_object);
 
 	char name[DDT_NAMELEN];
 	ddt_log_name(ddt, name, n);
 
-	ddl->ddl_object = dmu_object_alloc(ddt->ddt_os,
+	err = dmu_object_alloc(ddt->ddt_os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
-	    DMU_OTN_UINT64_METADATA, sizeof (ddt_log_header_t), tx);
-	VERIFY0(zap_add(ddt->ddt_os, ddt->ddt_dir_object, name,
-	    sizeof (uint64_t), 1, &ddl->ddl_object, tx));
+	    DMU_OTN_UINT64_METADATA, sizeof (ddt_log_header_t), tx,
+	    &ddl->ddl_object);
+	if (err && SPA_EXITING(ddt->ddt_os->os_spa))
+		return (err);
+	VERIFY0(err);
+
+	err = zap_add(ddt->ddt_os, ddt->ddt_dir_object, name,
+	    sizeof (uint64_t), 1, &ddl->ddl_object, tx);
+	if (err && SPA_EXITING(ddt->ddt_os->os_spa))
+		return (err);
+	VERIFY0(err);
 	ddl->ddl_length = 0;
 	ddl->ddl_first_txg = tx->tx_txg;
 	ddt_log_update_header(ddt, ddl, tx);
+
+	return (err);
 }
 
-static void
+static int
 ddt_log_create(ddt_t *ddt, dmu_tx_t *tx)
 {
-	ddt_log_create_one(ddt, ddt->ddt_log_active, 0, tx);
-	ddt_log_create_one(ddt, ddt->ddt_log_flushing, 1, tx);
+	int err = 0;
+
+	err = ddt_log_create_one(ddt, ddt->ddt_log_active, 0, tx);
+	if (err)
+		return (err);
+
+	err = ddt_log_create_one(ddt, ddt->ddt_log_flushing, 1, tx);
+
+	return (err);
 }
 
 static void
@@ -182,14 +202,21 @@ ddt_log_update_stats(ddt_t *ddt)
 	ddo->ddo_dspace = nblocks << 9;
 }
 
-void
+int
 ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 {
+	spa_t *spa = ddt->ddt_spa;
+	int err = 0;
+
 	ASSERT3U(nentries, >, 0);
 	ASSERT0P(dlu->dlu_dbp);
 
-	if (ddt->ddt_log_active->ddl_object == 0)
-		ddt_log_create(ddt, tx);
+	if (ddt->ddt_log_active->ddl_object == 0) {
+		err = ddt_log_create(ddt, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+	}
 
 	/*
 	 * We want to store as many entries as we can in a block, but never
@@ -201,8 +228,11 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 	ASSERT3U(reclen, <=, UINT16_MAX);
 	dlu->dlu_reclen = reclen;
 
-	VERIFY0(dnode_hold(ddt->ddt_os, ddt->ddt_log_active->ddl_object, dlu,
-	    &dlu->dlu_dn));
+	err = dnode_hold(ddt->ddt_os, ddt->ddt_log_active->ddl_object, dlu,
+	    &dlu->dlu_dn);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dnode_set_storage_type(dlu->dlu_dn, DMU_OT_DDT_ZAP);
 
 	uint64_t nblocks = howmany(nentries,
@@ -210,12 +240,16 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 	uint64_t offset = ddt->ddt_log_active->ddl_length;
 	uint64_t length = nblocks * dlu->dlu_dn->dn_datablksz;
 
-	VERIFY0(dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
+	err = dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
 	    B_FALSE, dlu, &dlu->dlu_ndbp, &dlu->dlu_dbp,
-	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO));
+	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dlu->dlu_tx = tx;
 	dlu->dlu_block = dlu->dlu_offset = 0;
+	return (err);
 }
 
 static ddt_log_entry_t *

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -106,10 +106,10 @@ ddt_zap_create(objset_t *os, uint64_t *objectp, dmu_tx_t *tx, boolean_t prehash)
 	if (prehash)
 		flags |= ZAP_FLAG_PRE_HASHED_KEY;
 
-	*objectp = zap_create_flags(os, 0, flags, DMU_OT_DDT_ZAP,
+	int err = zap_create_flags(os, 0, flags, DMU_OT_DDT_ZAP,
 	    ddt_zap_default_bs, ddt_zap_default_ibs,
-	    DMU_OT_NONE, 0, tx);
-	if (*objectp == 0)
+	    DMU_OT_NONE, 0, tx, objectp);
+	if (err || *objectp == 0)
 		return (SET_ERROR(ENOTSUP));
 
 	return (0);

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -96,10 +96,10 @@ ddt_zap_create(objset_t *os, uint64_t *objectp, dmu_tx_t *tx, boolean_t prehash)
 	if (prehash)
 		flags |= ZAP_FLAG_PRE_HASHED_KEY;
 
-	*objectp = zap_create_flags(os, 0, flags, DMU_OT_DDT_ZAP,
+	int err = zap_create_flags(os, 0, flags, DMU_OT_DDT_ZAP,
 	    ddt_zap_default_bs, ddt_zap_default_ibs,
-	    DMU_OT_NONE, 0, tx);
-	if (*objectp == 0)
+	    DMU_OT_NONE, 0, tx, objectp);
+	if (err || *objectp == 0)
 		return (SET_ERROR(ENOTSUP));
 
 	return (0);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -499,7 +499,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 	zstream_t *zs = NULL;
 	uint64_t blkid, nblks, i;
 	dmu_flags_t dbuf_flags;
-	int err;
+	int err = 0;
 	zio_t *zio = NULL;
 	boolean_t missed = B_FALSE;
 
@@ -578,7 +578,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 				else
 					dbuf_flags |= DMU_PARTIAL_MORE;
 			}
-			(void) dbuf_read(db, zio, dbuf_flags);
+			err = dbuf_read(db, zio, dbuf_flags) || err;
 			if (db->db_state != DB_CACHED)
 				missed = B_TRUE;
 		}
@@ -604,7 +604,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 
 	if (read) {
 		/* wait for async read i/o */
-		err = zio_wait(zio);
+		err = zio_wait(zio) || err;
 		if (err) {
 			dmu_buf_rele_array(dbp, nblks, tag);
 			return (err);
@@ -620,10 +620,10 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 			if (db->db_state == DB_UNCACHED)
 				err = SET_ERROR(EIO);
 			mutex_exit(&db->db_mtx);
-			if (err) {
-				dmu_buf_rele_array(dbp, nblks, tag);
-				return (err);
-			}
+		}
+		if (err) {
+			dmu_buf_rele_array(dbp, nblks, tag);
+			return (err);
 		}
 	}
 
@@ -1345,6 +1345,7 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		uint64_t tocpy;
 		int64_t bufoff;
 		dmu_buf_t *db = dbp[i];
+		spa_t *spa = ((dmu_buf_impl_t *)db)->db_objset->os_spa;
 
 		ASSERT(size > 0);
 
@@ -1364,12 +1365,14 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 			}
 			dmu_buf_will_dirty_flags(db, tx, flags);
 		}
+		if (!SPA_EXITING(spa)) {
+			ASSERT(db->db_data != NULL);
+			(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
+		}
 
-		ASSERT(db->db_data != NULL);
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
-
-		if (tocpy == db->db_size)
+		if (tocpy == db->db_size) {
 			dmu_buf_fill_done(db, tx, B_FALSE);
+		}
 
 		offset += tocpy;
 		size -= tocpy;
@@ -1382,13 +1385,16 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags)
 {
 	dmu_buf_t **dbp;
-	int numbufs;
+	int numbufs, err;
 
 	if (size == 0)
 		return;
 
-	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, flags));
+	err = dmu_buf_hold_array(os, object, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, flags);
+	if (err && SPA_EXITING(os->os_spa))
+		return;
+	VERIFY0(err);
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx, flags);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
@@ -1399,7 +1405,7 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 {
 	dmu_buf_t **dbp;
 	int numbufs;
-	int error;
+	int error = 0;
 
 	if (size == 0)
 		return (0);
@@ -1414,11 +1420,14 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 	}
 	flags &= ~DMU_DIRECTIO;
 
-	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, flags));
+	error = dmu_buf_hold_array_by_dnode(dn, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, flags);
+	if (error && SPA_EXITING(dn->dn_objset->os_spa))
+		return (error);
+	VERIFY0(error);
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx, flags);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (0);
+	return (error);
 }
 
 void

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1451,23 +1451,29 @@ dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
-void
+int
 dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
     void *data, uint8_t etype, uint8_t comp, int uncompressed_size,
     int compressed_size, int byteorder, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
+	int err = 0;
 
 	ASSERT3U(etype, <, NUM_BP_EMBEDDED_TYPES);
 	ASSERT3U(comp, <, ZIO_COMPRESS_FUNCTIONS);
-	VERIFY0(dmu_buf_hold_noread(os, object, offset,
-	    FTAG, &db));
+	err = dmu_buf_hold_noread(os, object, offset,
+	    FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_write_embedded(db,
 	    data, (bp_embedded_type_t)etype, (enum zio_compress)comp,
 	    uncompressed_size, compressed_size, byteorder, tx);
 
 	dmu_buf_rele(db, FTAG);
+
+	return (err);
 }
 
 void

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1562,23 +1562,29 @@ dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
-void
+int
 dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
     void *data, uint8_t etype, uint8_t comp, int uncompressed_size,
     int compressed_size, int byteorder, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
+	int err = 0;
 
 	ASSERT3U(etype, <, NUM_BP_EMBEDDED_TYPES);
 	ASSERT3U(comp, <, ZIO_COMPRESS_FUNCTIONS);
-	VERIFY0(dmu_buf_hold_noread(os, object, offset,
-	    FTAG, &db));
+	err = dmu_buf_hold_noread(os, object, offset,
+	    FTAG, &db);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_write_embedded(db,
 	    data, (bp_embedded_type_t)etype, (enum zio_compress)comp,
 	    uncompressed_size, compressed_size, byteorder, tx);
 
 	dmu_buf_rele(db, FTAG);
+
+	return (err);
 }
 
 void

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -490,7 +490,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 	zstream_t *zs = NULL;
 	uint64_t blkid, nblks, i;
 	dmu_flags_t dbuf_flags;
-	int err;
+	int err = 0;
 	zio_t *zio = NULL;
 	boolean_t missed = B_FALSE;
 
@@ -569,7 +569,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 				else
 					dbuf_flags |= DMU_PARTIAL_MORE;
 			}
-			(void) dbuf_read(db, zio, dbuf_flags);
+			err = dbuf_read(db, zio, dbuf_flags) || err;
 			if (db->db_state != DB_CACHED)
 				missed = B_TRUE;
 		}
@@ -595,7 +595,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 
 	if (read) {
 		/* wait for async read i/o */
-		err = zio_wait(zio);
+		err = zio_wait(zio) || err;
 		if (err) {
 			dmu_buf_rele_array(dbp, nblks, tag);
 			return (err);
@@ -611,10 +611,10 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 			if (db->db_state == DB_UNCACHED)
 				err = SET_ERROR(EIO);
 			mutex_exit(&db->db_mtx);
-			if (err) {
-				dmu_buf_rele_array(dbp, nblks, tag);
-				return (err);
-			}
+		}
+		if (err) {
+			dmu_buf_rele_array(dbp, nblks, tag);
+			return (err);
 		}
 	}
 
@@ -1476,12 +1476,14 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 			}
 			dmu_buf_will_dirty_flags(db, tx, flags);
 		}
+		if (!SPA_EXITING(dmu_tx_pool(tx)->dp_spa)) {
+			ASSERT(db->db_data != NULL);
+			(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
+		}
 
-		ASSERT(db->db_data != NULL);
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
-
-		if (tocpy == db->db_size)
+		if (tocpy == db->db_size) {
 			dmu_buf_fill_done(db, tx, B_FALSE);
+		}
 
 		offset += tocpy;
 		size -= tocpy;
@@ -1494,13 +1496,16 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags)
 {
 	dmu_buf_t **dbp;
-	int numbufs;
+	int numbufs, err;
 
 	if (size == 0)
 		return;
 
-	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, flags));
+	err = dmu_buf_hold_array(os, object, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, flags);
+	if (err && SPA_EXITING(os->os_spa))
+		return;
+	VERIFY0(err);
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx, flags);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
@@ -1511,7 +1516,7 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 {
 	dmu_buf_t **dbp;
 	int numbufs;
-	int error;
+	int error = 0;
 
 	if (size == 0)
 		return (0);
@@ -1526,11 +1531,14 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 	}
 	flags &= ~DMU_DIRECTIO;
 
-	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, flags));
+	error = dmu_buf_hold_array_by_dnode(dn, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, flags);
+	if (error && SPA_EXITING(dn->dn_objset->os_spa))
+		return (error);
+	VERIFY0(error);
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx, flags);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (0);
+	return (error);
 }
 
 void

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -44,10 +44,11 @@
  */
 uint_t dmu_object_alloc_chunk_shift = 7;
 
-static uint64_t
+static int
 dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	uint64_t object;
 	uint64_t L1_dnode_count = DNODES_PER_BLOCK <<
@@ -204,11 +205,15 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 				else
 					dnode_rele(dn, tag);
 
-				return (object);
+				*objectp = object;
+
+				return (0);
 			}
 			rw_exit(&dn->dn_struct_rwlock);
 			dnode_rele(dn, tag);
 			DNODE_STAT_BUMP(dnode_alloc_race);
+		} else if (SPA_EXITING(os->os_spa)) {
+			return (error);
 		}
 
 		/*
@@ -223,29 +228,30 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 	}
 }
 
-uint64_t
+int
 dmu_object_alloc(objset_t *os, dmu_object_type_t ot, int blocksize,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
-{
-	return dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
-	    bonuslen, 0, NULL, NULL, tx);
-}
-
-uint64_t
-dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
-    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    dmu_tx_t *tx)
-{
-	return dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
-	    bonustype, bonuslen, 0, NULL, NULL, tx);
-}
-
-uint64_t
-dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
-	    bonuslen, dnodesize, NULL, NULL, tx));
+	    bonuslen, 0, NULL, NULL, tx, objectp));
+}
+
+int
+dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
+    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
+    dmu_tx_t *tx, uint64_t *objectp)
+{
+	return (dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
+	    bonustype, bonuslen, 0, NULL, NULL, tx, objectp));
+}
+
+int
+dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
+{
+	return (dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
+	    bonuslen, dnodesize, NULL, NULL, tx, objectp));
 }
 
 /*
@@ -253,13 +259,14 @@ dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
  * via the allocated_dnode argument.  The returned dnode will be held and
  * the caller is responsible for releasing the hold by calling dnode_rele().
  */
-uint64_t
+int
 dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot, int blocksize,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
-	    bonustype, bonuslen, dnodesize, allocated_dnode, tag, tx));
+	    bonustype, bonuslen, dnodesize, allocated_dnode, tag, tx, objectp));
 }
 
 int
@@ -460,6 +467,7 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
     dmu_tx_t *tx)
 {
 	dnode_t *dn;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -476,7 +484,12 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 	 * so that concurrent calls to *_is_zapified() can determine if
 	 * the object has been completely zapified by checking the type.
 	 */
-	mzap_create_impl(dn, 0, 0, tx);
+	err = mzap_create_impl(dn, 0, 0, tx);
+	if (err && SPA_EXITING(dmu_objset_spa(mos))) {
+		dnode_rele(dn, FTAG);
+		return;
+	}
+	VERIFY0(err);
 
 	dn->dn_next_type[tx->tx_txg & TXG_MASK] = dn->dn_type =
 	    DMU_OTN_ZAP_METADATA;

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -466,12 +466,16 @@ void
 dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
     dmu_tx_t *tx)
 {
+	spa_t *spa = mos->os_spa;
 	dnode_t *dn;
 	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dnode_hold(mos, object, FTAG, &dn));
+	err = dnode_hold(mos, object, FTAG, &dn);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	if (dn->dn_type == DMU_OTN_ZAP_METADATA) {
 		dnode_rele(dn, FTAG);
 		return;
@@ -485,11 +489,11 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 	 * the object has been completely zapified by checking the type.
 	 */
 	err = mzap_create_impl(dn, 0, 0, tx);
-	if (err && SPA_EXITING(dmu_objset_spa(mos))) {
+	if (err && SPA_EXITING(spa)) {
 		dnode_rele(dn, FTAG);
 		return;
 	}
-	VERIFY0(err);
+	VERIFY0(err); /* XXX: orig code had no assertion */
 
 	dn->dn_next_type[tx->tx_txg & TXG_MASK] = dn->dn_type =
 	    DMU_OTN_ZAP_METADATA;
@@ -503,12 +507,18 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 void
 dmu_object_free_zapified(objset_t *mos, uint64_t object, dmu_tx_t *tx)
 {
+	spa_t *spa = mos->os_spa;
 	dnode_t *dn;
 	dmu_object_type_t t;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dnode_hold(mos, object, FTAG, &dn));
+	err = dnode_hold(mos, object, FTAG, &dn);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
 	t = dn->dn_type;
 	dnode_rele(dn, FTAG);
 
@@ -516,7 +526,9 @@ dmu_object_free_zapified(objset_t *mos, uint64_t object, dmu_tx_t *tx)
 		spa_feature_decr(dmu_objset_spa(mos),
 		    SPA_FEATURE_EXTENSIBLE_DATASET, tx);
 	}
-	VERIFY0(dmu_object_free(mos, object, tx));
+	err = dmu_object_free(mos, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 EXPORT_SYMBOL(dmu_object_alloc);

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -34,10 +34,11 @@
  */
 uint_t dmu_object_alloc_chunk_shift = 7;
 
-static uint64_t
+static int
 dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	uint64_t object;
 	uint64_t L1_dnode_count = DNODES_PER_BLOCK <<
@@ -194,11 +195,15 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 				else
 					dnode_rele(dn, tag);
 
-				return (object);
+				*objectp = object;
+
+				return (0);
 			}
 			rw_exit(&dn->dn_struct_rwlock);
 			dnode_rele(dn, tag);
 			DNODE_STAT_BUMP(dnode_alloc_race);
+		} else if (SPA_EXITING(os->os_spa)) {
+			return (error);
 		}
 
 		/*
@@ -213,29 +218,30 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 	}
 }
 
-uint64_t
+int
 dmu_object_alloc(objset_t *os, dmu_object_type_t ot, int blocksize,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
-{
-	return dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
-	    bonuslen, 0, NULL, NULL, tx);
-}
-
-uint64_t
-dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
-    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    dmu_tx_t *tx)
-{
-	return dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
-	    bonustype, bonuslen, 0, NULL, NULL, tx);
-}
-
-uint64_t
-dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
-	    bonuslen, dnodesize, NULL, NULL, tx));
+	    bonuslen, 0, NULL, NULL, tx, objectp));
+}
+
+int
+dmu_object_alloc_ibs(objset_t *os, dmu_object_type_t ot, int blocksize,
+    int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
+    dmu_tx_t *tx, uint64_t *objectp)
+{
+	return (dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
+	    bonustype, bonuslen, 0, NULL, NULL, tx, objectp));
+}
+
+int
+dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
+{
+	return (dmu_object_alloc_impl(os, ot, blocksize, 0, bonustype,
+	    bonuslen, dnodesize, NULL, NULL, tx, objectp));
 }
 
 /*
@@ -243,13 +249,14 @@ dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
  * via the allocated_dnode argument.  The returned dnode will be held and
  * the caller is responsible for releasing the hold by calling dnode_rele().
  */
-uint64_t
+int
 dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot, int blocksize,
     int indirect_blockshift, dmu_object_type_t bonustype, int bonuslen,
-    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    int dnodesize, dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (dmu_object_alloc_impl(os, ot, blocksize, indirect_blockshift,
-	    bonustype, bonuslen, dnodesize, allocated_dnode, tag, tx));
+	    bonustype, bonuslen, dnodesize, allocated_dnode, tag, tx, objectp));
 }
 
 int
@@ -450,6 +457,7 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
     dmu_tx_t *tx)
 {
 	dnode_t *dn;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -466,7 +474,12 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 	 * so that concurrent calls to *_is_zapified() can determine if
 	 * the object has been completely zapified by checking the type.
 	 */
-	mzap_create_impl(dn, 0, 0, tx);
+	err = mzap_create_impl(dn, 0, 0, tx);
+	if (err && SPA_EXITING(dmu_objset_spa(mos))) {
+		dnode_rele(dn, FTAG);
+		return;
+	}
+	VERIFY0(err);
 
 	dn->dn_next_type[tx->tx_txg & TXG_MASK] = dn->dn_type =
 	    DMU_OTN_ZAP_METADATA;

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -456,12 +456,16 @@ void
 dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
     dmu_tx_t *tx)
 {
+	spa_t *spa = mos->os_spa;
 	dnode_t *dn;
 	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dnode_hold(mos, object, FTAG, &dn));
+	err = dnode_hold(mos, object, FTAG, &dn);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	if (dn->dn_type == DMU_OTN_ZAP_METADATA) {
 		dnode_rele(dn, FTAG);
 		return;
@@ -475,11 +479,11 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 	 * the object has been completely zapified by checking the type.
 	 */
 	err = mzap_create_impl(dn, 0, 0, tx);
-	if (err && SPA_EXITING(dmu_objset_spa(mos))) {
+	if (err && SPA_EXITING(spa)) {
 		dnode_rele(dn, FTAG);
 		return;
 	}
-	VERIFY0(err);
+	VERIFY0(err); /* XXX: orig code had no assertion */
 
 	dn->dn_next_type[tx->tx_txg & TXG_MASK] = dn->dn_type =
 	    DMU_OTN_ZAP_METADATA;
@@ -493,12 +497,18 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 void
 dmu_object_free_zapified(objset_t *mos, uint64_t object, dmu_tx_t *tx)
 {
+	spa_t *spa = mos->os_spa;
 	dnode_t *dn;
 	dmu_object_type_t t;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	VERIFY0(dnode_hold(mos, object, FTAG, &dn));
+	err = dnode_hold(mos, object, FTAG, &dn);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
 	t = dn->dn_type;
 	dnode_rele(dn, FTAG);
 
@@ -506,7 +516,9 @@ dmu_object_free_zapified(objset_t *mos, uint64_t object, dmu_tx_t *tx)
 		spa_feature_decr(dmu_objset_spa(mos),
 		    SPA_FEATURE_EXTENSIBLE_DATASET, tx);
 	}
-	VERIFY0(dmu_object_free(mos, object, tx));
+	err = dmu_object_free(mos, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 EXPORT_SYMBOL(dmu_object_alloc);

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1551,7 +1551,7 @@ dmu_objset_write_done(zio_t *zio, arc_buf_t *abuf, void *arg)
 
 	if (zio->io_flags & ZIO_FLAG_IO_REWRITE) {
 		ASSERT(BP_EQUAL(bp, bp_orig));
-	} else {
+	} else if (!SPA_EXITING(os->os_spa)) {
 		dsl_dataset_t *ds = os->os_dsl_dataset;
 		dmu_tx_t *tx = os->os_synctx;
 
@@ -1866,8 +1866,10 @@ userquota_compare(const void *l, const void *r)
 static void
 do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	void *cookie;
 	userquota_node_t *uqn;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -1880,8 +1882,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 		 * is not thread-safe (i.e. not atomic).
 		 */
 		mutex_enter(&os->os_userused_lock);
-		VERIFY0(zap_increment(os, DMU_USERUSED_OBJECT,
-		    uqn->uqn_id, uqn->uqn_delta, tx));
+		err = zap_increment(os, DMU_USERUSED_OBJECT,
+		    uqn->uqn_id, uqn->uqn_delta, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		mutex_exit(&os->os_userused_lock);
 		kmem_free(uqn, sizeof (*uqn));
 	}
@@ -1891,8 +1895,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 	while ((uqn = avl_destroy_nodes(&cache->uqc_group_deltas,
 	    &cookie)) != NULL) {
 		mutex_enter(&os->os_userused_lock);
-		VERIFY0(zap_increment(os, DMU_GROUPUSED_OBJECT,
-		    uqn->uqn_id, uqn->uqn_delta, tx));
+		err = zap_increment(os, DMU_GROUPUSED_OBJECT,
+		    uqn->uqn_id, uqn->uqn_delta, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		mutex_exit(&os->os_userused_lock);
 		kmem_free(uqn, sizeof (*uqn));
 	}
@@ -1903,8 +1909,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 		while ((uqn = avl_destroy_nodes(&cache->uqc_project_deltas,
 		    &cookie)) != NULL) {
 			mutex_enter(&os->os_userused_lock);
-			VERIFY0(zap_increment(os, DMU_PROJECTUSED_OBJECT,
-			    uqn->uqn_id, uqn->uqn_delta, tx));
+			err = zap_increment(os, DMU_PROJECTUSED_OBJECT,
+			    uqn->uqn_id, uqn->uqn_delta, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			mutex_exit(&os->os_userused_lock);
 			kmem_free(uqn, sizeof (*uqn));
 		}
@@ -2208,6 +2216,7 @@ void
 dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 {
 	objset_t *os = dn->dn_objset;
+	spa_t *spa = os->os_spa;
 	void *data = NULL;
 	dmu_buf_impl_t *db = NULL;
 	int flags = dn->dn_id_flags;
@@ -2215,6 +2224,8 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 	boolean_t have_spill = B_FALSE;
 
 	if (!dmu_objset_userused_enabled(dn->dn_objset))
+		return;
+	if (SPA_EXITING(spa))
 		return;
 
 	/*
@@ -2250,6 +2261,8 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 				rf |= DB_RF_HAVESTRUCT;
 			error = dmu_spill_hold_by_dnode(dn, rf,
 			    FTAG, (dmu_buf_t **)&db);
+			if (error && SPA_EXITING(spa))
+				return;
 			ASSERT0(error);
 			mutex_enter(&db->db_mtx);
 			data = (before) ? db->db.db_data :

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1254,21 +1254,31 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 	dmu_objset_create_arg_t *doca = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	spa_t *spa = dp->dp_spa;
-	dsl_dir_t *pdd;
+	dsl_dir_t *pdd = NULL;
 	const char *tail;
-	dsl_dataset_t *ds;
+	dsl_dataset_t *ds = NULL;
 	uint64_t obj;
 	blkptr_t *bp;
 	objset_t *os;
 	zio_t *rzio;
+	int err = 0;
 
-	VERIFY0(dsl_dir_hold(dp, doca->doca_name, FTAG, &pdd, &tail));
+	err = dsl_dir_hold(dp, doca->doca_name, FTAG, &pdd, &tail);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	obj = dsl_dataset_create_sync(pdd, tail, NULL, doca->doca_flags,
-	    doca->doca_cred, doca->doca_dcp, tx);
+	err = dsl_dataset_create_sync(pdd, tail, NULL, doca->doca_flags,
+	    doca->doca_cred, doca->doca_dcp, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj_flags(pdd->dd_pool, obj,
-	    DS_HOLD_FLAG_DECRYPT, FTAG, &ds));
+	err = dsl_dataset_hold_obj_flags(pdd->dd_pool, obj,
+	    DS_HOLD_FLAG_DECRYPT, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
 	bp = dsl_dataset_get_blkptr(ds);
 	os = dmu_objset_create_impl(spa, ds, bp, doca->doca_type, tx);
@@ -1302,7 +1312,9 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 			dsl_dataset_sync(ds, rzio, tx);
 			need_sync_done = B_TRUE;
 		}
-		VERIFY0(zio_wait(rzio));
+		err = zio_wait(rzio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		dmu_objset_sync_done(os, tx);
 		taskq_wait(dp->dp_sync_taskq);
@@ -1318,7 +1330,9 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 			dmu_buf_rele(ds->ds_dbuf, ds);
 			dsl_dataset_sync(ds, rzio, tx);
 		}
-		VERIFY0(zio_wait(rzio));
+		err = zio_wait(rzio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		if (need_sync_done) {
 			ASSERT3P(ds->ds_key_mapping, !=, NULL);
@@ -1334,8 +1348,11 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 
 	spa_history_log_internal_ds(ds, "create", tx, " ");
 
-	dsl_dataset_rele_flags(ds, DS_HOLD_FLAG_DECRYPT, FTAG);
-	dsl_dir_rele(pdd, FTAG);
+out:
+	if (ds)
+		dsl_dataset_rele_flags(ds, DS_HOLD_FLAG_DECRYPT, FTAG);
+	if (pdd)
+		dsl_dir_rele(pdd, FTAG);
 }
 
 int

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1245,21 +1245,31 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 	dmu_objset_create_arg_t *doca = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	spa_t *spa = dp->dp_spa;
-	dsl_dir_t *pdd;
+	dsl_dir_t *pdd = NULL;
 	const char *tail;
-	dsl_dataset_t *ds;
+	dsl_dataset_t *ds = NULL;
 	uint64_t obj;
 	blkptr_t *bp;
 	objset_t *os;
 	zio_t *rzio;
+	int err = 0;
 
-	VERIFY0(dsl_dir_hold(dp, doca->doca_name, FTAG, &pdd, &tail));
+	err = dsl_dir_hold(dp, doca->doca_name, FTAG, &pdd, &tail);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	obj = dsl_dataset_create_sync(pdd, tail, NULL, doca->doca_flags,
-	    doca->doca_cred, doca->doca_dcp, tx);
+	err = dsl_dataset_create_sync(pdd, tail, NULL, doca->doca_flags,
+	    doca->doca_cred, doca->doca_dcp, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj_flags(pdd->dd_pool, obj,
-	    DS_HOLD_FLAG_DECRYPT, FTAG, &ds));
+	err = dsl_dataset_hold_obj_flags(pdd->dd_pool, obj,
+	    DS_HOLD_FLAG_DECRYPT, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
 	bp = dsl_dataset_get_blkptr(ds);
 	os = dmu_objset_create_impl(spa, ds, bp, doca->doca_type, tx);
@@ -1293,7 +1303,9 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 			dsl_dataset_sync(ds, rzio, tx);
 			need_sync_done = B_TRUE;
 		}
-		VERIFY0(zio_wait(rzio));
+		err = zio_wait(rzio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		dmu_objset_sync_done(os, tx);
 		taskq_wait(dp->dp_sync_taskq);
@@ -1309,7 +1321,9 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 			dmu_buf_rele(ds->ds_dbuf, ds);
 			dsl_dataset_sync(ds, rzio, tx);
 		}
-		VERIFY0(zio_wait(rzio));
+		err = zio_wait(rzio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		if (need_sync_done) {
 			ASSERT3P(ds->ds_key_mapping, !=, NULL);
@@ -1325,8 +1339,11 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 
 	spa_history_log_internal_ds(ds, "create", tx, " ");
 
-	dsl_dataset_rele_flags(ds, DS_HOLD_FLAG_DECRYPT, FTAG);
-	dsl_dir_rele(pdd, FTAG);
+out:
+	if (ds)
+		dsl_dataset_rele_flags(ds, DS_HOLD_FLAG_DECRYPT, FTAG);
+	if (pdd)
+		dsl_dir_rele(pdd, FTAG);
 }
 
 int

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1542,7 +1542,7 @@ dmu_objset_write_done(zio_t *zio, arc_buf_t *abuf, void *arg)
 
 	if (zio->io_flags & ZIO_FLAG_IO_REWRITE) {
 		ASSERT(BP_EQUAL(bp, bp_orig));
-	} else {
+	} else if (!SPA_EXITING(os->os_spa)) {
 		dsl_dataset_t *ds = os->os_dsl_dataset;
 		dmu_tx_t *tx = os->os_synctx;
 
@@ -1857,8 +1857,10 @@ userquota_compare(const void *l, const void *r)
 static void
 do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	void *cookie;
 	userquota_node_t *uqn;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
@@ -1871,8 +1873,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 		 * is not thread-safe (i.e. not atomic).
 		 */
 		mutex_enter(&os->os_userused_lock);
-		VERIFY0(zap_increment(os, DMU_USERUSED_OBJECT,
-		    uqn->uqn_id, uqn->uqn_delta, tx));
+		err = zap_increment(os, DMU_USERUSED_OBJECT,
+		    uqn->uqn_id, uqn->uqn_delta, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		mutex_exit(&os->os_userused_lock);
 		kmem_free(uqn, sizeof (*uqn));
 	}
@@ -1882,8 +1886,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 	while ((uqn = avl_destroy_nodes(&cache->uqc_group_deltas,
 	    &cookie)) != NULL) {
 		mutex_enter(&os->os_userused_lock);
-		VERIFY0(zap_increment(os, DMU_GROUPUSED_OBJECT,
-		    uqn->uqn_id, uqn->uqn_delta, tx));
+		err = zap_increment(os, DMU_GROUPUSED_OBJECT,
+		    uqn->uqn_id, uqn->uqn_delta, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		mutex_exit(&os->os_userused_lock);
 		kmem_free(uqn, sizeof (*uqn));
 	}
@@ -1894,8 +1900,10 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 		while ((uqn = avl_destroy_nodes(&cache->uqc_project_deltas,
 		    &cookie)) != NULL) {
 			mutex_enter(&os->os_userused_lock);
-			VERIFY0(zap_increment(os, DMU_PROJECTUSED_OBJECT,
-			    uqn->uqn_id, uqn->uqn_delta, tx));
+			err = zap_increment(os, DMU_PROJECTUSED_OBJECT,
+			    uqn->uqn_id, uqn->uqn_delta, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			mutex_exit(&os->os_userused_lock);
 			kmem_free(uqn, sizeof (*uqn));
 		}
@@ -2199,6 +2207,7 @@ void
 dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 {
 	objset_t *os = dn->dn_objset;
+	spa_t *spa = os->os_spa;
 	void *data = NULL;
 	dmu_buf_impl_t *db = NULL;
 	int flags = dn->dn_id_flags;
@@ -2206,6 +2215,8 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 	boolean_t have_spill = B_FALSE;
 
 	if (!dmu_objset_userused_enabled(dn->dn_objset))
+		return;
+	if (SPA_EXITING(spa))
 		return;
 
 	/*
@@ -2241,6 +2252,8 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 				rf |= DB_RF_HAVESTRUCT;
 			error = dmu_spill_hold_by_dnode(dn, rf,
 			    FTAG, (dmu_buf_t **)&db);
+			if (error && SPA_EXITING(spa))
+				return;
 			ASSERT0(error);
 			mutex_enter(&db->db_mtx);
 			data = (before) ? db->db.db_data :

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -888,9 +888,9 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 			VERIFY0(dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
 			    &dsobj));
 		} else {
-			dsobj = dsl_dataset_create_sync(ds->ds_dir,
+			VERIFY0(dsl_dataset_create_sync(ds->ds_dir,
 			    recv_clone_name, snap, crflags, drba->drba_cred,
-			    dcp, tx);
+			    dcp, tx, &dsobj));
 		}
 		if (drba->drba_cookie->drc_fromsnapobj != 0)
 			dsl_dataset_rele(snap, FTAG);
@@ -909,8 +909,8 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		}
 
 		/* Create new dataset. */
-		dsobj = dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
-		    origin, crflags, drba->drba_cred, dcp, tx);
+		VERIFY0(dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
+		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj));
 		if (origin != NULL)
 			dsl_dataset_rele(origin, FTAG);
 		dsl_dir_rele(dd, FTAG);
@@ -3678,9 +3678,12 @@ static void
 dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_cookie_t *drc = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	boolean_t encrypted = drc->drc_ds->ds_dir->dd_crypto_obj != 0;
 	uint64_t newsnapobj = 0;
+	dsl_dataset_t *origin_head = NULL;
+	int err = 0;
 
 	spa_history_log_internal_ds(drc->drc_ds, "finish receiving",
 	    tx, "snap=%s", drc->drc_tosnap);
@@ -3692,10 +3695,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 			drc->drc_keynvl = NULL;
 		}
 	} else if (!drc->drc_newfs) {
-		dsl_dataset_t *origin_head;
-
-		VERIFY0(dsl_dataset_hold(dp, drc->drc_tofs, FTAG,
-		    &origin_head));
+		err = dsl_dataset_hold(dp, drc->drc_tofs, FTAG,
+		    &origin_head);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		if (drc->drc_force) {
 			/*
@@ -3708,8 +3712,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 			while (obj !=
 			    dsl_dataset_phys(drc->drc_ds)->ds_prev_snap_obj) {
 				dsl_dataset_t *snap;
-				VERIFY0(dsl_dataset_hold_obj(dp, obj, FTAG,
-				    &snap));
+				err = dsl_dataset_hold_obj(dp, obj, FTAG,
+				    &snap);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 				ASSERT3P(snap->ds_dir, ==, origin_head->ds_dir);
 				obj = dsl_dataset_phys(snap)->ds_prev_snap_obj;
 				dsl_destroy_snapshot_sync_impl(snap,
@@ -3735,17 +3742,28 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		 */
 		drc->drc_os = NULL;
 
-		dsl_dataset_snapshot_sync_impl(origin_head,
+		err = dsl_dataset_snapshot_sync_impl(origin_head,
 		    drc->drc_tosnap, drc->drc_drrb->drr_creation_time, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 
 		/* set snapshot's guid */
 		dmu_buf_will_dirty(origin_head->ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin_head->ds_prev)->ds_guid =
 		    drc->drc_drrb->drr_toguid;
 		dsl_dataset_phys(origin_head->ds_prev)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
 		dmu_buf_will_dirty(origin_head->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin_head)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
@@ -3760,17 +3778,28 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 	} else {
 		dsl_dataset_t *ds = drc->drc_ds;
 
-		dsl_dataset_snapshot_sync_impl(ds, drc->drc_tosnap,
+		err = dsl_dataset_snapshot_sync_impl(ds, drc->drc_tosnap,
 		    drc->drc_drrb->drr_creation_time, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		/* set snapshot's guid */
 		dmu_buf_will_dirty(ds->ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		dsl_dataset_phys(ds->ds_prev)->ds_guid =
 		    drc->drc_drrb->drr_toguid;
 		dsl_dataset_phys(ds->ds_prev)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		dsl_dataset_phys(ds)->ds_flags &= ~DS_FLAG_INCONSISTENT;
 		if (dsl_dataset_has_resume_receive_state(ds)) {
 			(void) zap_remove(dp->dp_meta_objset, ds->ds_object,
@@ -3805,9 +3834,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 	if (!drc->drc_heal && drc->drc_raw && drc->drc_ivset_guid != 0) {
 		dmu_object_zapify(dp->dp_meta_objset, newsnapobj,
 		    DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_update(dp->dp_meta_objset, newsnapobj,
+		err = zap_update(dp->dp_meta_objset, newsnapobj,
 		    DS_FIELD_IVSET_GUID, sizeof (uint64_t), 1,
-		    &drc->drc_ivset_guid, tx));
+		    &drc->drc_ivset_guid, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	/*
@@ -3822,6 +3853,15 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		(void) spa_keystore_remove_mapping(dmu_tx_pool(tx)->dp_spa,
 		    drc->drc_ds->ds_object, drc->drc_ds);
 	}
+
+out:
+	dsl_dataset_disown(drc->drc_ds, 0, dmu_recv_tag);
+	drc->drc_ds = NULL;
+	return;
+
+spa_exiting:
+	if (origin_head)
+		dsl_dataset_rele(origin_head, FTAG);
 	dsl_dataset_disown(drc->drc_ds, 0, dmu_recv_tag);
 	drc->drc_ds = NULL;
 }

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -3488,7 +3488,7 @@ dmu_recv_stream(dmu_recv_cookie_t *drc, offset_t *voffp)
 	 * stream, then we free drc->drc_rrd and exit.
 	 */
 	while (rwa->err == 0) {
-		if (issig()) {
+		if (issig() || drc->drc_os->os_spa->spa_forced_exit_required) {
 			err = SET_ERROR(EINTR);
 			break;
 		}

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -839,6 +839,7 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_begin_arg_t *drba = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dmu_recv_cookie_t *drc = drba->drba_cookie;
 	struct drr_begin *drrb = drc->drc_drrb;
@@ -879,18 +880,33 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_t *snap = NULL;
 
 		if (drba->drba_cookie->drc_fromsnapobj != 0) {
-			VERIFY0(dsl_dataset_hold_obj(dp,
-			    drba->drba_cookie->drc_fromsnapobj, FTAG, &snap));
+			error = dsl_dataset_hold_obj(dp,
+			    drba->drba_cookie->drc_fromsnapobj, FTAG, &snap);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 			ASSERT0P(dcp);
 		}
 		if (drc->drc_heal) {
 			/* When healing we want to use the provided snapshot */
-			VERIFY0(dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
-			    &dsobj));
+			error = dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
+			    &dsobj);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 		} else {
-			VERIFY0(dsl_dataset_create_sync(ds->ds_dir,
+			error = dsl_dataset_create_sync(ds->ds_dir,
 			    recv_clone_name, snap, crflags, drba->drba_cred,
-			    dcp, tx, &dsobj));
+			    dcp, tx, &dsobj);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 		}
 		if (drba->drba_cookie->drc_fromsnapobj != 0)
 			dsl_dataset_rele(snap, FTAG);
@@ -900,24 +916,43 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		const char *tail;
 		dsl_dataset_t *origin = NULL;
 
-		VERIFY0(dsl_dir_hold(dp, tofs, FTAG, &dd, &tail));
+		error = dsl_dir_hold(dp, tofs, FTAG, &dd, &tail);
+		if (error && SPA_EXITING(spa))
+			return;
+		VERIFY0(error);
 
 		if (drba->drba_origin != NULL) {
-			VERIFY0(dsl_dataset_hold(dp, drba->drba_origin,
-			    FTAG, &origin));
+			error = dsl_dataset_hold(dp, drba->drba_origin,
+			    FTAG, &origin);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dir_rele(dd, FTAG);
+				return;
+			}
+			VERIFY0(error);
 			ASSERT0P(dcp);
 		}
 
 		/* Create new dataset. */
-		VERIFY0(dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
-		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj));
+		error = dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
+		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj);
+		if (error && SPA_EXITING(spa)) {
+			if (origin != NULL)
+				dsl_dataset_rele(origin, FTAG);
+			dsl_dir_rele(dd, FTAG);
+			return;
+		}
+		VERIFY0(error);
 		if (origin != NULL)
 			dsl_dataset_rele(origin, FTAG);
 		dsl_dir_rele(dd, FTAG);
 		drc->drc_newfs = B_TRUE;
 	}
-	VERIFY0(dsl_dataset_own_obj_force(dp, dsobj, dsflags, dmu_recv_tag,
-	    &newds));
+	drc->drc_ds = NULL;
+	error = dsl_dataset_own_obj_force(dp, dsobj, dsflags, dmu_recv_tag,
+	    &newds);
+	if (error && SPA_EXITING(spa))
+		return;
+	VERIFY0(error);
 	if (dsl_dataset_feature_is_active(newds,
 	    SPA_FEATURE_REDACTED_DATASETS)) {
 		/*
@@ -929,41 +964,74 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_deactivate_feature(newds,
 		    SPA_FEATURE_REDACTED_DATASETS, tx);
 	}
-	VERIFY0(dmu_objset_from_ds(newds, &os));
+	error = dmu_objset_from_ds(newds, &os);
+	if (error && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(error);
 
 	if (drc->drc_resumable) {
 		dsl_dataset_zapify(newds, tx);
 		if (drrb->drr_fromguid != 0) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_FROMGUID,
-			    8, 1, &drrb->drr_fromguid, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_FROMGUID,
+			    8, 1, &drrb->drr_fromguid, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_TOGUID,
-		    8, 1, &drrb->drr_toguid, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_TONAME,
-		    1, strlen(drrb->drr_toname) + 1, drrb->drr_toname, tx));
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_TOGUID,
+		    8, 1, &drrb->drr_toguid, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_TONAME,
+		    1, strlen(drrb->drr_toname) + 1, drrb->drr_toname, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
 		uint64_t one = 1;
 		uint64_t zero = 0;
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_OBJECT,
-		    8, 1, &one, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_OFFSET,
-		    8, 1, &zero, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_BYTES,
-		    8, 1, &zero, tx));
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_OBJECT,
+		    8, 1, &one, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_OFFSET,
+		    8, 1, &zero, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_BYTES,
+		    8, 1, &zero, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
 		if (featureflags & DMU_BACKUP_FEATURE_LARGE_BLOCKS) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_LARGEBLOCK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_LARGEBLOCK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_EMBED_DATA) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_EMBEDOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_EMBEDOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_COMPRESSED) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_COMPRESSOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_COMPRESSOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_RAW) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_RAWOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_RAWOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 
 		uint64_t *redact_snaps;
@@ -971,10 +1039,13 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		if (nvlist_lookup_uint64_array(drc->drc_begin_nvl,
 		    BEGINNV_REDACT_FROM_SNAPS, &redact_snaps,
 		    &numredactsnaps) == 0) {
-			VERIFY0(zap_add(mos, dsobj,
+			error = zap_add(mos, dsobj,
 			    DS_FIELD_RESUME_REDACT_BOOKMARK_SNAPS,
 			    sizeof (*redact_snaps), numredactsnaps,
-			    redact_snaps, tx));
+			    redact_snaps, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 	}
 
@@ -998,6 +1069,8 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 	}
 
 	dmu_buf_will_dirty(newds->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 	dsl_dataset_phys(newds)->ds_flags |= DS_FLAG_INCONSISTENT;
 
 	/*
@@ -1065,6 +1138,13 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 	drba->drba_cookie->drc_os = os;
 
 	spa_history_log_internal_ds(newds, "receive", tx, " ");
+
+	return;
+
+spa_exiting:
+	dsl_dataset_disown(drc->drc_ds, dsflags, dmu_recv_tag);
+	drba->drba_cookie->drc_ds = NULL;
+	drba->drba_cookie->drc_os = NULL;
 }
 
 static int
@@ -2521,7 +2601,7 @@ receive_write_embedded(struct receive_writer_arg *rwa,
     struct drr_write_embedded *drrwe, void *data)
 {
 	dmu_tx_t *tx;
-	int err;
+	int err = 0;
 
 	if (drrwe->drr_offset + drrwe->drr_length < drrwe->drr_offset)
 		return (SET_ERROR(EINVAL));
@@ -2549,15 +2629,19 @@ receive_write_embedded(struct receive_writer_arg *rwa,
 		return (err);
 	}
 
-	dmu_write_embedded(rwa->os, drrwe->drr_object,
+	err = dmu_write_embedded(rwa->os, drrwe->drr_object,
 	    drrwe->drr_offset, data, drrwe->drr_etype,
 	    drrwe->drr_compression, drrwe->drr_lsize, drrwe->drr_psize,
 	    rwa->byteswap ^ ZFS_HOST_BYTEORDER, tx);
+	if (err && SPA_EXITING(rwa->os->os_spa))
+		goto out;
+	VERIFY0(err);
 
 	/* See comment in restore_write. */
 	save_resume_state(rwa, drrwe->drr_object, drrwe->drr_offset, tx);
+out:
 	dmu_tx_commit(tx);
-	return (0);
+	return (err);
 }
 
 static int
@@ -3369,13 +3453,22 @@ int
 dmu_recv_stream(dmu_recv_cookie_t *drc, offset_t *voffp)
 {
 	int err = 0;
+
+	if (drc->drc_ds == NULL)
+		return (SET_ERROR(EIO));
+
 	struct receive_writer_arg *rwa = kmem_zalloc(sizeof (*rwa), KM_SLEEP);
 
 	if (dsl_dataset_has_resume_receive_state(drc->drc_ds)) {
 		uint64_t bytes = 0;
-		(void) zap_lookup(drc->drc_ds->ds_dir->dd_pool->dp_meta_objset,
+		err = zap_lookup(drc->drc_ds->ds_dir->dd_pool->dp_meta_objset,
 		    drc->drc_ds->ds_object, DS_FIELD_RESUME_BYTES,
 		    sizeof (bytes), 1, &bytes);
+		if (err && SPA_EXITING(drc->drc_ds->ds_objset->os_spa)) {
+			kmem_free(rwa, sizeof (*rwa));
+			return (SET_ERROR(EIO));
+		}
+		VERIFY0(err);
 		drc->drc_bytes_read += bytes;
 	}
 
@@ -3600,9 +3693,11 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_cookie_t *drc = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	int error;
 
-	ASSERT3P(drc->drc_ds->ds_owner, ==, dmu_recv_tag);
+	if (!SPA_EXITING(spa))
+		ASSERT3P(drc->drc_ds->ds_owner, ==, dmu_recv_tag);
 
 	if (drc->drc_heal) {
 		error = 0;
@@ -3899,6 +3994,11 @@ dmu_recv_end(dmu_recv_cookie_t *drc, void *owner)
 {
 	int error;
 
+	if (drc->drc_ds == NULL) {
+		error = SET_ERROR(EIO);
+		goto out;
+	}
+
 	drc->drc_owner = owner;
 
 	if (drc->drc_newfs)
@@ -3919,6 +4019,7 @@ dmu_recv_end(dmu_recv_cookie_t *drc, void *owner)
 		kmem_strfree(snapname);
 	}
 
+out:
 	crfree(drc->drc_cred);
 	drc->drc_cred = NULL;
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -4992,7 +4992,7 @@ dmu_recv_stream(dmu_recv_cookie_t *drc, offset_t *voffp)
 	 * stream, then we free drc->drc_rrd and exit.
 	 */
 	while (rwa->err == 0) {
-		if (issig()) {
+		if (issig() || drc->drc_os->os_spa->spa_forced_exit_required) {
 			err = SET_ERROR(EINTR);
 			break;
 		}

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -876,6 +876,7 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_begin_arg_t *drba = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dmu_recv_cookie_t *drc = drba->drba_cookie;
 	struct drr_begin *drrb = drc->drc_drrb;
@@ -916,18 +917,33 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_t *snap = NULL;
 
 		if (drba->drba_cookie->drc_fromsnapobj != 0) {
-			VERIFY0(dsl_dataset_hold_obj(dp,
-			    drba->drba_cookie->drc_fromsnapobj, FTAG, &snap));
+			error = dsl_dataset_hold_obj(dp,
+			    drba->drba_cookie->drc_fromsnapobj, FTAG, &snap);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 			ASSERT0P(dcp);
 		}
 		if (drc->drc_heal) {
 			/* When healing we want to use the provided snapshot */
-			VERIFY0(dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
-			    &dsobj));
+			error = dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
+			    &dsobj);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 		} else {
-			VERIFY0(dsl_dataset_create_sync(ds->ds_dir,
+			error = dsl_dataset_create_sync(ds->ds_dir,
 			    recv_clone_name, snap, crflags, drba->drba_cred,
-			    dcp, tx, &dsobj));
+			    dcp, tx, &dsobj);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return;
+			}
+			VERIFY0(error);
 		}
 		if (drba->drba_cookie->drc_fromsnapobj != 0)
 			dsl_dataset_rele(snap, FTAG);
@@ -937,24 +953,43 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		const char *tail;
 		dsl_dataset_t *origin = NULL;
 
-		VERIFY0(dsl_dir_hold(dp, tofs, FTAG, &dd, &tail));
+		error = dsl_dir_hold(dp, tofs, FTAG, &dd, &tail);
+		if (error && SPA_EXITING(spa))
+			return;
+		VERIFY0(error);
 
 		if (drba->drba_origin != NULL) {
-			VERIFY0(dsl_dataset_hold(dp, drba->drba_origin,
-			    FTAG, &origin));
+			error = dsl_dataset_hold(dp, drba->drba_origin,
+			    FTAG, &origin);
+			if (error && SPA_EXITING(spa)) {
+				dsl_dir_rele(dd, FTAG);
+				return;
+			}
+			VERIFY0(error);
 			ASSERT0P(dcp);
 		}
 
 		/* Create new dataset. */
-		VERIFY0(dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
-		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj));
+		error = dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
+		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj);
+		if (error && SPA_EXITING(spa)) {
+			if (origin != NULL)
+				dsl_dataset_rele(origin, FTAG);
+			dsl_dir_rele(dd, FTAG);
+			return;
+		}
+		VERIFY0(error);
 		if (origin != NULL)
 			dsl_dataset_rele(origin, FTAG);
 		dsl_dir_rele(dd, FTAG);
 		drc->drc_newfs = B_TRUE;
 	}
-	VERIFY0(dsl_dataset_own_obj_force(dp, dsobj, dsflags, dmu_recv_tag,
-	    &newds));
+	drc->drc_ds = NULL;
+	error = dsl_dataset_own_obj_force(dp, dsobj, dsflags, dmu_recv_tag,
+	    &newds);
+	if (error && SPA_EXITING(spa))
+		return;
+	VERIFY0(error);
 	if (dsl_dataset_feature_is_active(newds,
 	    SPA_FEATURE_REDACTED_DATASETS)) {
 		/*
@@ -966,41 +1001,74 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_deactivate_feature(newds,
 		    SPA_FEATURE_REDACTED_DATASETS, tx);
 	}
-	VERIFY0(dmu_objset_from_ds(newds, &os));
+	error = dmu_objset_from_ds(newds, &os);
+	if (error && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(error);
 
 	if (drc->drc_resumable) {
 		dsl_dataset_zapify(newds, tx);
 		if (drrb->drr_fromguid != 0) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_FROMGUID,
-			    8, 1, &drrb->drr_fromguid, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_FROMGUID,
+			    8, 1, &drrb->drr_fromguid, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_TOGUID,
-		    8, 1, &drrb->drr_toguid, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_TONAME,
-		    1, strlen(drrb->drr_toname) + 1, drrb->drr_toname, tx));
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_TOGUID,
+		    8, 1, &drrb->drr_toguid, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_TONAME,
+		    1, strlen(drrb->drr_toname) + 1, drrb->drr_toname, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
 		uint64_t one = 1;
 		uint64_t zero = 0;
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_OBJECT,
-		    8, 1, &one, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_OFFSET,
-		    8, 1, &zero, tx));
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_BYTES,
-		    8, 1, &zero, tx));
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_OBJECT,
+		    8, 1, &one, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_OFFSET,
+		    8, 1, &zero, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
+		error = zap_add(mos, dsobj, DS_FIELD_RESUME_BYTES,
+		    8, 1, &zero, tx);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(error);
 		if (featureflags & DMU_BACKUP_FEATURE_LARGE_BLOCKS) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_LARGEBLOCK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_LARGEBLOCK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_EMBED_DATA) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_EMBEDOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_EMBEDOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_COMPRESSED) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_COMPRESSOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_COMPRESSOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 		if (featureflags & DMU_BACKUP_FEATURE_RAW) {
-			VERIFY0(zap_add(mos, dsobj, DS_FIELD_RESUME_RAWOK,
-			    8, 1, &one, tx));
+			error = zap_add(mos, dsobj, DS_FIELD_RESUME_RAWOK,
+			    8, 1, &one, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 
 		uint64_t *redact_snaps;
@@ -1008,10 +1076,13 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		if (nvlist_lookup_uint64_array(drc->drc_begin_nvl,
 		    BEGINNV_REDACT_FROM_SNAPS, &redact_snaps,
 		    &numredactsnaps) == 0) {
-			VERIFY0(zap_add(mos, dsobj,
+			error = zap_add(mos, dsobj,
 			    DS_FIELD_RESUME_REDACT_BOOKMARK_SNAPS,
 			    sizeof (*redact_snaps), numredactsnaps,
-			    redact_snaps, tx));
+			    redact_snaps, tx);
+			if (error && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(error);
 		}
 	}
 
@@ -1035,6 +1106,8 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 	}
 
 	dmu_buf_will_dirty(newds->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 	dsl_dataset_phys(newds)->ds_flags |= DS_FLAG_INCONSISTENT;
 
 	/*
@@ -1102,6 +1175,13 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 	drba->drba_cookie->drc_os = os;
 
 	spa_history_log_internal_ds(newds, "receive", tx, " ");
+
+	return;
+
+spa_exiting:
+	dsl_dataset_disown(drc->drc_ds, dsflags, dmu_recv_tag);
+	drba->drba_cookie->drc_ds = NULL;
+	drba->drba_cookie->drc_os = NULL;
 }
 
 static int
@@ -3933,9 +4013,10 @@ receive_write_embedded(struct receive_writer_arg *rwa,
     struct drr_write_embedded *drrwe, void *data)
 {
 	dmu_tx_t *tx;
+	int err = 0;
 
 	/* Re-validate; stream errors are reported only by the reader. */
-	int err = recv_check_drr_write_embedded(drrwe, dmu_objset_spa(rwa->os),
+	err = recv_check_drr_write_embedded(drrwe, dmu_objset_spa(rwa->os),
 	    rwa->raw, rwa->featureflags, NULL, 0);
 	if (err != 0)
 		return (err);
@@ -3953,15 +4034,19 @@ receive_write_embedded(struct receive_writer_arg *rwa,
 		return (err);
 	}
 
-	dmu_write_embedded(rwa->os, drrwe->drr_object,
+	err = dmu_write_embedded(rwa->os, drrwe->drr_object,
 	    drrwe->drr_offset, data, drrwe->drr_etype,
 	    drrwe->drr_compression, drrwe->drr_lsize, drrwe->drr_psize,
 	    rwa->byteswap ^ ZFS_HOST_BYTEORDER, tx);
+	if (err && SPA_EXITING(rwa->os->os_spa))
+		goto out;
+	VERIFY0(err);
 
 	/* See comment in restore_write. */
 	save_resume_state(rwa, drrwe->drr_object, drrwe->drr_offset, tx);
+out:
 	dmu_tx_commit(tx);
-	return (0);
+	return (err);
 }
 
 static int
@@ -4867,13 +4952,22 @@ int
 dmu_recv_stream(dmu_recv_cookie_t *drc, offset_t *voffp)
 {
 	int err = 0;
+
+	if (drc->drc_ds == NULL)
+		return (SET_ERROR(EIO));
+
 	struct receive_writer_arg *rwa = kmem_zalloc(sizeof (*rwa), KM_SLEEP);
 
 	if (dsl_dataset_has_resume_receive_state(drc->drc_ds)) {
 		uint64_t bytes = 0;
-		(void) zap_lookup(drc->drc_ds->ds_dir->dd_pool->dp_meta_objset,
+		err = zap_lookup(drc->drc_ds->ds_dir->dd_pool->dp_meta_objset,
 		    drc->drc_ds->ds_object, DS_FIELD_RESUME_BYTES,
 		    sizeof (bytes), 1, &bytes);
+		if (err && SPA_EXITING(drc->drc_ds->ds_objset->os_spa)) {
+			kmem_free(rwa, sizeof (*rwa));
+			return (SET_ERROR(EIO));
+		}
+		VERIFY0(err);
 		drc->drc_bytes_read += bytes;
 	}
 
@@ -5106,9 +5200,11 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_cookie_t *drc = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	int error;
 
-	ASSERT3P(drc->drc_ds->ds_owner, ==, dmu_recv_tag);
+	if (!SPA_EXITING(spa))
+		ASSERT3P(drc->drc_ds->ds_owner, ==, dmu_recv_tag);
 
 	if (drc->drc_heal) {
 		error = 0;
@@ -5421,6 +5517,11 @@ dmu_recv_end(dmu_recv_cookie_t *drc, void *owner)
 {
 	int error;
 
+	if (drc->drc_ds == NULL) {
+		error = SET_ERROR(EIO);
+		goto out;
+	}
+
 	drc->drc_owner = owner;
 
 	if (drc->drc_newfs)
@@ -5441,6 +5542,7 @@ dmu_recv_end(dmu_recv_cookie_t *drc, void *owner)
 		kmem_strfree(snapname);
 	}
 
+out:
 	crfree(drc->drc_cred);
 	drc->drc_cred = NULL;
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -925,9 +925,9 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 			VERIFY0(dsl_dataset_snap_lookup(ds, drc->drc_tosnap,
 			    &dsobj));
 		} else {
-			dsobj = dsl_dataset_create_sync(ds->ds_dir,
+			VERIFY0(dsl_dataset_create_sync(ds->ds_dir,
 			    recv_clone_name, snap, crflags, drba->drba_cred,
-			    dcp, tx);
+			    dcp, tx, &dsobj));
 		}
 		if (drba->drba_cookie->drc_fromsnapobj != 0)
 			dsl_dataset_rele(snap, FTAG);
@@ -946,8 +946,8 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		}
 
 		/* Create new dataset. */
-		dsobj = dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
-		    origin, crflags, drba->drba_cred, dcp, tx);
+		VERIFY0(dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
+		    origin, crflags, drba->drba_cred, dcp, tx, &dsobj));
 		if (origin != NULL)
 			dsl_dataset_rele(origin, FTAG);
 		dsl_dir_rele(dd, FTAG);
@@ -5184,9 +5184,12 @@ static void
 dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 {
 	dmu_recv_cookie_t *drc = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	boolean_t encrypted = drc->drc_ds->ds_dir->dd_crypto_obj != 0;
 	uint64_t newsnapobj = 0;
+	dsl_dataset_t *origin_head = NULL;
+	int err = 0;
 
 	spa_history_log_internal_ds(drc->drc_ds, "finish receiving",
 	    tx, "snap=%s", drc->drc_tosnap);
@@ -5198,10 +5201,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 			drc->drc_keynvl = NULL;
 		}
 	} else if (!drc->drc_newfs) {
-		dsl_dataset_t *origin_head;
-
-		VERIFY0(dsl_dataset_hold(dp, drc->drc_tofs, FTAG,
-		    &origin_head));
+		err = dsl_dataset_hold(dp, drc->drc_tofs, FTAG,
+		    &origin_head);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		if (drc->drc_force) {
 			/*
@@ -5214,8 +5218,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 			while (obj !=
 			    dsl_dataset_phys(drc->drc_ds)->ds_prev_snap_obj) {
 				dsl_dataset_t *snap;
-				VERIFY0(dsl_dataset_hold_obj(dp, obj, FTAG,
-				    &snap));
+				err = dsl_dataset_hold_obj(dp, obj, FTAG,
+				    &snap);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 				ASSERT3P(snap->ds_dir, ==, origin_head->ds_dir);
 				obj = dsl_dataset_phys(snap)->ds_prev_snap_obj;
 				dsl_destroy_snapshot_sync_impl(snap,
@@ -5241,17 +5248,28 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		 */
 		drc->drc_os = NULL;
 
-		dsl_dataset_snapshot_sync_impl(origin_head,
+		err = dsl_dataset_snapshot_sync_impl(origin_head,
 		    drc->drc_tosnap, drc->drc_drrb->drr_creation_time, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 
 		/* set snapshot's guid */
 		dmu_buf_will_dirty(origin_head->ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin_head->ds_prev)->ds_guid =
 		    drc->drc_drrb->drr_toguid;
 		dsl_dataset_phys(origin_head->ds_prev)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
 		dmu_buf_will_dirty(origin_head->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin_head)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
@@ -5266,17 +5284,28 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 	} else {
 		dsl_dataset_t *ds = drc->drc_ds;
 
-		dsl_dataset_snapshot_sync_impl(ds, drc->drc_tosnap,
+		err = dsl_dataset_snapshot_sync_impl(ds, drc->drc_tosnap,
 		    drc->drc_drrb->drr_creation_time, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		/* set snapshot's guid */
 		dmu_buf_will_dirty(ds->ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		dsl_dataset_phys(ds->ds_prev)->ds_guid =
 		    drc->drc_drrb->drr_toguid;
 		dsl_dataset_phys(ds->ds_prev)->ds_flags &=
 		    ~DS_FLAG_INCONSISTENT;
 
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto out;
+		}
 		dsl_dataset_phys(ds)->ds_flags &= ~DS_FLAG_INCONSISTENT;
 		if (dsl_dataset_has_resume_receive_state(ds)) {
 			(void) zap_remove(dp->dp_meta_objset, ds->ds_object,
@@ -5311,9 +5340,11 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 	if (!drc->drc_heal && drc->drc_raw && drc->drc_ivset_guid != 0) {
 		dmu_object_zapify(dp->dp_meta_objset, newsnapobj,
 		    DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_update(dp->dp_meta_objset, newsnapobj,
+		err = zap_update(dp->dp_meta_objset, newsnapobj,
 		    DS_FIELD_IVSET_GUID, sizeof (uint64_t), 1,
-		    &drc->drc_ivset_guid, tx));
+		    &drc->drc_ivset_guid, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	/*
@@ -5344,6 +5375,15 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		(void) spa_keystore_remove_mapping(dmu_tx_pool(tx)->dp_spa,
 		    drc->drc_ds->ds_object, drc->drc_ds);
 	}
+
+out:
+	dsl_dataset_disown(drc->drc_ds, 0, dmu_recv_tag);
+	drc->drc_ds = NULL;
+	return;
+
+spa_exiting:
+	if (origin_head)
+		dsl_dataset_rele(origin_head, FTAG);
 	dsl_dataset_disown(drc->drc_ds, 0, dmu_recv_tag);
 	drc->drc_ds = NULL;
 }

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2603,7 +2603,7 @@ dmu_send_impl(struct dmu_send_params *dspp)
 	while (err == 0 && !range->eos_marker) {
 		err = do_dump(&dsc, range);
 		range = get_next_range(&srt_arg->q, range);
-		if (issig())
+		if (issig() || os->os_spa->spa_forced_exit_required)
 			err = SET_ERROR(EINTR);
 	}
 

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2616,7 +2616,7 @@ dmu_send_impl(struct dmu_send_params *dspp)
 	while (err == 0 && !range->eos_marker) {
 		err = do_dump(&dsc, range);
 		range = get_next_range(&srt_arg->q, range);
-		if (issig())
+		if (issig() || os->os_spa->spa_forced_exit_required)
 			err = SET_ERROR(EINTR);
 	}
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -442,6 +442,7 @@ dmu_tx_count_free(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 {
 	dmu_tx_t *tx = txh->txh_tx;
 	dnode_t *dn = txh->txh_dnode;
+	spa_t *spa = dn->dn_objset->os_spa;
 	int err;
 
 	ASSERT0(tx->tx_txg);
@@ -461,15 +462,24 @@ dmu_tx_count_free(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 	 * if they are blocksize-aligned.
 	 */
 	if (dn->dn_datablkshift == 0) {
-		if (off != 0 || len < dn->dn_datablksz)
+		if (off != 0 || len < dn->dn_datablksz) {
 			dmu_tx_count_write(txh, 0, dn->dn_datablksz);
+			if (SPA_EXITING(spa))
+				return;
+		}
 	} else {
 		/* first block will be modified if it is not aligned */
-		if (!IS_P2ALIGNED(off, 1 << dn->dn_datablkshift))
+		if (!IS_P2ALIGNED(off, 1 << dn->dn_datablkshift)) {
 			dmu_tx_count_write(txh, off, 1);
+			if (SPA_EXITING(spa))
+				return;
+		}
 		/* last block will be modified if it is not aligned */
-		if (!IS_P2ALIGNED(off + len, 1 << dn->dn_datablkshift))
+		if (!IS_P2ALIGNED(off + len, 1 << dn->dn_datablkshift)) {
 			dmu_tx_count_write(txh, off + len, 1);
+			if (SPA_EXITING(spa))
+				return;
+		}
 	}
 
 	/*
@@ -1058,7 +1068,7 @@ dmu_tx_try_assign(dmu_tx_t *tx)
 		return (SET_ERROR(EIO));
 	}
 
-	if (spa_suspended(spa)) {
+	if (spa_suspended(spa) && !SPA_EXITING(spa)) {
 		DMU_TX_STAT_BUMP(dmu_tx_suspended);
 
 		/*
@@ -1138,7 +1148,7 @@ dmu_tx_try_assign(dmu_tx_t *tx)
 	/* calculate memory footprint estimate */
 	uint64_t memory = towrite + tohold;
 
-	if (tx->tx_dir != NULL && asize != 0) {
+	if (tx->tx_dir != NULL && asize != 0 && !SPA_EXITING(spa)) {
 		int err = dsl_dir_tempreserve_space(tx->tx_dir, memory,
 		    asize, tx->tx_netfree, &tx->tx_tempreserve_cookie, tx);
 		if (err != 0)

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -433,6 +433,7 @@ dmu_tx_count_free(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 {
 	dmu_tx_t *tx = txh->txh_tx;
 	dnode_t *dn = txh->txh_dnode;
+	spa_t *spa = dn->dn_objset->os_spa;
 	int err;
 
 	ASSERT0(tx->tx_txg);
@@ -452,15 +453,24 @@ dmu_tx_count_free(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 	 * if they are blocksize-aligned.
 	 */
 	if (dn->dn_datablkshift == 0) {
-		if (off != 0 || len < dn->dn_datablksz)
+		if (off != 0 || len < dn->dn_datablksz) {
 			dmu_tx_count_write(txh, 0, dn->dn_datablksz);
+			if (SPA_EXITING(spa))
+				return;
+		}
 	} else {
 		/* first block will be modified if it is not aligned */
-		if (!IS_P2ALIGNED(off, 1 << dn->dn_datablkshift))
+		if (!IS_P2ALIGNED(off, 1 << dn->dn_datablkshift)) {
 			dmu_tx_count_write(txh, off, 1);
+			if (SPA_EXITING(spa))
+				return;
+		}
 		/* last block will be modified if it is not aligned */
-		if (!IS_P2ALIGNED(off + len, 1 << dn->dn_datablkshift))
+		if (!IS_P2ALIGNED(off + len, 1 << dn->dn_datablkshift)) {
 			dmu_tx_count_write(txh, off + len, 1);
+			if (SPA_EXITING(spa))
+				return;
+		}
 	}
 
 	/*
@@ -1063,7 +1073,7 @@ dmu_tx_try_assign(dmu_tx_t *tx)
 		return (SET_ERROR(EIO));
 	}
 
-	if (spa_suspended(spa)) {
+	if (spa_suspended(spa) && !SPA_EXITING(spa)) {
 		DMU_TX_STAT_BUMP(dmu_tx_suspended);
 
 		/*
@@ -1143,7 +1153,7 @@ dmu_tx_try_assign(dmu_tx_t *tx)
 	/* calculate memory footprint estimate */
 	uint64_t memory = towrite + tohold;
 
-	if (tx->tx_dir != NULL && asize != 0) {
+	if (tx->tx_dir != NULL && asize != 0 && !SPA_EXITING(spa)) {
 		int err = dsl_dir_tempreserve_space(tx->tx_dir, memory,
 		    asize, tx->tx_netfree, &tx->tx_tempreserve_cookie, tx);
 		if (err != 0)

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2191,6 +2191,8 @@ dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 	/*
 	 * Walk all the in-core level-1 dbufs and verify they have been dirtied.
 	 */
+	if (SPA_EXITING(dn->dn_objset->os_spa))
+		goto skip;
 	db_search->db_level = 1;
 	db_search->db_blkid = start_blkid + 1;
 	db_search->db_state = DB_SEARCH;
@@ -2203,6 +2205,7 @@ dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 		if (db->db_state != DB_EVICTING)
 			ASSERT(db->db_dirtycnt > 0);
 	}
+skip:
 #endif
 	kmem_free(db_search, sizeof (dmu_buf_impl_t));
 	mutex_exit(&dn->dn_dbufs_mtx);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2192,6 +2192,8 @@ dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 	/*
 	 * Walk all the in-core level-1 dbufs and verify they have been dirtied.
 	 */
+	if (SPA_EXITING(dn->dn_objset->os_spa))
+		goto skip;
 	db_search->db_level = 1;
 	db_search->db_blkid = start_blkid + 1;
 	db_search->db_state = DB_SEARCH;
@@ -2204,6 +2206,7 @@ dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 		if (db->db_state != DB_EVICTING)
 			ASSERT(db->db_dirtycnt > 0);
 	}
+skip:
 #endif
 	kmem_free(db_search, sizeof (dmu_buf_impl_t));
 	mutex_exit(&dn->dn_dbufs_mtx);

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -39,15 +39,16 @@
 #include <sys/range_tree.h>
 #include <sys/zfeature.h>
 
-static void
+static int
 dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db;
+	spa_t *spa = dn->dn_objset->os_spa;
 	int txgoff = tx->tx_txg & TXG_MASK;
 	int nblkptr = dn->dn_phys->dn_nblkptr;
 	int old_toplvl = dn->dn_phys->dn_nlevels - 1;
 	int new_level = dn->dn_next_nlevels[txgoff];
-	int i;
+	int i, err = 0;
 
 	rw_enter(&dn->dn_struct_rwlock, RW_WRITER);
 
@@ -56,6 +57,10 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	ASSERT(new_level > 1 && dn->dn_phys->dn_nlevels > 0);
 
 	db = dbuf_hold_level(dn, dn->dn_phys->dn_nlevels, 0, FTAG);
+	if (db == NULL && SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out1;
+	}
 	ASSERT(db != NULL);
 
 	dn->dn_phys->dn_nlevels = new_level;
@@ -76,7 +81,15 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	/* transfer dnode's block pointers to new indirect block */
-	(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED|DB_RF_HAVESTRUCT);
+	err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED|DB_RF_HAVESTRUCT);
+	if (err && SPA_EXITING(spa)) {
+		for (i = 0; i < nblkptr; i++)
+			if (children[i] != NULL)
+				mutex_exit(&children[i]->db_mtx);
+		dn->dn_phys->dn_nlevels = old_toplvl + 1;
+		goto out2;
+	}
+	VERIFY0(err);
 	if (dn->dn_dbuf != NULL)
 		rw_enter(&dn->dn_dbuf->db_rwlock, RW_WRITER);
 	rw_enter(&db->db_rwlock, RW_WRITER);
@@ -126,9 +139,13 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	if (dn->dn_dbuf != NULL)
 		rw_exit(&dn->dn_dbuf->db_rwlock);
 
+out2:
 	dbuf_rele(db, FTAG);
 
+out1:
 	rw_exit(&dn->dn_struct_rwlock);
+
+	return (err);
 }
 
 static void
@@ -270,15 +287,17 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
  * being freed.  Therefore, we free the indirect blocks immediately in that
  * case.
  */
-static void
+static int
 free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
     boolean_t free_indirects, dmu_tx_t *tx)
 {
+	spa_t *spa = db->db_dnode->dn_objset->os_spa;
 	dnode_t *dn;
 	blkptr_t *bp;
 	dmu_buf_impl_t *subdb;
 	uint64_t start, end, dbstart, dbend;
 	unsigned int epbs, shift, i;
+	int err = 0;
 
 	/*
 	 * There is a small possibility that this block will not be cached:
@@ -286,8 +305,12 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	 *   2 - if this block was evicted since we read it from
 	 *	 dmu_tx_hold_free().
 	 */
-	if (db->db_state != DB_CACHED)
-		(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+	if (db->db_state != DB_CACHED) {
+		err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+	}
 
 	/*
 	 * If we modify this indirect block, and we are not freeing the
@@ -305,9 +328,11 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	 * ancestor of the first or last block to be freed.  The first and
 	 * last L1 indirect blocks are always dirtied by dnode_free_range().
 	 */
-	db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
-	VERIFY(BP_GET_FILL(db->db_blkptr) == 0 || db->db_dirtycnt > 0);
-	dmu_buf_unlock_parent(db, dblt, FTAG);
+	if (!SPA_EXITING(spa)) {
+		db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
+		VERIFY(BP_GET_FILL(db->db_blkptr) == 0 || db->db_dirtycnt > 0);
+		dmu_buf_unlock_parent(db, dblt, FTAG);
+	}
 
 	dbuf_release_bp(db);
 	bp = db->db.db_data;
@@ -341,17 +366,24 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 			if (BP_IS_HOLE(bp))
 				continue;
 			rw_enter(&dn->dn_struct_rwlock, RW_READER);
-			VERIFY0(dbuf_hold_impl(dn, db->db_level - 1,
-			    id, TRUE, FALSE, FTAG, &subdb));
+			err = dbuf_hold_impl(dn, db->db_level - 1,
+			    id, TRUE, FALSE, FTAG, &subdb);
 			rw_exit(&dn->dn_struct_rwlock);
+			if (err && SPA_EXITING(tx->tx_objset->os_spa))
+				break;
+			VERIFY0(err);
 			ASSERT3P(bp, ==, subdb->db_blkptr);
 
-			free_children(subdb, blkid, nblks, free_indirects, tx);
+			err = free_children(subdb, blkid, nblks, free_indirects,
+			    tx);
 			dbuf_rele(subdb, FTAG);
+			if (err && SPA_EXITING(spa))
+				break;
+			VERIFY0(err);
 		}
 	}
 
-	if (free_indirects) {
+	if (!err && free_indirects) {
 		rw_enter(&db->db_rwlock, RW_WRITER);
 		for (i = 0, bp = db->db.db_data; i < 1 << epbs; i++, bp++)
 			ASSERT(BP_IS_HOLE(bp));
@@ -362,6 +394,8 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 
 	DB_DNODE_EXIT(db);
 	arc_buf_freeze(db->db_buf);
+
+	return (err);
 }
 
 /*
@@ -406,11 +440,19 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 			if (BP_IS_HOLE(bp))
 				continue;
 			rw_enter(&dn->dn_struct_rwlock, RW_READER);
-			VERIFY0(dbuf_hold_impl(dn, dnlevel - 1, i,
-			    TRUE, FALSE, FTAG, &db));
+			int err = dbuf_hold_impl(dn, dnlevel - 1, i,
+			    TRUE, FALSE, FTAG, &db);
+			if (err && SPA_EXITING(dn->dn_objset->os_spa)) {
+				rw_exit(&dn->dn_struct_rwlock);
+				return;
+			}
+			VERIFY0(err);
 			rw_exit(&dn->dn_struct_rwlock);
-			free_children(db, blkid, nblks, free_indirects, tx);
+			err = free_children(db, blkid, nblks, free_indirects,
+			    tx);
 			dbuf_rele(db, FTAG);
+			if (err)
+				return;
 		}
 	}
 
@@ -436,7 +478,8 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 		    (dn->dn_phys->dn_datablkszsec << SPA_MINBLOCKSHIFT);
 		ASSERT(off < dn->dn_phys->dn_maxblkid ||
 		    dn->dn_phys->dn_maxblkid == 0 ||
-		    dnode_next_offset(dn, 0, &off, 1, 1, 0) != 0);
+		    dnode_next_offset(dn, 0, &off, 1, 1, 0) != 0 ||
+		    SPA_EXITING(dn->dn_objset->os_spa));
 	}
 }
 
@@ -566,8 +609,10 @@ dnode_sync_free(dnode_t *dn, dmu_tx_t *tx)
 	 * Our contents should have been freed in dnode_sync() by the
 	 * free range record inserted by the caller of dnode_free().
 	 */
-	ASSERT0(DN_USED_BYTES(dn->dn_phys));
-	ASSERT(BP_IS_HOLE(dn->dn_phys->dn_blkptr));
+	if (!SPA_EXITING(tx->tx_pool->dp_spa)) {
+		ASSERT0(DN_USED_BYTES(dn->dn_phys));
+		ASSERT(BP_IS_HOLE(dn->dn_phys->dn_blkptr));
+	}
 
 	dnode_undirty_dbufs(&dn->dn_dirty_records[txgoff]);
 	dnode_evict_dbufs(dn);
@@ -687,6 +732,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	list_t *list = &dn->dn_dirty_records[txgoff];
 	static const dnode_phys_t zerodn __maybe_unused = { 0 };
 	boolean_t kill_spill = B_FALSE;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(dnp->dn_type != DMU_OT_NONE || dn->dn_allocated_txg);
@@ -838,7 +884,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	if (dn->dn_next_nlevels[txgoff]) {
-		dnode_increase_indirection(dn, tx);
+		err = dnode_increase_indirection(dn, tx);
 		dn->dn_next_nlevels[txgoff] = 0;
 	}
 
@@ -847,7 +893,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	 * and dnode_increase_indirection(). See dnode_new_blkid()
 	 * for an explanation of the high bit being set.
 	 */
-	if (dn->dn_next_maxblkid[txgoff]) {
+	if (!err && dn->dn_next_maxblkid[txgoff]) {
 		mutex_enter(&dn->dn_mtx);
 		dnp->dn_maxblkid =
 		    dn->dn_next_maxblkid[txgoff] & ~DMU_NEXT_MAXBLKID_SET;
@@ -855,7 +901,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		mutex_exit(&dn->dn_mtx);
 	}
 
-	if (dn->dn_next_nblkptr[txgoff]) {
+	if (!err && dn->dn_next_nblkptr[txgoff]) {
 		/* this should only happen on a realloc */
 		ASSERT(dn->dn_allocated_txg == tx->tx_txg);
 		if (dn->dn_next_nblkptr[txgoff] > dnp->dn_nblkptr) {
@@ -880,7 +926,10 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		mutex_exit(&dn->dn_mtx);
 	}
 
-	dbuf_sync_list(list, dn->dn_phys->dn_nlevels - 1, tx);
+	if (!err)
+		err = dbuf_sync_list(list, dn->dn_phys->dn_nlevels - 1, tx);
+	if (err)
+		dbuf_drain_list(list, tx);
 
 	if (!DMU_OBJECT_IS_SPECIAL(dn->dn_object)) {
 		ASSERT0P(list_head(list));

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -29,15 +29,16 @@
 #include <sys/range_tree.h>
 #include <sys/zfeature.h>
 
-static void
+static int
 dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db;
+	spa_t *spa = dn->dn_objset->os_spa;
 	int txgoff = tx->tx_txg & TXG_MASK;
 	int nblkptr = dn->dn_phys->dn_nblkptr;
 	int old_toplvl = dn->dn_phys->dn_nlevels - 1;
 	int new_level = dn->dn_next_nlevels[txgoff];
-	int i;
+	int i, err = 0;
 
 	rw_enter(&dn->dn_struct_rwlock, RW_WRITER);
 
@@ -46,6 +47,10 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	ASSERT(new_level > 1 && dn->dn_phys->dn_nlevels > 0);
 
 	db = dbuf_hold_level(dn, dn->dn_phys->dn_nlevels, 0, FTAG);
+	if (db == NULL && SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out1;
+	}
 	ASSERT(db != NULL);
 
 	dn->dn_phys->dn_nlevels = new_level;
@@ -66,7 +71,15 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	/* transfer dnode's block pointers to new indirect block */
-	(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED|DB_RF_HAVESTRUCT);
+	err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED|DB_RF_HAVESTRUCT);
+	if (err && SPA_EXITING(spa)) {
+		for (i = 0; i < nblkptr; i++)
+			if (children[i] != NULL)
+				mutex_exit(&children[i]->db_mtx);
+		dn->dn_phys->dn_nlevels = old_toplvl + 1;
+		goto out2;
+	}
+	VERIFY0(err);
 	if (dn->dn_dbuf != NULL)
 		rw_enter(&dn->dn_dbuf->db_rwlock, RW_WRITER);
 	rw_enter(&db->db_rwlock, RW_WRITER);
@@ -116,9 +129,13 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	if (dn->dn_dbuf != NULL)
 		rw_exit(&dn->dn_dbuf->db_rwlock);
 
+out2:
 	dbuf_rele(db, FTAG);
 
+out1:
 	rw_exit(&dn->dn_struct_rwlock);
+
+	return (err);
 }
 
 static void
@@ -260,15 +277,17 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
  * being freed.  Therefore, we free the indirect blocks immediately in that
  * case.
  */
-static void
+static int
 free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
     boolean_t free_indirects, dmu_tx_t *tx)
 {
+	spa_t *spa = db->db_dnode->dn_objset->os_spa;
 	dnode_t *dn;
 	blkptr_t *bp;
 	dmu_buf_impl_t *subdb;
 	uint64_t start, end, dbstart, dbend;
 	unsigned int epbs, shift, i;
+	int err = 0;
 
 	/*
 	 * There is a small possibility that this block will not be cached:
@@ -276,8 +295,12 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	 *   2 - if this block was evicted since we read it from
 	 *	 dmu_tx_hold_free().
 	 */
-	if (db->db_state != DB_CACHED)
-		(void) dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+	if (db->db_state != DB_CACHED) {
+		err = dbuf_read(db, NULL, DB_RF_MUST_SUCCEED);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+	}
 
 	/*
 	 * If we modify this indirect block, and we are not freeing the
@@ -295,7 +318,7 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	 * ancestor of the first or last block to be freed.  The first and
 	 * last L1 indirect blocks are always dirtied by dnode_free_range().
 	 */
-	if (!free_indirects) {
+	if (!free_indirects && !SPA_EXITING(spa)) {
 		db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
 		VERIFY_IMPLY(BP_GET_FILL(db->db_blkptr) > 0,
 		    db->db_dirtycnt > 0);
@@ -334,17 +357,24 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 			if (BP_IS_HOLE(bp))
 				continue;
 			rw_enter(&dn->dn_struct_rwlock, RW_READER);
-			VERIFY0(dbuf_hold_impl(dn, db->db_level - 1,
-			    id, TRUE, FALSE, FTAG, &subdb));
+			err = dbuf_hold_impl(dn, db->db_level - 1,
+			    id, TRUE, FALSE, FTAG, &subdb);
 			rw_exit(&dn->dn_struct_rwlock);
+			if (err && SPA_EXITING(tx->tx_objset->os_spa))
+				break;
+			VERIFY0(err);
 			ASSERT3P(bp, ==, subdb->db_blkptr);
 
-			free_children(subdb, blkid, nblks, free_indirects, tx);
+			err = free_children(subdb, blkid, nblks, free_indirects,
+			    tx);
 			dbuf_rele(subdb, FTAG);
+			if (err && SPA_EXITING(spa))
+				break;
+			VERIFY0(err);
 		}
 	}
 
-	if (free_indirects) {
+	if (!err && free_indirects) {
 		rw_enter(&db->db_rwlock, RW_WRITER);
 		for (i = 0, bp = db->db.db_data; i < 1 << epbs; i++, bp++)
 			ASSERT(BP_IS_HOLE(bp));
@@ -355,6 +385,8 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 
 	DB_DNODE_EXIT(db);
 	arc_buf_freeze(db->db_buf);
+
+	return (err);
 }
 
 /*
@@ -399,11 +431,19 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 			if (BP_IS_HOLE(bp))
 				continue;
 			rw_enter(&dn->dn_struct_rwlock, RW_READER);
-			VERIFY0(dbuf_hold_impl(dn, dnlevel - 1, i,
-			    TRUE, FALSE, FTAG, &db));
+			int err = dbuf_hold_impl(dn, dnlevel - 1, i,
+			    TRUE, FALSE, FTAG, &db);
+			if (err && SPA_EXITING(dn->dn_objset->os_spa)) {
+				rw_exit(&dn->dn_struct_rwlock);
+				return;
+			}
+			VERIFY0(err);
 			rw_exit(&dn->dn_struct_rwlock);
-			free_children(db, blkid, nblks, free_indirects, tx);
+			err = free_children(db, blkid, nblks, free_indirects,
+			    tx);
 			dbuf_rele(db, FTAG);
+			if (err)
+				return;
 		}
 	}
 
@@ -429,7 +469,8 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 		    (dn->dn_phys->dn_datablkszsec << SPA_MINBLOCKSHIFT);
 		ASSERT(off < dn->dn_phys->dn_maxblkid ||
 		    dn->dn_phys->dn_maxblkid == 0 ||
-		    dnode_next_offset(dn, 0, &off, 1, 1, 0) != 0);
+		    dnode_next_offset(dn, 0, &off, 1, 1, 0) != 0 ||
+		    SPA_EXITING(dn->dn_objset->os_spa));
 	}
 }
 
@@ -559,8 +600,10 @@ dnode_sync_free(dnode_t *dn, dmu_tx_t *tx)
 	 * Our contents should have been freed in dnode_sync() by the
 	 * free range record inserted by the caller of dnode_free().
 	 */
-	ASSERT0(DN_USED_BYTES(dn->dn_phys));
-	ASSERT(BP_IS_HOLE(dn->dn_phys->dn_blkptr));
+	if (!SPA_EXITING(tx->tx_pool->dp_spa)) {
+		ASSERT0(DN_USED_BYTES(dn->dn_phys));
+		ASSERT(BP_IS_HOLE(dn->dn_phys->dn_blkptr));
+	}
 
 	dnode_undirty_dbufs(&dn->dn_dirty_records[txgoff]);
 	dnode_evict_dbufs(dn);
@@ -680,6 +723,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	list_t *list = &dn->dn_dirty_records[txgoff];
 	static const dnode_phys_t zerodn __maybe_unused = { 0 };
 	boolean_t kill_spill = B_FALSE;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(dnp->dn_type != DMU_OT_NONE || dn->dn_allocated_txg);
@@ -831,7 +875,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	if (dn->dn_next_nlevels[txgoff]) {
-		dnode_increase_indirection(dn, tx);
+		err = dnode_increase_indirection(dn, tx);
 		dn->dn_next_nlevels[txgoff] = 0;
 	}
 
@@ -840,7 +884,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	 * and dnode_increase_indirection(). See dnode_new_blkid()
 	 * for an explanation of the high bit being set.
 	 */
-	if (dn->dn_next_maxblkid[txgoff]) {
+	if (!err && dn->dn_next_maxblkid[txgoff]) {
 		mutex_enter(&dn->dn_mtx);
 		dnp->dn_maxblkid =
 		    dn->dn_next_maxblkid[txgoff] & ~DMU_NEXT_MAXBLKID_SET;
@@ -848,7 +892,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		mutex_exit(&dn->dn_mtx);
 	}
 
-	if (dn->dn_next_nblkptr[txgoff]) {
+	if (!err && dn->dn_next_nblkptr[txgoff]) {
 		/* this should only happen on a realloc */
 		ASSERT(dn->dn_allocated_txg == tx->tx_txg);
 		if (dn->dn_next_nblkptr[txgoff] > dnp->dn_nblkptr) {
@@ -873,7 +917,10 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		mutex_exit(&dn->dn_mtx);
 	}
 
-	dbuf_sync_list(list, dn->dn_phys->dn_nlevels - 1, tx);
+	if (!err)
+		err = dbuf_sync_list(list, dn->dn_phys->dn_nlevels - 1, tx);
+	if (err)
+		dbuf_drain_list(list, tx);
 
 	if (!DMU_OBJECT_IS_SPECIAL(dn->dn_object)) {
 		ASSERT0P(list_head(list));

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1056,7 +1056,7 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg) {
 			dsl_dir_remove_clones_key(ds->ds_dir,
 			    dbn->dbn_phys.zbm_creation_txg, tx);
-			dsl_deadlist_remove_key(&ds->ds_deadlist,
+			(void) dsl_deadlist_remove_key(&ds->ds_deadlist,
 			    dbn->dbn_phys.zbm_creation_txg, tx);
 		}
 
@@ -1312,12 +1312,24 @@ boolean_t
 dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	dsl_dataset_t *head, *next;
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &head));
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &next));
+
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &head);
+	if (err && SPA_EXITING(spa))
+		return (B_FALSE);
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &next);
+	if (err && SPA_EXITING(spa)) {
+		dsl_dataset_rele(head, FTAG);
+		return (B_FALSE);
+	}
+	VERIFY0(err);
 
 	/*
 	 * Find the first bookmark that HAS_FBN at or after the
@@ -1365,10 +1377,12 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    compressed;
 		dbn->dbn_phys.zbm_uncompressed_freed_before_next_snap +=
 		    uncompressed;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
+		err = zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
 		    dbn->dbn_name, sizeof (uint64_t),
 		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		    &dbn->dbn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 	dsl_dataset_rele(next, FTAG);
 
@@ -1390,10 +1404,12 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		}
 		ASSERT(dbn->dbn_phys.zbm_flags & ZBM_FLAG_SNAPSHOT_EXISTS);
 		dbn->dbn_phys.zbm_flags &= ~ZBM_FLAG_SNAPSHOT_EXISTS;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
+		err = zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
 		    dbn->dbn_name, sizeof (uint64_t),
 		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		    &dbn->dbn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		rv = B_TRUE;
 	}
 	dsl_dataset_rele(head, FTAG);

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -397,9 +397,9 @@ dsl_bookmark_node_add(dsl_dataset_t *hds, dsl_bookmark_node_t *dbn,
 	objset_t *mos = dp->dp_meta_objset;
 
 	if (hds->ds_bookmarks_obj == 0) {
-		hds->ds_bookmarks_obj = zap_create_norm(mos,
+		VERIFY0(zap_create_norm(mos,
 		    U8_TEXTPREP_TOUPPER, DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0,
-		    tx);
+		    tx, &hds->ds_bookmarks_obj));
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_BOOKMARKS, tx);
 
 		dsl_dataset_zapify(hds, tx);
@@ -470,9 +470,10 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 		    num_redact_snaps * sizeof (uint64_t);
 		if (bonuslen > dmu_bonus_max())
 			spill = B_TRUE;
-		dbn->dbn_phys.zbm_redaction_obj = dmu_object_alloc(mos,
+		VERIFY0(dmu_object_alloc(mos,
 		    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
-		    DMU_OTN_UINT64_METADATA, spill ? 0 : bonuslen, tx);
+		    DMU_OTN_UINT64_METADATA, spill ? 0 : bonuslen, tx,
+		    &dbn->dbn_phys.zbm_redaction_obj));
 		spa_feature_incr(dp->dp_spa,
 		    SPA_FEATURE_REDACTION_BOOKMARKS, tx);
 		if (spill) {

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -393,9 +393,9 @@ dsl_bookmark_node_add(dsl_dataset_t *hds, dsl_bookmark_node_t *dbn,
 	objset_t *mos = dp->dp_meta_objset;
 
 	if (hds->ds_bookmarks_obj == 0) {
-		hds->ds_bookmarks_obj = zap_create_norm(mos,
+		VERIFY0(zap_create_norm(mos,
 		    U8_TEXTPREP_TOUPPER, DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0,
-		    tx);
+		    tx, &hds->ds_bookmarks_obj));
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_BOOKMARKS, tx);
 
 		dsl_dataset_zapify(hds, tx);
@@ -466,9 +466,10 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 		    num_redact_snaps * sizeof (uint64_t);
 		if (bonuslen > dmu_bonus_max())
 			spill = B_TRUE;
-		dbn->dbn_phys.zbm_redaction_obj = dmu_object_alloc(mos,
+		VERIFY0(dmu_object_alloc(mos,
 		    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
-		    DMU_OTN_UINT64_METADATA, spill ? 0 : bonuslen, tx);
+		    DMU_OTN_UINT64_METADATA, spill ? 0 : bonuslen, tx,
+		    &dbn->dbn_phys.zbm_redaction_obj));
 		spa_feature_incr(dp->dp_spa,
 		    SPA_FEATURE_REDACTION_BOOKMARKS, tx);
 		if (spill) {

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1046,7 +1046,7 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg) {
 			dsl_dir_remove_clones_key(ds->ds_dir,
 			    dbn->dbn_phys.zbm_creation_txg, tx);
-			dsl_deadlist_remove_key(&ds->ds_deadlist,
+			(void) dsl_deadlist_remove_key(&ds->ds_deadlist,
 			    dbn->dbn_phys.zbm_creation_txg, tx);
 		}
 
@@ -1302,12 +1302,24 @@ boolean_t
 dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	dsl_dataset_t *head, *next;
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &head));
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &next));
+
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &head);
+	if (err && SPA_EXITING(spa))
+		return (B_FALSE);
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &next);
+	if (err && SPA_EXITING(spa)) {
+		dsl_dataset_rele(head, FTAG);
+		return (B_FALSE);
+	}
+	VERIFY0(err);
 
 	/*
 	 * Find the first bookmark that HAS_FBN at or after the
@@ -1355,10 +1367,12 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    compressed;
 		dbn->dbn_phys.zbm_uncompressed_freed_before_next_snap +=
 		    uncompressed;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
+		err = zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
 		    dbn->dbn_name, sizeof (uint64_t),
 		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		    &dbn->dbn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 	dsl_dataset_rele(next, FTAG);
 
@@ -1380,10 +1394,12 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		}
 		ASSERT(dbn->dbn_phys.zbm_flags & ZBM_FLAG_SNAPSHOT_EXISTS);
 		dbn->dbn_phys.zbm_flags &= ~ZBM_FLAG_SNAPSHOT_EXISTS;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
+		err = zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
 		    dbn->dbn_name, sizeof (uint64_t),
 		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		    &dbn->dbn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		rv = B_TRUE;
 	}
 	dsl_dataset_rele(head, FTAG);

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2319,7 +2319,7 @@ dsl_crypto_recv_raw_key_sync(dsl_dataset_t *ds, nvlist_t *nvl, dmu_tx_t *tx)
 		 * has been provided via the properties, this will be overridden
 		 * later.
 		 */
-		dsl_prop_set_sync_impl(ds,
+		(void) dsl_prop_set_sync_impl(ds,
 		    zfs_prop_to_name(ZFS_PROP_KEYLOCATION),
 		    ZPROP_SRC_LOCAL, 1, strlen(keylocation) + 1,
 		    keylocation, tx);

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2296,8 +2296,9 @@ dsl_crypto_recv_raw_key_sync(dsl_dataset_t *ds, nvlist_t *nvl, dmu_tx_t *tx)
 		dsl_dir_zapify(dd, tx);
 
 		/* create the DSL Crypto Key on disk and activate the feature */
-		dd->dd_crypto_obj = zap_create(mos,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx,
+		    &dd->dd_crypto_obj));
 		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
 		    dd->dd_crypto_obj, DSL_CRYPTO_KEY_REFCOUNT,
 		    sizeof (uint64_t), 1, &one, tx));
@@ -2575,8 +2576,8 @@ dsl_crypto_key_create_sync(uint64_t crypt, dsl_wrapping_key_t *wkey,
 	ASSERT3U(crypt, >, ZIO_CRYPT_OFF);
 
 	/* create the DSL Crypto Key ZAP object */
-	dck.dck_obj = zap_create(tx->tx_pool->dp_meta_objset,
-	    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(tx->tx_pool->dp_meta_objset,
+	    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx, &dck.dck_obj));
 
 	/* fill in the key (on the stack) and sync it to disk */
 	dck.dck_wkey = wkey;

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2421,7 +2421,7 @@ dsl_crypto_recv_raw_key_sync(dsl_dataset_t *ds, nvlist_t *nvl, dmu_tx_t *tx)
 		 * has been provided via the properties, this will be overridden
 		 * later.
 		 */
-		dsl_prop_set_sync_impl(ds,
+		(void) dsl_prop_set_sync_impl(ds,
 		    zfs_prop_to_name(ZFS_PROP_KEYLOCATION),
 		    ZPROP_SRC_LOCAL, 1, strlen(keylocation) + 1,
 		    keylocation, tx);

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2398,8 +2398,9 @@ dsl_crypto_recv_raw_key_sync(dsl_dataset_t *ds, nvlist_t *nvl, dmu_tx_t *tx)
 		dsl_dir_zapify(dd, tx);
 
 		/* create the DSL Crypto Key on disk and activate the feature */
-		dd->dd_crypto_obj = zap_create(mos,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx,
+		    &dd->dd_crypto_obj));
 		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
 		    dd->dd_crypto_obj, DSL_CRYPTO_KEY_REFCOUNT,
 		    sizeof (uint64_t), 1, &one, tx));
@@ -2677,8 +2678,8 @@ dsl_crypto_key_create_sync(uint64_t crypt, dsl_wrapping_key_t *wkey,
 	ASSERT3U(crypt, >, ZIO_CRYPT_OFF);
 
 	/* create the DSL Crypto Key ZAP object */
-	dck.dck_obj = zap_create(tx->tx_pool->dp_meta_objset,
-	    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(tx->tx_pool->dp_meta_objset,
+	    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx, &dck.dck_obj));
 
 	/* fill in the key (on the stack) and sync it to disk */
 	dck.dck_wkey = wkey;

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -321,6 +321,9 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			dsl_free(tx->tx_pool, tx->tx_txg, bp);
 		}
 
+		if (SPA_EXITING(spa))
+			return (0);
+
 		mutex_enter(&ds->ds_lock);
 		ASSERT(dsl_dataset_phys(ds)->ds_unique_bytes >= used ||
 		    !DS_UNIQUE_IS_ACCURATE(ds));

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -245,8 +245,8 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 		DVA_SET_VDEV(dva, vdev);
 		DVA_SET_OFFSET(dva, offset);
 		DVA_SET_ASIZE(dva, size);
-		dsl_deadlist_insert(&ds->ds_remap_deadlist, &fakebp, B_FALSE,
-		    tx);
+		(void) dsl_deadlist_insert(&ds->ds_remap_deadlist, &fakebp,
+		    B_FALSE, tx);
 	}
 }
 
@@ -341,7 +341,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			 */
 			bplist_append(&ds->ds_pending_deadlist, bp);
 		} else {
-			dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx);
+			VERIFY0(dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx));
 		}
 		ASSERT3U(ds->ds_prev->ds_object, ==,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj);
@@ -1173,15 +1173,16 @@ dsl_dataset_deactivate_feature(dsl_dataset_t *ds, spa_feature_t f, dmu_tx_t *tx)
 	dsl_dataset_deactivate_feature_impl(ds, f, tx);
 }
 
-uint64_t
+int
 dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
-    dsl_crypto_params_t *dcp, uint64_t flags, dmu_tx_t *tx)
+    dsl_crypto_params_t *dcp, uint64_t flags, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dd->dd_pool->dp_spa;
 	dsl_pool_t *dp = dd->dd_pool;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
 	dsl_dataset_phys_t *dsphys;
-	uint64_t dsobj;
 	objset_t *mos = dp->dp_meta_objset;
+	int err = 0;
 
 	if (origin == NULL)
 		origin = dp->dp_origin_snap;
@@ -1191,10 +1192,20 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
-	dsobj = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
-	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
-	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
+	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dmu_bonus_hold(mos, *objectp, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 	dsphys = dbuf->db_data;
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = dd->dd_object;
@@ -1202,14 +1213,19 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	dsphys->ds_fsid_guid = unique_create();
 	(void) random_get_pseudo_bytes((void*)&dsphys->ds_guid,
 	    sizeof (dsphys->ds_guid));
-	dsphys->ds_snapnames_zapobj =
-	    zap_create_norm(mos, U8_TEXTPREP_TOUPPER, DMU_OT_DSL_DS_SNAP_MAP,
-	    DMU_OT_NONE, 0, tx);
+	err = zap_create_norm(mos, U8_TEXTPREP_TOUPPER, DMU_OT_DSL_DS_SNAP_MAP,
+	    DMU_OT_NONE, 0, tx, &dsphys->ds_snapnames_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsphys->ds_creation_time = gethrestime_sec();
 	dsphys->ds_creation_txg = tx->tx_txg == TXG_INITIAL ? 1 : tx->tx_txg;
 
 	if (origin == NULL) {
-		dsphys->ds_deadlist_obj = dsl_deadlist_alloc(mos, tx);
+		err = dsl_deadlist_alloc(mos, tx, &dsphys->ds_deadlist_obj);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	} else {
 		dsl_dataset_t *ohds; /* head of the origin snapshot */
 
@@ -1235,49 +1251,83 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 
 		for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 			if (zfeature_active(f, origin->ds_feature[f])) {
-				dsl_dataset_activate_feature(dsobj, f,
+				dsl_dataset_activate_feature(*objectp, f,
 				    origin->ds_feature[f], tx);
 			}
 		}
 
 		dmu_buf_will_dirty(origin->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin)->ds_num_children++;
 
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dir_phys(origin->ds_dir)->dd_head_dataset_obj,
-		    FTAG, &ohds));
-		dsphys->ds_deadlist_obj = dsl_deadlist_clone(&ohds->ds_deadlist,
-		    dsphys->ds_prev_snap_txg, dsphys->ds_prev_snap_obj, tx);
+		    FTAG, &ohds);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+		err = dsl_deadlist_clone(&ohds->ds_deadlist,
+		    dsphys->ds_prev_snap_txg, dsphys->ds_prev_snap_obj, tx,
+		    &dsphys->ds_deadlist_obj);
+		if (err && SPA_EXITING(spa)) {
+			dsl_dataset_rele(ohds, FTAG);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 		dsl_dataset_rele(ohds, FTAG);
 
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_NEXT_CLONES) {
 			if (dsl_dataset_phys(origin)->ds_next_clones_obj == 0) {
-				dsl_dataset_phys(origin)->ds_next_clones_obj =
-				    zap_create(mos,
-				    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx);
+				err = zap_create(mos,
+				    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
+				    &dsl_dataset_phys(origin)->
+				    ds_next_clones_obj);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 			}
-			VERIFY0(zap_add_int(mos,
+			err = zap_add_int(mos,
 			    dsl_dataset_phys(origin)->ds_next_clones_obj,
-			    dsobj, tx));
+			    *objectp, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dir_phys(dd)->dd_origin_obj = origin->ds_object;
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_DIR_CLONES) {
 			if (dsl_dir_phys(origin->ds_dir)->dd_clones == 0) {
 				dmu_buf_will_dirty(origin->ds_dir->dd_dbuf, tx);
-				dsl_dir_phys(origin->ds_dir)->dd_clones =
-				    zap_create(mos,
-				    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx);
+				if (SPA_EXITING(spa)) {
+					err = SET_ERROR(EIO);
+					goto spa_exiting;
+				}
+				err = zap_create(mos,
+				    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx,
+				    &dsl_dir_phys(origin->ds_dir)->dd_clones);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 			}
-			VERIFY0(zap_add_int(mos,
+			err = zap_add_int(mos,
 			    dsl_dir_phys(origin->ds_dir)->dd_clones,
-			    dsobj, tx));
+			    *objectp, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 	}
 
 	/* handle encryption */
-	dsl_dataset_create_crypt_sync(dsobj, dd, origin, dcp, tx);
+	dsl_dataset_create_crypt_sync(*objectp, dd, origin, dcp, tx);
 
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_UNIQUE_ACCURATE)
 		dsphys->ds_flags |= DS_FLAG_UNIQUE_ACCURATE;
@@ -1285,9 +1335,18 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	dmu_buf_rele(dbuf, FTAG);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
-	dsl_dir_phys(dd)->dd_head_dataset_obj = dsobj;
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
+	dsl_dir_phys(dd)->dd_head_dataset_obj = *objectp;
 
-	return (dsobj);
+	return (err);
+
+spa_exiting:
+	if (dbuf != NULL)
+		dmu_buf_rele(dbuf, FTAG);
+	return (err || SET_ERROR(EIO));
 }
 
 static void
@@ -1311,14 +1370,16 @@ dsl_dataset_zero_zil(dsl_dataset_t *ds, dmu_tx_t *tx)
 	}
 }
 
-uint64_t
+int
 dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
     dsl_dataset_t *origin, uint64_t flags, cred_t *cr,
-    dsl_crypto_params_t *dcp, dmu_tx_t *tx)
+    dsl_crypto_params_t *dcp, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = pdd->dd_pool->dp_spa;
 	dsl_pool_t *dp = pdd->dd_pool;
-	uint64_t dsobj, ddobj;
-	dsl_dir_t *dd;
+	uint64_t ddobj;
+	dsl_dir_t *dd = NULL;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(lastname[0] != '@');
@@ -1331,11 +1392,21 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	if (origin != NULL)
 		ASSERT3P(origin, !=, dp->dp_origin_snap);
 
-	ddobj = dsl_dir_create_sync(dp, pdd, lastname, tx);
-	VERIFY0(dsl_dir_hold_obj(dp, ddobj, lastname, FTAG, &dd));
+	err = dsl_dir_create_sync(dp, pdd, lastname, tx, &ddobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	dsobj = dsl_dataset_create_sync_dd(dd, origin, dcp,
-	    flags & ~DS_CREATE_FLAG_NODIRTY, tx);
+	err = dsl_dir_hold_obj(dp, ddobj, lastname, FTAG, &dd);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_create_sync_dd(dd, origin, dcp,
+	    flags & ~DS_CREATE_FLAG_NODIRTY, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dsl_deleg_set_create_perms(dd, tx, cr);
 
@@ -1347,9 +1418,16 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	    spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_LIVELIST)) {
 		objset_t *mos = dd->dd_pool->dp_meta_objset;
 		dsl_dir_zapify(dd, tx);
-		uint64_t obj = dsl_deadlist_alloc(mos, tx);
-		VERIFY0(zap_add(mos, dd->dd_object, DD_FIELD_LIVELIST,
-		    sizeof (uint64_t), 1, &obj, tx));
+		uint64_t obj;
+		err = dsl_deadlist_alloc(mos, tx, &obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(mos, dd->dd_object, DD_FIELD_LIVELIST,
+		    sizeof (uint64_t), 1, &obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_LIVELIST, tx);
 	}
 
@@ -1362,13 +1440,20 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 		objset_t *os = dd->dd_pool->dp_meta_objset;
 
 		dsl_dir_zapify(dd, tx);
-		VERIFY0(zap_add(os, dd->dd_object, DD_FIELD_FILESYSTEM_COUNT,
-		    sizeof (cnt), 1, &cnt, tx));
-		VERIFY0(zap_add(os, dd->dd_object, DD_FIELD_SNAPSHOT_COUNT,
-		    sizeof (cnt), 1, &cnt, tx));
+		err = zap_add(os, dd->dd_object, DD_FIELD_FILESYSTEM_COUNT,
+		    sizeof (cnt), 1, &cnt, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(os, dd->dd_object, DD_FIELD_SNAPSHOT_COUNT,
+		    sizeof (cnt), 1, &cnt, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	dsl_dir_rele(dd, FTAG);
+	dd = NULL;
 
 	/*
 	 * If we are creating a clone, make sure we zero out any stale
@@ -1377,12 +1462,18 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	if (origin != NULL && !(flags & DS_CREATE_FLAG_NODIRTY)) {
 		dsl_dataset_t *ds;
 
-		VERIFY0(dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+		err = dsl_dataset_hold_obj(dp, *objectp, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		dsl_dataset_zero_zil(ds, tx);
 		dsl_dataset_rele(ds, FTAG);
 	}
 
-	return (dsobj);
+out:
+	if (dd)
+		dsl_dir_rele(dd, FTAG);
+	return (err);
 }
 
 /*
@@ -1721,16 +1812,18 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 	return (rv);
 }
 
-void
+int
 dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     uint64_t crtime, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
 	dsl_dataset_phys_t *dsphys;
 	uint64_t dsobj, crtxg;
 	objset_t *mos = dp->dp_meta_objset;
 	objset_t *os __maybe_unused;
+	int err = 0;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -1757,10 +1850,20 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	else
 		crtxg = tx->tx_txg;
 
-	dsobj = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
-	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
-	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
+	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx, &dsobj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dmu_bonus_hold(mos, dsobj, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 	dsphys = dbuf->db_data;
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = ds->ds_dir->dd_object;
@@ -1783,6 +1886,7 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	dsphys->ds_bp = dsl_dataset_phys(ds)->ds_bp;
 	rrw_exit(&ds->ds_bp_rwlock, FTAG);
 	dmu_buf_rele(dbuf, FTAG);
+	dbuf = NULL;
 
 	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (zfeature_active(f, ds->ds_feature[f])) {
@@ -1808,8 +1912,10 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		} else if (next_clones_obj != 0) {
 			dsl_dataset_remove_from_next_clones(ds->ds_prev,
 			    dsphys->ds_next_snap_obj, tx);
-			VERIFY0(zap_add_int(mos,
-			    next_clones_obj, dsobj, tx));
+			err = zap_add_int(mos, next_clones_obj, dsobj, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 	}
 
@@ -1828,12 +1934,23 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	}
 
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
-	dsl_dataset_phys(ds)->ds_deadlist_obj =
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
+	err =
 	    dsl_deadlist_clone(&ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx);
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx,
+	    &dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_deadlist_close(&ds->ds_deadlist);
-	VERIFY0(dsl_deadlist_open(&ds->ds_deadlist, mos,
-	    dsl_dataset_phys(ds)->ds_deadlist_obj));
+	err = dsl_deadlist_open(&ds->ds_deadlist, mos,
+	    dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_deadlist_add_key(&ds->ds_deadlist,
 	    dsl_dataset_phys(ds)->ds_prev_snap_txg, tx);
 	dsl_bookmark_snapshotted(ds, tx);
@@ -1850,8 +1967,11 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		dsl_deadlist_close(&ds->ds_remap_deadlist);
 
 		dmu_object_zapify(mos, dsobj, DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_REMAP_DEADLIST,
-		    sizeof (remap_deadlist_obj), 1, &remap_deadlist_obj, tx));
+		err = zap_add(mos, dsobj, DS_FIELD_REMAP_DEADLIST,
+		    sizeof (remap_deadlist_obj), 1, &remap_deadlist_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	/*
@@ -1874,8 +1994,11 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		uint64_t ivset_guid = unique_create();
 
 		dmu_object_zapify(mos, dsobj, DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_IVSET_GUID,
-		    sizeof (ivset_guid), 1, &ivset_guid, tx));
+		err = zap_add(mos, dsobj, DS_FIELD_IVSET_GUID,
+		    sizeof (ivset_guid), 1, &ivset_guid, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	ASSERT3U(dsl_dataset_phys(ds)->ds_prev_snap_txg, <, tx->tx_txg);
@@ -1886,13 +2009,19 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_UNIQUE_ACCURATE)
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_UNIQUE_ACCURATE;
 
-	VERIFY0(zap_add(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj,
-	    snapname, 8, 1, &dsobj, tx));
+	err = zap_add(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj,
+	    snapname, 8, 1, &dsobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	if (ds->ds_prev)
 		dsl_dataset_rele(ds->ds_prev, ds);
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	dsl_scan_ds_snapshotted(ds, tx);
 
@@ -1900,14 +2029,23 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 
 	if (zfs_snapshot_history_enabled)
 		spa_history_log_internal_ds(ds->ds_prev, "snapshot", tx, " ");
+
+	return (0);
+
+spa_exiting:
+	if (dbuf != NULL)
+		dmu_buf_rele(dbuf, FTAG);
+	return (err);
 }
 
 void
 dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 {
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_dataset_snapshot_arg_t *ddsa = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	nvpair_t *pair;
+	int err = 0;
 
 	/*
 	 * All snapshots created by one request are taken atomically in a
@@ -1926,13 +2064,23 @@ dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 		name = nvpair_name(pair);
 		atp = strchr(name, '@');
 		(void) strlcpy(dsname, name, atp - name + 1);
-		VERIFY0(dsl_dataset_hold(dp, dsname, FTAG, &ds));
+		err = dsl_dataset_hold(dp, dsname, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
-		dsl_dataset_snapshot_sync_impl(ds, atp + 1, crtime, tx);
+		err = dsl_dataset_snapshot_sync_impl(ds, atp + 1, crtime, tx);
+		if (err && SPA_EXITING(spa)) {
+			dsl_dataset_rele(ds, FTAG);
+			break;
+		}
+		VERIFY0(err);
+
 		if (ddsa->ddsa_props != NULL) {
 			dsl_props_set_sync_impl(ds->ds_prev,
 			    ZPROP_SRC_LOCAL, ddsa->ddsa_props, tx);
 		}
+
 		dsl_dataset_rele(ds, FTAG);
 	}
 }
@@ -2067,18 +2215,28 @@ dsl_dataset_snapshot_tmp_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_dataset_snapshot_tmp_sync(void *arg, dmu_tx_t *tx)
 {
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_dataset_snapshot_tmp_arg_t *ddsta = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds = NULL;
+	int err = 0;
 
-	VERIFY0(dsl_dataset_hold(dp, ddsta->ddsta_fsname, FTAG, &ds));
+	err = dsl_dataset_hold(dp, ddsta->ddsta_fsname, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
-	dsl_dataset_snapshot_sync_impl(ds, ddsta->ddsta_snapname,
+	err = dsl_dataset_snapshot_sync_impl(ds, ddsta->ddsta_snapname,
 	    gethrestime_sec(), tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
 	dsl_dataset_user_hold_sync_one(ds->ds_prev, ddsta->ddsta_htag,
 	    ddsta->ddsta_cleanup_minor, gethrestime_sec(), tx);
 	dsl_destroy_snapshot_sync_impl(ds->ds_prev, B_TRUE, tx);
 
+out:
 	dsl_dataset_rele(ds, FTAG);
 }
 
@@ -3283,21 +3441,33 @@ dsl_dataset_rollback_check(void *arg, dmu_tx_t *tx)
 void
 dsl_dataset_rollback_sync(void *arg, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	dsl_dataset_rollback_arg_t *ddra = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds, *clone;
 	uint64_t cloneobj;
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 
-	VERIFY0(dsl_dataset_hold(dp, ddra->ddra_fsname, FTAG, &ds));
+	err = dsl_dataset_hold(dp, ddra->ddra_fsname, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	dsl_dataset_name(ds->ds_prev, namebuf);
 	fnvlist_add_string(ddra->ddra_result, "target", namebuf);
 
-	cloneobj = dsl_dataset_create_sync(ds->ds_dir, "%rollback",
-	    ds->ds_prev, DS_CREATE_FLAG_NODIRTY, kcred, NULL, tx);
+	err = dsl_dataset_create_sync(ds->ds_dir, "%rollback",
+	    ds->ds_prev, DS_CREATE_FLAG_NODIRTY, kcred, NULL, tx, &cloneobj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj(dp, cloneobj, FTAG, &clone));
+	err = dsl_dataset_hold_obj(dp, cloneobj, FTAG, &clone);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	dsl_dataset_clone_swap_sync_impl(clone, ds, tx);
 	dsl_dataset_zero_zil(ds, tx);
@@ -3390,27 +3560,48 @@ dsl_dataset_clone_check(void *arg, dmu_tx_t *tx)
 void
 dsl_dataset_clone_sync(void *arg, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	dsl_dataset_clone_arg_t *ddca = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
-	dsl_dir_t *pdd;
+	dsl_dir_t *pdd = NULL;
 	const char *tail;
-	dsl_dataset_t *origin, *ds;
+	dsl_dataset_t *origin = NULL, *ds = NULL;
 	uint64_t obj;
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 
-	VERIFY0(dsl_dir_hold(dp, ddca->ddca_clone, FTAG, &pdd, &tail));
-	VERIFY0(dsl_dataset_hold(dp, ddca->ddca_origin, FTAG, &origin));
+	err = dsl_dir_hold(dp, ddca->ddca_clone, FTAG, &pdd, &tail);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	obj = dsl_dataset_create_sync(pdd, tail, origin, 0,
-	    ddca->ddca_cred, NULL, tx);
+	err = dsl_dataset_hold(dp, ddca->ddca_origin, FTAG, &origin);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj(pdd->dd_pool, obj, FTAG, &ds));
+	err = dsl_dataset_create_sync(pdd, tail, origin, 0,
+	    ddca->ddca_cred, NULL, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(pdd->dd_pool, obj, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dsl_dataset_name(origin, namebuf);
 	spa_history_log_internal_ds(ds, "clone", tx,
 	    "origin=%s (%llu)", namebuf, (u_longlong_t)origin->ds_object);
-	dsl_dataset_rele(ds, FTAG);
-	dsl_dataset_rele(origin, FTAG);
-	dsl_dir_rele(pdd, FTAG);
+
+out:
+	if (ds)
+		dsl_dataset_rele(ds, FTAG);
+	if (origin)
+		dsl_dataset_rele(origin, FTAG);
+	if (pdd)
+		dsl_dir_rele(pdd, FTAG);
 }
 
 int
@@ -3747,9 +3938,9 @@ dsl_dataset_promote_sync(void *arg, dmu_tx_t *tx)
 		    dsl_dir_phys(ddpa->origin_origin->ds_dir)->dd_clones,
 		    origin_head->ds_object, tx));
 		if (dsl_dir_phys(dd)->dd_clones == 0) {
-			dsl_dir_phys(dd)->dd_clones =
-			    zap_create(dp->dp_meta_objset, DMU_OT_DSL_CLONES,
-			    DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(dp->dp_meta_objset,
+			    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx,
+			    &dsl_dir_phys(dd)->dd_clones));
 		}
 		VERIFY0(zap_add_int(dp->dp_meta_objset,
 		    dsl_dir_phys(dd)->dd_clones, origin_head->ds_object, tx));
@@ -5089,9 +5280,9 @@ dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 */
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_DEVICE_REMOVAL));
 
-	remap_deadlist_obj = dsl_deadlist_clone(
+	VERIFY0(dsl_deadlist_clone(
 	    &ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx);
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj));
 	dsl_dataset_set_remap_deadlist_object(ds,
 	    remap_deadlist_obj, tx);
 	VERIFY0(dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -102,7 +102,7 @@ int zfs_snapshot_history_enabled = 1;
 
 #define	DS_REF_MAX	(1ULL << 62)
 
-static void dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds,
+static int dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds,
     uint64_t obj, dmu_tx_t *tx);
 static void dsl_dataset_unset_remap_deadlist_object(dsl_dataset_t *ds,
     dmu_tx_t *tx);
@@ -221,6 +221,7 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
     uint64_t size, uint64_t birth, dmu_tx_t *tx)
 {
 	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(birth <= tx->tx_txg);
@@ -236,7 +237,12 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 
 		mutex_enter(&ds->ds_remap_deadlist_lock);
 		if (!dsl_dataset_remap_deadlist_exists(ds)) {
-			dsl_dataset_create_remap_deadlist(ds, tx);
+			err = dsl_dataset_create_remap_deadlist(ds, tx);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&ds->ds_remap_deadlist_lock);
+				return;
+			}
+			VERIFY0(err);
 		}
 		mutex_exit(&ds->ds_remap_deadlist_lock);
 
@@ -255,7 +261,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
     boolean_t async)
 {
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
-
+	int err;
 	int used = bp_get_dsize_sync(spa, bp);
 	int compressed = BP_GET_PSIZE(bp);
 	int uncompressed = BP_GET_UCSIZE(bp);
@@ -341,7 +347,11 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			 */
 			bplist_append(&ds->ds_pending_deadlist, bp);
 		} else {
-			VERIFY0(dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx));
+			err = dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE,
+			    tx);
+			if (err && SPA_EXITING(spa))
+				return (0);
+			VERIFY0(err);
 		}
 		ASSERT3U(ds->ds_prev->ds_object, ==,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj);
@@ -401,6 +411,7 @@ unload_zfeature(dsl_dataset_t *ds, spa_feature_t f)
 static int
 load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 {
+	spa_t *spa = mos->os_spa;
 	int err = 0;
 	switch (spa_feature_table[f].fi_type) {
 	case ZFEATURE_TYPE_BOOLEAN:
@@ -409,6 +420,8 @@ load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 		if (err == 0) {
 			ds->ds_feature[f] = (void *)B_TRUE;
 		} else {
+			if (err != ENOENT && SPA_EXITING(spa))
+				break;
 			ASSERT3U(err, ==, ENOENT);
 			err = 0;
 		}
@@ -420,14 +433,21 @@ load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 		err = zap_length(mos, ds->ds_object,
 		    spa_feature_table[f].fi_guid, &int_size, &num_int);
 		if (err != 0) {
+			if (err != ENOENT && SPA_EXITING(spa))
+				break;
 			ASSERT3U(err, ==, ENOENT);
 			err = 0;
 			break;
 		}
 		ASSERT3U(int_size, ==, sizeof (uint64_t));
 		data = kmem_alloc(int_size * num_int, KM_SLEEP);
-		VERIFY0(zap_lookup(mos, ds->ds_object,
-		    spa_feature_table[f].fi_guid, int_size, num_int, data));
+		err = zap_lookup(mos, ds->ds_object,
+		    spa_feature_table[f].fi_guid, int_size, num_int, data);
+		if (err && SPA_EXITING(spa)) {
+			kmem_free(data, int_size * num_int);
+			break;
+		}
+		VERIFY0(err);
 		struct feature_type_uint64_array_arg *ftuaa =
 		    kmem_alloc(sizeof (*ftuaa), KM_SLEEP);
 		ftuaa->length = num_int;
@@ -710,9 +730,12 @@ dsl_dataset_hold_obj(dsl_pool_t *dp, uint64_t dsobj, const void *tag,
 			    mos, dsl_dataset_phys(ds)->ds_deadlist_obj);
 		}
 		if (err == 0) {
-			uint64_t remap_deadlist_obj =
-			    dsl_dataset_get_remap_deadlist_object(ds);
-			if (remap_deadlist_obj != 0) {
+			uint64_t remap_deadlist_obj;
+			err = dsl_dataset_get_remap_deadlist_object(ds,
+			    &remap_deadlist_obj);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
+			if (!err && remap_deadlist_obj != 0) {
 				err = dsl_deadlist_open(&ds->ds_remap_deadlist,
 				    mos, remap_deadlist_obj);
 			}
@@ -1127,6 +1150,7 @@ dsl_dataset_activate_feature(uint64_t dsobj, spa_feature_t f, void *arg,
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = dmu_tx_pool(tx)->dp_meta_objset;
 	uint64_t zero = 0;
+	int err;
 
 	VERIFY(spa_feature_table[f].fi_flags & ZFEATURE_FLAG_PER_DATASET);
 
@@ -1136,14 +1160,18 @@ dsl_dataset_activate_feature(uint64_t dsobj, spa_feature_t f, void *arg,
 	switch (spa_feature_table[f].fi_type) {
 	case ZFEATURE_TYPE_BOOLEAN:
 		ASSERT3S((boolean_t)(uintptr_t)arg, ==, B_TRUE);
-		VERIFY0(zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
-		    sizeof (zero), 1, &zero, tx));
+		err = zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
+		    sizeof (zero), 1, &zero, tx);
+		if (!spa_exiting(spa))
+			VERIFY0(err);
 		break;
 	case ZFEATURE_TYPE_UINT64_ARRAY:
 	{
 		struct feature_type_uint64_array_arg *ftuaa = arg;
-		VERIFY0(zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
-		    sizeof (uint64_t), ftuaa->length, ftuaa->array, tx));
+		err = zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
+		    sizeof (uint64_t), ftuaa->length, ftuaa->array, tx);
+		if (!spa_exiting(spa))
+			VERIFY0(err);
 		break;
 	}
 	default:
@@ -1158,10 +1186,13 @@ dsl_dataset_deactivate_feature_impl(dsl_dataset_t *ds, spa_feature_t f,
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = dmu_tx_pool(tx)->dp_meta_objset;
 	uint64_t dsobj = ds->ds_object;
+	int err;
 
 	VERIFY(spa_feature_table[f].fi_flags & ZFEATURE_FLAG_PER_DATASET);
 
-	VERIFY0(zap_remove(mos, dsobj, spa_feature_table[f].fi_guid, tx));
+	err = zap_remove(mos, dsobj, spa_feature_table[f].fi_guid, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	spa_feature_decr(spa, f, tx);
 	ds->ds_feature[f] = NULL;
 }
@@ -1349,25 +1380,33 @@ spa_exiting:
 	return (err || SET_ERROR(EIO));
 }
 
-static void
+static int
 dsl_dataset_zero_zil(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *os;
+	int err = 0;
 
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (memcmp(&os->os_zil_header, &zero_zil, sizeof (zero_zil)) != 0) {
-		dsl_pool_t *dp = ds->ds_dir->dd_pool;
 		zio_t *zio;
 
 		memset(&os->os_zil_header, 0, sizeof (os->os_zil_header));
 		if (os->os_encrypted)
 			os->os_next_write_raw[tx->tx_txg & TXG_MASK] = B_TRUE;
 
-		zio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
+		zio = zio_root(spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
 		dsl_dataset_sync(ds, zio, tx);
-		VERIFY0(zio_wait(zio));
+		err = zio_wait(zio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_sync_done(ds, tx);
 	}
+
+	return (err);
 }
 
 int
@@ -1466,7 +1505,9 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 		if (err && SPA_EXITING(spa))
 			goto out;
 		VERIFY0(err);
-		dsl_dataset_zero_zil(ds, tx);
+		err = dsl_dataset_zero_zil(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_rele(ds, FTAG);
 	}
 
@@ -1499,9 +1540,12 @@ dsl_dataset_recalc_head_uniq(dsl_dataset_t *ds)
 
 	dsl_deadlist_space(&ds->ds_deadlist, &dlused, &dlcomp, &dluncomp);
 
-	ASSERT3U(dlused, <=, mrs_used);
-	dsl_dataset_phys(ds)->ds_unique_bytes =
-	    dsl_dataset_phys(ds)->ds_referenced_bytes - (mrs_used - dlused);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa)) {
+		ASSERT3U(dlused, <=, mrs_used);
+		dsl_dataset_phys(ds)->ds_unique_bytes =
+		    dsl_dataset_phys(ds)->ds_referenced_bytes -
+		    (mrs_used - dlused);
+	}
 
 	if (spa_version(ds->ds_dir->dd_pool->dp_spa) >=
 	    SPA_VERSION_UNIQUE_ACCURATE)
@@ -1512,6 +1556,7 @@ void
 dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *mos = ds->ds_dir->dd_pool->dp_meta_objset;
 	uint64_t count __maybe_unused;
 	int err;
@@ -1529,10 +1574,16 @@ dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,
 	 * too many entries in the next_clones_obj even after failing to
 	 * remove this one.
 	 */
+	if (!(err == ENOENT || err == 0) && SPA_EXITING(spa))
+		return;
 	if (err != ENOENT)
 		VERIFY0(err);
-	ASSERT0(zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
-	    &count));
+
+	err = zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
+	    &count);
+	if (err && SPA_EXITING(spa))
+		return;
+	ASSERT0(err);
 	ASSERT3U(count, <=, dsl_dataset_phys(ds)->ds_num_children - 2);
 }
 
@@ -1956,8 +2007,12 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	dsl_bookmark_snapshotted(ds, tx);
 
 	if (dsl_dataset_remap_deadlist_exists(ds)) {
-		uint64_t remap_deadlist_obj =
-		    dsl_dataset_get_remap_deadlist_object(ds);
+		uint64_t remap_deadlist_obj;
+		err = dsl_dataset_get_remap_deadlist_object(ds,
+		    &remap_deadlist_obj);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		/*
 		 * Move the remap_deadlist to the snapshot.  The head
 		 * will create a new remap deadlist on demand, from
@@ -2015,8 +2070,10 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		goto spa_exiting;
 	VERIFY0(err);
 
-	if (ds->ds_prev)
+	if (ds->ds_prev) {
 		dsl_dataset_rele(ds->ds_prev, ds);
+		ds->ds_prev = NULL;
+	}
 	err = dsl_dataset_hold_obj(dp,
 	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev);
 	if (err && SPA_EXITING(spa))
@@ -2279,6 +2336,9 @@ dsl_dataset_snapshot_tmp(const char *fsname, const char *snapname,
 void
 dsl_dataset_sync(dsl_dataset_t *ds, zio_t *rio, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_objset->os_spa;
+	int err;
+
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(ds->ds_objset != NULL);
 	ASSERT0(dsl_dataset_phys(ds)->ds_next_snap_obj);
@@ -2288,18 +2348,25 @@ dsl_dataset_sync(dsl_dataset_t *ds, zio_t *rio, dmu_tx_t *tx)
 	 * sync it out now.
 	 */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
-	dsl_dataset_phys(ds)->ds_fsid_guid = ds->ds_fsid_guid;
+	if (!SPA_EXITING(spa))
+		dsl_dataset_phys(ds)->ds_fsid_guid = ds->ds_fsid_guid;
 
 	if (ds->ds_resume_bytes[tx->tx_txg & TXG_MASK] != 0) {
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_OBJECT, 8, 1,
-		    &ds->ds_resume_object[tx->tx_txg & TXG_MASK], tx));
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		    &ds->ds_resume_object[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_OFFSET, 8, 1,
-		    &ds->ds_resume_offset[tx->tx_txg & TXG_MASK], tx));
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		    &ds->ds_resume_offset[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_BYTES, 8, 1,
-		    &ds->ds_resume_bytes[tx->tx_txg & TXG_MASK], tx));
+		    &ds->ds_resume_bytes[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		ds->ds_resume_object[tx->tx_txg & TXG_MASK] = 0;
 		ds->ds_resume_offset[tx->tx_txg & TXG_MASK] = 0;
 		ds->ds_resume_bytes[tx->tx_txg & TXG_MASK] = 0;
@@ -3470,7 +3537,9 @@ dsl_dataset_rollback_sync(void *arg, dmu_tx_t *tx)
 	VERIFY0(err);
 
 	dsl_dataset_clone_swap_sync_impl(clone, ds, tx);
-	dsl_dataset_zero_zil(ds, tx);
+	err = dsl_dataset_zero_zil(ds, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	dsl_destroy_head_sync_impl(clone, tx);
 
@@ -4346,17 +4415,27 @@ dsl_dataset_clone_swap_check_impl(dsl_dataset_t *clone,
 	return (0);
 }
 
-static void
+static int
 dsl_dataset_swap_remap_deadlists(dsl_dataset_t *clone,
     dsl_dataset_t *origin, dmu_tx_t *tx)
 {
 	uint64_t clone_remap_dl_obj, origin_remap_dl_obj;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(dp));
 
-	clone_remap_dl_obj = dsl_dataset_get_remap_deadlist_object(clone);
-	origin_remap_dl_obj = dsl_dataset_get_remap_deadlist_object(origin);
+	err = dsl_dataset_get_remap_deadlist_object(clone, &clone_remap_dl_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_dataset_get_remap_deadlist_object(origin,
+	    &origin_remap_dl_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (clone_remap_dl_obj != 0) {
 		dsl_deadlist_close(&clone->ds_remap_deadlist);
@@ -4368,17 +4447,31 @@ dsl_dataset_swap_remap_deadlists(dsl_dataset_t *clone,
 	}
 
 	if (clone_remap_dl_obj != 0) {
-		dsl_dataset_set_remap_deadlist_object(origin,
+		err = dsl_dataset_set_remap_deadlist_object(origin,
 		    clone_remap_dl_obj, tx);
-		VERIFY0(dsl_deadlist_open(&origin->ds_remap_deadlist,
-		    dp->dp_meta_objset, clone_remap_dl_obj));
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = dsl_deadlist_open(&origin->ds_remap_deadlist,
+		    dp->dp_meta_objset, clone_remap_dl_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 	if (origin_remap_dl_obj != 0) {
-		dsl_dataset_set_remap_deadlist_object(clone,
+		err = dsl_dataset_set_remap_deadlist_object(clone,
 		    origin_remap_dl_obj, tx);
-		VERIFY0(dsl_deadlist_open(&clone->ds_remap_deadlist,
-		    dp->dp_meta_objset, origin_remap_dl_obj));
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = dsl_deadlist_open(&clone->ds_remap_deadlist,
+		    dp->dp_meta_objset, origin_remap_dl_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
+
+	return (err);
 }
 
 void
@@ -4552,7 +4645,7 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	    dsl_dataset_phys(clone)->ds_deadlist_obj));
 	VERIFY0(dsl_deadlist_open(&origin_head->ds_deadlist, dp->dp_meta_objset,
 	    dsl_dataset_phys(origin_head)->ds_deadlist_obj));
-	dsl_dataset_swap_remap_deadlists(clone, origin_head, tx);
+	VERIFY0(dsl_dataset_swap_remap_deadlists(clone, origin_head, tx));
 
 	/*
 	 * If there is a bookmark at the origin, its "next dataset" is
@@ -4800,21 +4893,29 @@ dsl_dataset_set_refreservation_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
-void
+int
 dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
     zprop_source_t source, uint64_t value, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	uint64_t newval;
 	uint64_t unique;
 	int64_t delta;
+	int err = 0;
 
-	dsl_prop_set_sync_impl(ds, zfs_prop_to_name(ZFS_PROP_REFRESERVATION),
-	    source, sizeof (value), 1, &value, tx);
+	dsl_prop_set_sync_impl(ds,
+	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), source, sizeof (value),
+	    1, &value, tx);
 
-	VERIFY0(dsl_prop_get_int_ds(ds,
-	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), &newval));
+	err = dsl_prop_get_int_ds(ds,
+	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), &newval);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		return (SET_ERROR(EIO));
 	mutex_enter(&ds->ds_dir->dd_lock);
 	mutex_enter(&ds->ds_lock);
 	ASSERT(DS_UNIQUE_IS_ACCURATE(ds));
@@ -4826,6 +4927,8 @@ dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
 
 	dsl_dir_diduse_space(ds->ds_dir, DD_USED_REFRSRV, delta, 0, 0, tx);
 	mutex_exit(&ds->ds_dir->dd_lock);
+
+	return (err);
 }
 
 static void
@@ -4833,11 +4936,20 @@ dsl_dataset_set_refreservation_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_dataset_set_qr_arg_t *ddsqra = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	dsl_dataset_t *ds = NULL;
+	int err;
 
-	VERIFY0(dsl_dataset_hold(dp, ddsqra->ddsqra_name, FTAG, &ds));
-	dsl_dataset_set_refreservation_sync_impl(ds,
+	err = dsl_dataset_hold(dp, ddsqra->ddsqra_name, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
+	err = dsl_dataset_set_refreservation_sync_impl(ds,
 	    ddsqra->ddsqra_source, ddsqra->ddsqra_value, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
 	dsl_dataset_rele(ds, FTAG);
 }
 
@@ -5203,51 +5315,66 @@ dsl_dataset_has_resume_receive_state(dsl_dataset_t *ds)
 	    ds->ds_object, DS_FIELD_RESUME_TOGUID) == 0);
 }
 
-uint64_t
-dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds)
+int
+dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds, uint64_t *objectp)
 {
-	uint64_t remap_deadlist_obj;
-	int err;
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err = 0;
 
-	if (!dsl_dataset_is_zapified(ds))
+	if (!dsl_dataset_is_zapified(ds)) {
+		*objectp = 0;
 		return (0);
+	}
 
 	err = zap_lookup(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
-	    DS_FIELD_REMAP_DEADLIST, sizeof (remap_deadlist_obj), 1,
-	    &remap_deadlist_obj);
+	    DS_FIELD_REMAP_DEADLIST, sizeof (*objectp), 1, objectp);
 
 	if (err != 0) {
+		*objectp = 0;
+		if (!(err == ENOENT) && SPA_EXITING(spa))
+			return (SET_ERROR(EIO));
 		VERIFY3S(err, ==, ENOENT);
 		return (0);
 	}
 
-	ASSERT(remap_deadlist_obj != 0);
-	return (remap_deadlist_obj);
+	ASSERT(*objectp != 0);
+	return (0);
 }
 
 boolean_t
 dsl_dataset_remap_deadlist_exists(dsl_dataset_t *ds)
 {
-	EQUIV(dsl_deadlist_is_open(&ds->ds_remap_deadlist),
-	    dsl_dataset_get_remap_deadlist_object(ds) != 0);
-	return (dsl_deadlist_is_open(&ds->ds_remap_deadlist));
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	uint64_t object = 0;
+	boolean_t isopen = dsl_deadlist_is_open(&ds->ds_remap_deadlist);
+	int err = dsl_dataset_get_remap_deadlist_object(ds, &object);
+	if (err && SPA_EXITING(spa))
+		return (isopen);
+	VERIFY0(err);
+	EQUIV(isopen, object != 0);
+	return (isopen);
 }
 
-static void
+static int
 dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds, uint64_t obj,
     dmu_tx_t *tx)
 {
 	ASSERT(obj != 0);
 	dsl_dataset_zapify(ds, tx);
-	VERIFY0(zap_add(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
-	    DS_FIELD_REMAP_DEADLIST, sizeof (obj), 1, &obj, tx));
+	int err = zap_add(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
+	    DS_FIELD_REMAP_DEADLIST, sizeof (obj), 1, &obj, tx);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa))
+		VERIFY0(err);
+	return (err);
 }
 
 static void
 dsl_dataset_unset_remap_deadlist_object(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
-	VERIFY0(zap_remove(ds->ds_dir->dd_pool->dp_meta_objset,
-	    ds->ds_object, DS_FIELD_REMAP_DEADLIST, tx));
+	int err = zap_remove(ds->ds_dir->dd_pool->dp_meta_objset,
+	    ds->ds_object, DS_FIELD_REMAP_DEADLIST, tx);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa))
+		VERIFY0(err);
 }
 
 void
@@ -5266,11 +5393,12 @@ dsl_dataset_destroy_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 }
 
-void
+int
 dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t remap_deadlist_obj;
 	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(MUTEX_HELD(&ds->ds_remap_deadlist_lock));
@@ -5280,14 +5408,27 @@ dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 */
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_DEVICE_REMOVAL));
 
-	VERIFY0(dsl_deadlist_clone(
+	err = dsl_deadlist_clone(
 	    &ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj));
-	dsl_dataset_set_remap_deadlist_object(ds,
-	    remap_deadlist_obj, tx);
-	VERIFY0(dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),
-	    remap_deadlist_obj));
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_dataset_set_remap_deadlist_object(ds, remap_deadlist_obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),
+	    remap_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
 	spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
+
+	return (err);
 }
 
 void

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -235,8 +235,8 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 		DVA_SET_VDEV(dva, vdev);
 		DVA_SET_OFFSET(dva, offset);
 		DVA_SET_ASIZE(dva, size);
-		dsl_deadlist_insert(&ds->ds_remap_deadlist, &fakebp, B_FALSE,
-		    tx);
+		(void) dsl_deadlist_insert(&ds->ds_remap_deadlist, &fakebp,
+		    B_FALSE, tx);
 	}
 }
 
@@ -331,7 +331,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			 */
 			bplist_append(&ds->ds_pending_deadlist, bp);
 		} else {
-			dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx);
+			VERIFY0(dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx));
 		}
 		ASSERT3U(ds->ds_prev->ds_object, ==,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj);
@@ -1177,15 +1177,16 @@ dsl_dataset_deactivate_feature(dsl_dataset_t *ds, spa_feature_t f, dmu_tx_t *tx)
 	dsl_dataset_deactivate_feature_impl(ds, f, tx);
 }
 
-uint64_t
+int
 dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
-    dsl_crypto_params_t *dcp, uint64_t flags, dmu_tx_t *tx)
+    dsl_crypto_params_t *dcp, uint64_t flags, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dd->dd_pool->dp_spa;
 	dsl_pool_t *dp = dd->dd_pool;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
 	dsl_dataset_phys_t *dsphys;
-	uint64_t dsobj;
 	objset_t *mos = dp->dp_meta_objset;
+	int err = 0;
 
 	if (origin == NULL)
 		origin = dp->dp_origin_snap;
@@ -1195,10 +1196,20 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
-	dsobj = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
-	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
-	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
+	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dmu_bonus_hold(mos, *objectp, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 	dsphys = dbuf->db_data;
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = dd->dd_object;
@@ -1206,14 +1217,19 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	dsphys->ds_fsid_guid = unique_create();
 	(void) random_get_pseudo_bytes((void*)&dsphys->ds_guid,
 	    sizeof (dsphys->ds_guid));
-	dsphys->ds_snapnames_zapobj =
-	    zap_create_norm(mos, U8_TEXTPREP_TOUPPER, DMU_OT_DSL_DS_SNAP_MAP,
-	    DMU_OT_NONE, 0, tx);
+	err = zap_create_norm(mos, U8_TEXTPREP_TOUPPER, DMU_OT_DSL_DS_SNAP_MAP,
+	    DMU_OT_NONE, 0, tx, &dsphys->ds_snapnames_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsphys->ds_creation_time = gethrestime_sec();
 	dsphys->ds_creation_txg = tx->tx_txg == TXG_INITIAL ? 1 : tx->tx_txg;
 
 	if (origin == NULL) {
-		dsphys->ds_deadlist_obj = dsl_deadlist_alloc(mos, tx);
+		err = dsl_deadlist_alloc(mos, tx, &dsphys->ds_deadlist_obj);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	} else {
 		dsl_dataset_t *ohds; /* head of the origin snapshot */
 
@@ -1239,49 +1255,83 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 
 		for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 			if (zfeature_active(f, origin->ds_feature[f])) {
-				dsl_dataset_activate_feature(dsobj, f,
+				dsl_dataset_activate_feature(*objectp, f,
 				    origin->ds_feature[f], tx);
 			}
 		}
 
 		dmu_buf_will_dirty(origin->ds_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dataset_phys(origin)->ds_num_children++;
 
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dir_phys(origin->ds_dir)->dd_head_dataset_obj,
-		    FTAG, &ohds));
-		dsphys->ds_deadlist_obj = dsl_deadlist_clone(&ohds->ds_deadlist,
-		    dsphys->ds_prev_snap_txg, dsphys->ds_prev_snap_obj, tx);
+		    FTAG, &ohds);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+		err = dsl_deadlist_clone(&ohds->ds_deadlist,
+		    dsphys->ds_prev_snap_txg, dsphys->ds_prev_snap_obj, tx,
+		    &dsphys->ds_deadlist_obj);
+		if (err && SPA_EXITING(spa)) {
+			dsl_dataset_rele(ohds, FTAG);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 		dsl_dataset_rele(ohds, FTAG);
 
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_NEXT_CLONES) {
 			if (dsl_dataset_phys(origin)->ds_next_clones_obj == 0) {
-				dsl_dataset_phys(origin)->ds_next_clones_obj =
-				    zap_create(mos,
-				    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx);
+				err = zap_create(mos,
+				    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
+				    &dsl_dataset_phys(origin)->
+				    ds_next_clones_obj);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 			}
-			VERIFY0(zap_add_int(mos,
+			err = zap_add_int(mos,
 			    dsl_dataset_phys(origin)->ds_next_clones_obj,
-			    dsobj, tx));
+			    *objectp, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			err = SET_ERROR(EIO);
+			goto spa_exiting;
+		}
 		dsl_dir_phys(dd)->dd_origin_obj = origin->ds_object;
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_DIR_CLONES) {
 			if (dsl_dir_phys(origin->ds_dir)->dd_clones == 0) {
 				dmu_buf_will_dirty(origin->ds_dir->dd_dbuf, tx);
-				dsl_dir_phys(origin->ds_dir)->dd_clones =
-				    zap_create(mos,
-				    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx);
+				if (SPA_EXITING(spa)) {
+					err = SET_ERROR(EIO);
+					goto spa_exiting;
+				}
+				err = zap_create(mos,
+				    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx,
+				    &dsl_dir_phys(origin->ds_dir)->dd_clones);
+				if (err && SPA_EXITING(spa))
+					goto spa_exiting;
+				VERIFY0(err);
 			}
-			VERIFY0(zap_add_int(mos,
+			err = zap_add_int(mos,
 			    dsl_dir_phys(origin->ds_dir)->dd_clones,
-			    dsobj, tx));
+			    *objectp, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 	}
 
 	/* handle encryption */
-	dsl_dataset_create_crypt_sync(dsobj, dd, origin, dcp, tx);
+	dsl_dataset_create_crypt_sync(*objectp, dd, origin, dcp, tx);
 
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_UNIQUE_ACCURATE)
 		dsphys->ds_flags |= DS_FLAG_UNIQUE_ACCURATE;
@@ -1289,9 +1339,18 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	dmu_buf_rele(dbuf, FTAG);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
-	dsl_dir_phys(dd)->dd_head_dataset_obj = dsobj;
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
+	dsl_dir_phys(dd)->dd_head_dataset_obj = *objectp;
 
-	return (dsobj);
+	return (err);
+
+spa_exiting:
+	if (dbuf != NULL)
+		dmu_buf_rele(dbuf, FTAG);
+	return (err || SET_ERROR(EIO));
 }
 
 static void
@@ -1315,14 +1374,16 @@ dsl_dataset_zero_zil(dsl_dataset_t *ds, dmu_tx_t *tx)
 	}
 }
 
-uint64_t
+int
 dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
     dsl_dataset_t *origin, uint64_t flags, cred_t *cr,
-    dsl_crypto_params_t *dcp, dmu_tx_t *tx)
+    dsl_crypto_params_t *dcp, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = pdd->dd_pool->dp_spa;
 	dsl_pool_t *dp = pdd->dd_pool;
-	uint64_t dsobj, ddobj;
-	dsl_dir_t *dd;
+	uint64_t ddobj;
+	dsl_dir_t *dd = NULL;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(lastname[0] != '@');
@@ -1335,11 +1396,21 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	if (origin != NULL)
 		ASSERT3P(origin, !=, dp->dp_origin_snap);
 
-	ddobj = dsl_dir_create_sync(dp, pdd, lastname, tx);
-	VERIFY0(dsl_dir_hold_obj(dp, ddobj, lastname, FTAG, &dd));
+	err = dsl_dir_create_sync(dp, pdd, lastname, tx, &ddobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	dsobj = dsl_dataset_create_sync_dd(dd, origin, dcp,
-	    flags & ~DS_CREATE_FLAG_NODIRTY, tx);
+	err = dsl_dir_hold_obj(dp, ddobj, lastname, FTAG, &dd);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_create_sync_dd(dd, origin, dcp,
+	    flags & ~DS_CREATE_FLAG_NODIRTY, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dsl_deleg_set_create_perms(dd, tx, cr);
 
@@ -1351,9 +1422,16 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	    spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_LIVELIST)) {
 		objset_t *mos = dd->dd_pool->dp_meta_objset;
 		dsl_dir_zapify(dd, tx);
-		uint64_t obj = dsl_deadlist_alloc(mos, tx);
-		VERIFY0(zap_add(mos, dd->dd_object, DD_FIELD_LIVELIST,
-		    sizeof (uint64_t), 1, &obj, tx));
+		uint64_t obj;
+		err = dsl_deadlist_alloc(mos, tx, &obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(mos, dd->dd_object, DD_FIELD_LIVELIST,
+		    sizeof (uint64_t), 1, &obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_LIVELIST, tx);
 	}
 
@@ -1366,13 +1444,20 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 		objset_t *os = dd->dd_pool->dp_meta_objset;
 
 		dsl_dir_zapify(dd, tx);
-		VERIFY0(zap_add(os, dd->dd_object, DD_FIELD_FILESYSTEM_COUNT,
-		    sizeof (cnt), 1, &cnt, tx));
-		VERIFY0(zap_add(os, dd->dd_object, DD_FIELD_SNAPSHOT_COUNT,
-		    sizeof (cnt), 1, &cnt, tx));
+		err = zap_add(os, dd->dd_object, DD_FIELD_FILESYSTEM_COUNT,
+		    sizeof (cnt), 1, &cnt, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(os, dd->dd_object, DD_FIELD_SNAPSHOT_COUNT,
+		    sizeof (cnt), 1, &cnt, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	dsl_dir_rele(dd, FTAG);
+	dd = NULL;
 
 	/*
 	 * If we are creating a clone, make sure we zero out any stale
@@ -1381,12 +1466,18 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	if (origin != NULL && !(flags & DS_CREATE_FLAG_NODIRTY)) {
 		dsl_dataset_t *ds;
 
-		VERIFY0(dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+		err = dsl_dataset_hold_obj(dp, *objectp, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		dsl_dataset_zero_zil(ds, tx);
 		dsl_dataset_rele(ds, FTAG);
 	}
 
-	return (dsobj);
+out:
+	if (dd)
+		dsl_dir_rele(dd, FTAG);
+	return (err);
 }
 
 /*
@@ -1725,16 +1816,18 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 	return (rv);
 }
 
-void
+int
 dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
     uint64_t crtime, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
 	dsl_dataset_phys_t *dsphys;
 	uint64_t dsobj, crtxg;
 	objset_t *mos = dp->dp_meta_objset;
 	objset_t *os __maybe_unused;
+	int err = 0;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -1761,10 +1854,20 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	else
 		crtxg = tx->tx_txg;
 
-	dsobj = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
-	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
-	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
+	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx, &dsobj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dmu_bonus_hold(mos, dsobj, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 	dsphys = dbuf->db_data;
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = ds->ds_dir->dd_object;
@@ -1787,6 +1890,7 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	dsphys->ds_bp = dsl_dataset_phys(ds)->ds_bp;
 	rrw_exit(&ds->ds_bp_rwlock, FTAG);
 	dmu_buf_rele(dbuf, FTAG);
+	dbuf = NULL;
 
 	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (zfeature_active(f, ds->ds_feature[f])) {
@@ -1812,8 +1916,10 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		} else if (next_clones_obj != 0) {
 			dsl_dataset_remove_from_next_clones(ds->ds_prev,
 			    dsphys->ds_next_snap_obj, tx);
-			VERIFY0(zap_add_int(mos,
-			    next_clones_obj, dsobj, tx));
+			err = zap_add_int(mos, next_clones_obj, dsobj, tx);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		}
 	}
 
@@ -1832,12 +1938,23 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	}
 
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
-	dsl_dataset_phys(ds)->ds_deadlist_obj =
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
+	err =
 	    dsl_deadlist_clone(&ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx);
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx,
+	    &dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_deadlist_close(&ds->ds_deadlist);
-	VERIFY0(dsl_deadlist_open(&ds->ds_deadlist, mos,
-	    dsl_dataset_phys(ds)->ds_deadlist_obj));
+	err = dsl_deadlist_open(&ds->ds_deadlist, mos,
+	    dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_deadlist_add_key(&ds->ds_deadlist,
 	    dsl_dataset_phys(ds)->ds_prev_snap_txg, tx);
 	dsl_bookmark_snapshotted(ds, tx);
@@ -1854,8 +1971,11 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		dsl_deadlist_close(&ds->ds_remap_deadlist);
 
 		dmu_object_zapify(mos, dsobj, DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_REMAP_DEADLIST,
-		    sizeof (remap_deadlist_obj), 1, &remap_deadlist_obj, tx));
+		err = zap_add(mos, dsobj, DS_FIELD_REMAP_DEADLIST,
+		    sizeof (remap_deadlist_obj), 1, &remap_deadlist_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	/*
@@ -1878,8 +1998,11 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		uint64_t ivset_guid = unique_create();
 
 		dmu_object_zapify(mos, dsobj, DMU_OT_DSL_DATASET, tx);
-		VERIFY0(zap_add(mos, dsobj, DS_FIELD_IVSET_GUID,
-		    sizeof (ivset_guid), 1, &ivset_guid, tx));
+		err = zap_add(mos, dsobj, DS_FIELD_IVSET_GUID,
+		    sizeof (ivset_guid), 1, &ivset_guid, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	ASSERT3U(dsl_dataset_phys(ds)->ds_prev_snap_txg, <, tx->tx_txg);
@@ -1890,13 +2013,19 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_UNIQUE_ACCURATE)
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_UNIQUE_ACCURATE;
 
-	VERIFY0(zap_add(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj,
-	    snapname, 8, 1, &dsobj, tx));
+	err = zap_add(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj,
+	    snapname, 8, 1, &dsobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	if (ds->ds_prev)
 		dsl_dataset_rele(ds->ds_prev, ds);
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	dsl_scan_ds_snapshotted(ds, tx);
 
@@ -1904,14 +2033,23 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 
 	if (zfs_snapshot_history_enabled)
 		spa_history_log_internal_ds(ds->ds_prev, "snapshot", tx, " ");
+
+	return (0);
+
+spa_exiting:
+	if (dbuf != NULL)
+		dmu_buf_rele(dbuf, FTAG);
+	return (err);
 }
 
 void
 dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 {
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_dataset_snapshot_arg_t *ddsa = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	nvpair_t *pair;
+	int err = 0;
 
 	/*
 	 * All snapshots created by one request are taken atomically in a
@@ -1930,13 +2068,23 @@ dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 		name = nvpair_name(pair);
 		atp = strchr(name, '@');
 		(void) strlcpy(dsname, name, atp - name + 1);
-		VERIFY0(dsl_dataset_hold(dp, dsname, FTAG, &ds));
+		err = dsl_dataset_hold(dp, dsname, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
-		dsl_dataset_snapshot_sync_impl(ds, atp + 1, crtime, tx);
+		err = dsl_dataset_snapshot_sync_impl(ds, atp + 1, crtime, tx);
+		if (err && SPA_EXITING(spa)) {
+			dsl_dataset_rele(ds, FTAG);
+			break;
+		}
+		VERIFY0(err);
+
 		if (ddsa->ddsa_props != NULL) {
 			dsl_props_set_sync_impl(ds->ds_prev,
 			    ZPROP_SRC_LOCAL, ddsa->ddsa_props, tx);
 		}
+
 		dsl_dataset_rele(ds, FTAG);
 	}
 }
@@ -2071,18 +2219,28 @@ dsl_dataset_snapshot_tmp_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_dataset_snapshot_tmp_sync(void *arg, dmu_tx_t *tx)
 {
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_dataset_snapshot_tmp_arg_t *ddsta = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds = NULL;
+	int err = 0;
 
-	VERIFY0(dsl_dataset_hold(dp, ddsta->ddsta_fsname, FTAG, &ds));
+	err = dsl_dataset_hold(dp, ddsta->ddsta_fsname, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
-	dsl_dataset_snapshot_sync_impl(ds, ddsta->ddsta_snapname,
+	err = dsl_dataset_snapshot_sync_impl(ds, ddsta->ddsta_snapname,
 	    gethrestime_sec(), tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
 	dsl_dataset_user_hold_sync_one(ds->ds_prev, ddsta->ddsta_htag,
 	    ddsta->ddsta_cleanup_minor, gethrestime_sec(), tx);
 	dsl_destroy_snapshot_sync_impl(ds->ds_prev, B_TRUE, tx);
 
+out:
 	dsl_dataset_rele(ds, FTAG);
 }
 
@@ -3287,21 +3445,33 @@ dsl_dataset_rollback_check(void *arg, dmu_tx_t *tx)
 void
 dsl_dataset_rollback_sync(void *arg, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	dsl_dataset_rollback_arg_t *ddra = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds, *clone;
 	uint64_t cloneobj;
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 
-	VERIFY0(dsl_dataset_hold(dp, ddra->ddra_fsname, FTAG, &ds));
+	err = dsl_dataset_hold(dp, ddra->ddra_fsname, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	dsl_dataset_name(ds->ds_prev, namebuf);
 	fnvlist_add_string(ddra->ddra_result, "target", namebuf);
 
-	cloneobj = dsl_dataset_create_sync(ds->ds_dir, "%rollback",
-	    ds->ds_prev, DS_CREATE_FLAG_NODIRTY, kcred, NULL, tx);
+	err = dsl_dataset_create_sync(ds->ds_dir, "%rollback",
+	    ds->ds_prev, DS_CREATE_FLAG_NODIRTY, kcred, NULL, tx, &cloneobj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj(dp, cloneobj, FTAG, &clone));
+	err = dsl_dataset_hold_obj(dp, cloneobj, FTAG, &clone);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	dsl_dataset_clone_swap_sync_impl(clone, ds, tx);
 	dsl_dataset_zero_zil(ds, tx);
@@ -3394,27 +3564,48 @@ dsl_dataset_clone_check(void *arg, dmu_tx_t *tx)
 void
 dsl_dataset_clone_sync(void *arg, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	dsl_dataset_clone_arg_t *ddca = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
-	dsl_dir_t *pdd;
+	dsl_dir_t *pdd = NULL;
 	const char *tail;
-	dsl_dataset_t *origin, *ds;
+	dsl_dataset_t *origin = NULL, *ds = NULL;
 	uint64_t obj;
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 
-	VERIFY0(dsl_dir_hold(dp, ddca->ddca_clone, FTAG, &pdd, &tail));
-	VERIFY0(dsl_dataset_hold(dp, ddca->ddca_origin, FTAG, &origin));
+	err = dsl_dir_hold(dp, ddca->ddca_clone, FTAG, &pdd, &tail);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	obj = dsl_dataset_create_sync(pdd, tail, origin, 0,
-	    ddca->ddca_cred, NULL, tx);
+	err = dsl_dataset_hold(dp, ddca->ddca_origin, FTAG, &origin);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	VERIFY0(dsl_dataset_hold_obj(pdd->dd_pool, obj, FTAG, &ds));
+	err = dsl_dataset_create_sync(pdd, tail, origin, 0,
+	    ddca->ddca_cred, NULL, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(pdd->dd_pool, obj, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dsl_dataset_name(origin, namebuf);
 	spa_history_log_internal_ds(ds, "clone", tx,
 	    "origin=%s (%llu)", namebuf, (u_longlong_t)origin->ds_object);
-	dsl_dataset_rele(ds, FTAG);
-	dsl_dataset_rele(origin, FTAG);
-	dsl_dir_rele(pdd, FTAG);
+
+out:
+	if (ds)
+		dsl_dataset_rele(ds, FTAG);
+	if (origin)
+		dsl_dataset_rele(origin, FTAG);
+	if (pdd)
+		dsl_dir_rele(pdd, FTAG);
 }
 
 int
@@ -3751,9 +3942,9 @@ dsl_dataset_promote_sync(void *arg, dmu_tx_t *tx)
 		    dsl_dir_phys(ddpa->origin_origin->ds_dir)->dd_clones,
 		    origin_head->ds_object, tx));
 		if (dsl_dir_phys(dd)->dd_clones == 0) {
-			dsl_dir_phys(dd)->dd_clones =
-			    zap_create(dp->dp_meta_objset, DMU_OT_DSL_CLONES,
-			    DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(dp->dp_meta_objset,
+			    DMU_OT_DSL_CLONES, DMU_OT_NONE, 0, tx,
+			    &dsl_dir_phys(dd)->dd_clones));
 		}
 		VERIFY0(zap_add_int(dp->dp_meta_objset,
 		    dsl_dir_phys(dd)->dd_clones, origin_head->ds_object, tx));
@@ -5093,9 +5284,9 @@ dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 */
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_DEVICE_REMOVAL));
 
-	remap_deadlist_obj = dsl_deadlist_clone(
+	VERIFY0(dsl_deadlist_clone(
 	    &ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx);
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj));
 	dsl_dataset_set_remap_deadlist_object(ds,
 	    remap_deadlist_obj, tx);
 	VERIFY0(dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -92,7 +92,7 @@ int zfs_snapshot_history_enabled = 1;
 
 #define	DS_REF_MAX	(1ULL << 62)
 
-static void dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds,
+static int dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds,
     uint64_t obj, dmu_tx_t *tx);
 static void dsl_dataset_unset_remap_deadlist_object(dsl_dataset_t *ds,
     dmu_tx_t *tx);
@@ -211,6 +211,7 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
     uint64_t size, uint64_t birth, dmu_tx_t *tx)
 {
 	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(birth <= tx->tx_txg);
@@ -226,7 +227,12 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 
 		mutex_enter(&ds->ds_remap_deadlist_lock);
 		if (!dsl_dataset_remap_deadlist_exists(ds)) {
-			dsl_dataset_create_remap_deadlist(ds, tx);
+			err = dsl_dataset_create_remap_deadlist(ds, tx);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&ds->ds_remap_deadlist_lock);
+				return;
+			}
+			VERIFY0(err);
 		}
 		mutex_exit(&ds->ds_remap_deadlist_lock);
 
@@ -245,7 +251,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
     boolean_t async)
 {
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
-
+	int err;
 	int used = bp_get_dsize_sync(spa, bp);
 	int compressed = BP_GET_PSIZE(bp);
 	int uncompressed = BP_GET_UCSIZE(bp);
@@ -331,7 +337,11 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			 */
 			bplist_append(&ds->ds_pending_deadlist, bp);
 		} else {
-			VERIFY0(dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE, tx));
+			err = dsl_deadlist_insert(&ds->ds_deadlist, bp, B_FALSE,
+			    tx);
+			if (err && SPA_EXITING(spa))
+				return (0);
+			VERIFY0(err);
 		}
 		ASSERT3U(ds->ds_prev->ds_object, ==,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj);
@@ -391,6 +401,7 @@ unload_zfeature(dsl_dataset_t *ds, spa_feature_t f)
 static int
 load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 {
+	spa_t *spa = mos->os_spa;
 	int err = 0;
 	switch (spa_feature_table[f].fi_type) {
 	case ZFEATURE_TYPE_BOOLEAN:
@@ -399,6 +410,8 @@ load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 		if (err == 0) {
 			ds->ds_feature[f] = (void *)B_TRUE;
 		} else {
+			if (err != ENOENT && SPA_EXITING(spa))
+				break;
 			ASSERT3U(err, ==, ENOENT);
 			err = 0;
 		}
@@ -410,14 +423,21 @@ load_zfeature(objset_t *mos, dsl_dataset_t *ds, spa_feature_t f)
 		err = zap_length(mos, ds->ds_object,
 		    spa_feature_table[f].fi_guid, &int_size, &num_int);
 		if (err != 0) {
+			if (err != ENOENT && SPA_EXITING(spa))
+				break;
 			ASSERT3U(err, ==, ENOENT);
 			err = 0;
 			break;
 		}
 		ASSERT3U(int_size, ==, sizeof (uint64_t));
 		data = kmem_alloc(int_size * num_int, KM_SLEEP);
-		VERIFY0(zap_lookup(mos, ds->ds_object,
-		    spa_feature_table[f].fi_guid, int_size, num_int, data));
+		err = zap_lookup(mos, ds->ds_object,
+		    spa_feature_table[f].fi_guid, int_size, num_int, data);
+		if (err && SPA_EXITING(spa)) {
+			kmem_free(data, int_size * num_int);
+			break;
+		}
+		VERIFY0(err);
 		struct feature_type_uint64_array_arg *ftuaa =
 		    kmem_alloc(sizeof (*ftuaa), KM_SLEEP);
 		ftuaa->length = num_int;
@@ -700,9 +720,12 @@ dsl_dataset_hold_obj(dsl_pool_t *dp, uint64_t dsobj, const void *tag,
 			    mos, dsl_dataset_phys(ds)->ds_deadlist_obj);
 		}
 		if (err == 0) {
-			uint64_t remap_deadlist_obj =
-			    dsl_dataset_get_remap_deadlist_object(ds);
-			if (remap_deadlist_obj != 0) {
+			uint64_t remap_deadlist_obj;
+			err = dsl_dataset_get_remap_deadlist_object(ds,
+			    &remap_deadlist_obj);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
+			if (!err && remap_deadlist_obj != 0) {
 				err = dsl_deadlist_open(&ds->ds_remap_deadlist,
 				    mos, remap_deadlist_obj);
 			}
@@ -1131,6 +1154,7 @@ dsl_dataset_activate_feature(uint64_t dsobj, spa_feature_t f, void *arg,
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = dmu_tx_pool(tx)->dp_meta_objset;
 	uint64_t zero = 0;
+	int err;
 
 	VERIFY(spa_feature_table[f].fi_flags & ZFEATURE_FLAG_PER_DATASET);
 
@@ -1140,14 +1164,18 @@ dsl_dataset_activate_feature(uint64_t dsobj, spa_feature_t f, void *arg,
 	switch (spa_feature_table[f].fi_type) {
 	case ZFEATURE_TYPE_BOOLEAN:
 		ASSERT3S((boolean_t)(uintptr_t)arg, ==, B_TRUE);
-		VERIFY0(zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
-		    sizeof (zero), 1, &zero, tx));
+		err = zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
+		    sizeof (zero), 1, &zero, tx);
+		if (!spa_exiting(spa))
+			VERIFY0(err);
 		break;
 	case ZFEATURE_TYPE_UINT64_ARRAY:
 	{
 		struct feature_type_uint64_array_arg *ftuaa = arg;
-		VERIFY0(zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
-		    sizeof (uint64_t), ftuaa->length, ftuaa->array, tx));
+		err = zap_add(mos, dsobj, spa_feature_table[f].fi_guid,
+		    sizeof (uint64_t), ftuaa->length, ftuaa->array, tx);
+		if (!spa_exiting(spa))
+			VERIFY0(err);
 		break;
 	}
 	default:
@@ -1162,10 +1190,13 @@ dsl_dataset_deactivate_feature_impl(dsl_dataset_t *ds, spa_feature_t f,
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = dmu_tx_pool(tx)->dp_meta_objset;
 	uint64_t dsobj = ds->ds_object;
+	int err;
 
 	VERIFY(spa_feature_table[f].fi_flags & ZFEATURE_FLAG_PER_DATASET);
 
-	VERIFY0(zap_remove(mos, dsobj, spa_feature_table[f].fi_guid, tx));
+	err = zap_remove(mos, dsobj, spa_feature_table[f].fi_guid, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	spa_feature_decr(spa, f, tx);
 	ds->ds_feature[f] = NULL;
 }
@@ -1353,25 +1384,33 @@ spa_exiting:
 	return (err || SET_ERROR(EIO));
 }
 
-static void
+static int
 dsl_dataset_zero_zil(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *os;
+	int err = 0;
 
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (memcmp(&os->os_zil_header, &zero_zil, sizeof (zero_zil)) != 0) {
-		dsl_pool_t *dp = ds->ds_dir->dd_pool;
 		zio_t *zio;
 
 		memset(&os->os_zil_header, 0, sizeof (os->os_zil_header));
 		if (os->os_encrypted)
 			os->os_next_write_raw[tx->tx_txg & TXG_MASK] = B_TRUE;
 
-		zio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
+		zio = zio_root(spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
 		dsl_dataset_sync(ds, zio, tx);
-		VERIFY0(zio_wait(zio));
+		err = zio_wait(zio);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_sync_done(ds, tx);
 	}
+
+	return (err);
 }
 
 int
@@ -1470,7 +1509,9 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 		if (err && SPA_EXITING(spa))
 			goto out;
 		VERIFY0(err);
-		dsl_dataset_zero_zil(ds, tx);
+		err = dsl_dataset_zero_zil(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_rele(ds, FTAG);
 	}
 
@@ -1503,9 +1544,12 @@ dsl_dataset_recalc_head_uniq(dsl_dataset_t *ds)
 
 	dsl_deadlist_space(&ds->ds_deadlist, &dlused, &dlcomp, &dluncomp);
 
-	ASSERT3U(dlused, <=, mrs_used);
-	dsl_dataset_phys(ds)->ds_unique_bytes =
-	    dsl_dataset_phys(ds)->ds_referenced_bytes - (mrs_used - dlused);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa)) {
+		ASSERT3U(dlused, <=, mrs_used);
+		dsl_dataset_phys(ds)->ds_unique_bytes =
+		    dsl_dataset_phys(ds)->ds_referenced_bytes -
+		    (mrs_used - dlused);
+	}
 
 	if (spa_version(ds->ds_dir->dd_pool->dp_spa) >=
 	    SPA_VERSION_UNIQUE_ACCURATE)
@@ -1516,6 +1560,7 @@ void
 dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *mos = ds->ds_dir->dd_pool->dp_meta_objset;
 	uint64_t count __maybe_unused;
 	int err;
@@ -1533,10 +1578,16 @@ dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,
 	 * too many entries in the next_clones_obj even after failing to
 	 * remove this one.
 	 */
+	if (!(err == ENOENT || err == 0) && SPA_EXITING(spa))
+		return;
 	if (err != ENOENT)
 		VERIFY0(err);
-	ASSERT0(zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
-	    &count));
+
+	err = zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
+	    &count);
+	if (err && SPA_EXITING(spa))
+		return;
+	ASSERT0(err);
 	ASSERT3U(count, <=, dsl_dataset_phys(ds)->ds_num_children - 2);
 }
 
@@ -1960,8 +2011,12 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	dsl_bookmark_snapshotted(ds, tx);
 
 	if (dsl_dataset_remap_deadlist_exists(ds)) {
-		uint64_t remap_deadlist_obj =
-		    dsl_dataset_get_remap_deadlist_object(ds);
+		uint64_t remap_deadlist_obj;
+		err = dsl_dataset_get_remap_deadlist_object(ds,
+		    &remap_deadlist_obj);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		/*
 		 * Move the remap_deadlist to the snapshot.  The head
 		 * will create a new remap deadlist on demand, from
@@ -2019,8 +2074,10 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 		goto spa_exiting;
 	VERIFY0(err);
 
-	if (ds->ds_prev)
+	if (ds->ds_prev) {
 		dsl_dataset_rele(ds->ds_prev, ds);
+		ds->ds_prev = NULL;
+	}
 	err = dsl_dataset_hold_obj(dp,
 	    dsl_dataset_phys(ds)->ds_prev_snap_obj, ds, &ds->ds_prev);
 	if (err && SPA_EXITING(spa))
@@ -2283,6 +2340,9 @@ dsl_dataset_snapshot_tmp(const char *fsname, const char *snapname,
 void
 dsl_dataset_sync(dsl_dataset_t *ds, zio_t *rio, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_objset->os_spa;
+	int err;
+
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(ds->ds_objset != NULL);
 	ASSERT0(dsl_dataset_phys(ds)->ds_next_snap_obj);
@@ -2292,18 +2352,25 @@ dsl_dataset_sync(dsl_dataset_t *ds, zio_t *rio, dmu_tx_t *tx)
 	 * sync it out now.
 	 */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
-	dsl_dataset_phys(ds)->ds_fsid_guid = ds->ds_fsid_guid;
+	if (!SPA_EXITING(spa))
+		dsl_dataset_phys(ds)->ds_fsid_guid = ds->ds_fsid_guid;
 
 	if (ds->ds_resume_bytes[tx->tx_txg & TXG_MASK] != 0) {
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_OBJECT, 8, 1,
-		    &ds->ds_resume_object[tx->tx_txg & TXG_MASK], tx));
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		    &ds->ds_resume_object[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_OFFSET, 8, 1,
-		    &ds->ds_resume_offset[tx->tx_txg & TXG_MASK], tx));
-		VERIFY0(zap_update(tx->tx_pool->dp_meta_objset,
+		    &ds->ds_resume_offset[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_update(tx->tx_pool->dp_meta_objset,
 		    ds->ds_object, DS_FIELD_RESUME_BYTES, 8, 1,
-		    &ds->ds_resume_bytes[tx->tx_txg & TXG_MASK], tx));
+		    &ds->ds_resume_bytes[tx->tx_txg & TXG_MASK], tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		ds->ds_resume_object[tx->tx_txg & TXG_MASK] = 0;
 		ds->ds_resume_offset[tx->tx_txg & TXG_MASK] = 0;
 		ds->ds_resume_bytes[tx->tx_txg & TXG_MASK] = 0;
@@ -3474,7 +3541,9 @@ dsl_dataset_rollback_sync(void *arg, dmu_tx_t *tx)
 	VERIFY0(err);
 
 	dsl_dataset_clone_swap_sync_impl(clone, ds, tx);
-	dsl_dataset_zero_zil(ds, tx);
+	err = dsl_dataset_zero_zil(ds, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	dsl_destroy_head_sync_impl(clone, tx);
 
@@ -4350,17 +4419,27 @@ dsl_dataset_clone_swap_check_impl(dsl_dataset_t *clone,
 	return (0);
 }
 
-static void
+static int
 dsl_dataset_swap_remap_deadlists(dsl_dataset_t *clone,
     dsl_dataset_t *origin, dmu_tx_t *tx)
 {
 	uint64_t clone_remap_dl_obj, origin_remap_dl_obj;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(dp));
 
-	clone_remap_dl_obj = dsl_dataset_get_remap_deadlist_object(clone);
-	origin_remap_dl_obj = dsl_dataset_get_remap_deadlist_object(origin);
+	err = dsl_dataset_get_remap_deadlist_object(clone, &clone_remap_dl_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_dataset_get_remap_deadlist_object(origin,
+	    &origin_remap_dl_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (clone_remap_dl_obj != 0) {
 		dsl_deadlist_close(&clone->ds_remap_deadlist);
@@ -4372,17 +4451,31 @@ dsl_dataset_swap_remap_deadlists(dsl_dataset_t *clone,
 	}
 
 	if (clone_remap_dl_obj != 0) {
-		dsl_dataset_set_remap_deadlist_object(origin,
+		err = dsl_dataset_set_remap_deadlist_object(origin,
 		    clone_remap_dl_obj, tx);
-		VERIFY0(dsl_deadlist_open(&origin->ds_remap_deadlist,
-		    dp->dp_meta_objset, clone_remap_dl_obj));
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = dsl_deadlist_open(&origin->ds_remap_deadlist,
+		    dp->dp_meta_objset, clone_remap_dl_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 	if (origin_remap_dl_obj != 0) {
-		dsl_dataset_set_remap_deadlist_object(clone,
+		err = dsl_dataset_set_remap_deadlist_object(clone,
 		    origin_remap_dl_obj, tx);
-		VERIFY0(dsl_deadlist_open(&clone->ds_remap_deadlist,
-		    dp->dp_meta_objset, origin_remap_dl_obj));
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = dsl_deadlist_open(&clone->ds_remap_deadlist,
+		    dp->dp_meta_objset, origin_remap_dl_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
+
+	return (err);
 }
 
 void
@@ -4556,7 +4649,7 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	    dsl_dataset_phys(clone)->ds_deadlist_obj));
 	VERIFY0(dsl_deadlist_open(&origin_head->ds_deadlist, dp->dp_meta_objset,
 	    dsl_dataset_phys(origin_head)->ds_deadlist_obj));
-	dsl_dataset_swap_remap_deadlists(clone, origin_head, tx);
+	VERIFY0(dsl_dataset_swap_remap_deadlists(clone, origin_head, tx));
 
 	/*
 	 * If there is a bookmark at the origin, its "next dataset" is
@@ -4804,21 +4897,29 @@ dsl_dataset_set_refreservation_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
-void
+int
 dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
     zprop_source_t source, uint64_t value, dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	uint64_t newval;
 	uint64_t unique;
 	int64_t delta;
+	int err = 0;
 
-	dsl_prop_set_sync_impl(ds, zfs_prop_to_name(ZFS_PROP_REFRESERVATION),
-	    source, sizeof (value), 1, &value, tx);
+	dsl_prop_set_sync_impl(ds,
+	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), source, sizeof (value),
+	    1, &value, tx);
 
-	VERIFY0(dsl_prop_get_int_ds(ds,
-	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), &newval));
+	err = dsl_prop_get_int_ds(ds,
+	    zfs_prop_to_name(ZFS_PROP_REFRESERVATION), &newval);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		return (SET_ERROR(EIO));
 	mutex_enter(&ds->ds_dir->dd_lock);
 	mutex_enter(&ds->ds_lock);
 	ASSERT(DS_UNIQUE_IS_ACCURATE(ds));
@@ -4830,6 +4931,8 @@ dsl_dataset_set_refreservation_sync_impl(dsl_dataset_t *ds,
 
 	dsl_dir_diduse_space(ds->ds_dir, DD_USED_REFRSRV, delta, 0, 0, tx);
 	mutex_exit(&ds->ds_dir->dd_lock);
+
+	return (err);
 }
 
 static void
@@ -4837,11 +4940,20 @@ dsl_dataset_set_refreservation_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_dataset_set_qr_arg_t *ddsqra = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	dsl_dataset_t *ds = NULL;
+	int err;
 
-	VERIFY0(dsl_dataset_hold(dp, ddsqra->ddsqra_name, FTAG, &ds));
-	dsl_dataset_set_refreservation_sync_impl(ds,
+	err = dsl_dataset_hold(dp, ddsqra->ddsqra_name, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
+	err = dsl_dataset_set_refreservation_sync_impl(ds,
 	    ddsqra->ddsqra_source, ddsqra->ddsqra_value, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
 	dsl_dataset_rele(ds, FTAG);
 }
 
@@ -5207,51 +5319,66 @@ dsl_dataset_has_resume_receive_state(dsl_dataset_t *ds)
 	    ds->ds_object, DS_FIELD_RESUME_TOGUID) == 0);
 }
 
-uint64_t
-dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds)
+int
+dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds, uint64_t *objectp)
 {
-	uint64_t remap_deadlist_obj;
-	int err;
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err = 0;
 
-	if (!dsl_dataset_is_zapified(ds))
+	if (!dsl_dataset_is_zapified(ds)) {
+		*objectp = 0;
 		return (0);
+	}
 
 	err = zap_lookup(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
-	    DS_FIELD_REMAP_DEADLIST, sizeof (remap_deadlist_obj), 1,
-	    &remap_deadlist_obj);
+	    DS_FIELD_REMAP_DEADLIST, sizeof (*objectp), 1, objectp);
 
 	if (err != 0) {
+		*objectp = 0;
+		if (!(err == ENOENT) && SPA_EXITING(spa))
+			return (SET_ERROR(EIO));
 		VERIFY3S(err, ==, ENOENT);
 		return (0);
 	}
 
-	ASSERT(remap_deadlist_obj != 0);
-	return (remap_deadlist_obj);
+	ASSERT(*objectp != 0);
+	return (0);
 }
 
 boolean_t
 dsl_dataset_remap_deadlist_exists(dsl_dataset_t *ds)
 {
-	EQUIV(dsl_deadlist_is_open(&ds->ds_remap_deadlist),
-	    dsl_dataset_get_remap_deadlist_object(ds) != 0);
-	return (dsl_deadlist_is_open(&ds->ds_remap_deadlist));
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	uint64_t object = 0;
+	boolean_t isopen = dsl_deadlist_is_open(&ds->ds_remap_deadlist);
+	int err = dsl_dataset_get_remap_deadlist_object(ds, &object);
+	if (err && SPA_EXITING(spa))
+		return (isopen);
+	VERIFY0(err);
+	EQUIV(isopen, object != 0);
+	return (isopen);
 }
 
-static void
+static int
 dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds, uint64_t obj,
     dmu_tx_t *tx)
 {
 	ASSERT(obj != 0);
 	dsl_dataset_zapify(ds, tx);
-	VERIFY0(zap_add(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
-	    DS_FIELD_REMAP_DEADLIST, sizeof (obj), 1, &obj, tx));
+	int err = zap_add(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
+	    DS_FIELD_REMAP_DEADLIST, sizeof (obj), 1, &obj, tx);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa))
+		VERIFY0(err);
+	return (err);
 }
 
 static void
 dsl_dataset_unset_remap_deadlist_object(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
-	VERIFY0(zap_remove(ds->ds_dir->dd_pool->dp_meta_objset,
-	    ds->ds_object, DS_FIELD_REMAP_DEADLIST, tx));
+	int err = zap_remove(ds->ds_dir->dd_pool->dp_meta_objset,
+	    ds->ds_object, DS_FIELD_REMAP_DEADLIST, tx);
+	if (!SPA_EXITING(ds->ds_dir->dd_pool->dp_spa))
+		VERIFY0(err);
 }
 
 void
@@ -5270,11 +5397,12 @@ dsl_dataset_destroy_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 }
 
-void
+int
 dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t remap_deadlist_obj;
 	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(MUTEX_HELD(&ds->ds_remap_deadlist_lock));
@@ -5284,14 +5412,27 @@ dsl_dataset_create_remap_deadlist(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 */
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_DEVICE_REMOVAL));
 
-	VERIFY0(dsl_deadlist_clone(
+	err = dsl_deadlist_clone(
 	    &ds->ds_deadlist, UINT64_MAX,
-	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj));
-	dsl_dataset_set_remap_deadlist_object(ds,
-	    remap_deadlist_obj, tx);
-	VERIFY0(dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),
-	    remap_deadlist_obj));
+	    dsl_dataset_phys(ds)->ds_prev_snap_obj, tx, &remap_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_dataset_set_remap_deadlist_object(ds, remap_deadlist_obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	err = dsl_deadlist_open(&ds->ds_remap_deadlist, spa_meta_objset(spa),
+	    remap_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
 	spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
+
+	return (err);
 }
 
 void

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -311,6 +311,9 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 			dsl_free(tx->tx_pool, tx->tx_txg, bp);
 		}
 
+		if (SPA_EXITING(spa))
+			return (0);
+
 		mutex_enter(&ds->ds_lock);
 		ASSERT(dsl_dataset_phys(ds)->ds_unique_bytes >= used ||
 		    !DS_UNIQUE_IS_ACCURATE(ds));

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -134,6 +134,7 @@ dsl_deadlist_cache_compare(const void *arg1, const void *arg2)
 static int
 dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	zap_cursor_t zc;
 	zap_attribute_t *za;
 	int error = 0;
@@ -181,20 +182,33 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 
 		avl_add(&dl->dl_tree, dle);
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_attribute_free(za);
 
+	error = 0;
 	for (dsl_deadlist_entry_t *dle = avl_first(&dl->dl_tree);
 	    dle != NULL; dle = AVL_NEXT(&dl->dl_tree, dle)) {
+		if (error) {
+			dle->dle_bpobj.bpo_object = 0;
+			continue;
+		}
 		error = bpobj_open(&dle->dle_bpobj, dl->dl_os,
 		    dle->dle_bpobj.bpo_object);
-		if (error)
-			return (error);
+		if (error && SPA_EXITING(dl->dl_os->os_spa)) {
+			/* align with bpobj_is_open() */
+			dle->dle_bpobj.bpo_object = 0;
+			continue;
+		}
+		VERIFY0(error);
 	}
-	dl->dl_havetree = B_TRUE;
+	if (error)
+		dsl_deadlist_discard_tree(dl);
+	else
+		dl->dl_havetree = B_TRUE;
 
-	return (0);
+	return (error);
 }
 
 /*
@@ -270,10 +284,13 @@ dsl_deadlist_load_cache(dsl_deadlist_t *dl)
 void
 dsl_deadlist_discard_tree(dsl_deadlist_t *dl)
 {
-	mutex_enter(&dl->dl_lock);
+	boolean_t locked_already = MUTEX_HELD(&dl->dl_lock);
+	if (!locked_already)
+		mutex_enter(&dl->dl_lock);
 
 	if (!dl->dl_havetree) {
-		mutex_exit(&dl->dl_lock);
+		if (!locked_already)
+			mutex_exit(&dl->dl_lock);
 		return;
 	}
 	dsl_deadlist_entry_t *dle;
@@ -285,7 +302,9 @@ dsl_deadlist_discard_tree(dsl_deadlist_t *dl)
 	avl_destroy(&dl->dl_tree);
 
 	dl->dl_havetree = B_FALSE;
-	mutex_exit(&dl->dl_lock);
+
+	if (!locked_already)
+		mutex_exit(&dl->dl_lock);
 }
 
 void
@@ -394,12 +413,16 @@ dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 void
 dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	dmu_object_info_t doi;
 	zap_cursor_t zc;
 	zap_attribute_t *za;
 	int error;
 
-	VERIFY0(dmu_object_info(os, dlobj, &doi));
+	error = dmu_object_info(os, dlobj, &doi);
+	if (error && SPA_EXITING(spa))
+		return;
+	VERIFY0(error);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		bpobj_free(os, dlobj, tx);
 		return;
@@ -415,10 +438,13 @@ dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 		else
 			bpobj_free(os, obj, tx);
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_attribute_free(za);
-	VERIFY0(dmu_object_free(os, dlobj, tx));
+	error = dmu_object_free(os, dlobj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(error);
 }
 
 static int
@@ -432,8 +458,11 @@ dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
 		uint64_t obj;
 		err = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
-		if (err && SPA_EXITING(dl->dl_os->os_spa))
+		if (err && SPA_EXITING(dl->dl_os->os_spa)) {
+			bpobj_close(&dle->dle_bpobj);
+			bpobj_decr_empty(dl->dl_os, tx);
 			return (err);
+		}
 		VERIFY0(err);
 
 		bpobj_close(&dle->dle_bpobj);
@@ -446,9 +475,8 @@ dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 
 		err = zap_update_int_key(dl->dl_os, dl->dl_object,
 		    dle->dle_mintxg, obj, tx);
-		if (err && SPA_EXITING(dl->dl_os->os_spa))
-			return (err);
-		VERIFY0(err);
+		if (!SPA_EXITING(dl->dl_os->os_spa))
+			VERIFY0(err);
 	}
 	bpobj_enqueue(&dle->dle_bpobj, bp, bp_freed, tx);
 
@@ -568,43 +596,69 @@ dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
  * Insert new key in deadlist, which must be > all current entries.
  * mintxg is not inclusive.
  */
-void
+int
 dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	uint64_t obj;
 	dsl_deadlist_entry_t *dle;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 
 	dle = kmem_alloc(sizeof (*dle), KM_SLEEP);
 	dle->dle_mintxg = mintxg;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
 
-	VERIFY0(bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj));
-	VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
 	avl_add(&dl->dl_tree, dle);
 
-	VERIFY0(zap_add_int_key(dl->dl_os, dl->dl_object,
-	    mintxg, obj, tx));
+	err = zap_add_int_key(dl->dl_os, dl->dl_object,
+	    mintxg, obj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 /*
  * Remove this key, merging its entries into the previous key.
  */
-void
+int
 dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle, *dle_prev;
+	spa_t *spa = dl->dl_os->os_spa;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
@@ -618,8 +672,13 @@ dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	bpobj_close(&dle->dle_bpobj);
 	kmem_free(dle, sizeof (*dle));
 
-	VERIFY0(zap_remove_int(dl->dl_os, dl->dl_object, mintxg, tx));
+	err = zap_remove_int(dl->dl_os, dl->dl_object, mintxg, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+out:
 	mutex_exit(&dl->dl_lock);
+	return (err);
 }
 
 /*
@@ -627,27 +686,39 @@ dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
  * the deadlist's avl tree, freeing the entry's bpobj and adjusting the
  * deadlist's space accounting accordingly.
  */
-void
+int
 dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
 	uint64_t used, comp, uncomp;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle;
 	objset_t *os = dl->dl_os;
+	spa_t *spa = os->os_spa;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
-
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa)) {
+		mutex_exit(&dl->dl_lock);
+		return (err);
+	}
+	VERIFY0(err);
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
 	VERIFY3P(dle, !=, NULL);
 
 	avl_remove(&dl->dl_tree, dle);
-	VERIFY0(zap_remove_int(os, dl->dl_object, mintxg, tx));
-	VERIFY0(bpobj_space(&dle->dle_bpobj, &used, &comp, &uncomp));
+	err = zap_remove_int(os, dl->dl_object, mintxg, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+	err = bpobj_space(&dle->dle_bpobj, &used, &comp, &uncomp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
 	dl->dl_phys->dl_used -= used;
 	dl->dl_phys->dl_comp -= comp;
@@ -657,9 +728,12 @@ dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	} else {
 		bpobj_free(os, dle->dle_bpobj.bpo_object, tx);
 	}
+out:
 	bpobj_close(&dle->dle_bpobj);
 	kmem_free(dle, sizeof (*dle));
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 /*
@@ -700,11 +774,15 @@ dsl_deadlist_clear_entry(dsl_deadlist_entry_t *dle, dsl_deadlist_t *dl,
 dsl_deadlist_entry_t *
 dsl_deadlist_first(dsl_deadlist_t *dl)
 {
-	dsl_deadlist_entry_t *dle;
+	dsl_deadlist_entry_t *dle = NULL;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(dl->dl_os->os_spa))
+		goto out;
+	VERIFY0(err);
 	dle = avl_first(&dl->dl_tree);
+out:
 	mutex_exit(&dl->dl_lock);
 
 	return (dle);
@@ -716,11 +794,15 @@ dsl_deadlist_first(dsl_deadlist_t *dl)
 dsl_deadlist_entry_t *
 dsl_deadlist_last(dsl_deadlist_t *dl)
 {
-	dsl_deadlist_entry_t *dle;
+	dsl_deadlist_entry_t *dle = NULL;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(dl->dl_os->os_spa))
+		goto out;
+	VERIFY0(err);
 	dle = avl_last(&dl->dl_tree);
+out:
 	mutex_exit(&dl->dl_lock);
 
 	return (dle);
@@ -772,7 +854,10 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 	}
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	for (dle = avl_first(&dl->dl_tree); dle;
 	    dle = AVL_NEXT(&dl->dl_tree, dle)) {
@@ -793,6 +878,7 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 			break;
 		VERIFY0(err);
 	}
+out:
 	mutex_exit(&dl->dl_lock);
 	return (err);
 }
@@ -923,9 +1009,10 @@ dsl_deadlist_insert_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
  * Merge the deadlist pointed to by 'obj' into dl.  obj will be left as
  * an empty deadlist.
  */
-void
+int
 dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	zap_cursor_t zc, pzc;
 	zap_attribute_t *za, *pza;
 	dmu_buf_t *bonus;
@@ -933,13 +1020,21 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	dmu_object_info_t doi;
 	int error, perror, i;
 
-	VERIFY0(dmu_object_info(dl->dl_os, obj, &doi));
+	error = dmu_object_info(dl->dl_os, obj, &doi);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		bpobj_t bpo;
-		VERIFY0(bpobj_open(&bpo, dl->dl_os, obj));
-		VERIFY0(bpobj_iterate(&bpo, dsl_deadlist_insert_cb, dl, tx));
+		error = bpobj_open(&bpo, dl->dl_os, obj);
+		if (error && SPA_EXITING(spa))
+			return (error);
+		VERIFY0(error);
+		error = bpobj_iterate(&bpo, dsl_deadlist_insert_cb, dl, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		bpobj_close(&bpo);
-		return;
+		return (error);
 	}
 
 	za = zap_attribute_alloc();
@@ -961,7 +1056,9 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	    zap_cursor_advance(&zc)) {
 		dsl_deadlist_insert_bpobj(dl, za->za_first_integer,
 		    zfs_strtonum(za->za_name, NULL), tx);
-		VERIFY0(zap_remove(dl->dl_os, obj, za->za_name, tx));
+		error = zap_remove(dl->dl_os, obj, za->za_name, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		if (perror == 0) {
 			dsl_deadlist_prefetch_bpobj(dl, pza->za_first_integer,
 			    zfs_strtonum(pza->za_name, NULL));
@@ -969,38 +1066,56 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 			perror = zap_cursor_retrieve(&pzc, pza);
 		}
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_cursor_fini(&pzc);
 
-	VERIFY0(dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus));
+	error = dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus);
+	if (error && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(error);
 	dlp = bonus->db_data;
 	dmu_buf_will_dirty(bonus, tx);
+	if (SPA_EXITING(spa))
+		error = SET_ERROR(EIO);
 	memset(dlp, 0, sizeof (*dlp));
 	dmu_buf_rele(bonus, FTAG);
+
+out:
 	mutex_exit(&dl->dl_lock);
 
 	zap_attribute_free(za);
 	zap_attribute_free(pza);
+
+	return (error);
 }
 
 /*
  * Remove entries on dl that are born > mintxg, and put them on the bpobj.
  */
-void
+int
 dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
     dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle, *pdle;
 	avl_index_t where;
-	int i;
+	int i, err = 0;
 
 	ASSERT(!dl->dl_oldfmt);
 
 	mutex_enter(&dl->dl_lock);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
-	dsl_deadlist_load_tree(dl);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, &where);
@@ -1018,15 +1133,23 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		uint64_t used, comp, uncomp;
 		dsl_deadlist_entry_t *dle_next;
 
-		VERIFY0(bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object,
-		    tx));
+		if (err)
+			goto next;
+
+		err = bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err); // the orig code had no assertion here
 		if (pdle) {
 			bpobj_prefetch_subobj(bpo, pdle->dle_bpobj.bpo_object);
 			pdle = AVL_NEXT(&dl->dl_tree, pdle);
 		}
 
-		VERIFY0(bpobj_space(&dle->dle_bpobj,
-		    &used, &comp, &uncomp));
+		err = bpobj_space(&dle->dle_bpobj,
+		    &used, &comp, &uncomp);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err);
 		ASSERT3U(dl->dl_phys->dl_used, >=, used);
 		ASSERT3U(dl->dl_phys->dl_comp, >=, comp);
 		ASSERT3U(dl->dl_phys->dl_uncomp, >=, uncomp);
@@ -1034,16 +1157,23 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		dl->dl_phys->dl_comp -= comp;
 		dl->dl_phys->dl_uncomp -= uncomp;
 
-		VERIFY0(zap_remove_int(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, tx));
+		err = zap_remove_int(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, tx);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err);
 
+next:
 		dle_next = AVL_NEXT(&dl->dl_tree, dle);
 		avl_remove(&dl->dl_tree, dle);
 		bpobj_close(&dle->dle_bpobj);
 		kmem_free(dle, sizeof (*dle));
 		dle = dle_next;
 	}
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 typedef struct livelist_entry {

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -26,6 +26,7 @@
  */
 
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/zap.h>
 #include <sys/zfs_context.h>
 #include <sys/dsl_pool.h>
@@ -130,12 +131,12 @@ dsl_deadlist_cache_compare(const void *arg1, const void *arg2)
 	return (TREE_CMP(dlce1->dlce_mintxg, dlce2->dlce_mintxg));
 }
 
-static void
+static int
 dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 {
 	zap_cursor_t zc;
 	zap_attribute_t *za;
-	int error;
+	int error = 0;
 
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 
@@ -158,7 +159,7 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 		dl->dl_havecache = B_FALSE;
 	}
 	if (dl->dl_havetree)
-		return;
+		return (0);
 
 	za = zap_attribute_alloc();
 	avl_create(&dl->dl_tree, dsl_deadlist_compare,
@@ -186,10 +187,14 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 
 	for (dsl_deadlist_entry_t *dle = avl_first(&dl->dl_tree);
 	    dle != NULL; dle = AVL_NEXT(&dl->dl_tree, dle)) {
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os,
-		    dle->dle_bpobj.bpo_object));
+		error = bpobj_open(&dle->dle_bpobj, dl->dl_os,
+		    dle->dle_bpobj.bpo_object);
+		if (error)
+			return (error);
 	}
 	dl->dl_havetree = B_TRUE;
+
+	return (0);
 }
 
 /*
@@ -291,8 +296,10 @@ dsl_deadlist_iterate(dsl_deadlist_t *dl, deadlist_iter_t func, void *args)
 	ASSERT(dsl_deadlist_is_open(dl));
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
 	mutex_exit(&dl->dl_lock);
+	if (err)
+		return;
 	for (dle = avl_first(&dl->dl_tree); dle != NULL;
 	    dle = AVL_NEXT(&dl->dl_tree, dle)) {
 		if (func(args, dle) != 0)
@@ -375,13 +382,13 @@ dsl_deadlist_close(dsl_deadlist_t *dl)
 	dl->dl_object = 0;
 }
 
-uint64_t
-dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx)
+int
+dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
 	if (spa_version(dmu_objset_spa(os)) < SPA_VERSION_DEADLISTS)
-		return (bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx));
+		return (bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx, objectp));
 	return (zap_create(os, DMU_OT_DEADLIST, DMU_OT_DEADLIST_HDR,
-	    sizeof (dsl_deadlist_phys_t), tx));
+	    sizeof (dsl_deadlist_phys_t), tx, objectp));
 }
 
 void
@@ -414,37 +421,65 @@ dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 	VERIFY0(dmu_object_free(os, dlobj, tx));
 }
 
-static void
+static int
 dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
     const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 	if (dle->dle_bpobj.bpo_object ==
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
-		uint64_t obj = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
+		uint64_t obj;
+		err = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
+
 		bpobj_close(&dle->dle_bpobj);
 		bpobj_decr_empty(dl->dl_os, tx);
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
-		VERIFY0(zap_update_int_key(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, obj, tx));
+
+		err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
+
+		err = zap_update_int_key(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
 	}
 	bpobj_enqueue(&dle->dle_bpobj, bp, bp_freed, tx);
+
+	return (err);
 }
 
 static void
 dle_enqueue_subobj(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
     uint64_t obj, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 	if (dle->dle_bpobj.bpo_object !=
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
-		bpobj_enqueue_subobj(&dle->dle_bpobj, obj, tx);
+		err = bpobj_enqueue_subobj(&dle->dle_bpobj, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
 	} else {
 		bpobj_close(&dle->dle_bpobj);
 		bpobj_decr_empty(dl->dl_os, tx);
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
-		VERIFY0(zap_update_int_key(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, obj, tx));
+		err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
+		err = zap_update_int_key(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -460,23 +495,32 @@ dle_prefetch_subobj(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 		bpobj_prefetch_subobj(&dle->dle_bpobj, obj);
 }
 
-void
+int
 dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle;
 	avl_index_t where;
+	int err = 0;
 
 	if (dl->dl_oldfmt) {
 		bpobj_enqueue(&dl->dl_bpobj, bp, bp_freed, tx);
-		return;
+		return (err);
 	}
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	int sign = bp_freed ? -1 : +1;
 	dl->dl_phys->dl_used +=
@@ -498,24 +542,26 @@ dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp, boolean_t bp_freed,
 	}
 
 	ASSERT3P(dle, !=, NULL);
-	dle_enqueue(dl, dle, bp, bp_freed, tx);
+	err = dle_enqueue(dl, dle, bp, bp_freed, tx);
+
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 int
 dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, B_FALSE, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, B_FALSE, tx));
 }
 
 int
 dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, B_TRUE, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, B_TRUE, tx));
 }
 
 /*
@@ -537,7 +583,7 @@ dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
 
-	obj = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
+	VERIFY0(bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj));
 	VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
 	avl_add(&dl->dl_tree, dle);
 
@@ -640,7 +686,7 @@ dsl_deadlist_clear_entry(dsl_deadlist_entry_t *dle, dsl_deadlist_t *dl,
 	else
 		bpobj_free(os, dle->dle_bpobj.bpo_object, tx);
 	bpobj_close(&dle->dle_bpobj);
-	new_obj = bpobj_alloc_empty(os, SPA_OLD_MAXBLOCKSIZE, tx);
+	VERIFY0(bpobj_alloc_empty(os, SPA_OLD_MAXBLOCKSIZE, tx, &new_obj));
 	VERIFY0(bpobj_open(&dle->dle_bpobj, os, new_obj));
 	VERIFY0(zap_add_int_key(os, dl->dl_object, dle->dle_mintxg,
 	    new_obj, tx));
@@ -707,18 +753,22 @@ dsl_deadlist_regenerate(objset_t *os, uint64_t dlobj,
 	dsl_deadlist_close(&dl);
 }
 
-uint64_t
+int
 dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
-    uint64_t mrs_obj, dmu_tx_t *tx)
+    uint64_t mrs_obj, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t *dle;
-	uint64_t newobj;
+	int err = 0;
 
-	newobj = dsl_deadlist_alloc(dl->dl_os, tx);
+	err = dsl_deadlist_alloc(dl->dl_os, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (dl->dl_oldfmt) {
-		dsl_deadlist_regenerate(dl->dl_os, newobj, mrs_obj, tx);
-		return (newobj);
+		dsl_deadlist_regenerate(dl->dl_os, *objectp, mrs_obj, tx);
+		return (err);
 	}
 
 	mutex_enter(&dl->dl_lock);
@@ -731,12 +781,20 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 		if (dle->dle_mintxg >= maxtxg)
 			break;
 
-		obj = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
-		VERIFY0(zap_add_int_key(dl->dl_os, newobj,
-		    dle->dle_mintxg, obj, tx));
+		err = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx,
+		    &obj);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
+
+		err = zap_add_int_key(dl->dl_os, *objectp,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 	}
 	mutex_exit(&dl->dl_lock);
-	return (newobj);
+	return (err);
 }
 
 void
@@ -858,8 +916,7 @@ dsl_deadlist_insert_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, bp_freed, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, bp_freed, tx));
 }
 
 /*
@@ -961,7 +1018,8 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		uint64_t used, comp, uncomp;
 		dsl_deadlist_entry_t *dle_next;
 
-		bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object, tx);
+		VERIFY0(bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object,
+		    tx));
 		if (pdle) {
 			bpobj_prefetch_subobj(bpo, pdle->dle_bpobj.bpo_object);
 			pdle = AVL_NEXT(&dl->dl_tree, pdle);

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -335,11 +335,11 @@ dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object)
 	ASSERT(!dsl_deadlist_is_open(dl));
 
 	mutex_init(&dl->dl_lock, NULL, MUTEX_DEFAULT, NULL);
-	dl->dl_os = os;
-	dl->dl_object = object;
 	err = dmu_bonus_hold(os, object, dl, &dl->dl_dbuf);
 	if (err != 0)
 		return (err);
+	dl->dl_os = os;
+	dl->dl_object = object;
 	dmu_object_info_from_db(dl->dl_dbuf, &doi);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		dmu_buf_rele(dl->dl_dbuf, dl);

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -16,6 +16,7 @@
  */
 
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/zap.h>
 #include <sys/zfs_context.h>
 #include <sys/dsl_pool.h>
@@ -120,12 +121,12 @@ dsl_deadlist_cache_compare(const void *arg1, const void *arg2)
 	return (TREE_CMP(dlce1->dlce_mintxg, dlce2->dlce_mintxg));
 }
 
-static void
+static int
 dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 {
 	zap_cursor_t zc;
 	zap_attribute_t *za;
-	int error;
+	int error = 0;
 
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 
@@ -148,7 +149,7 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 		dl->dl_havecache = B_FALSE;
 	}
 	if (dl->dl_havetree)
-		return;
+		return (0);
 
 	za = zap_attribute_alloc();
 	avl_create(&dl->dl_tree, dsl_deadlist_compare,
@@ -176,10 +177,14 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 
 	for (dsl_deadlist_entry_t *dle = avl_first(&dl->dl_tree);
 	    dle != NULL; dle = AVL_NEXT(&dl->dl_tree, dle)) {
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os,
-		    dle->dle_bpobj.bpo_object));
+		error = bpobj_open(&dle->dle_bpobj, dl->dl_os,
+		    dle->dle_bpobj.bpo_object);
+		if (error)
+			return (error);
 	}
 	dl->dl_havetree = B_TRUE;
+
+	return (0);
 }
 
 /*
@@ -281,8 +286,10 @@ dsl_deadlist_iterate(dsl_deadlist_t *dl, deadlist_iter_t func, void *args)
 	ASSERT(dsl_deadlist_is_open(dl));
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
 	mutex_exit(&dl->dl_lock);
+	if (err)
+		return;
 	for (dle = avl_first(&dl->dl_tree); dle != NULL;
 	    dle = AVL_NEXT(&dl->dl_tree, dle)) {
 		if (func(args, dle) != 0)
@@ -365,13 +372,13 @@ dsl_deadlist_close(dsl_deadlist_t *dl)
 	dl->dl_object = 0;
 }
 
-uint64_t
-dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx)
+int
+dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
 	if (spa_version(dmu_objset_spa(os)) < SPA_VERSION_DEADLISTS)
-		return (bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx));
+		return (bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx, objectp));
 	return (zap_create(os, DMU_OT_DEADLIST, DMU_OT_DEADLIST_HDR,
-	    sizeof (dsl_deadlist_phys_t), tx));
+	    sizeof (dsl_deadlist_phys_t), tx, objectp));
 }
 
 void
@@ -404,37 +411,65 @@ dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 	VERIFY0(dmu_object_free(os, dlobj, tx));
 }
 
-static void
+static int
 dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
     const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 	if (dle->dle_bpobj.bpo_object ==
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
-		uint64_t obj = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
+		uint64_t obj;
+		err = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
+
 		bpobj_close(&dle->dle_bpobj);
 		bpobj_decr_empty(dl->dl_os, tx);
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
-		VERIFY0(zap_update_int_key(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, obj, tx));
+
+		err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
+
+		err = zap_update_int_key(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return (err);
+		VERIFY0(err);
 	}
 	bpobj_enqueue(&dle->dle_bpobj, bp, bp_freed, tx);
+
+	return (err);
 }
 
 static void
 dle_enqueue_subobj(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
     uint64_t obj, dmu_tx_t *tx)
 {
+	int err = 0;
+
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 	if (dle->dle_bpobj.bpo_object !=
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
-		bpobj_enqueue_subobj(&dle->dle_bpobj, obj, tx);
+		err = bpobj_enqueue_subobj(&dle->dle_bpobj, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
 	} else {
 		bpobj_close(&dle->dle_bpobj);
 		bpobj_decr_empty(dl->dl_os, tx);
-		VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
-		VERIFY0(zap_update_int_key(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, obj, tx));
+		err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
+		err = zap_update_int_key(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(dl->dl_os->os_spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -450,23 +485,32 @@ dle_prefetch_subobj(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 		bpobj_prefetch_subobj(&dle->dle_bpobj, obj);
 }
 
-void
+int
 dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle;
 	avl_index_t where;
+	int err = 0;
 
 	if (dl->dl_oldfmt) {
 		bpobj_enqueue(&dl->dl_bpobj, bp, bp_freed, tx);
-		return;
+		return (err);
 	}
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	int sign = bp_freed ? -1 : +1;
 	dl->dl_phys->dl_used +=
@@ -488,24 +532,26 @@ dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp, boolean_t bp_freed,
 	}
 
 	ASSERT3P(dle, !=, NULL);
-	dle_enqueue(dl, dle, bp, bp_freed, tx);
+	err = dle_enqueue(dl, dle, bp, bp_freed, tx);
+
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 int
 dsl_deadlist_insert_alloc_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, B_FALSE, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, B_FALSE, tx));
 }
 
 int
 dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, B_TRUE, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, B_TRUE, tx));
 }
 
 /*
@@ -527,7 +573,7 @@ dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
 
-	obj = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
+	VERIFY0(bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj));
 	VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
 	avl_add(&dl->dl_tree, dle);
 
@@ -630,7 +676,7 @@ dsl_deadlist_clear_entry(dsl_deadlist_entry_t *dle, dsl_deadlist_t *dl,
 	else
 		bpobj_free(os, dle->dle_bpobj.bpo_object, tx);
 	bpobj_close(&dle->dle_bpobj);
-	new_obj = bpobj_alloc_empty(os, SPA_OLD_MAXBLOCKSIZE, tx);
+	VERIFY0(bpobj_alloc_empty(os, SPA_OLD_MAXBLOCKSIZE, tx, &new_obj));
 	VERIFY0(bpobj_open(&dle->dle_bpobj, os, new_obj));
 	VERIFY0(zap_add_int_key(os, dl->dl_object, dle->dle_mintxg,
 	    new_obj, tx));
@@ -697,18 +743,22 @@ dsl_deadlist_regenerate(objset_t *os, uint64_t dlobj,
 	dsl_deadlist_close(&dl);
 }
 
-uint64_t
+int
 dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
-    uint64_t mrs_obj, dmu_tx_t *tx)
+    uint64_t mrs_obj, dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t *dle;
-	uint64_t newobj;
+	int err = 0;
 
-	newobj = dsl_deadlist_alloc(dl->dl_os, tx);
+	err = dsl_deadlist_alloc(dl->dl_os, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (dl->dl_oldfmt) {
-		dsl_deadlist_regenerate(dl->dl_os, newobj, mrs_obj, tx);
-		return (newobj);
+		dsl_deadlist_regenerate(dl->dl_os, *objectp, mrs_obj, tx);
+		return (err);
 	}
 
 	mutex_enter(&dl->dl_lock);
@@ -721,12 +771,20 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 		if (dle->dle_mintxg >= maxtxg)
 			break;
 
-		obj = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
-		VERIFY0(zap_add_int_key(dl->dl_os, newobj,
-		    dle->dle_mintxg, obj, tx));
+		err = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx,
+		    &obj);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
+
+		err = zap_add_int_key(dl->dl_os, *objectp,
+		    dle->dle_mintxg, obj, tx);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 	}
 	mutex_exit(&dl->dl_lock);
-	return (newobj);
+	return (err);
 }
 
 void
@@ -848,8 +906,7 @@ dsl_deadlist_insert_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
 	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, bp_freed, tx);
-	return (0);
+	return (dsl_deadlist_insert(dl, bp, bp_freed, tx));
 }
 
 /*
@@ -951,7 +1008,8 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		uint64_t used, comp, uncomp;
 		dsl_deadlist_entry_t *dle_next;
 
-		bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object, tx);
+		VERIFY0(bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object,
+		    tx));
 		if (pdle) {
 			bpobj_prefetch_subobj(bpo, pdle->dle_bpobj.bpo_object);
 			pdle = AVL_NEXT(&dl->dl_tree, pdle);

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -124,6 +124,7 @@ dsl_deadlist_cache_compare(const void *arg1, const void *arg2)
 static int
 dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	zap_cursor_t zc;
 	zap_attribute_t *za;
 	int error = 0;
@@ -171,20 +172,33 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 
 		avl_add(&dl->dl_tree, dle);
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_attribute_free(za);
 
+	error = 0;
 	for (dsl_deadlist_entry_t *dle = avl_first(&dl->dl_tree);
 	    dle != NULL; dle = AVL_NEXT(&dl->dl_tree, dle)) {
+		if (error) {
+			dle->dle_bpobj.bpo_object = 0;
+			continue;
+		}
 		error = bpobj_open(&dle->dle_bpobj, dl->dl_os,
 		    dle->dle_bpobj.bpo_object);
-		if (error)
-			return (error);
+		if (error && SPA_EXITING(dl->dl_os->os_spa)) {
+			/* align with bpobj_is_open() */
+			dle->dle_bpobj.bpo_object = 0;
+			continue;
+		}
+		VERIFY0(error);
 	}
-	dl->dl_havetree = B_TRUE;
+	if (error)
+		dsl_deadlist_discard_tree(dl);
+	else
+		dl->dl_havetree = B_TRUE;
 
-	return (0);
+	return (error);
 }
 
 /*
@@ -260,10 +274,13 @@ dsl_deadlist_load_cache(dsl_deadlist_t *dl)
 void
 dsl_deadlist_discard_tree(dsl_deadlist_t *dl)
 {
-	mutex_enter(&dl->dl_lock);
+	boolean_t locked_already = MUTEX_HELD(&dl->dl_lock);
+	if (!locked_already)
+		mutex_enter(&dl->dl_lock);
 
 	if (!dl->dl_havetree) {
-		mutex_exit(&dl->dl_lock);
+		if (!locked_already)
+			mutex_exit(&dl->dl_lock);
 		return;
 	}
 	dsl_deadlist_entry_t *dle;
@@ -275,7 +292,9 @@ dsl_deadlist_discard_tree(dsl_deadlist_t *dl)
 	avl_destroy(&dl->dl_tree);
 
 	dl->dl_havetree = B_FALSE;
-	mutex_exit(&dl->dl_lock);
+
+	if (!locked_already)
+		mutex_exit(&dl->dl_lock);
 }
 
 void
@@ -384,12 +403,16 @@ dsl_deadlist_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 void
 dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 {
+	spa_t *spa = os->os_spa;
 	dmu_object_info_t doi;
 	zap_cursor_t zc;
 	zap_attribute_t *za;
 	int error;
 
-	VERIFY0(dmu_object_info(os, dlobj, &doi));
+	error = dmu_object_info(os, dlobj, &doi);
+	if (error && SPA_EXITING(spa))
+		return;
+	VERIFY0(error);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		bpobj_free(os, dlobj, tx);
 		return;
@@ -405,10 +428,13 @@ dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 		else
 			bpobj_free(os, obj, tx);
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_attribute_free(za);
-	VERIFY0(dmu_object_free(os, dlobj, tx));
+	error = dmu_object_free(os, dlobj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(error);
 }
 
 static int
@@ -422,8 +448,11 @@ dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 	    dmu_objset_pool(dl->dl_os)->dp_empty_bpobj) {
 		uint64_t obj;
 		err = bpobj_alloc(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
-		if (err && SPA_EXITING(dl->dl_os->os_spa))
+		if (err && SPA_EXITING(dl->dl_os->os_spa)) {
+			bpobj_close(&dle->dle_bpobj);
+			bpobj_decr_empty(dl->dl_os, tx);
 			return (err);
+		}
 		VERIFY0(err);
 
 		bpobj_close(&dle->dle_bpobj);
@@ -436,9 +465,8 @@ dle_enqueue(dsl_deadlist_t *dl, dsl_deadlist_entry_t *dle,
 
 		err = zap_update_int_key(dl->dl_os, dl->dl_object,
 		    dle->dle_mintxg, obj, tx);
-		if (err && SPA_EXITING(dl->dl_os->os_spa))
-			return (err);
-		VERIFY0(err);
+		if (!SPA_EXITING(dl->dl_os->os_spa))
+			VERIFY0(err);
 	}
 	bpobj_enqueue(&dle->dle_bpobj, bp, bp_freed, tx);
 
@@ -558,43 +586,69 @@ dsl_deadlist_insert_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
  * Insert new key in deadlist, which must be > all current entries.
  * mintxg is not inclusive.
  */
-void
+int
 dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	uint64_t obj;
 	dsl_deadlist_entry_t *dle;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 
 	dle = kmem_alloc(sizeof (*dle), KM_SLEEP);
 	dle->dle_mintxg = mintxg;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
 
-	VERIFY0(bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj));
-	VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = bpobj_open(&dle->dle_bpobj, dl->dl_os, obj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
 	avl_add(&dl->dl_tree, dle);
 
-	VERIFY0(zap_add_int_key(dl->dl_os, dl->dl_object,
-	    mintxg, obj, tx));
+	err = zap_add_int_key(dl->dl_os, dl->dl_object,
+	    mintxg, obj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 /*
  * Remove this key, merging its entries into the previous key.
  */
-void
+int
 dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle, *dle_prev;
+	spa_t *spa = dl->dl_os->os_spa;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
@@ -608,8 +662,13 @@ dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	bpobj_close(&dle->dle_bpobj);
 	kmem_free(dle, sizeof (*dle));
 
-	VERIFY0(zap_remove_int(dl->dl_os, dl->dl_object, mintxg, tx));
+	err = zap_remove_int(dl->dl_os, dl->dl_object, mintxg, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+out:
 	mutex_exit(&dl->dl_lock);
+	return (err);
 }
 
 /*
@@ -617,27 +676,39 @@ dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
  * the deadlist's avl tree, freeing the entry's bpobj and adjusting the
  * deadlist's space accounting accordingly.
  */
-void
+int
 dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 {
 	uint64_t used, comp, uncomp;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle;
 	objset_t *os = dl->dl_os;
+	spa_t *spa = os->os_spa;
+	int err = 0;
 
 	if (dl->dl_oldfmt)
-		return;
+		return (0);
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
-
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa)) {
+		mutex_exit(&dl->dl_lock);
+		return (err);
+	}
+	VERIFY0(err);
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
 	VERIFY3P(dle, !=, NULL);
 
 	avl_remove(&dl->dl_tree, dle);
-	VERIFY0(zap_remove_int(os, dl->dl_object, mintxg, tx));
-	VERIFY0(bpobj_space(&dle->dle_bpobj, &used, &comp, &uncomp));
+	err = zap_remove_int(os, dl->dl_object, mintxg, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+	err = bpobj_space(&dle->dle_bpobj, &used, &comp, &uncomp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
 	dl->dl_phys->dl_used -= used;
 	dl->dl_phys->dl_comp -= comp;
@@ -647,9 +718,12 @@ dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 	} else {
 		bpobj_free(os, dle->dle_bpobj.bpo_object, tx);
 	}
+out:
 	bpobj_close(&dle->dle_bpobj);
 	kmem_free(dle, sizeof (*dle));
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 /*
@@ -690,11 +764,15 @@ dsl_deadlist_clear_entry(dsl_deadlist_entry_t *dle, dsl_deadlist_t *dl,
 dsl_deadlist_entry_t *
 dsl_deadlist_first(dsl_deadlist_t *dl)
 {
-	dsl_deadlist_entry_t *dle;
+	dsl_deadlist_entry_t *dle = NULL;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(dl->dl_os->os_spa))
+		goto out;
+	VERIFY0(err);
 	dle = avl_first(&dl->dl_tree);
+out:
 	mutex_exit(&dl->dl_lock);
 
 	return (dle);
@@ -706,11 +784,15 @@ dsl_deadlist_first(dsl_deadlist_t *dl)
 dsl_deadlist_entry_t *
 dsl_deadlist_last(dsl_deadlist_t *dl)
 {
-	dsl_deadlist_entry_t *dle;
+	dsl_deadlist_entry_t *dle = NULL;
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	int err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(dl->dl_os->os_spa))
+		goto out;
+	VERIFY0(err);
 	dle = avl_last(&dl->dl_tree);
+out:
 	mutex_exit(&dl->dl_lock);
 
 	return (dle);
@@ -762,7 +844,10 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 	}
 
 	mutex_enter(&dl->dl_lock);
-	dsl_deadlist_load_tree(dl);
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	for (dle = avl_first(&dl->dl_tree); dle;
 	    dle = AVL_NEXT(&dl->dl_tree, dle)) {
@@ -783,6 +868,7 @@ dsl_deadlist_clone(dsl_deadlist_t *dl, uint64_t maxtxg,
 			break;
 		VERIFY0(err);
 	}
+out:
 	mutex_exit(&dl->dl_lock);
 	return (err);
 }
@@ -913,9 +999,10 @@ dsl_deadlist_insert_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
  * Merge the deadlist pointed to by 'obj' into dl.  obj will be left as
  * an empty deadlist.
  */
-void
+int
 dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	zap_cursor_t zc, pzc;
 	zap_attribute_t *za, *pza;
 	dmu_buf_t *bonus;
@@ -923,13 +1010,21 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	dmu_object_info_t doi;
 	int error, perror, i;
 
-	VERIFY0(dmu_object_info(dl->dl_os, obj, &doi));
+	error = dmu_object_info(dl->dl_os, obj, &doi);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		bpobj_t bpo;
-		VERIFY0(bpobj_open(&bpo, dl->dl_os, obj));
-		VERIFY0(bpobj_iterate(&bpo, dsl_deadlist_insert_cb, dl, tx));
+		error = bpobj_open(&bpo, dl->dl_os, obj);
+		if (error && SPA_EXITING(spa))
+			return (error);
+		VERIFY0(error);
+		error = bpobj_iterate(&bpo, dsl_deadlist_insert_cb, dl, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		bpobj_close(&bpo);
-		return;
+		return (error);
 	}
 
 	za = zap_attribute_alloc();
@@ -951,7 +1046,9 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	    zap_cursor_advance(&zc)) {
 		dsl_deadlist_insert_bpobj(dl, za->za_first_integer,
 		    zfs_strtonum(za->za_name, NULL), tx);
-		VERIFY0(zap_remove(dl->dl_os, obj, za->za_name, tx));
+		error = zap_remove(dl->dl_os, obj, za->za_name, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		if (perror == 0) {
 			dsl_deadlist_prefetch_bpobj(dl, pza->za_first_integer,
 			    zfs_strtonum(pza->za_name, NULL));
@@ -959,38 +1056,56 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 			perror = zap_cursor_retrieve(&pzc, pza);
 		}
 	}
-	VERIFY3U(error, ==, ENOENT);
+	if (!SPA_EXITING(spa))
+		VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_cursor_fini(&pzc);
 
-	VERIFY0(dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus));
+	error = dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus);
+	if (error && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(error);
 	dlp = bonus->db_data;
 	dmu_buf_will_dirty(bonus, tx);
+	if (SPA_EXITING(spa))
+		error = SET_ERROR(EIO);
 	memset(dlp, 0, sizeof (*dlp));
 	dmu_buf_rele(bonus, FTAG);
+
+out:
 	mutex_exit(&dl->dl_lock);
 
 	zap_attribute_free(za);
 	zap_attribute_free(pza);
+
+	return (error);
 }
 
 /*
  * Remove entries on dl that are born > mintxg, and put them on the bpobj.
  */
-void
+int
 dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
     dmu_tx_t *tx)
 {
+	spa_t *spa = dl->dl_os->os_spa;
 	dsl_deadlist_entry_t dle_tofind;
 	dsl_deadlist_entry_t *dle, *pdle;
 	avl_index_t where;
-	int i;
+	int i, err = 0;
 
 	ASSERT(!dl->dl_oldfmt);
 
 	mutex_enter(&dl->dl_lock);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
-	dsl_deadlist_load_tree(dl);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
+	err = dsl_deadlist_load_tree(dl);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, &where);
@@ -1008,15 +1123,23 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		uint64_t used, comp, uncomp;
 		dsl_deadlist_entry_t *dle_next;
 
-		VERIFY0(bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object,
-		    tx));
+		if (err)
+			goto next;
+
+		err = bpobj_enqueue_subobj(bpo, dle->dle_bpobj.bpo_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err); // the orig code had no assertion here
 		if (pdle) {
 			bpobj_prefetch_subobj(bpo, pdle->dle_bpobj.bpo_object);
 			pdle = AVL_NEXT(&dl->dl_tree, pdle);
 		}
 
-		VERIFY0(bpobj_space(&dle->dle_bpobj,
-		    &used, &comp, &uncomp));
+		err = bpobj_space(&dle->dle_bpobj,
+		    &used, &comp, &uncomp);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err);
 		ASSERT3U(dl->dl_phys->dl_used, >=, used);
 		ASSERT3U(dl->dl_phys->dl_comp, >=, comp);
 		ASSERT3U(dl->dl_phys->dl_uncomp, >=, uncomp);
@@ -1024,16 +1147,23 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 		dl->dl_phys->dl_comp -= comp;
 		dl->dl_phys->dl_uncomp -= uncomp;
 
-		VERIFY0(zap_remove_int(dl->dl_os, dl->dl_object,
-		    dle->dle_mintxg, tx));
+		err = zap_remove_int(dl->dl_os, dl->dl_object,
+		    dle->dle_mintxg, tx);
+		if (err && SPA_EXITING(spa))
+			goto next;
+		VERIFY0(err);
 
+next:
 		dle_next = AVL_NEXT(&dl->dl_tree, dle);
 		avl_remove(&dl->dl_tree, dle);
 		bpobj_close(&dle->dle_bpobj);
 		kmem_free(dle, sizeof (*dle));
 		dle = dle_next;
 	}
+out:
 	mutex_exit(&dl->dl_lock);
+
+	return (err);
 }
 
 typedef struct livelist_entry {

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -325,11 +325,11 @@ dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object)
 	ASSERT(!dsl_deadlist_is_open(dl));
 
 	mutex_init(&dl->dl_lock, NULL, MUTEX_DEFAULT, NULL);
-	dl->dl_os = os;
-	dl->dl_object = object;
 	err = dmu_bonus_hold(os, object, dl, &dl->dl_dbuf);
 	if (err != 0)
 		return (err);
+	dl->dl_os = os;
+	dl->dl_object = object;
 	dmu_object_info_from_db(dl->dl_dbuf, &doi);
 	if (doi.doi_type == DMU_OT_BPOBJ) {
 		dmu_buf_rele(dl->dl_dbuf, dl);

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -168,8 +168,10 @@ dsl_deleg_set_sync(void *arg, dmu_tx_t *tx)
 	zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	if (zapobj == 0) {
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
-		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj = zap_create(mos,
-		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &dsl_dir_phys(dd)->dd_deleg_zapobj));
+		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	}
 
 	while ((whopair = nvlist_next_nvpair(dda->dda_nvlist, whopair))) {
@@ -181,8 +183,8 @@ dsl_deleg_set_sync(void *arg, dmu_tx_t *tx)
 		perms = fnvpair_value_nvlist(whopair);
 
 		if (zap_lookup(mos, zapobj, whokey, 8, 1, &jumpobj) != 0) {
-			jumpobj = zap_create_link(mos, DMU_OT_DSL_PERMS,
-			    zapobj, whokey, tx);
+			VERIFY0(zap_create_link(mos, DMU_OT_DSL_PERMS,
+			    zapobj, whokey, tx, &jumpobj));
 		}
 
 		while ((permpair = nvlist_next_nvpair(perms, permpair))) {
@@ -695,15 +697,18 @@ copy_create_perms(dsl_dir_t *dd, uint64_t pzapobj,
 
 	if (zapobj == 0) {
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
-		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj = zap_create(mos,
-		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &dsl_dir_phys(dd)->dd_deleg_zapobj));
+		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	}
 
 	zfs_deleg_whokey(whokey,
 	    dosets ? ZFS_DELEG_USER_SETS : ZFS_DELEG_USER,
 	    ZFS_DELEG_LOCAL, &uid);
 	if (zap_lookup(mos, zapobj, whokey, 8, 1, &jumpobj) == ENOENT) {
-		jumpobj = zap_create(mos, DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &jumpobj));
 		VERIFY0(zap_add(mos, zapobj, whokey, 8, 1, &jumpobj, tx));
 	}
 

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -158,8 +158,10 @@ dsl_deleg_set_sync(void *arg, dmu_tx_t *tx)
 	zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	if (zapobj == 0) {
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
-		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj = zap_create(mos,
-		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &dsl_dir_phys(dd)->dd_deleg_zapobj));
+		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	}
 
 	while ((whopair = nvlist_next_nvpair(dda->dda_nvlist, whopair))) {
@@ -171,8 +173,8 @@ dsl_deleg_set_sync(void *arg, dmu_tx_t *tx)
 		perms = fnvpair_value_nvlist(whopair);
 
 		if (zap_lookup(mos, zapobj, whokey, 8, 1, &jumpobj) != 0) {
-			jumpobj = zap_create_link(mos, DMU_OT_DSL_PERMS,
-			    zapobj, whokey, tx);
+			VERIFY0(zap_create_link(mos, DMU_OT_DSL_PERMS,
+			    zapobj, whokey, tx, &jumpobj));
 		}
 
 		while ((permpair = nvlist_next_nvpair(perms, permpair))) {
@@ -685,15 +687,18 @@ copy_create_perms(dsl_dir_t *dd, uint64_t pzapobj,
 
 	if (zapobj == 0) {
 		dmu_buf_will_dirty(dd->dd_dbuf, tx);
-		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj = zap_create(mos,
-		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos,
+		    DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &dsl_dir_phys(dd)->dd_deleg_zapobj));
+		zapobj = dsl_dir_phys(dd)->dd_deleg_zapobj;
 	}
 
 	zfs_deleg_whokey(whokey,
 	    dosets ? ZFS_DELEG_USER_SETS : ZFS_DELEG_USER,
 	    ZFS_DELEG_LOCAL, &uid);
 	if (zap_lookup(mos, zapobj, whokey, 8, 1, &jumpobj) == ENOENT) {
-		jumpobj = zap_create(mos, DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx,
+		    &jumpobj));
 		VERIFY0(zap_add(mos, zapobj, whokey, 8, 1, &jumpobj, tx));
 	}
 

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -282,30 +282,47 @@ dsl_destroy_snapshot_handle_remaps(dsl_dataset_t *ds, dsl_dataset_t *ds_next,
     dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	/* Move blocks to be obsoleted to pool's obsolete list. */
 	if (dsl_dataset_remap_deadlist_exists(ds_next)) {
 		if (!bpobj_is_open(&dp->dp_obsolete_bpobj))
 			dsl_pool_create_obsolete_bpobj(dp, tx);
 
-		dsl_deadlist_move_bpobj(&ds_next->ds_remap_deadlist,
+		err = dsl_deadlist_move_bpobj(&ds_next->ds_remap_deadlist,
 		    &dp->dp_obsolete_bpobj,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 
 	/* Merge our deadlist into next's and free it. */
 	if (dsl_dataset_remap_deadlist_exists(ds)) {
-		uint64_t remap_deadlist_object =
-		    dsl_dataset_get_remap_deadlist_object(ds);
+		uint64_t remap_deadlist_object;
+		err = dsl_dataset_get_remap_deadlist_object(ds,
+		    &remap_deadlist_object);
+		if (err && SPA_EXITING(spa)) {
+			dsl_deadlist_close(&ds->ds_remap_deadlist);
+			return;
+		}
 		ASSERT(remap_deadlist_object != 0);
 
 		mutex_enter(&ds_next->ds_remap_deadlist_lock);
-		if (!dsl_dataset_remap_deadlist_exists(ds_next))
-			dsl_dataset_create_remap_deadlist(ds_next, tx);
+		if (!dsl_dataset_remap_deadlist_exists(ds_next)) {
+			err = dsl_dataset_create_remap_deadlist(ds_next, tx);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
+		}
 		mutex_exit(&ds_next->ds_remap_deadlist_lock);
 
-		dsl_deadlist_merge(&ds_next->ds_remap_deadlist,
+		err = dsl_deadlist_merge(&ds_next->ds_remap_deadlist,
 		    remap_deadlist_object, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		dsl_dataset_destroy_remap_deadlist(ds, tx);
 	}
 }

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -130,12 +130,18 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
 	struct process_old_arg *poa = arg;
 	dsl_pool_t *dp = poa->ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err = 0;
 
 	ASSERT(!BP_IS_HOLE(bp));
 
 	if (BP_GET_BIRTH(bp) <=
 	    dsl_dataset_phys(poa->ds)->ds_prev_snap_txg) {
-		dsl_deadlist_insert(&poa->ds->ds_deadlist, bp, bp_freed, tx);
+		err = dsl_deadlist_insert(&poa->ds->ds_deadlist, bp, bp_freed,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		if (poa->ds_prev && !poa->after_branch_point &&
 		    BP_GET_BIRTH(bp) >
 		    dsl_dataset_phys(poa->ds_prev)->ds_prev_snap_txg) {
@@ -148,7 +154,7 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 		poa->uncomp += BP_GET_UCSIZE(bp);
 		dsl_free_sync(poa->pio, dp, tx->tx_txg, bp);
 	}
-	return (0);
+	return (err);
 }
 
 static void
@@ -930,8 +936,8 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1, &zap_obj);
 	if (error == ENOENT) {
-		zap_obj = zap_create(mos, DMU_OTN_ZAP_METADATA,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OTN_ZAP_METADATA,
+		    DMU_OT_NONE, 0, tx, &zap_obj));
 		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1,
 		    &(zap_obj), tx));
@@ -958,13 +964,18 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
  * Move the bptree into the pool's list of trees to clean up, update space
  * accounting information and destroy the zil.
  */
-static void
+static int
 dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t used, comp, uncomp;
 	objset_t *os;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	int err = 0;
 
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
 
@@ -979,11 +990,17 @@ dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 		dsl_scan_t *scn = dp->dp_scan;
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_ASYNC_DESTROY,
 		    tx);
-		dp->dp_bptree_obj = bptree_alloc(mos, tx);
-		VERIFY0(zap_add(mos,
+		err = bptree_alloc(mos, tx, &dp->dp_bptree_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = zap_add(mos,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_BPTREE_OBJ, sizeof (uint64_t), 1,
-		    &dp->dp_bptree_obj, tx));
+		    &dp->dp_bptree_obj, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		ASSERT(!scn->scn_async_destroying);
 		scn->scn_async_destroying = B_TRUE;
 	}
@@ -1005,6 +1022,8 @@ dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	    -used, -comp, -uncomp, tx);
 	dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
 	    used, comp, uncomp, tx);
+
+	return (err);
 }
 
 void
@@ -1087,7 +1106,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 		dsl_async_clone_destroy(ds, tx);
 	} else if (spa_feature_is_enabled(dp->dp_spa,
 	    SPA_FEATURE_ASYNC_DESTROY)) {
-		dsl_async_dataset_destroy(ds, tx);
+		(void) dsl_async_dataset_destroy(ds, tx);
 	} else {
 		old_synchronous_dataset_destroy(ds, tx);
 	}

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -157,14 +157,16 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 	return (err);
 }
 
-static void
+static int
 process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
     dsl_dataset_t *ds_next, boolean_t after_branch_point, dmu_tx_t *tx)
 {
 	struct process_old_arg poa = { 0 };
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	uint64_t deadlist_obj;
+	int err = 0;
 
 	ASSERT(ds->ds_deadlist.dl_oldfmt);
 	ASSERT(ds_next->ds_deadlist.dl_oldfmt);
@@ -173,9 +175,15 @@ process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
 	poa.ds_prev = ds_prev;
 	poa.after_branch_point = after_branch_point;
 	poa.pio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
-	VERIFY0(bpobj_iterate(&ds_next->ds_deadlist.dl_bpobj,
-	    process_old_cb, &poa, tx));
-	VERIFY0(zio_wait(poa.pio));
+	err = bpobj_iterate(&ds_next->ds_deadlist.dl_bpobj,
+	    process_old_cb, &poa, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zio_wait(poa.pio);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(poa.used, ==, dsl_dataset_phys(ds)->ds_unique_bytes);
 
 	/* change snapused */
@@ -189,10 +197,18 @@ process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
 	dsl_dataset_phys(ds)->ds_deadlist_obj =
 	    dsl_dataset_phys(ds_next)->ds_deadlist_obj;
 	dsl_dataset_phys(ds_next)->ds_deadlist_obj = deadlist_obj;
-	VERIFY0(dsl_deadlist_open(&ds->ds_deadlist, mos,
-	    dsl_dataset_phys(ds)->ds_deadlist_obj));
-	VERIFY0(dsl_deadlist_open(&ds_next->ds_deadlist, mos,
-	    dsl_dataset_phys(ds_next)->ds_deadlist_obj));
+	err = dsl_deadlist_open(&ds->ds_deadlist, mos,
+	    dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dsl_deadlist_open(&ds_next->ds_deadlist, mos,
+	    dsl_dataset_phys(ds_next)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 typedef struct remaining_clones_key {
@@ -208,11 +224,13 @@ rck_alloc(dsl_dataset_t *clone)
 	return (rck);
 }
 
-static void
+static int
 dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
     list_t *stack, const void *tag)
 {
 	objset_t *mos = dd->dd_pool->dp_meta_objset;
+	spa_t *spa = mos->os_spa;
+	int err = 0;
 
 	/*
 	 * If it is the old version, dd_clones doesn't exist so we can't
@@ -220,7 +238,7 @@ dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
 	 * doesn't matter.
 	 */
 	if (dsl_dir_phys(dd)->dd_clones == 0)
-		return;
+		return (0);
 
 	zap_cursor_t *zc = kmem_alloc(sizeof (zap_cursor_t), KM_SLEEP);
 	zap_attribute_t *za = zap_attribute_alloc();
@@ -230,38 +248,54 @@ dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
 	    zap_cursor_advance(zc)) {
 		dsl_dataset_t *clone;
 
-		VERIFY0(dsl_dataset_hold_obj(dd->dd_pool,
-		    za->za_first_integer, tag, &clone));
+		err = dsl_dataset_hold_obj(dd->dd_pool,
+		    za->za_first_integer, tag, &clone);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
 		if (clone->ds_dir->dd_origin_txg > mintxg) {
-			dsl_deadlist_remove_key(&clone->ds_deadlist,
+			err = dsl_deadlist_remove_key(&clone->ds_deadlist,
 			    mintxg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 
-			if (dsl_dataset_remap_deadlist_exists(clone)) {
-				dsl_deadlist_remove_key(
+			if (!err && dsl_dataset_remap_deadlist_exists(clone)) {
+				err = dsl_deadlist_remove_key(
 				    &clone->ds_remap_deadlist, mintxg, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 			}
 
 			list_insert_head(stack, rck_alloc(clone));
 		} else {
 			dsl_dataset_rele(clone, tag);
 		}
+
+		if (err)
+			break;
 	}
 	zap_cursor_fini(zc);
 
 	zap_attribute_free(za);
 	kmem_free(zc, sizeof (zap_cursor_t));
+
+	return (err);
 }
 
 void
 dsl_dir_remove_clones_key(dsl_dir_t *top_dd, uint64_t mintxg, dmu_tx_t *tx)
 {
+	spa_t *spa = top_dd->dd_pool->dp_spa;
 	list_t stack;
+	int err;
 
 	list_create(&stack, sizeof (remaining_clones_key_t),
 	    offsetof(remaining_clones_key_t, rck_node));
 
-	dsl_dir_remove_clones_key_impl(top_dd, mintxg, tx, &stack, FTAG);
+	err = dsl_dir_remove_clones_key_impl(top_dd, mintxg, tx, &stack, FTAG);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	for (remaining_clones_key_t *rck = list_remove_head(&stack);
 	    rck != NULL; rck = list_remove_head(&stack)) {
 		dsl_dataset_t *clone = rck->rck_clone;
@@ -269,8 +303,10 @@ dsl_dir_remove_clones_key(dsl_dir_t *top_dd, uint64_t mintxg, dmu_tx_t *tx)
 
 		kmem_free(rck, sizeof (*rck));
 
-		dsl_dir_remove_clones_key_impl(clone_dir, mintxg, tx,
+		err = dsl_dir_remove_clones_key_impl(clone_dir, mintxg, tx,
 		    &stack, FTAG);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_rele(clone, FTAG);
 	}
 
@@ -332,9 +368,14 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 {
 	int after_branch_point = FALSE;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dsl_dataset_t *ds_prev = NULL;
+	dsl_dataset_t *ds_next = NULL;
+	dsl_dataset_t *ds_nextnext = NULL;
+	dsl_dataset_t *ds_head = NULL;
 	uint64_t obj;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
@@ -347,6 +388,8 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	    dsl_dataset_phys(ds)->ds_num_children > 1)) {
 		ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
+		if (SPA_EXITING(spa))
+			return;
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_DEFER_DESTROY;
 		if (zfs_snapshot_history_enabled) {
 			spa_history_log_internal_ds(ds, "defer_destroy", tx,
@@ -374,21 +417,28 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 	if (dsl_dataset_phys(ds)->ds_prev_snap_obj != 0) {
 		ASSERT0P(ds->ds_prev);
-		VERIFY0(dsl_dataset_hold_obj(dp,
-		    dsl_dataset_phys(ds)->ds_prev_snap_obj, FTAG, &ds_prev));
+		err = dsl_dataset_hold_obj(dp,
+		    dsl_dataset_phys(ds)->ds_prev_snap_obj, FTAG, &ds_prev);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		after_branch_point =
 		    (dsl_dataset_phys(ds_prev)->ds_next_snap_obj != obj);
 
 		dmu_buf_will_dirty(ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		if (after_branch_point &&
 		    dsl_dataset_phys(ds_prev)->ds_next_clones_obj != 0) {
 			dsl_dataset_remove_from_next_clones(ds_prev, obj, tx);
 			if (dsl_dataset_phys(ds)->ds_next_snap_obj != 0) {
-				VERIFY0(zap_add_int(mos,
+				err = zap_add_int(mos,
 				    dsl_dataset_phys(ds_prev)->
 				    ds_next_clones_obj,
 				    dsl_dataset_phys(ds)->ds_next_snap_obj,
-				    tx));
+				    tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 			}
 		}
 		if (!after_branch_point) {
@@ -397,17 +447,21 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		}
 	}
 
-	dsl_dataset_t *ds_next;
 	uint64_t old_unique;
 	uint64_t used = 0, comp = 0, uncomp = 0;
 
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &ds_next));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &ds_next);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	ASSERT3U(dsl_dataset_phys(ds_next)->ds_prev_snap_obj, ==, obj);
 
 	old_unique = dsl_dataset_phys(ds_next)->ds_unique_bytes;
 
 	dmu_buf_will_dirty(ds_next->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 	dsl_dataset_phys(ds_next)->ds_prev_snap_obj =
 	    dsl_dataset_phys(ds)->ds_prev_snap_obj;
 	dsl_dataset_phys(ds_next)->ds_prev_snap_txg =
@@ -416,8 +470,10 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	    ds_prev ? dsl_dataset_phys(ds_prev)->ds_creation_txg : 0);
 
 	if (ds_next->ds_deadlist.dl_oldfmt) {
-		process_old_deadlist(ds, ds_prev, ds_next,
+		err = process_old_deadlist(ds, ds_prev, ds_next,
 		    after_branch_point, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else {
 		/* Adjust prev's unique space. */
 		if (ds_prev && !after_branch_point) {
@@ -436,15 +492,19 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		    -used, -comp, -uncomp, tx);
 
 		/* Move blocks to be freed to pool's free list. */
-		dsl_deadlist_move_bpobj(&ds_next->ds_deadlist,
+		err = dsl_deadlist_move_bpobj(&ds_next->ds_deadlist,
 		    &dp->dp_free_bpobj, dsl_dataset_phys(ds)->ds_prev_snap_txg,
 		    tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dir_diduse_space(tx->tx_pool->dp_free_dir,
 		    DD_USED_HEAD, used, comp, uncomp, tx);
 
 		/* Merge our deadlist into next's and free it. */
-		dsl_deadlist_merge(&ds_next->ds_deadlist,
+		err = dsl_deadlist_merge(&ds_next->ds_deadlist,
 		    dsl_dataset_phys(ds)->ds_deadlist_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		/*
 		 * We are done with the deadlist tree (generated/used
@@ -468,8 +528,6 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 
 	if (ds_next->ds_is_snapshot) {
-		dsl_dataset_t *ds_nextnext;
-
 		/*
 		 * Update next's unique to include blocks which
 		 * were previously shared by only this snapshot
@@ -479,29 +537,36 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		 * after that (ie. be on the snap after next's
 		 * deadlist).
 		 */
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dataset_phys(ds_next)->ds_next_snap_obj,
-		    FTAG, &ds_nextnext));
+		    FTAG, &ds_nextnext);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		dsl_deadlist_space_range(&ds_nextnext->ds_deadlist,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg,
 		    dsl_dataset_phys(ds)->ds_creation_txg,
 		    &used, &comp, &uncomp);
 		dsl_dataset_phys(ds_next)->ds_unique_bytes += used;
 		dsl_dataset_rele(ds_nextnext, FTAG);
+		ds_nextnext = NULL;
 		ASSERT0P(ds_next->ds_prev);
 
 		/* Collapse range in this head. */
 		dsl_dataset_t *hds;
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj,
-		    FTAG, &hds));
+		    FTAG, &hds);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		if (!book_exists) {
 			/* Collapse range in this head. */
-			dsl_deadlist_remove_key(&hds->ds_deadlist,
+			(void) dsl_deadlist_remove_key(&hds->ds_deadlist,
 			    dsl_dataset_phys(ds)->ds_creation_txg, tx);
 		}
 		if (dsl_dataset_remap_deadlist_exists(hds)) {
-			dsl_deadlist_remove_key(&hds->ds_remap_deadlist,
+			(void) dsl_deadlist_remove_key(&hds->ds_remap_deadlist,
 			    dsl_dataset_phys(ds)->ds_creation_txg, tx);
 		}
 		dsl_dataset_rele(hds, FTAG);
@@ -511,9 +576,12 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		dsl_dataset_rele(ds_next->ds_prev, ds_next);
 		ds_next->ds_prev = NULL;
 		if (ds_prev) {
-			VERIFY0(dsl_dataset_hold_obj(dp,
+			err = dsl_dataset_hold_obj(dp,
 			    dsl_dataset_phys(ds)->ds_prev_snap_obj,
-			    ds_next, &ds_next->ds_prev));
+			    ds_next, &ds_next->ds_prev);
+			if (err && SPA_EXITING(spa))
+				goto skip;
+			VERIFY0(err);
 		}
 
 		dsl_dataset_recalc_head_uniq(ds_next);
@@ -535,7 +603,9 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 			    DD_USED_REFRSRV, -mrsdelta, 0, 0, tx);
 		}
 	}
+skip:
 	dsl_dataset_rele(ds_next, FTAG);
+	ds_next = NULL;
 
 	/*
 	 * This must be done after the dsl_traverse(), because it will
@@ -547,11 +617,16 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 
 	/* remove from snapshot namespace */
-	dsl_dataset_t *ds_head;
 	ASSERT0(dsl_dataset_phys(ds)->ds_snapnames_zapobj);
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head));
-	VERIFY0(dsl_dataset_get_snapname(ds));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
+	err = dsl_dataset_get_snapname(ds);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 #ifdef ZFS_DEBUG
 	{
 		uint64_t val;
@@ -559,35 +634,71 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 
 		err = dsl_dataset_snap_lookup(ds_head,
 		    ds->ds_snapname, &val);
-		ASSERT0(err);
-		ASSERT3U(val, ==, obj);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(err);
+			ASSERT3U(val, ==, obj);
+		}
 	}
 #endif
-	VERIFY0(dsl_dataset_snap_remove(ds_head, ds->ds_snapname, tx, B_TRUE));
+	err = dsl_dataset_snap_remove(ds_head, ds->ds_snapname, tx, B_TRUE);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_dataset_rele(ds_head, FTAG);
+	ds_head = NULL;
 
-	if (ds_prev != NULL)
+	if (ds_prev != NULL) {
 		dsl_dataset_rele(ds_prev, FTAG);
+		ds_prev = NULL;
+	}
 
 	spa_prop_clear_bootfs(dp->dp_spa, ds->ds_object, tx);
 
 	if (dsl_dataset_phys(ds)->ds_next_clones_obj != 0) {
 		uint64_t count __maybe_unused;
-		ASSERT0(zap_count(mos,
-		    dsl_dataset_phys(ds)->ds_next_clones_obj, &count) &&
-		    count == 0);
-		VERIFY0(dmu_object_free(mos,
-		    dsl_dataset_phys(ds)->ds_next_clones_obj, tx));
+		err = zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
+		    &count);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		ASSERT0(err);
+		ASSERT3U(count, ==, 0);
+
+		err = dmu_object_free(mos,
+		    dsl_dataset_phys(ds)->ds_next_clones_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
-	if (dsl_dataset_phys(ds)->ds_props_obj != 0)
-		VERIFY0(zap_destroy(mos, dsl_dataset_phys(ds)->ds_props_obj,
-		    tx));
-	if (dsl_dataset_phys(ds)->ds_userrefs_obj != 0)
-		VERIFY0(zap_destroy(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
-		    tx));
+	if (dsl_dataset_phys(ds)->ds_props_obj != 0) {
+		err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_props_obj,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+	}
+	if (dsl_dataset_phys(ds)->ds_userrefs_obj != 0) {
+		err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+	}
 	dsl_dir_rele(ds->ds_dir, ds);
 	ds->ds_dir = NULL;
 	dmu_object_free_zapified(mos, obj, tx);
+	return;
+
+spa_exiting:
+	if (ds_nextnext)
+		dsl_dataset_rele(ds_nextnext, FTAG);
+	if (ds_next)
+		dsl_dataset_rele(ds_next, FTAG);
+	if (ds_head)
+		dsl_dataset_rele(ds_head, FTAG);
+	if (ds_prev)
+		dsl_dataset_rele(ds_prev, FTAG);
+	dsl_dir_rele(ds->ds_dir, ds);
+	ds->ds_dir = NULL;
 }
 
 void
@@ -602,6 +713,8 @@ dsl_destroy_snapshot_sync(void *arg, dmu_tx_t *tx)
 
 	int error = dsl_dataset_hold(dp, dsname, FTAG, &ds);
 	if (error == ENOENT)
+		return;
+	if (error && SPA_EXITING(dp->dp_spa))
 		return;
 	ASSERT0(error);
 	dsl_destroy_snapshot_sync_impl(ds, defer, tx);
@@ -852,14 +965,19 @@ dsl_destroy_head_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 {
-	dsl_dir_t *dd;
+	dsl_dir_t *dd = NULL;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dd_used_t t;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dmu_tx_pool(tx)->dp_config_rwlock));
 
-	VERIFY0(dsl_dir_hold_obj(dp, ddobj, NULL, FTAG, &dd));
+	err = dsl_dir_hold_obj(dp, ddobj, NULL, FTAG, &dd);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
@@ -874,6 +992,8 @@ dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 	 */
 	dsl_dir_set_reservation_sync_impl(dd, 0, tx);
 
+	if (SPA_EXITING(spa))
+		goto out;
 	ASSERT0(dsl_dir_phys(dd)->dd_used_bytes);
 	ASSERT0(dsl_dir_phys(dd)->dd_reserved);
 	for (t = 0; t < DD_USED_NUM; t++)
@@ -884,16 +1004,38 @@ dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 		(void) spa_keystore_unload_wkey_impl(dp->dp_spa, dd->dd_object);
 	}
 
-	VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_child_dir_zapobj, tx));
-	VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_props_zapobj, tx));
-	if (dsl_dir_phys(dd)->dd_clones != 0)
-		VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_clones, tx));
-	VERIFY0(dsl_deleg_destroy(mos, dsl_dir_phys(dd)->dd_deleg_zapobj, tx));
-	VERIFY0(zap_remove(mos,
-	    dsl_dir_phys(dd->dd_parent)->dd_child_dir_zapobj,
-	    dd->dd_myname, tx));
+	err = zap_destroy(mos, dsl_dir_phys(dd)->dd_child_dir_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	dsl_dir_rele(dd, FTAG);
+	err = zap_destroy(mos, dsl_dir_phys(dd)->dd_props_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	if (dsl_dir_phys(dd)->dd_clones != 0) {
+		err = zap_destroy(mos, dsl_dir_phys(dd)->dd_clones, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+	}
+
+	err = dsl_deleg_destroy(mos, dsl_dir_phys(dd)->dd_deleg_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_remove(mos,
+	    dsl_dir_phys(dd->dd_parent)->dd_child_dir_zapobj,
+	    dd->dd_myname, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	if (dd)
+		dsl_dir_rele(dd, FTAG);
 	dmu_object_free_zapified(mos, ddobj, tx);
 }
 
@@ -922,16 +1064,21 @@ dsl_clone_destroy_assert(dsl_dir_t *dd)
  * and queue the blkptrs for deletion by adding the livelist to the pool-wide
  * delete queue.
  */
-static void
+static int
 dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t zap_obj, to_delete, used, comp, uncomp;
-	objset_t *os;
+	objset_t *os = NULL;
 	dsl_dir_t *dd = ds->ds_dir;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	int err = 0;
+
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	uint64_t mintxg = 0;
 	dsl_deadlist_entry_t *dle = dsl_deadlist_first(&dd->dd_livelist);
@@ -947,24 +1094,38 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	/* Destroy the zil */
 	zil_destroy_sync(dmu_objset_zil(os), tx);
 
-	VERIFY0(zap_lookup(mos, dd->dd_object,
-	    DD_FIELD_LIVELIST, sizeof (uint64_t), 1, &to_delete));
+	err = zap_lookup(mos, dd->dd_object,
+	    DD_FIELD_LIVELIST, sizeof (uint64_t), 1, &to_delete);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	/* Initialize deleted_clones entry to track livelists to cleanup */
-	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1, &zap_obj);
-	if (error == ENOENT) {
-		VERIFY0(zap_create(mos, DMU_OTN_ZAP_METADATA,
-		    DMU_OT_NONE, 0, tx, &zap_obj));
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+	if (err == ENOENT) {
+		err = zap_create(mos, DMU_OTN_ZAP_METADATA,
+		    DMU_OT_NONE, 0, tx, &zap_obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1,
-		    &(zap_obj), tx));
+		    &(zap_obj), tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		spa->spa_livelists_to_delete = zap_obj;
-	} else if (error != 0) {
+	} else if (err != 0) {
+		if (SPA_EXITING(spa))
+			goto out;
 		zfs_panic_recover("zfs: error %d was returned while looking "
-		    "up DMU_POOL_DELETED_CLONES in the zap", error);
-		return;
+		    "up DMU_POOL_DELETED_CLONES in the zap", err);
+		return (err);
 	}
-	VERIFY0(zap_add_int(mos, zap_obj, to_delete, tx));
+	err = zap_add_int(mos, zap_obj, to_delete, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	/* Clone is no longer using space, now tracked by dp_free_dir */
 	dsl_deadlist_space(&dd->dd_livelist, &used, &comp, &uncomp);
@@ -974,7 +1135,10 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
 	    used, comp, uncomp, tx);
 	dsl_dir_remove_livelist(dd, tx, B_FALSE);
+out:
 	zthr_wakeup(spa->spa_livelist_delete_zthr);
+
+	return (err);
 }
 
 /*
@@ -1047,9 +1211,11 @@ void
 dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	uint64_t obj, ddobj, prevobj = 0;
 	boolean_t rmorigin;
+	int err;
 
 	ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
 	ASSERT(ds->ds_prev == NULL ||
@@ -1068,10 +1234,13 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	/* Remove our reservation. */
 	if (ds->ds_reserved != 0) {
-		dsl_dataset_set_refreservation_sync_impl(ds,
+		err = dsl_dataset_set_refreservation_sync_impl(ds,
 		    (ZPROP_SRC_NONE | ZPROP_SRC_LOCAL | ZPROP_SRC_RECEIVED),
 		    0, tx);
-		ASSERT0(ds->ds_reserved);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(err);
+			ASSERT0(ds->ds_reserved);
+		}
 	}
 
 	obj = ds->ds_object;
@@ -1120,19 +1289,25 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 * those belonging to the zil.
 	 */
 	if (dsl_deadlist_is_open(&ds->ds_dir->dd_livelist)) {
-		dsl_async_clone_destroy(ds, tx);
+		err = dsl_async_clone_destroy(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else if (spa_feature_is_enabled(dp->dp_spa,
 	    SPA_FEATURE_ASYNC_DESTROY)) {
-		(void) dsl_async_dataset_destroy(ds, tx);
+		err = dsl_async_dataset_destroy(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else {
 		old_synchronous_dataset_destroy(ds, tx);
 	}
 
 	if (ds->ds_prev != NULL) {
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_DIR_CLONES) {
-			VERIFY0(zap_remove_int(mos,
+			err = zap_remove_int(mos,
 			    dsl_dir_phys(ds->ds_prev->ds_dir)->dd_clones,
-			    ds->ds_object, tx));
+			    ds->ds_object, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		}
 		prevobj = ds->ds_prev->ds_object;
 		dsl_dataset_rele(ds->ds_prev, ds);
@@ -1153,8 +1328,9 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj = 0;
 	ddobj = ds->ds_dir->dd_object;
 	ASSERT(dsl_dataset_phys(ds)->ds_snapnames_zapobj != 0);
-	VERIFY0(zap_destroy(mos,
-	    dsl_dataset_phys(ds)->ds_snapnames_zapobj, tx));
+	err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	if (ds->ds_bookmarks_obj != 0) {
 		void *cookie = NULL;
@@ -1164,17 +1340,22 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    NULL) {
 			if (dbn->dbn_phys.zbm_redaction_obj != 0) {
 				dnode_t *rl;
-				VERIFY0(dnode_hold(mos,
+				err = dnode_hold(mos,
 				    dbn->dbn_phys.zbm_redaction_obj, FTAG,
-				    &rl));
-				if (rl->dn_have_spill) {
+				    &rl);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+				if (!err && rl->dn_have_spill) {
 					spa_feature_decr(dmu_objset_spa(mos),
 					    SPA_FEATURE_REDACTION_LIST_SPILL,
 					    tx);
 				}
-				dnode_rele(rl, FTAG);
-				VERIFY0(dmu_object_free(mos,
-				    dbn->dbn_phys.zbm_redaction_obj, tx));
+				if (!err)
+					dnode_rele(rl, FTAG);
+				err = dmu_object_free(mos,
+				    dbn->dbn_phys.zbm_redaction_obj, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 				spa_feature_decr(dmu_objset_spa(mos),
 				    SPA_FEATURE_REDACTION_BOOKMARKS, tx);
 			}
@@ -1187,7 +1368,9 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 			kmem_free(dbn, sizeof (*dbn));
 		}
 		avl_destroy(&ds->ds_bookmarks);
-		VERIFY0(zap_destroy(mos, ds->ds_bookmarks_obj, tx));
+		err = zap_destroy(mos, ds->ds_bookmarks_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa_feature_decr(dp->dp_spa, SPA_FEATURE_BOOKMARKS, tx);
 	}
 
@@ -1204,7 +1387,10 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	if (rmorigin) {
 		dsl_dataset_t *prev;
-		VERIFY0(dsl_dataset_hold_obj(dp, prevobj, FTAG, &prev));
+		err = dsl_dataset_hold_obj(dp, prevobj, FTAG, &prev);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		dsl_destroy_snapshot_sync_impl(prev, B_FALSE, tx);
 		dsl_dataset_rele(prev, FTAG);
 	}
@@ -1218,9 +1404,13 @@ dsl_destroy_head_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_destroy_head_arg_t *ddha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	dsl_dataset_t *ds;
 
-	VERIFY0(dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds));
+	int err = dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	dsl_destroy_head_sync_impl(ds, tx);
 	zvol_remove_minors(dp->dp_spa, ddha->ddha_name, B_TRUE);
 	dsl_dataset_rele(ds, FTAG);
@@ -1233,7 +1423,10 @@ dsl_destroy_head_begin_sync(void *arg, dmu_tx_t *tx)
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds;
 
-	VERIFY0(dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds));
+	int err = dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
 
 	/* Mark it as inconsistent on-disk, in case we crash */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -281,30 +281,47 @@ dsl_destroy_snapshot_handle_remaps(dsl_dataset_t *ds, dsl_dataset_t *ds_next,
     dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	/* Move blocks to be obsoleted to pool's obsolete list. */
 	if (dsl_dataset_remap_deadlist_exists(ds_next)) {
 		if (!bpobj_is_open(&dp->dp_obsolete_bpobj))
 			dsl_pool_create_obsolete_bpobj(dp, tx);
 
-		dsl_deadlist_move_bpobj(&ds_next->ds_remap_deadlist,
+		err = dsl_deadlist_move_bpobj(&ds_next->ds_remap_deadlist,
 		    &dp->dp_obsolete_bpobj,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 
 	/* Merge our deadlist into next's and free it. */
 	if (dsl_dataset_remap_deadlist_exists(ds)) {
-		uint64_t remap_deadlist_object =
-		    dsl_dataset_get_remap_deadlist_object(ds);
+		uint64_t remap_deadlist_object;
+		err = dsl_dataset_get_remap_deadlist_object(ds,
+		    &remap_deadlist_object);
+		if (err && SPA_EXITING(spa)) {
+			dsl_deadlist_close(&ds->ds_remap_deadlist);
+			return;
+		}
 		ASSERT(remap_deadlist_object != 0);
 
 		mutex_enter(&ds_next->ds_remap_deadlist_lock);
-		if (!dsl_dataset_remap_deadlist_exists(ds_next))
-			dsl_dataset_create_remap_deadlist(ds_next, tx);
+		if (!dsl_dataset_remap_deadlist_exists(ds_next)) {
+			err = dsl_dataset_create_remap_deadlist(ds_next, tx);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
+		}
 		mutex_exit(&ds_next->ds_remap_deadlist_lock);
 
-		dsl_deadlist_merge(&ds_next->ds_remap_deadlist,
+		err = dsl_deadlist_merge(&ds_next->ds_remap_deadlist,
 		    remap_deadlist_object, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		dsl_dataset_destroy_remap_deadlist(ds, tx);
 	}
 }

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -129,12 +129,18 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
 	struct process_old_arg *poa = arg;
 	dsl_pool_t *dp = poa->ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
+	int err = 0;
 
 	ASSERT(!BP_IS_HOLE(bp));
 
 	if (BP_GET_BIRTH(bp) <=
 	    dsl_dataset_phys(poa->ds)->ds_prev_snap_txg) {
-		dsl_deadlist_insert(&poa->ds->ds_deadlist, bp, bp_freed, tx);
+		err = dsl_deadlist_insert(&poa->ds->ds_deadlist, bp, bp_freed,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		if (poa->ds_prev && !poa->after_branch_point &&
 		    BP_GET_BIRTH(bp) >
 		    dsl_dataset_phys(poa->ds_prev)->ds_prev_snap_txg) {
@@ -147,7 +153,7 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 		poa->uncomp += BP_GET_UCSIZE(bp);
 		dsl_free_sync(poa->pio, dp, tx->tx_txg, bp);
 	}
-	return (0);
+	return (err);
 }
 
 static void
@@ -979,8 +985,8 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1, &zap_obj);
 	if (error == ENOENT) {
-		zap_obj = zap_create(mos, DMU_OTN_ZAP_METADATA,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OTN_ZAP_METADATA,
+		    DMU_OT_NONE, 0, tx, &zap_obj));
 		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1,
 		    &(zap_obj), tx));
@@ -1007,13 +1013,18 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
  * Move the bptree into the pool's list of trees to clean up, update space
  * accounting information and destroy the zil.
  */
-static void
+static int
 dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t used, comp, uncomp;
 	objset_t *os;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	int err = 0;
 
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
 
@@ -1028,11 +1039,17 @@ dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 		dsl_scan_t *scn = dp->dp_scan;
 		spa_feature_incr(dp->dp_spa, SPA_FEATURE_ASYNC_DESTROY,
 		    tx);
-		dp->dp_bptree_obj = bptree_alloc(mos, tx);
-		VERIFY0(zap_add(mos,
+		err = bptree_alloc(mos, tx, &dp->dp_bptree_obj);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = zap_add(mos,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_BPTREE_OBJ, sizeof (uint64_t), 1,
-		    &dp->dp_bptree_obj, tx));
+		    &dp->dp_bptree_obj, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		ASSERT(!scn->scn_async_destroying);
 		scn->scn_async_destroying = B_TRUE;
 	}
@@ -1054,6 +1071,8 @@ dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	    -used, -comp, -uncomp, tx);
 	dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
 	    used, comp, uncomp, tx);
+
+	return (err);
 }
 
 void
@@ -1136,7 +1155,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 		dsl_async_clone_destroy(ds, tx);
 	} else if (spa_feature_is_enabled(dp->dp_spa,
 	    SPA_FEATURE_ASYNC_DESTROY)) {
-		dsl_async_dataset_destroy(ds, tx);
+		(void) dsl_async_dataset_destroy(ds, tx);
 	} else {
 		old_synchronous_dataset_destroy(ds, tx);
 	}

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -156,14 +156,16 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 	return (err);
 }
 
-static void
+static int
 process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
     dsl_dataset_t *ds_next, boolean_t after_branch_point, dmu_tx_t *tx)
 {
 	struct process_old_arg poa = { 0 };
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	uint64_t deadlist_obj;
+	int err = 0;
 
 	ASSERT(ds->ds_deadlist.dl_oldfmt);
 	ASSERT(ds_next->ds_deadlist.dl_oldfmt);
@@ -172,9 +174,15 @@ process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
 	poa.ds_prev = ds_prev;
 	poa.after_branch_point = after_branch_point;
 	poa.pio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
-	VERIFY0(bpobj_iterate(&ds_next->ds_deadlist.dl_bpobj,
-	    process_old_cb, &poa, tx));
-	VERIFY0(zio_wait(poa.pio));
+	err = bpobj_iterate(&ds_next->ds_deadlist.dl_bpobj,
+	    process_old_cb, &poa, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zio_wait(poa.pio);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(poa.used, ==, dsl_dataset_phys(ds)->ds_unique_bytes);
 
 	/* change snapused */
@@ -188,10 +196,18 @@ process_old_deadlist(dsl_dataset_t *ds, dsl_dataset_t *ds_prev,
 	dsl_dataset_phys(ds)->ds_deadlist_obj =
 	    dsl_dataset_phys(ds_next)->ds_deadlist_obj;
 	dsl_dataset_phys(ds_next)->ds_deadlist_obj = deadlist_obj;
-	VERIFY0(dsl_deadlist_open(&ds->ds_deadlist, mos,
-	    dsl_dataset_phys(ds)->ds_deadlist_obj));
-	VERIFY0(dsl_deadlist_open(&ds_next->ds_deadlist, mos,
-	    dsl_dataset_phys(ds_next)->ds_deadlist_obj));
+	err = dsl_deadlist_open(&ds->ds_deadlist, mos,
+	    dsl_dataset_phys(ds)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dsl_deadlist_open(&ds_next->ds_deadlist, mos,
+	    dsl_dataset_phys(ds_next)->ds_deadlist_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 typedef struct remaining_clones_key {
@@ -207,11 +223,13 @@ rck_alloc(dsl_dataset_t *clone)
 	return (rck);
 }
 
-static void
+static int
 dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
     list_t *stack, const void *tag)
 {
 	objset_t *mos = dd->dd_pool->dp_meta_objset;
+	spa_t *spa = mos->os_spa;
+	int err = 0;
 
 	/*
 	 * If it is the old version, dd_clones doesn't exist so we can't
@@ -219,7 +237,7 @@ dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
 	 * doesn't matter.
 	 */
 	if (dsl_dir_phys(dd)->dd_clones == 0)
-		return;
+		return (0);
 
 	zap_cursor_t *zc = kmem_alloc(sizeof (zap_cursor_t), KM_SLEEP);
 	zap_attribute_t *za = zap_attribute_alloc();
@@ -229,38 +247,54 @@ dsl_dir_remove_clones_key_impl(dsl_dir_t *dd, uint64_t mintxg, dmu_tx_t *tx,
 	    zap_cursor_advance(zc)) {
 		dsl_dataset_t *clone;
 
-		VERIFY0(dsl_dataset_hold_obj(dd->dd_pool,
-		    za->za_first_integer, tag, &clone));
+		err = dsl_dataset_hold_obj(dd->dd_pool,
+		    za->za_first_integer, tag, &clone);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
 		if (clone->ds_dir->dd_origin_txg > mintxg) {
-			dsl_deadlist_remove_key(&clone->ds_deadlist,
+			err = dsl_deadlist_remove_key(&clone->ds_deadlist,
 			    mintxg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 
-			if (dsl_dataset_remap_deadlist_exists(clone)) {
-				dsl_deadlist_remove_key(
+			if (!err && dsl_dataset_remap_deadlist_exists(clone)) {
+				err = dsl_deadlist_remove_key(
 				    &clone->ds_remap_deadlist, mintxg, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 			}
 
 			list_insert_head(stack, rck_alloc(clone));
 		} else {
 			dsl_dataset_rele(clone, tag);
 		}
+
+		if (err)
+			break;
 	}
 	zap_cursor_fini(zc);
 
 	zap_attribute_free(za);
 	kmem_free(zc, sizeof (zap_cursor_t));
+
+	return (err);
 }
 
 void
 dsl_dir_remove_clones_key(dsl_dir_t *top_dd, uint64_t mintxg, dmu_tx_t *tx)
 {
+	spa_t *spa = top_dd->dd_pool->dp_spa;
 	list_t stack;
+	int err;
 
 	list_create(&stack, sizeof (remaining_clones_key_t),
 	    offsetof(remaining_clones_key_t, rck_node));
 
-	dsl_dir_remove_clones_key_impl(top_dd, mintxg, tx, &stack, FTAG);
+	err = dsl_dir_remove_clones_key_impl(top_dd, mintxg, tx, &stack, FTAG);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	for (remaining_clones_key_t *rck = list_remove_head(&stack);
 	    rck != NULL; rck = list_remove_head(&stack)) {
 		dsl_dataset_t *clone = rck->rck_clone;
@@ -268,8 +302,10 @@ dsl_dir_remove_clones_key(dsl_dir_t *top_dd, uint64_t mintxg, dmu_tx_t *tx)
 
 		kmem_free(rck, sizeof (*rck));
 
-		dsl_dir_remove_clones_key_impl(clone_dir, mintxg, tx,
+		err = dsl_dir_remove_clones_key_impl(clone_dir, mintxg, tx,
 		    &stack, FTAG);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dataset_rele(clone, FTAG);
 	}
 
@@ -331,9 +367,14 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 {
 	int after_branch_point = FALSE;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dsl_dataset_t *ds_prev = NULL;
+	dsl_dataset_t *ds_next = NULL;
+	dsl_dataset_t *ds_nextnext = NULL;
+	dsl_dataset_t *ds_head = NULL;
 	uint64_t obj;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
@@ -346,6 +387,8 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	    dsl_dataset_long_held(ds))) {
 		ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
+		if (SPA_EXITING(spa))
+			return;
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_DEFER_DESTROY;
 		if (zfs_snapshot_history_enabled) {
 			spa_history_log_internal_ds(ds, "defer_destroy", tx,
@@ -382,21 +425,28 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 	if (dsl_dataset_phys(ds)->ds_prev_snap_obj != 0) {
 		ASSERT0P(ds->ds_prev);
-		VERIFY0(dsl_dataset_hold_obj(dp,
-		    dsl_dataset_phys(ds)->ds_prev_snap_obj, FTAG, &ds_prev));
+		err = dsl_dataset_hold_obj(dp,
+		    dsl_dataset_phys(ds)->ds_prev_snap_obj, FTAG, &ds_prev);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		after_branch_point =
 		    (dsl_dataset_phys(ds_prev)->ds_next_snap_obj != obj);
 
 		dmu_buf_will_dirty(ds_prev->ds_dbuf, tx);
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		if (after_branch_point &&
 		    dsl_dataset_phys(ds_prev)->ds_next_clones_obj != 0) {
 			dsl_dataset_remove_from_next_clones(ds_prev, obj, tx);
 			if (dsl_dataset_phys(ds)->ds_next_snap_obj != 0) {
-				VERIFY0(zap_add_int(mos,
+				err = zap_add_int(mos,
 				    dsl_dataset_phys(ds_prev)->
 				    ds_next_clones_obj,
 				    dsl_dataset_phys(ds)->ds_next_snap_obj,
-				    tx));
+				    tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 			}
 		}
 		if (!after_branch_point) {
@@ -405,17 +455,21 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		}
 	}
 
-	dsl_dataset_t *ds_next;
 	uint64_t old_unique;
 	uint64_t used = 0, comp = 0, uncomp = 0;
 
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &ds_next));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &ds_next);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	ASSERT3U(dsl_dataset_phys(ds_next)->ds_prev_snap_obj, ==, obj);
 
 	old_unique = dsl_dataset_phys(ds_next)->ds_unique_bytes;
 
 	dmu_buf_will_dirty(ds_next->ds_dbuf, tx);
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 	dsl_dataset_phys(ds_next)->ds_prev_snap_obj =
 	    dsl_dataset_phys(ds)->ds_prev_snap_obj;
 	dsl_dataset_phys(ds_next)->ds_prev_snap_txg =
@@ -424,8 +478,10 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	    ds_prev ? dsl_dataset_phys(ds_prev)->ds_creation_txg : 0);
 
 	if (ds_next->ds_deadlist.dl_oldfmt) {
-		process_old_deadlist(ds, ds_prev, ds_next,
+		err = process_old_deadlist(ds, ds_prev, ds_next,
 		    after_branch_point, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else {
 		/* Adjust prev's unique space. */
 		if (ds_prev && !after_branch_point) {
@@ -444,15 +500,19 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		    -used, -comp, -uncomp, tx);
 
 		/* Move blocks to be freed to pool's free list. */
-		dsl_deadlist_move_bpobj(&ds_next->ds_deadlist,
+		err = dsl_deadlist_move_bpobj(&ds_next->ds_deadlist,
 		    &dp->dp_free_bpobj, dsl_dataset_phys(ds)->ds_prev_snap_txg,
 		    tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dsl_dir_diduse_space(tx->tx_pool->dp_free_dir,
 		    DD_USED_HEAD, used, comp, uncomp, tx);
 
 		/* Merge our deadlist into next's and free it. */
-		dsl_deadlist_merge(&ds_next->ds_deadlist,
+		err = dsl_deadlist_merge(&ds_next->ds_deadlist,
 		    dsl_dataset_phys(ds)->ds_deadlist_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 
 		/*
 		 * We are done with the deadlist tree (generated/used
@@ -476,8 +536,6 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 
 	if (ds_next->ds_is_snapshot) {
-		dsl_dataset_t *ds_nextnext;
-
 		/*
 		 * Update next's unique to include blocks which
 		 * were previously shared by only this snapshot
@@ -487,29 +545,36 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		 * after that (ie. be on the snap after next's
 		 * deadlist).
 		 */
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dataset_phys(ds_next)->ds_next_snap_obj,
-		    FTAG, &ds_nextnext));
+		    FTAG, &ds_nextnext);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		dsl_deadlist_space_range(&ds_nextnext->ds_deadlist,
 		    dsl_dataset_phys(ds)->ds_prev_snap_txg,
 		    dsl_dataset_phys(ds)->ds_creation_txg,
 		    &used, &comp, &uncomp);
 		dsl_dataset_phys(ds_next)->ds_unique_bytes += used;
 		dsl_dataset_rele(ds_nextnext, FTAG);
+		ds_nextnext = NULL;
 		ASSERT0P(ds_next->ds_prev);
 
 		/* Collapse range in this head. */
 		dsl_dataset_t *hds;
-		VERIFY0(dsl_dataset_hold_obj(dp,
+		err = dsl_dataset_hold_obj(dp,
 		    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj,
-		    FTAG, &hds));
+		    FTAG, &hds);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		if (!book_exists) {
 			/* Collapse range in this head. */
-			dsl_deadlist_remove_key(&hds->ds_deadlist,
+			(void) dsl_deadlist_remove_key(&hds->ds_deadlist,
 			    dsl_dataset_phys(ds)->ds_creation_txg, tx);
 		}
 		if (dsl_dataset_remap_deadlist_exists(hds)) {
-			dsl_deadlist_remove_key(&hds->ds_remap_deadlist,
+			(void) dsl_deadlist_remove_key(&hds->ds_remap_deadlist,
 			    dsl_dataset_phys(ds)->ds_creation_txg, tx);
 		}
 		dsl_dataset_rele(hds, FTAG);
@@ -519,9 +584,12 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		dsl_dataset_rele(ds_next->ds_prev, ds_next);
 		ds_next->ds_prev = NULL;
 		if (ds_prev) {
-			VERIFY0(dsl_dataset_hold_obj(dp,
+			err = dsl_dataset_hold_obj(dp,
 			    dsl_dataset_phys(ds)->ds_prev_snap_obj,
-			    ds_next, &ds_next->ds_prev));
+			    ds_next, &ds_next->ds_prev);
+			if (err && SPA_EXITING(spa))
+				goto skip;
+			VERIFY0(err);
 		}
 
 		dsl_dataset_recalc_head_uniq(ds_next);
@@ -543,7 +611,9 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 			    DD_USED_REFRSRV, -mrsdelta, 0, 0, tx);
 		}
 	}
+skip:
 	dsl_dataset_rele(ds_next, FTAG);
+	ds_next = NULL;
 
 	/*
 	 * This must be done after the dsl_traverse(), because it will
@@ -555,11 +625,16 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 
 	/* remove from snapshot namespace */
-	dsl_dataset_t *ds_head;
 	ASSERT0(dsl_dataset_phys(ds)->ds_snapnames_zapobj);
-	VERIFY0(dsl_dataset_hold_obj(dp,
-	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head));
-	VERIFY0(dsl_dataset_get_snapname(ds));
+	err = dsl_dataset_hold_obj(dp,
+	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
+	err = dsl_dataset_get_snapname(ds);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 #ifdef ZFS_DEBUG
 	{
 		uint64_t val;
@@ -567,35 +642,71 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 
 		err = dsl_dataset_snap_lookup(ds_head,
 		    ds->ds_snapname, &val);
-		ASSERT0(err);
-		ASSERT3U(val, ==, obj);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(err);
+			ASSERT3U(val, ==, obj);
+		}
 	}
 #endif
-	VERIFY0(dsl_dataset_snap_remove(ds_head, ds->ds_snapname, tx, B_TRUE));
+	err = dsl_dataset_snap_remove(ds_head, ds->ds_snapname, tx, B_TRUE);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	dsl_dataset_rele(ds_head, FTAG);
+	ds_head = NULL;
 
-	if (ds_prev != NULL)
+	if (ds_prev != NULL) {
 		dsl_dataset_rele(ds_prev, FTAG);
+		ds_prev = NULL;
+	}
 
 	spa_prop_clear_bootfs(dp->dp_spa, ds->ds_object, tx);
 
 	if (dsl_dataset_phys(ds)->ds_next_clones_obj != 0) {
 		uint64_t count __maybe_unused;
-		ASSERT0(zap_count(mos,
-		    dsl_dataset_phys(ds)->ds_next_clones_obj, &count) &&
-		    count == 0);
-		VERIFY0(dmu_object_free(mos,
-		    dsl_dataset_phys(ds)->ds_next_clones_obj, tx));
+		err = zap_count(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
+		    &count);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		ASSERT0(err);
+		ASSERT3U(count, ==, 0);
+
+		err = dmu_object_free(mos,
+		    dsl_dataset_phys(ds)->ds_next_clones_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
-	if (dsl_dataset_phys(ds)->ds_props_obj != 0)
-		VERIFY0(zap_destroy(mos, dsl_dataset_phys(ds)->ds_props_obj,
-		    tx));
-	if (dsl_dataset_phys(ds)->ds_userrefs_obj != 0)
-		VERIFY0(zap_destroy(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
-		    tx));
+	if (dsl_dataset_phys(ds)->ds_props_obj != 0) {
+		err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_props_obj,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+	}
+	if (dsl_dataset_phys(ds)->ds_userrefs_obj != 0) {
+		err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
+		    tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
+	}
 	dsl_dir_rele(ds->ds_dir, ds);
 	ds->ds_dir = NULL;
 	dmu_object_free_zapified(mos, obj, tx);
+	return;
+
+spa_exiting:
+	if (ds_nextnext)
+		dsl_dataset_rele(ds_nextnext, FTAG);
+	if (ds_next)
+		dsl_dataset_rele(ds_next, FTAG);
+	if (ds_head)
+		dsl_dataset_rele(ds_head, FTAG);
+	if (ds_prev)
+		dsl_dataset_rele(ds_prev, FTAG);
+	dsl_dir_rele(ds->ds_dir, ds);
+	ds->ds_dir = NULL;
 }
 
 void
@@ -610,6 +721,8 @@ dsl_destroy_snapshot_sync(void *arg, dmu_tx_t *tx)
 
 	int error = dsl_dataset_hold(dp, dsname, FTAG, &ds);
 	if (error == ENOENT)
+		return;
+	if (error && SPA_EXITING(dp->dp_spa))
 		return;
 	ASSERT0(error);
 	dsl_destroy_snapshot_sync_impl(ds, defer, tx);
@@ -901,14 +1014,19 @@ dsl_destroy_head_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 {
-	dsl_dir_t *dd;
+	dsl_dir_t *dd = NULL;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	dd_used_t t;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dmu_tx_pool(tx)->dp_config_rwlock));
 
-	VERIFY0(dsl_dir_hold_obj(dp, ddobj, NULL, FTAG, &dd));
+	err = dsl_dir_hold_obj(dp, ddobj, NULL, FTAG, &dd);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
@@ -923,6 +1041,8 @@ dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 	 */
 	dsl_dir_set_reservation_sync_impl(dd, 0, tx);
 
+	if (SPA_EXITING(spa))
+		goto out;
 	ASSERT0(dsl_dir_phys(dd)->dd_used_bytes);
 	ASSERT0(dsl_dir_phys(dd)->dd_reserved);
 	for (t = 0; t < DD_USED_NUM; t++)
@@ -933,16 +1053,38 @@ dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 		(void) spa_keystore_unload_wkey_impl(dp->dp_spa, dd->dd_object);
 	}
 
-	VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_child_dir_zapobj, tx));
-	VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_props_zapobj, tx));
-	if (dsl_dir_phys(dd)->dd_clones != 0)
-		VERIFY0(zap_destroy(mos, dsl_dir_phys(dd)->dd_clones, tx));
-	VERIFY0(dsl_deleg_destroy(mos, dsl_dir_phys(dd)->dd_deleg_zapobj, tx));
-	VERIFY0(zap_remove(mos,
-	    dsl_dir_phys(dd->dd_parent)->dd_child_dir_zapobj,
-	    dd->dd_myname, tx));
+	err = zap_destroy(mos, dsl_dir_phys(dd)->dd_child_dir_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
-	dsl_dir_rele(dd, FTAG);
+	err = zap_destroy(mos, dsl_dir_phys(dd)->dd_props_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	if (dsl_dir_phys(dd)->dd_clones != 0) {
+		err = zap_destroy(mos, dsl_dir_phys(dd)->dd_clones, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+	}
+
+	err = dsl_deleg_destroy(mos, dsl_dir_phys(dd)->dd_deleg_zapobj, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_remove(mos,
+	    dsl_dir_phys(dd->dd_parent)->dd_child_dir_zapobj,
+	    dd->dd_myname, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	if (dd)
+		dsl_dir_rele(dd, FTAG);
 	dmu_object_free_zapified(mos, ddobj, tx);
 }
 
@@ -971,16 +1113,21 @@ dsl_clone_destroy_assert(dsl_dir_t *dd)
  * and queue the blkptrs for deletion by adding the livelist to the pool-wide
  * delete queue.
  */
-static void
+static int
 dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	uint64_t zap_obj, to_delete, used, comp, uncomp;
-	objset_t *os;
+	objset_t *os = NULL;
 	dsl_dir_t *dd = ds->ds_dir;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
-	VERIFY0(dmu_objset_from_ds(ds, &os));
+	int err = 0;
+
+	err = dmu_objset_from_ds(ds, &os);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	uint64_t mintxg = 0;
 	dsl_deadlist_entry_t *dle = dsl_deadlist_first(&dd->dd_livelist);
@@ -996,24 +1143,38 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	/* Destroy the zil */
 	zil_destroy_sync(dmu_objset_zil(os), tx);
 
-	VERIFY0(zap_lookup(mos, dd->dd_object,
-	    DD_FIELD_LIVELIST, sizeof (uint64_t), 1, &to_delete));
+	err = zap_lookup(mos, dd->dd_object,
+	    DD_FIELD_LIVELIST, sizeof (uint64_t), 1, &to_delete);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	/* Initialize deleted_clones entry to track livelists to cleanup */
-	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1, &zap_obj);
-	if (error == ENOENT) {
-		VERIFY0(zap_create(mos, DMU_OTN_ZAP_METADATA,
-		    DMU_OT_NONE, 0, tx, &zap_obj));
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+	if (err == ENOENT) {
+		err = zap_create(mos, DMU_OTN_ZAP_METADATA,
+		    DMU_OT_NONE, 0, tx, &zap_obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_DELETED_CLONES, sizeof (uint64_t), 1,
-		    &(zap_obj), tx));
+		    &(zap_obj), tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		spa->spa_livelists_to_delete = zap_obj;
-	} else if (error != 0) {
+	} else if (err != 0) {
+		if (SPA_EXITING(spa))
+			goto out;
 		zfs_panic_recover("zfs: error %d was returned while looking "
-		    "up DMU_POOL_DELETED_CLONES in the zap", error);
-		return;
+		    "up DMU_POOL_DELETED_CLONES in the zap", err);
+		return (err);
 	}
-	VERIFY0(zap_add_int(mos, zap_obj, to_delete, tx));
+	err = zap_add_int(mos, zap_obj, to_delete, tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 
 	/* Clone is no longer using space, now tracked by dp_free_dir */
 	dsl_deadlist_space(&dd->dd_livelist, &used, &comp, &uncomp);
@@ -1023,7 +1184,10 @@ dsl_async_clone_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
 	    used, comp, uncomp, tx);
 	dsl_dir_remove_livelist(dd, tx, B_FALSE);
+out:
 	zthr_wakeup(spa->spa_livelist_delete_zthr);
+
+	return (err);
 }
 
 /*
@@ -1096,9 +1260,11 @@ void
 dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
 	uint64_t obj, ddobj, prevobj = 0;
 	boolean_t rmorigin;
+	int err;
 
 	ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
 	ASSERT(ds->ds_prev == NULL ||
@@ -1117,10 +1283,13 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	/* Remove our reservation. */
 	if (ds->ds_reserved != 0) {
-		dsl_dataset_set_refreservation_sync_impl(ds,
+		err = dsl_dataset_set_refreservation_sync_impl(ds,
 		    (ZPROP_SRC_NONE | ZPROP_SRC_LOCAL | ZPROP_SRC_RECEIVED),
 		    0, tx);
-		ASSERT0(ds->ds_reserved);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(err);
+			ASSERT0(ds->ds_reserved);
+		}
 	}
 
 	obj = ds->ds_object;
@@ -1169,19 +1338,25 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 * those belonging to the zil.
 	 */
 	if (dsl_deadlist_is_open(&ds->ds_dir->dd_livelist)) {
-		dsl_async_clone_destroy(ds, tx);
+		err = dsl_async_clone_destroy(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else if (spa_feature_is_enabled(dp->dp_spa,
 	    SPA_FEATURE_ASYNC_DESTROY)) {
-		(void) dsl_async_dataset_destroy(ds, tx);
+		err = dsl_async_dataset_destroy(ds, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	} else {
 		old_synchronous_dataset_destroy(ds, tx);
 	}
 
 	if (ds->ds_prev != NULL) {
 		if (spa_version(dp->dp_spa) >= SPA_VERSION_DIR_CLONES) {
-			VERIFY0(zap_remove_int(mos,
+			err = zap_remove_int(mos,
 			    dsl_dir_phys(ds->ds_prev->ds_dir)->dd_clones,
-			    ds->ds_object, tx));
+			    ds->ds_object, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		}
 		prevobj = ds->ds_prev->ds_object;
 		dsl_dataset_rele(ds->ds_prev, ds);
@@ -1202,8 +1377,9 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj = 0;
 	ddobj = ds->ds_dir->dd_object;
 	ASSERT(dsl_dataset_phys(ds)->ds_snapnames_zapobj != 0);
-	VERIFY0(zap_destroy(mos,
-	    dsl_dataset_phys(ds)->ds_snapnames_zapobj, tx));
+	err = zap_destroy(mos, dsl_dataset_phys(ds)->ds_snapnames_zapobj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	if (ds->ds_bookmarks_obj != 0) {
 		void *cookie = NULL;
@@ -1213,17 +1389,22 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    NULL) {
 			if (dbn->dbn_phys.zbm_redaction_obj != 0) {
 				dnode_t *rl;
-				VERIFY0(dnode_hold(mos,
+				err = dnode_hold(mos,
 				    dbn->dbn_phys.zbm_redaction_obj, FTAG,
-				    &rl));
-				if (rl->dn_have_spill) {
+				    &rl);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
+				if (!err && rl->dn_have_spill) {
 					spa_feature_decr(dmu_objset_spa(mos),
 					    SPA_FEATURE_REDACTION_LIST_SPILL,
 					    tx);
 				}
-				dnode_rele(rl, FTAG);
-				VERIFY0(dmu_object_free(mos,
-				    dbn->dbn_phys.zbm_redaction_obj, tx));
+				if (!err)
+					dnode_rele(rl, FTAG);
+				err = dmu_object_free(mos,
+				    dbn->dbn_phys.zbm_redaction_obj, tx);
+				if (!SPA_EXITING(spa))
+					VERIFY0(err);
 				spa_feature_decr(dmu_objset_spa(mos),
 				    SPA_FEATURE_REDACTION_BOOKMARKS, tx);
 			}
@@ -1236,7 +1417,9 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 			kmem_free(dbn, sizeof (*dbn));
 		}
 		avl_destroy(&ds->ds_bookmarks);
-		VERIFY0(zap_destroy(mos, ds->ds_bookmarks_obj, tx));
+		err = zap_destroy(mos, ds->ds_bookmarks_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa_feature_decr(dp->dp_spa, SPA_FEATURE_BOOKMARKS, tx);
 	}
 
@@ -1253,7 +1436,10 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	if (rmorigin) {
 		dsl_dataset_t *prev;
-		VERIFY0(dsl_dataset_hold_obj(dp, prevobj, FTAG, &prev));
+		err = dsl_dataset_hold_obj(dp, prevobj, FTAG, &prev);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		dsl_destroy_snapshot_sync_impl(prev, B_FALSE, tx);
 		dsl_dataset_rele(prev, FTAG);
 	}
@@ -1267,9 +1453,13 @@ dsl_destroy_head_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_destroy_head_arg_t *ddha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	dsl_dataset_t *ds;
 
-	VERIFY0(dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds));
+	int err = dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	dsl_destroy_head_sync_impl(ds, tx);
 	zvol_remove_minors(dp->dp_spa, ddha->ddha_name, B_TRUE);
 	dsl_dataset_rele(ds, FTAG);
@@ -1282,7 +1472,10 @@ dsl_destroy_head_begin_sync(void *arg, dmu_tx_t *tx)
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds;
 
-	VERIFY0(dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds));
+	int err = dsl_dataset_hold(dp, ddha->ddha_name, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
 
 	/* Mark it as inconsistent on-disk, in case we crash */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -903,6 +903,7 @@ dsl_fs_ss_count_adjust(dsl_dir_t *dd, int64_t delta, const char *prop,
 {
 	int err;
 	objset_t *os = dd->dd_pool->dp_meta_objset;
+	spa_t *spa = os->os_spa;
 	uint64_t count;
 
 	ASSERT(dsl_pool_config_held(dd->dd_pool));
@@ -934,41 +935,62 @@ dsl_fs_ss_count_adjust(dsl_dir_t *dd, int64_t delta, const char *prop,
 	if (!dsl_dir_is_zapified(dd) || (err = zap_lookup(os, dd->dd_object,
 	    prop, sizeof (count), 1, &count)) == ENOENT)
 		return;
-	VERIFY0(err);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	count += delta;
 	/* Use a signed verify to make sure we're not neg. */
-	VERIFY3S(count, >=, 0);
+	if (!SPA_EXITING(spa))
+		VERIFY3S(count, >=, 0);
 
-	VERIFY0(zap_update(os, dd->dd_object, prop, sizeof (count), 1, &count,
-	    tx));
+	err = zap_update(os, dd->dd_object, prop, sizeof (count), 1, &count,
+	    tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	/* Roll up this additional count into our ancestors */
 	if (dd->dd_parent != NULL)
 		dsl_fs_ss_count_adjust(dd->dd_parent, delta, prop, tx);
 }
 
-uint64_t
+int
 dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds, const char *name,
-    dmu_tx_t *tx)
+    dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
-	uint64_t ddobj;
 	dsl_dir_phys_t *ddphys;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
+	int err = 0;
 
-	ddobj = dmu_object_alloc(mos, DMU_OT_DSL_DIR, 0,
-	    DMU_OT_DSL_DIR, sizeof (dsl_dir_phys_t), tx);
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DIR, 0,
+	    DMU_OT_DSL_DIR, sizeof (dsl_dir_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (pds) {
-		VERIFY0(zap_add(mos, dsl_dir_phys(pds)->dd_child_dir_zapobj,
-		    name, sizeof (uint64_t), 1, &ddobj, tx));
+		err = zap_add(mos, dsl_dir_phys(pds)->dd_child_dir_zapobj,
+		    name, sizeof (uint64_t), 1, objectp, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	} else {
 		/* it's the root dir */
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_ROOT_DATASET, sizeof (uint64_t), 1, &ddobj, tx));
+		err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_ROOT_DATASET, sizeof (uint64_t), 1, objectp, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
-	VERIFY0(dmu_bonus_hold(mos, ddobj, FTAG, &dbuf));
+	err = dmu_bonus_hold(mos, *objectp, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	ddphys = dbuf->db_data;
 
 	ddphys->dd_creation_time = gethrestime_sec();
@@ -978,16 +1000,26 @@ dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds, const char *name,
 		/* update the filesystem counts */
 		dsl_fs_ss_count_adjust(pds, 1, DD_FIELD_FILESYSTEM_COUNT, tx);
 	}
-	ddphys->dd_props_zapobj = zap_create(mos,
-	    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx);
-	ddphys->dd_child_dir_zapobj = zap_create(mos,
-	    DMU_OT_DSL_DIR_CHILD_MAP, DMU_OT_NONE, 0, tx);
+	err = zap_create(mos,
+	    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx, &ddphys->dd_props_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_create(mos,
+	    DMU_OT_DSL_DIR_CHILD_MAP, DMU_OT_NONE, 0, tx,
+	    &ddphys->dd_child_dir_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_USED_BREAKDOWN)
 		ddphys->dd_flags |= DD_FLAG_USED_BREAKDOWN;
 
-	dmu_buf_rele(dbuf, FTAG);
+out:
+	if (dbuf)
+		dmu_buf_rele(dbuf, FTAG);
 
-	return (ddobj);
+	return (err);
 }
 
 boolean_t

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1918,8 +1918,8 @@ dsl_dir_set_reservation_sync(void *arg, dmu_tx_t *tx)
 		    ddsqra->ddsqra_source, sizeof (ddsqra->ddsqra_value), 1,
 		    &ddsqra->ddsqra_value, tx);
 
-		VERIFY0(dsl_prop_get_int_ds(ds,
-		    zfs_prop_to_name(ZFS_PROP_RESERVATION), &newval));
+		dsl_prop_get_int_ds(ds,
+		    zfs_prop_to_name(ZFS_PROP_RESERVATION), &newval);
 	} else {
 		newval = ddsqra->ddsqra_value;
 		spa_history_log_internal_ds(ds, "set", tx, "%s=%lld",

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1595,6 +1595,8 @@ dsl_dir_diduse_space_impl(dsl_dir_t *dd, dd_used_t type,
 	ASSERT(type < DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
+	if (SPA_EXITING(tx->tx_pool->dp_spa))
+		return;
 
 	/*
 	 * dsl_dataset_set_refreservation_sync_impl() calls this with
@@ -1683,6 +1685,8 @@ dsl_dir_diduse_transfer_space_impl(dsl_dir_t *dd, int64_t used,
 	ASSERT(newtype < DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
+	if (SPA_EXITING(tx->tx_pool->dp_spa))
+		return;
 
 	dsl_dir_lock_enter(dd, nested);
 	dsl_dir_phys_t *ddp = dsl_dir_phys(dd);
@@ -2334,6 +2338,7 @@ dsl_dir_snap_cmtime(dsl_dir_t *dd)
 void
 dsl_dir_snap_cmtime_update(dsl_dir_t *dd, dmu_tx_t *tx)
 {
+	int err;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	inode_timespec_t t;
 
@@ -2356,9 +2361,11 @@ dsl_dir_snap_cmtime_update(dsl_dir_t *dd, dmu_tx_t *tx)
 	 * into space accounting, so do not call them with dd_lock held.
 	 */
 	dsl_dir_zapify(dd, tx);
-	VERIFY0(zap_update(mos, dd->dd_object, DD_FIELD_SNAPSHOTS_CHANGED,
+	err = zap_update(mos, dd->dd_object, DD_FIELD_SNAPSHOTS_CHANGED,
 	    sizeof (uint64_t),
-	    sizeof (inode_timespec_t) / sizeof (uint64_t), &t, tx));
+	    sizeof (inode_timespec_t) / sizeof (uint64_t), &t, tx);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 }
 
 void

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1585,6 +1585,8 @@ dsl_dir_diduse_space_impl(dsl_dir_t *dd, dd_used_t type,
 	ASSERT(type < DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
+	if (SPA_EXITING(tx->tx_pool->dp_spa))
+		return;
 
 	/*
 	 * dsl_dataset_set_refreservation_sync_impl() calls this with
@@ -1673,6 +1675,8 @@ dsl_dir_diduse_transfer_space_impl(dsl_dir_t *dd, int64_t used,
 	ASSERT(newtype < DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
+	if (SPA_EXITING(tx->tx_pool->dp_spa))
+		return;
 
 	dsl_dir_lock_enter(dd, nested);
 	dsl_dir_phys_t *ddp = dsl_dir_phys(dd);
@@ -2324,6 +2328,7 @@ dsl_dir_snap_cmtime(dsl_dir_t *dd)
 void
 dsl_dir_snap_cmtime_update(dsl_dir_t *dd, dmu_tx_t *tx)
 {
+	int err;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	inode_timespec_t t;
 
@@ -2346,9 +2351,11 @@ dsl_dir_snap_cmtime_update(dsl_dir_t *dd, dmu_tx_t *tx)
 	 * into space accounting, so do not call them with dd_lock held.
 	 */
 	dsl_dir_zapify(dd, tx);
-	VERIFY0(zap_update(mos, dd->dd_object, DD_FIELD_SNAPSHOTS_CHANGED,
+	err = zap_update(mos, dd->dd_object, DD_FIELD_SNAPSHOTS_CHANGED,
 	    sizeof (uint64_t),
-	    sizeof (inode_timespec_t) / sizeof (uint64_t), &t, tx));
+	    sizeof (inode_timespec_t) / sizeof (uint64_t), &t, tx);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 }
 
 void

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1908,8 +1908,8 @@ dsl_dir_set_reservation_sync(void *arg, dmu_tx_t *tx)
 		    ddsqra->ddsqra_source, sizeof (ddsqra->ddsqra_value), 1,
 		    &ddsqra->ddsqra_value, tx);
 
-		VERIFY0(dsl_prop_get_int_ds(ds,
-		    zfs_prop_to_name(ZFS_PROP_RESERVATION), &newval));
+		dsl_prop_get_int_ds(ds,
+		    zfs_prop_to_name(ZFS_PROP_RESERVATION), &newval);
 	} else {
 		newval = ddsqra->ddsqra_value;
 		spa_history_log_internal_ds(ds, "set", tx, "%s=%lld",

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -893,6 +893,7 @@ dsl_fs_ss_count_adjust(dsl_dir_t *dd, int64_t delta, const char *prop,
 {
 	int err;
 	objset_t *os = dd->dd_pool->dp_meta_objset;
+	spa_t *spa = os->os_spa;
 	uint64_t count;
 
 	ASSERT(dsl_pool_config_held(dd->dd_pool));
@@ -924,41 +925,62 @@ dsl_fs_ss_count_adjust(dsl_dir_t *dd, int64_t delta, const char *prop,
 	if (!dsl_dir_is_zapified(dd) || (err = zap_lookup(os, dd->dd_object,
 	    prop, sizeof (count), 1, &count)) == ENOENT)
 		return;
-	VERIFY0(err);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	count += delta;
 	/* Use a signed verify to make sure we're not neg. */
-	VERIFY3S(count, >=, 0);
+	if (!SPA_EXITING(spa))
+		VERIFY3S(count, >=, 0);
 
-	VERIFY0(zap_update(os, dd->dd_object, prop, sizeof (count), 1, &count,
-	    tx));
+	err = zap_update(os, dd->dd_object, prop, sizeof (count), 1, &count,
+	    tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	/* Roll up this additional count into our ancestors */
 	if (dd->dd_parent != NULL)
 		dsl_fs_ss_count_adjust(dd->dd_parent, delta, prop, tx);
 }
 
-uint64_t
+int
 dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds, const char *name,
-    dmu_tx_t *tx)
+    dmu_tx_t *tx, uint64_t *objectp)
 {
+	spa_t *spa = dp->dp_spa;
 	objset_t *mos = dp->dp_meta_objset;
-	uint64_t ddobj;
 	dsl_dir_phys_t *ddphys;
-	dmu_buf_t *dbuf;
+	dmu_buf_t *dbuf = NULL;
+	int err = 0;
 
-	ddobj = dmu_object_alloc(mos, DMU_OT_DSL_DIR, 0,
-	    DMU_OT_DSL_DIR, sizeof (dsl_dir_phys_t), tx);
+	err = dmu_object_alloc(mos, DMU_OT_DSL_DIR, 0,
+	    DMU_OT_DSL_DIR, sizeof (dsl_dir_phys_t), tx, objectp);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (pds) {
-		VERIFY0(zap_add(mos, dsl_dir_phys(pds)->dd_child_dir_zapobj,
-		    name, sizeof (uint64_t), 1, &ddobj, tx));
+		err = zap_add(mos, dsl_dir_phys(pds)->dd_child_dir_zapobj,
+		    name, sizeof (uint64_t), 1, objectp, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	} else {
 		/* it's the root dir */
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_ROOT_DATASET, sizeof (uint64_t), 1, &ddobj, tx));
+		err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_ROOT_DATASET, sizeof (uint64_t), 1, objectp, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
-	VERIFY0(dmu_bonus_hold(mos, ddobj, FTAG, &dbuf));
+	err = dmu_bonus_hold(mos, *objectp, FTAG, &dbuf);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(dbuf, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	ddphys = dbuf->db_data;
 
 	ddphys->dd_creation_time = gethrestime_sec();
@@ -968,16 +990,26 @@ dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds, const char *name,
 		/* update the filesystem counts */
 		dsl_fs_ss_count_adjust(pds, 1, DD_FIELD_FILESYSTEM_COUNT, tx);
 	}
-	ddphys->dd_props_zapobj = zap_create(mos,
-	    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx);
-	ddphys->dd_child_dir_zapobj = zap_create(mos,
-	    DMU_OT_DSL_DIR_CHILD_MAP, DMU_OT_NONE, 0, tx);
+	err = zap_create(mos,
+	    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx, &ddphys->dd_props_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = zap_create(mos,
+	    DMU_OT_DSL_DIR_CHILD_MAP, DMU_OT_NONE, 0, tx,
+	    &ddphys->dd_child_dir_zapobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	if (spa_version(dp->dp_spa) >= SPA_VERSION_USED_BREAKDOWN)
 		ddphys->dd_flags |= DD_FLAG_USED_BREAKDOWN;
 
-	dmu_buf_rele(dbuf, FTAG);
+out:
+	if (dbuf)
+		dmu_buf_rele(dbuf, FTAG);
 
-	return (ddobj);
+	return (err);
 }
 
 boolean_t

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -444,21 +444,35 @@ dsl_pool_close(dsl_pool_t *dp)
 	kmem_free(dp, sizeof (dsl_pool_t));
 }
 
-void
+int
 dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t obj;
+	int err = 0;
+
 	/*
 	 * Currently, we only create the obsolete_bpobj where there are
 	 * indirect vdevs with referenced mappings.
 	 */
 	ASSERT(spa_feature_is_active(dp->dp_spa, SPA_FEATURE_DEVICE_REMOVAL));
 	/* create and open the obsolete_bpobj */
-	obj = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx);
-	VERIFY0(bpobj_open(&dp->dp_obsolete_bpobj, dp->dp_meta_objset, obj));
-	VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_OBSOLETE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
+	err = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = bpobj_open(&dp->dp_obsolete_bpobj, dp->dp_meta_objset, obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_OBSOLETE_BPOBJ, sizeof (uint64_t), 1, &obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	spa_feature_incr(dp->dp_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
+
+	return (err);
 }
 
 void
@@ -504,24 +518,26 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
 	VERIFY0(dsl_scan_init(dp, txg));
 
 	/* create and open the root dir */
-	dp->dp_root_dir_obj = dsl_dir_create_sync(dp, NULL, NULL, tx);
+	VERIFY0(dsl_dir_create_sync(dp, NULL, NULL, tx, &dp->dp_root_dir_obj));
 	VERIFY0(dsl_dir_hold_obj(dp, dp->dp_root_dir_obj,
 	    NULL, dp, &dp->dp_root_dir));
 
 	/* create and open the meta-objset dir */
-	(void) dsl_dir_create_sync(dp, dp->dp_root_dir, MOS_DIR_NAME, tx);
+	VERIFY0(dsl_dir_create_sync(dp, dp->dp_root_dir, MOS_DIR_NAME, tx,
+	    &obj));
 	VERIFY0(dsl_pool_open_special_dir(dp,
 	    MOS_DIR_NAME, &dp->dp_mos_dir));
 
 	if (spa_version(spa) >= SPA_VERSION_DEADLISTS) {
 		/* create and open the free dir */
-		(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
-		    FREE_DIR_NAME, tx);
+		VERIFY0(dsl_dir_create_sync(dp, dp->dp_root_dir,
+		    FREE_DIR_NAME, tx, &obj));
 		VERIFY0(dsl_pool_open_special_dir(dp,
 		    FREE_DIR_NAME, &dp->dp_free_dir));
 
 		/* create and open the free_bplist */
-		obj = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx);
+		VERIFY0(bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE,
+		    tx, &obj));
 		VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
 		VERIFY0(bpobj_open(&dp->dp_free_bpobj,
@@ -543,7 +559,8 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
 		spa_feature_enable(spa, SPA_FEATURE_ENCRYPTION, tx);
 
 	/* create the root dataset */
-	obj = dsl_dataset_create_sync_dd(dp->dp_root_dir, NULL, dcp, 0, tx);
+	VERIFY0(dsl_dataset_create_sync_dd(dp->dp_root_dir, NULL, dcp, 0, tx,
+	    &obj));
 
 	/* create the root objset */
 	VERIFY0(dsl_dataset_hold_obj_flags(dp, obj,
@@ -590,7 +607,8 @@ dsl_pool_sync_mos(dsl_pool_t *dp, dmu_tx_t *tx)
 	multilist_destroy(&dp->dp_meta_objset->os_synced_dnodes);
 
 	dprintf_bp(&dp->dp_meta_rootbp, "meta objset rootbp is %s", "");
-	spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
+	if (!spa_exiting(dp->dp_spa))
+		spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
 }
 
 static void
@@ -1089,9 +1107,9 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 	if (dsl_dataset_phys(prev)->ds_next_clones_obj == 0) {
 		dmu_buf_will_dirty(prev->ds_dbuf, tx);
-		dsl_dataset_phys(prev)->ds_next_clones_obj =
-		    zap_create(dp->dp_meta_objset,
-		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(dp->dp_meta_objset,
+		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(prev)->ds_next_clones_obj));
 	}
 	VERIFY0(zap_add_int(dp->dp_meta_objset,
 	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx));
@@ -1126,9 +1144,8 @@ upgrade_dir_clones_cb(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 
 		if (dsl_dir_phys(origin->ds_dir)->dd_clones == 0) {
 			dmu_buf_will_dirty(origin->ds_dir->dd_dbuf, tx);
-			dsl_dir_phys(origin->ds_dir)->dd_clones =
-			    zap_create(mos, DMU_OT_DSL_CLONES, DMU_OT_NONE,
-			    0, tx);
+			VERIFY0(zap_create(mos, DMU_OT_DSL_CLONES, DMU_OT_NONE,
+			    0, tx, &dsl_dir_phys(origin->ds_dir)->dd_clones));
 		}
 
 		VERIFY0(zap_add_int(dp->dp_meta_objset,
@@ -1140,51 +1157,93 @@ upgrade_dir_clones_cb(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 	return (0);
 }
 
-void
+int
 dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t obj;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	(void) dsl_dir_create_sync(dp, dp->dp_root_dir, FREE_DIR_NAME, tx);
-	VERIFY0(dsl_pool_open_special_dir(dp,
-	    FREE_DIR_NAME, &dp->dp_free_dir));
+	err = dsl_dir_create_sync(dp, dp->dp_root_dir, FREE_DIR_NAME, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dsl_pool_open_special_dir(dp, FREE_DIR_NAME, &dp->dp_free_dir);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * We can't use bpobj_alloc(), because spa_version() still
 	 * returns the old version, and we need a new-version bpobj with
 	 * subobj support.  So call dmu_object_alloc() directly.
 	 */
-	obj = dmu_object_alloc(dp->dp_meta_objset, DMU_OT_BPOBJ,
-	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_BPOBJ_HDR, sizeof (bpobj_phys_t), tx);
-	VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
-	VERIFY0(bpobj_open(&dp->dp_free_bpobj, dp->dp_meta_objset, obj));
+	err = dmu_object_alloc(dp->dp_meta_objset, DMU_OT_BPOBJ,
+	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_BPOBJ_HDR, sizeof (bpobj_phys_t), tx,
+	    &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = bpobj_open(&dp->dp_free_bpobj, dp->dp_meta_objset, obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-	    upgrade_dir_clones_cb, tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE));
+	err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+	    upgrade_dir_clones_cb, tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 void
 dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t dsobj;
-	dsl_dataset_t *ds;
+	dsl_dataset_t *ds = NULL;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT0P(dp->dp_origin_snap);
 	ASSERT(rrw_held(&dp->dp_config_rwlock, RW_WRITER));
 
 	/* create the origin dir, ds, & snap-ds */
-	dsobj = dsl_dataset_create_sync(dp->dp_root_dir, ORIGIN_DIR_NAME,
-	    NULL, 0, kcred, NULL, tx);
-	VERIFY0(dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
-	dsl_dataset_snapshot_sync_impl(ds, ORIGIN_DIR_NAME, gethrestime_sec(),
-	    tx);
-	VERIFY0(dsl_dataset_hold_obj(dp, dsl_dataset_phys(ds)->ds_prev_snap_obj,
-	    dp, &dp->dp_origin_snap));
-	dsl_dataset_rele(ds, FTAG);
+	err = dsl_dataset_create_sync(dp->dp_root_dir, ORIGIN_DIR_NAME,
+	    NULL, 0, kcred, NULL, tx, &dsobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_snapshot_sync_impl(ds, ORIGIN_DIR_NAME,
+	    gethrestime_sec(), tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp, dsl_dataset_phys(ds)->ds_prev_snap_obj,
+	    dp, &dp->dp_origin_snap);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	if (ds)
+		dsl_dataset_rele(ds, FTAG);
 }
 
 taskq_t *
@@ -1254,8 +1313,9 @@ dsl_pool_user_hold_create_obj(dsl_pool_t *dp, dmu_tx_t *tx)
 	ASSERT0(dp->dp_tmp_userrefs_obj);
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	dp->dp_tmp_userrefs_obj = zap_create_link(mos, DMU_OT_USERREFS,
-	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_TMP_USERREFS, tx);
+	VERIFY0(zap_create_link(mos, DMU_OT_USERREFS,
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_TMP_USERREFS, tx,
+	    &dp->dp_tmp_userrefs_obj));
 }
 
 static int

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -601,13 +601,15 @@ dsl_pool_sync_mos(dsl_pool_t *dp, dmu_tx_t *tx)
 {
 	zio_t *zio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
 	dmu_objset_sync(dp->dp_meta_objset, zio, tx);
-	VERIFY0(zio_wait(zio));
+	int err = zio_wait(zio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 	dmu_objset_sync_done(dp->dp_meta_objset, tx);
 	taskq_wait(dp->dp_sync_taskq);
 	multilist_destroy(&dp->dp_meta_objset->os_synced_dnodes);
 
 	dprintf_bp(&dp->dp_meta_rootbp, "meta objset rootbp is %s", "");
-	if (!spa_exiting(dp->dp_spa))
+	if (!err)
 		spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
 }
 
@@ -700,6 +702,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 	dsl_dataset_t *ds;
 	objset_t *mos = dp->dp_meta_objset;
 	list_t synced_datasets;
+	int err;
 
 	list_create(&synced_datasets, sizeof (dsl_dataset_t),
 	    offsetof(dsl_dataset_t, ds_synced_link));
@@ -738,7 +741,9 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 		list_insert_tail(&synced_datasets, ds);
 		dsl_dataset_sync(ds, rio, tx);
 	}
-	VERIFY0(zio_wait(rio));
+	err = zio_wait(rio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	/*
 	 * Update the long range free counter after
@@ -788,7 +793,9 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 			key_mapping_rele(dp->dp_spa, ds->ds_key_mapping, ds);
 		}
 	}
-	VERIFY0(zio_wait(rio));
+	err = zio_wait(rio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	/*
 	 * Now that the datasets have been completely synced, we can
@@ -1096,9 +1103,11 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 		if (dsl_dataset_phys(ds)->ds_next_snap_obj == 0) {
 			ASSERT0P(ds->ds_prev);
-			VERIFY0(dsl_dataset_hold_obj(dp,
+			err = dsl_dataset_hold_obj(dp,
 			    dsl_dataset_phys(ds)->ds_prev_snap_obj,
-			    ds, &ds->ds_prev));
+			    ds, &ds->ds_prev);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -1107,12 +1116,16 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 	if (dsl_dataset_phys(prev)->ds_next_clones_obj == 0) {
 		dmu_buf_will_dirty(prev->ds_dbuf, tx);
-		VERIFY0(zap_create(dp->dp_meta_objset,
+		err = zap_create(dp->dp_meta_objset,
 		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
-		    &dsl_dataset_phys(prev)->ds_next_clones_obj));
+		    &dsl_dataset_phys(prev)->ds_next_clones_obj);
+		if (!SPA_EXITING(dp->dp_spa))
+			VERIFY0(err);
 	}
-	VERIFY0(zap_add_int(dp->dp_meta_objset,
-	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx));
+	err = zap_add_int(dp->dp_meta_objset,
+	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	dsl_dataset_rele(ds, FTAG);
 	if (prev != dp->dp_origin_snap)
@@ -1126,8 +1139,10 @@ dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx)
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(dp->dp_origin_snap != NULL);
 
-	VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj, upgrade_clones_cb,
-	    tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE));
+	int err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj, upgrade_clones_cb,
+	    tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 }
 
 static int

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -442,21 +442,35 @@ dsl_pool_close(dsl_pool_t *dp)
 	kmem_free(dp, sizeof (dsl_pool_t));
 }
 
-void
+int
 dsl_pool_create_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t obj;
+	int err = 0;
+
 	/*
 	 * Currently, we only create the obsolete_bpobj where there are
 	 * indirect vdevs with referenced mappings.
 	 */
 	ASSERT(spa_feature_is_active(dp->dp_spa, SPA_FEATURE_DEVICE_REMOVAL));
 	/* create and open the obsolete_bpobj */
-	obj = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx);
-	VERIFY0(bpobj_open(&dp->dp_obsolete_bpobj, dp->dp_meta_objset, obj));
-	VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_OBSOLETE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
+	err = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = bpobj_open(&dp->dp_obsolete_bpobj, dp->dp_meta_objset, obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_OBSOLETE_BPOBJ, sizeof (uint64_t), 1, &obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	spa_feature_incr(dp->dp_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
+
+	return (err);
 }
 
 void
@@ -502,24 +516,26 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
 	VERIFY0(dsl_scan_init(dp, txg));
 
 	/* create and open the root dir */
-	dp->dp_root_dir_obj = dsl_dir_create_sync(dp, NULL, NULL, tx);
+	VERIFY0(dsl_dir_create_sync(dp, NULL, NULL, tx, &dp->dp_root_dir_obj));
 	VERIFY0(dsl_dir_hold_obj(dp, dp->dp_root_dir_obj,
 	    NULL, dp, &dp->dp_root_dir));
 
 	/* create and open the meta-objset dir */
-	(void) dsl_dir_create_sync(dp, dp->dp_root_dir, MOS_DIR_NAME, tx);
+	VERIFY0(dsl_dir_create_sync(dp, dp->dp_root_dir, MOS_DIR_NAME, tx,
+	    &obj));
 	VERIFY0(dsl_pool_open_special_dir(dp,
 	    MOS_DIR_NAME, &dp->dp_mos_dir));
 
 	if (spa_version(spa) >= SPA_VERSION_DEADLISTS) {
 		/* create and open the free dir */
-		(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
-		    FREE_DIR_NAME, tx);
+		VERIFY0(dsl_dir_create_sync(dp, dp->dp_root_dir,
+		    FREE_DIR_NAME, tx, &obj));
 		VERIFY0(dsl_pool_open_special_dir(dp,
 		    FREE_DIR_NAME, &dp->dp_free_dir));
 
 		/* create and open the free_bplist */
-		obj = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx);
+		VERIFY0(bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE,
+		    tx, &obj));
 		VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
 		VERIFY0(bpobj_open(&dp->dp_free_bpobj,
@@ -541,7 +557,8 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
 		spa_feature_enable(spa, SPA_FEATURE_ENCRYPTION, tx);
 
 	/* create the root dataset */
-	obj = dsl_dataset_create_sync_dd(dp->dp_root_dir, NULL, dcp, 0, tx);
+	VERIFY0(dsl_dataset_create_sync_dd(dp->dp_root_dir, NULL, dcp, 0, tx,
+	    &obj));
 
 	/* create the root objset */
 	VERIFY0(dsl_dataset_hold_obj_flags(dp, obj,
@@ -586,7 +603,8 @@ dsl_pool_sync_mos(dsl_pool_t *dp, dmu_tx_t *tx)
 	multilist_destroy(&dp->dp_meta_objset->os_synced_dnodes);
 
 	dprintf_bp(&dp->dp_meta_rootbp, "meta objset rootbp is %s", "");
-	spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
+	if (!spa_exiting(dp->dp_spa))
+		spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
 }
 
 static void
@@ -1167,9 +1185,9 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 	if (dsl_dataset_phys(prev)->ds_next_clones_obj == 0) {
 		dmu_buf_will_dirty(prev->ds_dbuf, tx);
-		dsl_dataset_phys(prev)->ds_next_clones_obj =
-		    zap_create(dp->dp_meta_objset,
-		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(dp->dp_meta_objset,
+		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(prev)->ds_next_clones_obj));
 	}
 	VERIFY0(zap_add_int(dp->dp_meta_objset,
 	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx));
@@ -1204,9 +1222,8 @@ upgrade_dir_clones_cb(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 
 		if (dsl_dir_phys(origin->ds_dir)->dd_clones == 0) {
 			dmu_buf_will_dirty(origin->ds_dir->dd_dbuf, tx);
-			dsl_dir_phys(origin->ds_dir)->dd_clones =
-			    zap_create(mos, DMU_OT_DSL_CLONES, DMU_OT_NONE,
-			    0, tx);
+			VERIFY0(zap_create(mos, DMU_OT_DSL_CLONES, DMU_OT_NONE,
+			    0, tx, &dsl_dir_phys(origin->ds_dir)->dd_clones));
 		}
 
 		VERIFY0(zap_add_int(dp->dp_meta_objset,
@@ -1218,51 +1235,93 @@ upgrade_dir_clones_cb(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 	return (0);
 }
 
-void
+int
 dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t obj;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	(void) dsl_dir_create_sync(dp, dp->dp_root_dir, FREE_DIR_NAME, tx);
-	VERIFY0(dsl_pool_open_special_dir(dp,
-	    FREE_DIR_NAME, &dp->dp_free_dir));
+	err = dsl_dir_create_sync(dp, dp->dp_root_dir, FREE_DIR_NAME, tx, &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = dsl_pool_open_special_dir(dp, FREE_DIR_NAME, &dp->dp_free_dir);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	/*
 	 * We can't use bpobj_alloc(), because spa_version() still
 	 * returns the old version, and we need a new-version bpobj with
 	 * subobj support.  So call dmu_object_alloc() directly.
 	 */
-	obj = dmu_object_alloc(dp->dp_meta_objset, DMU_OT_BPOBJ,
-	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_BPOBJ_HDR, sizeof (bpobj_phys_t), tx);
-	VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
-	VERIFY0(bpobj_open(&dp->dp_free_bpobj, dp->dp_meta_objset, obj));
+	err = dmu_object_alloc(dp->dp_meta_objset, DMU_OT_BPOBJ,
+	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_BPOBJ_HDR, sizeof (bpobj_phys_t), tx,
+	    &obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+	err = bpobj_open(&dp->dp_free_bpobj, dp->dp_meta_objset, obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-	    upgrade_dir_clones_cb, tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE));
+	err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+	    upgrade_dir_clones_cb, tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 void
 dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx)
 {
+	spa_t *spa = dp->dp_spa;
 	uint64_t dsobj;
-	dsl_dataset_t *ds;
+	dsl_dataset_t *ds = NULL;
+	int err = 0;
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT0P(dp->dp_origin_snap);
 	ASSERT(rrw_held(&dp->dp_config_rwlock, RW_WRITER));
 
 	/* create the origin dir, ds, & snap-ds */
-	dsobj = dsl_dataset_create_sync(dp->dp_root_dir, ORIGIN_DIR_NAME,
-	    NULL, 0, kcred, NULL, tx);
-	VERIFY0(dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
-	dsl_dataset_snapshot_sync_impl(ds, ORIGIN_DIR_NAME, gethrestime_sec(),
-	    tx);
-	VERIFY0(dsl_dataset_hold_obj(dp, dsl_dataset_phys(ds)->ds_prev_snap_obj,
-	    dp, &dp->dp_origin_snap));
-	dsl_dataset_rele(ds, FTAG);
+	err = dsl_dataset_create_sync(dp->dp_root_dir, ORIGIN_DIR_NAME,
+	    NULL, 0, kcred, NULL, tx, &dsobj);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_snapshot_sync_impl(ds, ORIGIN_DIR_NAME,
+	    gethrestime_sec(), tx);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+	err = dsl_dataset_hold_obj(dp, dsl_dataset_phys(ds)->ds_prev_snap_obj,
+	    dp, &dp->dp_origin_snap);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
+
+out:
+	if (ds)
+		dsl_dataset_rele(ds, FTAG);
 }
 
 taskq_t *
@@ -1332,8 +1391,9 @@ dsl_pool_user_hold_create_obj(dsl_pool_t *dp, dmu_tx_t *tx)
 	ASSERT0(dp->dp_tmp_userrefs_obj);
 	ASSERT(dmu_tx_is_syncing(tx));
 
-	dp->dp_tmp_userrefs_obj = zap_create_link(mos, DMU_OT_USERREFS,
-	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_TMP_USERREFS, tx);
+	VERIFY0(zap_create_link(mos, DMU_OT_USERREFS,
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_TMP_USERREFS, tx,
+	    &dp->dp_tmp_userrefs_obj));
 }
 
 static int

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -597,13 +597,15 @@ dsl_pool_sync_mos(dsl_pool_t *dp, dmu_tx_t *tx)
 {
 	zio_t *zio = zio_root(dp->dp_spa, NULL, NULL, ZIO_FLAG_MUSTSUCCEED);
 	dmu_objset_sync(dp->dp_meta_objset, zio, tx);
-	VERIFY0(zio_wait(zio));
+	int err = zio_wait(zio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 	dmu_objset_sync_done(dp->dp_meta_objset, tx);
 	taskq_wait(dp->dp_sync_taskq);
 	multilist_destroy(&dp->dp_meta_objset->os_synced_dnodes);
 
 	dprintf_bp(&dp->dp_meta_rootbp, "meta objset rootbp is %s", "");
-	if (!spa_exiting(dp->dp_spa))
+	if (!err)
 		spa_set_rootblkptr(dp->dp_spa, &dp->dp_meta_rootbp);
 }
 
@@ -696,6 +698,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 	dsl_dataset_t *ds;
 	objset_t *mos = dp->dp_meta_objset;
 	list_t synced_datasets;
+	int err;
 
 	list_create(&synced_datasets, sizeof (dsl_dataset_t),
 	    offsetof(dsl_dataset_t, ds_synced_link));
@@ -734,7 +737,9 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 		list_insert_tail(&synced_datasets, ds);
 		dsl_dataset_sync(ds, rio, tx);
 	}
-	VERIFY0(zio_wait(rio));
+	err = zio_wait(rio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	/*
 	 * Update the long range free counter after
@@ -784,7 +789,9 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 			key_mapping_rele(dp->dp_spa, ds->ds_key_mapping, ds);
 		}
 	}
-	VERIFY0(zio_wait(rio));
+	err = zio_wait(rio);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	/*
 	 * Now that the datasets have been completely synced, we can
@@ -1174,9 +1181,11 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 		if (dsl_dataset_phys(ds)->ds_next_snap_obj == 0) {
 			ASSERT0P(ds->ds_prev);
-			VERIFY0(dsl_dataset_hold_obj(dp,
+			err = dsl_dataset_hold_obj(dp,
 			    dsl_dataset_phys(ds)->ds_prev_snap_obj,
-			    ds, &ds->ds_prev));
+			    ds, &ds->ds_prev);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -1185,12 +1194,16 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 
 	if (dsl_dataset_phys(prev)->ds_next_clones_obj == 0) {
 		dmu_buf_will_dirty(prev->ds_dbuf, tx);
-		VERIFY0(zap_create(dp->dp_meta_objset,
+		err = zap_create(dp->dp_meta_objset,
 		    DMU_OT_NEXT_CLONES, DMU_OT_NONE, 0, tx,
-		    &dsl_dataset_phys(prev)->ds_next_clones_obj));
+		    &dsl_dataset_phys(prev)->ds_next_clones_obj);
+		if (!SPA_EXITING(dp->dp_spa))
+			VERIFY0(err);
 	}
-	VERIFY0(zap_add_int(dp->dp_meta_objset,
-	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx));
+	err = zap_add_int(dp->dp_meta_objset,
+	    dsl_dataset_phys(prev)->ds_next_clones_obj, ds->ds_object, tx);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 
 	dsl_dataset_rele(ds, FTAG);
 	if (prev != dp->dp_origin_snap)
@@ -1204,8 +1217,10 @@ dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx)
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(dp->dp_origin_snap != NULL);
 
-	VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj, upgrade_clones_cb,
-	    tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE));
+	int err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj, upgrade_clones_cb,
+	    tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE);
+	if (!SPA_EXITING(dp->dp_spa))
+		VERIFY0(err);
 }
 
 static int

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -685,13 +685,14 @@ dsl_prop_changed_notify(dsl_pool_t *dp, uint64_t ddobj,
  * versions and the default property value from the existing prop key is
  * used.
  */
-static void
+static int
 dsl_prop_set_iuv(objset_t *mos, uint64_t zapobj, const char *propname,
     int intsz, int numints, const void *value, dmu_tx_t *tx)
 {
 	char *iuvstr = kmem_asprintf("%s%s", propname, ZPROP_IUV_SUFFIX);
 	boolean_t iuv = B_FALSE;
 	zfs_prop_t prop = zfs_name_to_prop(propname);
+	int err = 0;
 
 	switch (prop) {
 	case ZFS_PROP_REDUNDANT_METADATA:
@@ -708,15 +709,24 @@ dsl_prop_set_iuv(objset_t *mos, uint64_t zapobj, const char *propname,
 	}
 
 	if (iuv) {
-		VERIFY0(zap_update(mos, zapobj, iuvstr, intsz, numints,
-		    value, tx));
+		err = zap_update(mos, zapobj, iuvstr, intsz, numints,
+		    value, tx);
+		if (err && SPA_EXITING(mos->os_spa))
+			goto out;
+		VERIFY0(err);
 		uint64_t val = zfs_prop_default_numeric(prop);
-		VERIFY0(zap_update(mos, zapobj, propname, intsz, numints,
-		    &val, tx));
+		err = zap_update(mos, zapobj, propname, intsz, numints,
+		    &val, tx);
+		if (err && SPA_EXITING(mos->os_spa))
+			goto out;
+		VERIFY0(err);
 	} else {
-		zap_remove(mos, zapobj, iuvstr, tx);
+		err = zap_remove(mos, zapobj, iuvstr, tx);
 	}
+out:
 	kmem_strfree(iuvstr);
+
+	return (err);
 }
 
 void
@@ -724,6 +734,7 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
     zprop_source_t source, int intsz, int numints, const void *value,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *mos = ds->ds_dir->dd_pool->dp_meta_objset;
 	uint64_t zapobj, intval, dummy, count;
 	int isint;
@@ -733,8 +744,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	char *recvdstr;
 	char *iuvstr;
 	char *tbuf = NULL;
-	int err;
-	uint64_t version = spa_version(ds->ds_dir->dd_pool->dp_spa);
+	int err = 0;
+	uint64_t version = spa_version(spa);
 
 	isint = (dodefault(zfs_name_to_prop(propname), 8, 1, &intval) == 0);
 
@@ -743,9 +754,14 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		if (dsl_dataset_phys(ds)->ds_props_obj == 0 &&
 		    (source & ZPROP_SRC_NONE) == 0) {
 			dmu_buf_will_dirty(ds->ds_dbuf, tx);
-			VERIFY0(zap_create(mos,
+			if (SPA_EXITING(spa))
+				return;
+			err = zap_create(mos,
 			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx,
-			    &dsl_dataset_phys(ds)->ds_props_obj));
+			    &dsl_dataset_phys(ds)->ds_props_obj);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
 		}
 		zapobj = dsl_dataset_phys(ds)->ds_props_obj;
 	} else {
@@ -775,8 +791,12 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - remove propname$inherit
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		break;
 	case ZPROP_SRC_LOCAL:
@@ -786,10 +806,15 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * set propname$iuv -> new property value
 		 */
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
-		VERIFY0(zap_update(mos, zapobj, propname,
-		    intsz, numints, value, tx));
-		(void) dsl_prop_set_iuv(mos, zapobj, propname, intsz,
+		err = zap_update(mos, zapobj, propname,
+		    intsz, numints, value, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = dsl_prop_set_iuv(mos, zapobj, propname, intsz,
 		    numints, value, tx);
 		break;
 	case ZPROP_SRC_INHERITED:
@@ -799,14 +824,21 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - set propname$inherit
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, iuvstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		if (version >= SPA_VERSION_RECVD_PROPS &&
 		    dsl_prop_get_int_ds(ds, ZPROP_HAS_RECVD, &dummy) == 0) {
 			dummy = 0;
-			VERIFY0(zap_update(mos, zapobj, inheritstr,
-			    8, 1, &dummy, tx));
+			err = zap_update(mos, zapobj, inheritstr,
+			    8, 1, &dummy, tx);
+			if (err && SPA_EXITING(spa))
+				goto out;
+			VERIFY0(err);
 		}
 		break;
 	case ZPROP_SRC_RECEIVED:
@@ -815,6 +847,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 */
 		err = zap_update(mos, zapobj, recvdstr,
 		    intsz, numints, value, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
 		ASSERT0(err);
 		break;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_LOCAL | ZPROP_SRC_RECEIVED):
@@ -825,8 +859,12 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - remove propname$recvd
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		zfs_fallthrough;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_RECEIVED):
@@ -834,15 +872,13 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * remove propname$recvd
 		 */
 		err = zap_remove(mos, zapobj, recvdstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		break;
 	default:
 		cmn_err(CE_PANIC, "unexpected property source: %d", source);
 	}
-
-	kmem_strfree(inheritstr);
-	kmem_strfree(recvdstr);
-	kmem_strfree(iuvstr);
 
 	/*
 	 * If we are left with an empty snap zap we can destroy it.
@@ -857,7 +893,10 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	}
 
 	if (isint) {
-		VERIFY0(dsl_prop_get_int_ds(ds, propname, &intval));
+		err = dsl_prop_get_int_ds(ds, propname, &intval);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		if (ds->ds_is_snapshot) {
 			dsl_prop_cb_record_t *cbr;
@@ -896,6 +935,11 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	spa_history_log_internal_ds(ds, (source == ZPROP_SRC_NONE ||
 	    source == ZPROP_SRC_INHERITED) ? "inherit" : "set", tx,
 	    "%s=%s", propname, (valstr == NULL ? "" : valstr));
+
+out:
+	kmem_strfree(inheritstr);
+	kmem_strfree(recvdstr);
+	kmem_strfree(iuvstr);
 
 	if (tbuf != NULL)
 		kmem_free(tbuf, ZAP_MAXVALUELEN);
@@ -1024,9 +1068,16 @@ dsl_props_set_sync(void *arg, dmu_tx_t *tx)
 	dsl_props_set_arg_t *dpsa = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds;
+	int err = 0;
 
-	VERIFY0(dsl_dataset_hold(dp, dpsa->dpsa_dsname, FTAG, &ds));
-	dsl_props_set_sync_impl(ds, dpsa->dpsa_source, dpsa->dpsa_props, tx);
+	err = dsl_dataset_hold(dp, dpsa->dpsa_dsname, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
+
+	dsl_props_set_sync_impl(ds, dpsa->dpsa_source, dpsa->dpsa_props,
+	    tx);
+
 	dsl_dataset_rele(ds, FTAG);
 }
 

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -743,9 +743,9 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		if (dsl_dataset_phys(ds)->ds_props_obj == 0 &&
 		    (source & ZPROP_SRC_NONE) == 0) {
 			dmu_buf_will_dirty(ds->ds_dbuf, tx);
-			dsl_dataset_phys(ds)->ds_props_obj =
-			    zap_create(mos,
-			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(mos,
+			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx,
+			    &dsl_dataset_phys(ds)->ds_props_obj));
 		}
 		zapobj = dsl_dataset_phys(ds)->ds_props_obj;
 	} else {

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -733,9 +733,9 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		if (dsl_dataset_phys(ds)->ds_props_obj == 0 &&
 		    (source & ZPROP_SRC_NONE) == 0) {
 			dmu_buf_will_dirty(ds->ds_dbuf, tx);
-			dsl_dataset_phys(ds)->ds_props_obj =
-			    zap_create(mos,
-			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(mos,
+			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx,
+			    &dsl_dataset_phys(ds)->ds_props_obj));
 		}
 		zapobj = dsl_dataset_phys(ds)->ds_props_obj;
 	} else {

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -675,13 +675,14 @@ dsl_prop_changed_notify(dsl_pool_t *dp, uint64_t ddobj,
  * versions and the default property value from the existing prop key is
  * used.
  */
-static void
+static int
 dsl_prop_set_iuv(objset_t *mos, uint64_t zapobj, const char *propname,
     int intsz, int numints, const void *value, dmu_tx_t *tx)
 {
 	char *iuvstr = kmem_asprintf("%s%s", propname, ZPROP_IUV_SUFFIX);
 	boolean_t iuv = B_FALSE;
 	zfs_prop_t prop = zfs_name_to_prop(propname);
+	int err = 0;
 
 	switch (prop) {
 	case ZFS_PROP_REDUNDANT_METADATA:
@@ -698,15 +699,24 @@ dsl_prop_set_iuv(objset_t *mos, uint64_t zapobj, const char *propname,
 	}
 
 	if (iuv) {
-		VERIFY0(zap_update(mos, zapobj, iuvstr, intsz, numints,
-		    value, tx));
+		err = zap_update(mos, zapobj, iuvstr, intsz, numints,
+		    value, tx);
+		if (err && SPA_EXITING(mos->os_spa))
+			goto out;
+		VERIFY0(err);
 		uint64_t val = zfs_prop_default_numeric(prop);
-		VERIFY0(zap_update(mos, zapobj, propname, intsz, numints,
-		    &val, tx));
+		err = zap_update(mos, zapobj, propname, intsz, numints,
+		    &val, tx);
+		if (err && SPA_EXITING(mos->os_spa))
+			goto out;
+		VERIFY0(err);
 	} else {
-		zap_remove(mos, zapobj, iuvstr, tx);
+		err = zap_remove(mos, zapobj, iuvstr, tx);
 	}
+out:
 	kmem_strfree(iuvstr);
+
+	return (err);
 }
 
 void
@@ -714,6 +724,7 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
     zprop_source_t source, int intsz, int numints, const void *value,
     dmu_tx_t *tx)
 {
+	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 	objset_t *mos = ds->ds_dir->dd_pool->dp_meta_objset;
 	uint64_t zapobj, intval, dummy, count;
 	int isint;
@@ -723,8 +734,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	char *recvdstr;
 	char *iuvstr;
 	char *tbuf = NULL;
-	int err;
-	uint64_t version = spa_version(ds->ds_dir->dd_pool->dp_spa);
+	int err = 0;
+	uint64_t version = spa_version(spa);
 
 	isint = (dodefault(zfs_name_to_prop(propname), 8, 1, &intval) == 0);
 
@@ -733,9 +744,14 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		if (dsl_dataset_phys(ds)->ds_props_obj == 0 &&
 		    (source & ZPROP_SRC_NONE) == 0) {
 			dmu_buf_will_dirty(ds->ds_dbuf, tx);
-			VERIFY0(zap_create(mos,
+			if (SPA_EXITING(spa))
+				return;
+			err = zap_create(mos,
 			    DMU_OT_DSL_PROPS, DMU_OT_NONE, 0, tx,
-			    &dsl_dataset_phys(ds)->ds_props_obj));
+			    &dsl_dataset_phys(ds)->ds_props_obj);
+			if (err && SPA_EXITING(spa))
+				return;
+			VERIFY0(err);
 		}
 		zapobj = dsl_dataset_phys(ds)->ds_props_obj;
 	} else {
@@ -765,8 +781,12 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - remove propname$inherit
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		break;
 	case ZPROP_SRC_LOCAL:
@@ -776,10 +796,15 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * set propname$iuv -> new property value
 		 */
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
-		VERIFY0(zap_update(mos, zapobj, propname,
-		    intsz, numints, value, tx));
-		(void) dsl_prop_set_iuv(mos, zapobj, propname, intsz,
+		err = zap_update(mos, zapobj, propname,
+		    intsz, numints, value, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = dsl_prop_set_iuv(mos, zapobj, propname, intsz,
 		    numints, value, tx);
 		break;
 	case ZPROP_SRC_INHERITED:
@@ -789,14 +814,21 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - set propname$inherit
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, iuvstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		if (version >= SPA_VERSION_RECVD_PROPS &&
 		    dsl_prop_get_int_ds(ds, ZPROP_HAS_RECVD, &dummy) == 0) {
 			dummy = 0;
-			VERIFY0(zap_update(mos, zapobj, inheritstr,
-			    8, 1, &dummy, tx));
+			err = zap_update(mos, zapobj, inheritstr,
+			    8, 1, &dummy, tx);
+			if (err && SPA_EXITING(spa))
+				goto out;
+			VERIFY0(err);
 		}
 		break;
 	case ZPROP_SRC_RECEIVED:
@@ -805,6 +837,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 */
 		err = zap_update(mos, zapobj, recvdstr,
 		    intsz, numints, value, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
 		ASSERT0(err);
 		break;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_LOCAL | ZPROP_SRC_RECEIVED):
@@ -815,8 +849,12 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * - remove propname$recvd
 		 */
 		err = zap_remove(mos, zapobj, propname, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, inheritstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		zfs_fallthrough;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_RECEIVED):
@@ -824,15 +862,13 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 * remove propname$recvd
 		 */
 		err = zap_remove(mos, zapobj, recvdstr, tx);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+			goto out;
 		ASSERT(err == 0 || err == ENOENT);
 		break;
 	default:
 		cmn_err(CE_PANIC, "unexpected property source: %d", source);
 	}
-
-	kmem_strfree(inheritstr);
-	kmem_strfree(recvdstr);
-	kmem_strfree(iuvstr);
 
 	/*
 	 * If we are left with an empty snap zap we can destroy it.
@@ -847,7 +883,10 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	}
 
 	if (isint) {
-		VERIFY0(dsl_prop_get_int_ds(ds, propname, &intval));
+		err = dsl_prop_get_int_ds(ds, propname, &intval);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 
 		if (ds->ds_is_snapshot) {
 			dsl_prop_cb_record_t *cbr;
@@ -886,6 +925,11 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	spa_history_log_internal_ds(ds, (source == ZPROP_SRC_NONE ||
 	    source == ZPROP_SRC_INHERITED) ? "inherit" : "set", tx,
 	    "%s=%s", propname, (valstr == NULL ? "" : valstr));
+
+out:
+	kmem_strfree(inheritstr);
+	kmem_strfree(recvdstr);
+	kmem_strfree(iuvstr);
 
 	if (tbuf != NULL)
 		kmem_free(tbuf, ZAP_MAXVALUELEN);
@@ -1014,9 +1058,16 @@ dsl_props_set_sync(void *arg, dmu_tx_t *tx)
 	dsl_props_set_arg_t *dpsa = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *ds;
+	int err = 0;
 
-	VERIFY0(dsl_dataset_hold(dp, dpsa->dpsa_dsname, FTAG, &ds));
-	dsl_props_set_sync_impl(ds, dpsa->dpsa_source, dpsa->dpsa_props, tx);
+	err = dsl_dataset_hold(dp, dpsa->dpsa_dsname, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
+
+	dsl_props_set_sync_impl(ds, dpsa->dpsa_source, dpsa->dpsa_props,
+	    tx);
+
 	dsl_dataset_rele(ds, FTAG);
 }
 

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -4004,7 +4004,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 			    "traverse_dataset_destroyed()", err);
 		}
 
-		if (bptree_is_empty(dp->dp_meta_objset, dp->dp_bptree_obj)) {
+		boolean_t empty;
+		err = bptree_is_empty(dp->dp_meta_objset, dp->dp_bptree_obj,
+		    &empty);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		if (empty) {
 			/* finished; deactivate async destroy feature */
 			spa_feature_decr(spa, SPA_FEATURE_ASYNC_DESTROY, tx);
 			ASSERT(!spa_feature_is_active(spa,

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -827,13 +827,17 @@ dsl_scan_is_thorough_scrub(const dsl_scan_t *scn)
 static void
 dsl_errorscrub_sync_state(dsl_scan_t *scn, dmu_tx_t *tx)
 {
+	spa_t *spa = scn->scn_dp->dp_spa;
+
 	scn->errorscrub_phys.dep_cursor =
 	    zap_cursor_serialize(&scn->errorscrub_cursor);
 
-	VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+	int err = zap_update(scn->scn_dp->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_ERRORSCRUB, sizeof (uint64_t), ERRORSCRUB_PHYS_NUMINTS,
-	    &scn->errorscrub_phys, tx));
+	    &scn->errorscrub_phys, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -977,6 +981,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	dmu_object_type_t ot = 0;
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
+	int err;
 
 	ASSERT(!dsl_scan_is_running(scn));
 	ASSERT3U(setup_sync_arg->func, >, POOL_SCAN_NONE);
@@ -1074,8 +1079,11 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	if (spa_version(spa) < SPA_VERSION_DSL_SCRUB)
 		ot = DMU_OT_ZAP_OTHER;
 
-	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset,
-	    ot ? ot : DMU_OT_SCAN_QUEUE, DMU_OT_NONE, 0, tx);
+	err = zap_create(dp->dp_meta_objset,
+	    ot ? ot : DMU_OT_SCAN_QUEUE, DMU_OT_NONE, 0, tx,
+	    &scn->scn_phys.scn_queue_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	memcpy(&scn->scn_phys_cached, &scn->scn_phys, sizeof (scn->scn_phys));
 
@@ -1565,7 +1573,12 @@ dsl_scan_restart_resilver(dsl_pool_t *dp, uint64_t txg)
 	if (txg == 0) {
 		dmu_tx_t *tx;
 		tx = dmu_tx_create_dd(dp->dp_mos_dir);
-		VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+		int err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+		if (err && SPA_EXITING(dp->dp_spa)) {
+			dmu_tx_abort(tx);
+			return;
+		}
+		VERIFY0(err);
 
 		txg = dmu_tx_get_txg(tx);
 		dp->dp_scan->scn_restart_txg = txg;
@@ -1653,14 +1666,21 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 	spa_t *spa = dp->dp_spa;
 	dmu_object_type_t ot = (spa_version(spa) >= SPA_VERSION_DSL_SCRUB) ?
 	    DMU_OT_SCAN_QUEUE : DMU_OT_ZAP_OTHER;
+	int err;
 
 	ASSERT0(scn->scn_queues_pending);
 	ASSERT(scn->scn_phys.scn_queue_obj != 0);
 
-	VERIFY0(dmu_object_free(dp->dp_meta_objset,
-	    scn->scn_phys.scn_queue_obj, tx));
-	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset, ot,
-	    DMU_OT_NONE, 0, tx);
+	err = dmu_object_free(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
+	    tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+	err = zap_create(dp->dp_meta_objset, ot,
+	    DMU_OT_NONE, 0, tx, &scn->scn_phys.scn_queue_obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	for (scan_ds_t *sds = avl_first(&scn->scn_queue);
 	    sds != NULL; sds = AVL_NEXT(&scn->scn_queue, sds)) {
 		VERIFY0(zap_add_int_key(dp->dp_meta_objset,
@@ -3948,7 +3968,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bpobj_iterate(&dp->dp_free_bpobj,
 		    bpobj_dsl_scan_free_block_cb, scn, tx);
-		VERIFY0(zio_wait(scn->scn_zio_root));
+		int zioerr = zio_wait(scn->scn_zio_root);
+		if (zioerr && SPA_EXITING(spa)) {
+			if (err == 0)
+				err = zioerr;
+		} else {
+			VERIFY0(zioerr);
+		}
 		scn->scn_zio_root = NULL;
 
 		if (err != 0 && err != ERESTART)
@@ -3962,7 +3988,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bptree_iterate(dp->dp_meta_objset,
 		    dp->dp_bptree_obj, B_TRUE, dsl_scan_free_block_cb, scn, tx);
-		VERIFY0(zio_wait(scn->scn_zio_root));
+		int zioerr = zio_wait(scn->scn_zio_root);
+		if (zioerr && SPA_EXITING(spa)) {
+			if (err == 0)
+				err = zioerr;
+		} else {
+			VERIFY0(zioerr);
+		}
 		scn->scn_zio_root = NULL;
 
 		if (err == EIO || err == ECKSUM) {
@@ -4029,21 +4061,27 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		 * space to the dp_leak_dir.
 		 */
 		if (dp->dp_leak_dir == NULL) {
+			uint64_t object;
 			rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
-			(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
-			    LEAK_DIR_NAME, tx);
-			VERIFY0(dsl_pool_open_special_dir(dp,
-			    LEAK_DIR_NAME, &dp->dp_leak_dir));
+			err = dsl_dir_create_sync(dp, dp->dp_root_dir,
+			    LEAK_DIR_NAME, tx, &object);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+			if (!err)
+				err = dsl_pool_open_special_dir(dp,
+				    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			rrw_exit(&dp->dp_config_rwlock, FTAG);
 		}
-		dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-		dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		if (!err) {
+			dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+			dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		}
 	}
 
 	if (dp->dp_free_dir != NULL && !scn->scn_async_destroying &&

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -915,7 +915,7 @@ dsl_errorscrub_setup_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 {
-	int i;
+	int i, err;
 	spa_t *spa = scn->scn_dp->dp_spa;
 
 	ASSERT(sync_type != SYNC_MANDATORY || scn->scn_queues_pending == 0);
@@ -938,10 +938,12 @@ dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 
 		if (scn->scn_phys.scn_queue_obj != 0)
 			scan_ds_queue_sync(scn, tx);
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+		err = zap_update(scn->scn_dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys, tx));
+		    &scn->scn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		memcpy(&scn->scn_phys_cached, &scn->scn_phys,
 		    sizeof (scn->scn_phys));
 
@@ -952,10 +954,12 @@ dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 		scn->scn_checkpointing = B_FALSE;
 		scn->scn_last_checkpoint = ddi_get_lbolt();
 	} else if (sync_type == SYNC_CACHED) {
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+		err = zap_update(scn->scn_dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys_cached, tx));
+		    &scn->scn_phys_cached, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 }
 
@@ -1230,7 +1234,7 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
-	int i;
+	int i, err;
 
 	/* Remove any remnants of an old-style scrub. */
 	for (i = 0; old_names[i]; i++) {
@@ -1239,8 +1243,10 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 	}
 
 	if (scn->scn_phys.scn_queue_obj != 0) {
-		VERIFY0(dmu_object_free(dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj, tx));
+		err = dmu_object_free(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		scn->scn_phys.scn_queue_obj = 0;
 	}
 	scan_ds_queue_clear(scn);
@@ -1277,11 +1283,13 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 		spa_history_log_internal(spa, "scan done", tx,
 		    "errors=%llu", (u_longlong_t)spa_approx_errlog_size(spa));
 		if (DSL_SCAN_IS_SCRUB(scn)) {
-			VERIFY0(zap_update(dp->dp_meta_objset,
+			err = zap_update(dp->dp_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT,
 			    DMU_POOL_LAST_SCRUBBED_TXG,
 			    sizeof (uint64_t), 1,
-			    &scn->scn_phys.scn_max_txg, tx));
+			    &scn->scn_phys.scn_max_txg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			spa->spa_scrubbed_last_txg = scn->scn_phys.scn_max_txg;
 		}
 	}
@@ -1683,9 +1691,12 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 	VERIFY0(err);
 	for (scan_ds_t *sds = avl_first(&scn->scn_queue);
 	    sds != NULL; sds = AVL_NEXT(&scn->scn_queue, sds)) {
-		VERIFY0(zap_add_int_key(dp->dp_meta_objset,
+		err = zap_add_int_key(dp->dp_meta_objset,
 		    scn->scn_phys.scn_queue_obj, sds->sds_dsobj,
-		    sds->sds_txg, tx));
+		    sds->sds_txg, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -1819,6 +1830,7 @@ dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
 	    txg_sync_waiting(scn->scn_dp) ||
 	    NSEC2SEC(sync_time_ns) >= zfs_txg_timeout)) ||
 	    spa_shutting_down(scn->scn_dp->dp_spa) ||
+	    SPA_EXITING(scn->scn_dp->dp_spa) ||
 	    (zfs_scan_strict_mem_lim && dsl_scan_should_clear(scn)) ||
 	    !ddt_walk_ready(scn->scn_dp->dp_spa)) {
 		if (zb && zb->zb_level == ZB_ROOT_LEVEL) {
@@ -2653,8 +2665,10 @@ void
 dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
 	uint64_t mintxg;
+	int err;
 
 	if (!dsl_scan_is_running(scn))
 		return;
@@ -2672,18 +2686,22 @@ dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
 	    ds->ds_object, &mintxg) == 0) {
 		ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
-		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx));
+		err = zap_remove_int(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		if (ds->ds_is_snapshot) {
 			/*
 			 * We keep the same mintxg; it could be >
 			 * ds_creation_txg if the previous snapshot was
 			 * deleted too.
 			 */
-			VERIFY(zap_add_int_key(dp->dp_meta_objset,
+			err = zap_add_int_key(dp->dp_meta_objset,
 			    scn->scn_phys.scn_queue_obj,
 			    dsl_dataset_phys(ds)->ds_next_snap_obj,
-			    mintxg, tx) == 0);
+			    mintxg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			zfs_dbgmsg("destroying ds %llu on %s; in queue; "
 			    "replacing with %llu",
 			    (u_longlong_t)ds->ds_object,
@@ -2927,8 +2945,12 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = scn->scn_dp;
 	dsl_dataset_t *ds;
+	int err;
 
-	VERIFY3U(0, ==, dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+	err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
 
 	if (scn->scn_phys.scn_cur_min_txg >=
 	    scn->scn_phys.scn_max_txg) {
@@ -2993,6 +3015,8 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	 * Iterate over the bps in this ds.
 	 */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	if (SPA_EXITING(dp->dp_spa))
+		goto out;
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
 	dsl_scan_visit_rootbp(scn, ds, &dsl_dataset_phys(ds)->ds_bp, tx);
 	rrw_exit(&ds->ds_bp_rwlock, FTAG);
@@ -3066,9 +3090,11 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 			zap_cursor_fini(&zc);
 			zap_attribute_free(za);
 		} else {
-			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+			err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
 			    enqueue_clones_cb, &ds->ds_object,
-			    DS_FIND_CHILDREN));
+			    DS_FIND_CHILDREN);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -3192,12 +3218,13 @@ dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
 static void
 dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 {
+	spa_t *spa = scn->scn_dp->dp_spa;
 	ddt_bookmark_t *ddb = &scn->scn_phys.scn_ddt_bookmark;
 	ddt_lightweight_entry_t ddlwe = {0};
 	int error;
 	uint64_t n = 0;
 
-	while ((error = ddt_walk(scn->scn_dp->dp_spa, ddb, &ddlwe)) == 0) {
+	while ((error = ddt_walk(spa, ddb, &ddlwe)) == 0) {
 		ddt_t *ddt;
 
 		if (ddb->ddb_class > scn->scn_phys.scn_ddt_class_max)
@@ -3209,7 +3236,7 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 		    (longlong_t)ddb->ddb_cursor);
 
 		/* There should be no pending changes to the dedup table */
-		ddt = scn->scn_dp->dp_spa->spa_ddt[ddb->ddb_checksum];
+		ddt = spa->spa_ddt[ddb->ddb_checksum];
 		ASSERT(avl_first(&ddt->ddt_tree) == NULL);
 
 		dsl_scan_ddt_entry(scn, ddb->ddb_checksum, ddt, &ddlwe, tx);
@@ -3225,15 +3252,20 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 
 		zfs_dbgmsg("waiting for ddt to become ready for scan "
 		    "on %s with class_max = %u; suspending=%u",
-		    scn->scn_dp->dp_spa->spa_name,
+		    spa->spa_name,
 		    (int)scn->scn_phys.scn_ddt_class_max,
 		    (int)scn->scn_suspending);
-	} else
+	} else {
 		zfs_dbgmsg("scanned %llu ddt entries on %s with "
 		    "class_max = %u; suspending=%u", (longlong_t)n,
-		    scn->scn_dp->dp_spa->spa_name,
+		    spa->spa_name,
 		    (int)scn->scn_phys.scn_ddt_class_max,
 		    (int)scn->scn_suspending);
+		if (SPA_EXITING(spa)) {
+			dsl_scan_check_suspend(scn, NULL);
+			error = 0;
+		}
+	}
 
 	ASSERT(error == 0 || error == ENOENT);
 	ASSERT(error != ENOENT ||
@@ -3254,6 +3286,8 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 {
 	scan_ds_t *sds;
 	dsl_pool_t *dp = scn->scn_dp;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	if (scn->scn_phys.scn_ddt_bookmark.ddb_class <=
 	    scn->scn_phys.scn_ddt_class_max) {
@@ -3275,11 +3309,16 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 			return;
 
 		if (spa_version(dp->dp_spa) < SPA_VERSION_DSL_SCRUB) {
-			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-			    enqueue_cb, NULL, DS_FIND_CHILDREN));
+			err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+			    enqueue_cb, NULL, DS_FIND_CHILDREN);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		} else {
 			dsl_scan_visitds(scn,
 			    dp->dp_origin_snap->ds_object, tx);
+			if (SPA_EXITING(spa))
+				goto spa_exiting;
 		}
 		ASSERT(!scn->scn_suspending);
 	} else if (scn->scn_phys.scn_bookmark.zb_objset !=
@@ -3316,7 +3355,10 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		sds = NULL;
 
 		/* set up min / max txg */
-		VERIFY3U(0, ==, dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+		err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		if (txg != 0) {
 			scn->scn_phys.scn_cur_min_txg =
 			    MAX(scn->scn_phys.scn_min_txg, txg);
@@ -3332,10 +3374,16 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		if (scn->scn_suspending)
 			return;
 	}
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 
 	/* No more objsets to fetch, we're done */
 	scn->scn_phys.scn_bookmark.zb_objset = ZB_DESTROYED_OBJSET;
 	ASSERT0(scn->scn_suspending);
+	return;
+
+spa_exiting:
+	scn->scn_suspending = B_TRUE;
 }
 
 static uint64_t
@@ -3959,6 +4007,8 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 
 	if (spa_suspend_async_destroy(spa))
 		return (0);
+	if (SPA_EXITING(spa))
+		return (0);
 
 	if (zfs_free_bpobj_enabled &&
 	    spa_version(spa) >= SPA_VERSION_DEADLISTS) {
@@ -3969,16 +4019,16 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		err = bpobj_iterate(&dp->dp_free_bpobj,
 		    bpobj_dsl_scan_free_block_cb, scn, tx);
 		int zioerr = zio_wait(scn->scn_zio_root);
-		if (zioerr && SPA_EXITING(spa)) {
-			if (err == 0)
-				err = zioerr;
-		} else {
-			VERIFY0(zioerr);
-		}
+		if (zioerr && SPA_EXITING(spa))
+			return (zioerr);
+		VERIFY0(zioerr);
 		scn->scn_zio_root = NULL;
 
-		if (err != 0 && err != ERESTART)
+		if (err != 0 && err != ERESTART) {
+			if (SPA_EXITING(spa))
+				return (SET_ERROR(EIO));
 			zfs_panic_recover("error %u from bpobj_iterate()", err);
+		}
 	}
 
 	if (err == 0 && spa_feature_is_active(spa, SPA_FEATURE_ASYNC_DESTROY)) {
@@ -3989,17 +4039,15 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		err = bptree_iterate(dp->dp_meta_objset,
 		    dp->dp_bptree_obj, B_TRUE, dsl_scan_free_block_cb, scn, tx);
 		int zioerr = zio_wait(scn->scn_zio_root);
-		if (zioerr && SPA_EXITING(spa)) {
-			if (err == 0)
-				err = zioerr;
-		} else {
+		if (!SPA_EXITING(spa))
 			VERIFY0(zioerr);
-		}
 		scn->scn_zio_root = NULL;
 
 		if (err == EIO || err == ECKSUM) {
 			err = 0;
 		} else if (err != 0 && err != ERESTART) {
+			if (SPA_EXITING(spa))
+				return (err);
 			zfs_panic_recover("error %u from "
 			    "traverse_dataset_destroyed()", err);
 		}
@@ -4014,12 +4062,16 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 			/* finished; deactivate async destroy feature */
 			spa_feature_decr(spa, SPA_FEATURE_ASYNC_DESTROY, tx);
 			ASSERT(!spa_feature_is_active(spa,
-			    SPA_FEATURE_ASYNC_DESTROY));
-			VERIFY0(zap_remove(dp->dp_meta_objset,
+			    SPA_FEATURE_ASYNC_DESTROY) || SPA_EXITING(spa));
+			err = zap_remove(dp->dp_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT,
-			    DMU_POOL_BPTREE_OBJ, tx));
-			VERIFY0(bptree_free(dp->dp_meta_objset,
-			    dp->dp_bptree_obj, tx));
+			    DMU_POOL_BPTREE_OBJ, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+			err = bptree_free(dp->dp_meta_objset,
+			    dp->dp_bptree_obj, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			dp->dp_bptree_obj = 0;
 			scn->scn_async_destroying = B_FALSE;
 			scn->scn_async_stalled = B_FALSE;
@@ -4069,29 +4121,26 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		if (dp->dp_leak_dir == NULL) {
 			uint64_t object;
 			rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
-			err = dsl_dir_create_sync(dp, dp->dp_root_dir,
+			(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
 			    LEAK_DIR_NAME, tx, &object);
+			err = dsl_pool_open_special_dir(dp,
+			    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			if (!SPA_EXITING(spa))
 				VERIFY0(err);
-			if (!err)
-				err = dsl_pool_open_special_dir(dp,
-				    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			rrw_exit(&dp->dp_config_rwlock, FTAG);
 		}
-		if (!err) {
-			dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-			dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-		}
+		dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
 	}
 
 	if (dp->dp_free_dir != NULL && !scn->scn_async_destroying &&
-	    !spa_livelist_delete_check(spa)) {
+	    !spa_livelist_delete_check(spa) && !SPA_EXITING(spa)) {
 		/* finished; verify that space accounting went to zero */
 		ASSERT0(dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes);
 		ASSERT0(dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes);
@@ -4100,9 +4149,11 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 
 	spa_notify_waiters(spa);
 
-	EQUIV(bpobj_is_open(&dp->dp_obsolete_bpobj),
-	    0 == zap_contains(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_OBSOLETE_BPOBJ));
+	boolean_t isopen = bpobj_is_open(&dp->dp_obsolete_bpobj);
+	boolean_t contains = (0 == zap_contains(dp->dp_meta_objset,
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_OBSOLETE_BPOBJ));
+	if (!SPA_EXITING(spa))
+		EQUIV(isopen, contains);
 	if (err == 0 && bpobj_is_open(&dp->dp_obsolete_bpobj)) {
 		ASSERT(spa_feature_is_active(dp->dp_spa,
 		    SPA_FEATURE_OBSOLETE_COUNTS));
@@ -4111,7 +4162,7 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		scn->scn_async_block_min_time_ms = zfs_obsolete_min_time_ms;
 		err = bpobj_iterate(&dp->dp_obsolete_bpobj,
 		    dsl_scan_obsolete_block_cb, scn, tx);
-		if (err != 0 && err != ERESTART)
+		if (err != 0 && err != ERESTART && !SPA_EXITING(spa))
 			zfs_panic_recover("error %u from bpobj_iterate()", err);
 
 		if (bpobj_is_empty(&dp->dp_obsolete_bpobj))
@@ -4766,8 +4817,10 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		mutex_exit(&dp->dp_spa->spa_scrub_lock);
 
 		taskq_wait_id(dp->dp_sync_taskq, prefetch_tqid);
-		(void) zio_wait(scn->scn_zio_root);
+		err = zio_wait(scn->scn_zio_root);
 		scn->scn_zio_root = NULL;
+		if (err && SPA_EXITING(spa))
+			return;
 
 		zfs_dbgmsg("scan visited %llu blocks of %s in %llums "
 		    "(%llu os's, %llu holes, %llu < mintxg, "
@@ -4803,8 +4856,10 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
 		    NULL, ZIO_FLAG_CANFAIL);
 		scan_io_queues_run(scn);
-		(void) zio_wait(scn->scn_zio_root);
+		err = zio_wait(scn->scn_zio_root);
 		scn->scn_zio_root = NULL;
+		if (err && SPA_EXITING(spa))
+			return;
 
 		/* calculate and dprintf the current memory usage */
 		(void) dsl_scan_should_clear(scn);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -4024,7 +4024,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 			    "traverse_dataset_destroyed()", err);
 		}
 
-		if (bptree_is_empty(dp->dp_meta_objset, dp->dp_bptree_obj)) {
+		boolean_t empty;
+		err = bptree_is_empty(dp->dp_meta_objset, dp->dp_bptree_obj,
+		    &empty);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		if (empty) {
 			/* finished; deactivate async destroy feature */
 			spa_feature_decr(spa, SPA_FEATURE_ASYNC_DESTROY, tx);
 			ASSERT(!spa_feature_is_active(spa,

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -907,7 +907,7 @@ dsl_errorscrub_setup_check(void *arg, dmu_tx_t *tx)
 static void
 dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 {
-	int i;
+	int i, err;
 	spa_t *spa = scn->scn_dp->dp_spa;
 
 	ASSERT(sync_type != SYNC_MANDATORY || scn->scn_queues_pending == 0);
@@ -930,10 +930,12 @@ dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 
 		if (scn->scn_phys.scn_queue_obj != 0)
 			scan_ds_queue_sync(scn, tx);
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+		err = zap_update(scn->scn_dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys, tx));
+		    &scn->scn_phys, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		memcpy(&scn->scn_phys_cached, &scn->scn_phys,
 		    sizeof (scn->scn_phys));
 
@@ -944,10 +946,12 @@ dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 		scn->scn_checkpointing = B_FALSE;
 		scn->scn_last_checkpoint = ddi_get_lbolt();
 	} else if (sync_type == SYNC_CACHED) {
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+		err = zap_update(scn->scn_dp->dp_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys_cached, tx));
+		    &scn->scn_phys_cached, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 }
 
@@ -1222,7 +1226,7 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
-	int i;
+	int i, err;
 
 	/* Remove any remnants of an old-style scrub. */
 	for (i = 0; old_names[i]; i++) {
@@ -1231,8 +1235,10 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 	}
 
 	if (scn->scn_phys.scn_queue_obj != 0) {
-		VERIFY0(dmu_object_free(dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj, tx));
+		err = dmu_object_free(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		scn->scn_phys.scn_queue_obj = 0;
 	}
 	scan_ds_queue_clear(scn);
@@ -1269,11 +1275,13 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 		spa_history_log_internal(spa, "scan done", tx,
 		    "errors=%llu", (u_longlong_t)spa_approx_errlog_size(spa));
 		if (DSL_SCAN_IS_SCRUB(scn)) {
-			VERIFY0(zap_update(dp->dp_meta_objset,
+			err = zap_update(dp->dp_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT,
 			    DMU_POOL_LAST_SCRUBBED_TXG,
 			    sizeof (uint64_t), 1,
-			    &scn->scn_phys.scn_max_txg, tx));
+			    &scn->scn_phys.scn_max_txg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			spa->spa_scrubbed_last_txg = scn->scn_phys.scn_max_txg;
 		}
 	}
@@ -1675,9 +1683,12 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 	VERIFY0(err);
 	for (scan_ds_t *sds = avl_first(&scn->scn_queue);
 	    sds != NULL; sds = AVL_NEXT(&scn->scn_queue, sds)) {
-		VERIFY0(zap_add_int_key(dp->dp_meta_objset,
+		err = zap_add_int_key(dp->dp_meta_objset,
 		    scn->scn_phys.scn_queue_obj, sds->sds_dsobj,
-		    sds->sds_txg, tx));
+		    sds->sds_txg, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	}
 }
 
@@ -1811,6 +1822,7 @@ dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
 	    txg_sync_waiting(scn->scn_dp) ||
 	    NSEC2SEC(sync_time_ns) >= zfs_txg_timeout)) ||
 	    spa_shutting_down(scn->scn_dp->dp_spa) ||
+	    SPA_EXITING(scn->scn_dp->dp_spa) ||
 	    (zfs_scan_strict_mem_lim && dsl_scan_should_clear(scn)) ||
 	    !ddt_walk_ready(scn->scn_dp->dp_spa)) {
 		if (zb && zb->zb_level == ZB_ROOT_LEVEL) {
@@ -2645,8 +2657,10 @@ void
 dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
 	uint64_t mintxg;
+	int err;
 
 	if (!dsl_scan_is_running(scn))
 		return;
@@ -2664,18 +2678,22 @@ dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
 	    ds->ds_object, &mintxg) == 0) {
 		ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
-		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx));
+		err = zap_remove_int(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		if (ds->ds_is_snapshot) {
 			/*
 			 * We keep the same mintxg; it could be >
 			 * ds_creation_txg if the previous snapshot was
 			 * deleted too.
 			 */
-			VERIFY(zap_add_int_key(dp->dp_meta_objset,
+			err = zap_add_int_key(dp->dp_meta_objset,
 			    scn->scn_phys.scn_queue_obj,
 			    dsl_dataset_phys(ds)->ds_next_snap_obj,
-			    mintxg, tx) == 0);
+			    mintxg, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			zfs_dbgmsg("destroying ds %llu on %s; in queue; "
 			    "replacing with %llu",
 			    (u_longlong_t)ds->ds_object,
@@ -2919,8 +2937,12 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = scn->scn_dp;
 	dsl_dataset_t *ds;
+	int err;
 
-	VERIFY3U(0, ==, dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+	err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err && SPA_EXITING(dp->dp_spa))
+		return;
+	VERIFY0(err);
 
 	if (scn->scn_phys.scn_cur_min_txg >=
 	    scn->scn_phys.scn_max_txg) {
@@ -2985,6 +3007,8 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	 * Iterate over the bps in this ds.
 	 */
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	if (SPA_EXITING(dp->dp_spa))
+		goto out;
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
 	dsl_scan_visit_rootbp(scn, ds, &dsl_dataset_phys(ds)->ds_bp, tx);
 	rrw_exit(&ds->ds_bp_rwlock, FTAG);
@@ -3058,9 +3082,11 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 			zap_cursor_fini(&zc);
 			zap_attribute_free(za);
 		} else {
-			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+			err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
 			    enqueue_clones_cb, &ds->ds_object,
-			    DS_FIND_CHILDREN));
+			    DS_FIND_CHILDREN);
+			if (!SPA_EXITING(dp->dp_spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -3184,12 +3210,13 @@ dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
 static void
 dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 {
+	spa_t *spa = scn->scn_dp->dp_spa;
 	ddt_bookmark_t *ddb = &scn->scn_phys.scn_ddt_bookmark;
 	ddt_lightweight_entry_t ddlwe = {0};
 	int error;
 	uint64_t n = 0;
 
-	while ((error = ddt_walk(scn->scn_dp->dp_spa, ddb, &ddlwe)) == 0) {
+	while ((error = ddt_walk(spa, ddb, &ddlwe)) == 0) {
 		ddt_t *ddt;
 
 		if (ddb->ddb_class > scn->scn_phys.scn_ddt_class_max)
@@ -3201,7 +3228,7 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 		    (longlong_t)ddb->ddb_cursor);
 
 		/* There should be no pending changes to the dedup table */
-		ddt = scn->scn_dp->dp_spa->spa_ddt[ddb->ddb_checksum];
+		ddt = spa->spa_ddt[ddb->ddb_checksum];
 		ASSERT(avl_first(&ddt->ddt_tree) == NULL);
 
 		dsl_scan_ddt_entry(scn, ddb->ddb_checksum, ddt, &ddlwe, tx);
@@ -3217,15 +3244,20 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 
 		zfs_dbgmsg("waiting for ddt to become ready for scan "
 		    "on %s with class_max = %u; suspending=%u",
-		    scn->scn_dp->dp_spa->spa_name,
+		    spa->spa_name,
 		    (int)scn->scn_phys.scn_ddt_class_max,
 		    (int)scn->scn_suspending);
-	} else
+	} else {
 		zfs_dbgmsg("scanned %llu ddt entries on %s with "
 		    "class_max = %u; suspending=%u", (longlong_t)n,
-		    scn->scn_dp->dp_spa->spa_name,
+		    spa->spa_name,
 		    (int)scn->scn_phys.scn_ddt_class_max,
 		    (int)scn->scn_suspending);
+		if (SPA_EXITING(spa)) {
+			dsl_scan_check_suspend(scn, NULL);
+			error = 0;
+		}
+	}
 
 	ASSERT(error == 0 || error == ENOENT);
 	ASSERT(error != ENOENT ||
@@ -3246,6 +3278,8 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 {
 	scan_ds_t *sds;
 	dsl_pool_t *dp = scn->scn_dp;
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	if (scn->scn_phys.scn_ddt_bookmark.ddb_class <=
 	    scn->scn_phys.scn_ddt_class_max) {
@@ -3267,11 +3301,16 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 			return;
 
 		if (spa_version(dp->dp_spa) < SPA_VERSION_DSL_SCRUB) {
-			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-			    enqueue_cb, NULL, DS_FIND_CHILDREN));
+			err = dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
+			    enqueue_cb, NULL, DS_FIND_CHILDREN);
+			if (err && SPA_EXITING(spa))
+				goto spa_exiting;
+			VERIFY0(err);
 		} else {
 			dsl_scan_visitds(scn,
 			    dp->dp_origin_snap->ds_object, tx);
+			if (SPA_EXITING(spa))
+				goto spa_exiting;
 		}
 		ASSERT(!scn->scn_suspending);
 	} else if (scn->scn_phys.scn_bookmark.zb_objset !=
@@ -3308,7 +3347,10 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		sds = NULL;
 
 		/* set up min / max txg */
-		VERIFY3U(0, ==, dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+		err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		if (txg != 0) {
 			scn->scn_phys.scn_cur_min_txg =
 			    MAX(scn->scn_phys.scn_min_txg, txg);
@@ -3324,10 +3366,16 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		if (scn->scn_suspending)
 			return;
 	}
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 
 	/* No more objsets to fetch, we're done */
 	scn->scn_phys.scn_bookmark.zb_objset = ZB_DESTROYED_OBJSET;
 	ASSERT0(scn->scn_suspending);
+	return;
+
+spa_exiting:
+	scn->scn_suspending = B_TRUE;
 }
 
 static uint64_t
@@ -3979,6 +4027,8 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 
 	if (spa_suspend_async_destroy(spa))
 		return (0);
+	if (SPA_EXITING(spa))
+		return (0);
 
 	if (zfs_free_bpobj_enabled &&
 	    spa_version(spa) >= SPA_VERSION_DEADLISTS) {
@@ -3989,16 +4039,16 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		err = bpobj_iterate(&dp->dp_free_bpobj,
 		    bpobj_dsl_scan_free_block_cb, scn, tx);
 		int zioerr = zio_wait(scn->scn_zio_root);
-		if (zioerr && SPA_EXITING(spa)) {
-			if (err == 0)
-				err = zioerr;
-		} else {
-			VERIFY0(zioerr);
-		}
+		if (zioerr && SPA_EXITING(spa))
+			return (zioerr);
+		VERIFY0(zioerr);
 		scn->scn_zio_root = NULL;
 
-		if (err != 0 && err != ERESTART)
+		if (err != 0 && err != ERESTART) {
+			if (SPA_EXITING(spa))
+				return (SET_ERROR(EIO));
 			zfs_panic_recover("error %u from bpobj_iterate()", err);
+		}
 	}
 
 	if (err == 0 && spa_feature_is_active(spa, SPA_FEATURE_ASYNC_DESTROY)) {
@@ -4009,17 +4059,15 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		err = bptree_iterate(dp->dp_meta_objset,
 		    dp->dp_bptree_obj, B_TRUE, dsl_scan_free_block_cb, scn, tx);
 		int zioerr = zio_wait(scn->scn_zio_root);
-		if (zioerr && SPA_EXITING(spa)) {
-			if (err == 0)
-				err = zioerr;
-		} else {
+		if (!SPA_EXITING(spa))
 			VERIFY0(zioerr);
-		}
 		scn->scn_zio_root = NULL;
 
 		if (err == EIO || err == ECKSUM) {
 			err = 0;
 		} else if (err != 0 && err != ERESTART) {
+			if (SPA_EXITING(spa))
+				return (err);
 			zfs_panic_recover("error %u from "
 			    "traverse_dataset_destroyed()", err);
 		}
@@ -4034,12 +4082,16 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 			/* finished; deactivate async destroy feature */
 			spa_feature_decr(spa, SPA_FEATURE_ASYNC_DESTROY, tx);
 			ASSERT(!spa_feature_is_active(spa,
-			    SPA_FEATURE_ASYNC_DESTROY));
-			VERIFY0(zap_remove(dp->dp_meta_objset,
+			    SPA_FEATURE_ASYNC_DESTROY) || SPA_EXITING(spa));
+			err = zap_remove(dp->dp_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT,
-			    DMU_POOL_BPTREE_OBJ, tx));
-			VERIFY0(bptree_free(dp->dp_meta_objset,
-			    dp->dp_bptree_obj, tx));
+			    DMU_POOL_BPTREE_OBJ, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+			err = bptree_free(dp->dp_meta_objset,
+			    dp->dp_bptree_obj, tx);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 			dp->dp_bptree_obj = 0;
 			scn->scn_async_destroying = B_FALSE;
 			scn->scn_async_stalled = B_FALSE;
@@ -4089,29 +4141,26 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		if (dp->dp_leak_dir == NULL) {
 			uint64_t object;
 			rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
-			err = dsl_dir_create_sync(dp, dp->dp_root_dir,
+			(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
 			    LEAK_DIR_NAME, tx, &object);
+			err = dsl_pool_open_special_dir(dp,
+			    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			if (!SPA_EXITING(spa))
 				VERIFY0(err);
-			if (!err)
-				err = dsl_pool_open_special_dir(dp,
-				    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			rrw_exit(&dp->dp_config_rwlock, FTAG);
 		}
-		if (!err) {
-			dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-			    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-			dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-			    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-		}
+		dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+		    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+		    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
 	}
 
 	if (dp->dp_free_dir != NULL && !scn->scn_async_destroying &&
-	    !spa_livelist_delete_check(spa)) {
+	    !spa_livelist_delete_check(spa) && !SPA_EXITING(spa)) {
 		/* finished; verify that space accounting went to zero */
 		ASSERT0(dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes);
 		ASSERT0(dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes);
@@ -4120,9 +4169,11 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 
 	spa_notify_waiters(spa);
 
-	EQUIV(bpobj_is_open(&dp->dp_obsolete_bpobj),
-	    0 == zap_contains(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_OBSOLETE_BPOBJ));
+	boolean_t isopen = bpobj_is_open(&dp->dp_obsolete_bpobj);
+	boolean_t contains = (0 == zap_contains(dp->dp_meta_objset,
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_OBSOLETE_BPOBJ));
+	if (!SPA_EXITING(spa))
+		EQUIV(isopen, contains);
 	if (err == 0 && bpobj_is_open(&dp->dp_obsolete_bpobj)) {
 		ASSERT(spa_feature_is_active(dp->dp_spa,
 		    SPA_FEATURE_OBSOLETE_COUNTS));
@@ -4131,7 +4182,7 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		scn->scn_async_block_min_time_ms = zfs_obsolete_min_time_ms;
 		err = bpobj_iterate(&dp->dp_obsolete_bpobj,
 		    dsl_scan_obsolete_block_cb, scn, tx);
-		if (err != 0 && err != ERESTART)
+		if (err != 0 && err != ERESTART && !SPA_EXITING(spa))
 			zfs_panic_recover("error %u from bpobj_iterate()", err);
 
 		if (bpobj_is_empty(&dp->dp_obsolete_bpobj))
@@ -4788,8 +4839,10 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		mutex_exit(&dp->dp_spa->spa_scrub_lock);
 
 		taskq_wait_id(dp->dp_sync_taskq, prefetch_tqid);
-		(void) zio_wait(scn->scn_zio_root);
+		err = zio_wait(scn->scn_zio_root);
 		scn->scn_zio_root = NULL;
+		if (err && SPA_EXITING(spa))
+			return;
 
 		zfs_dbgmsg("scan visited %llu blocks of %s in %llums "
 		    "(%llu os's, %llu holes, %llu < mintxg, "
@@ -4825,8 +4878,10 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
 		    NULL, ZIO_FLAG_CANFAIL);
 		scan_io_queues_run(scn);
-		(void) zio_wait(scn->scn_zio_root);
+		err = zio_wait(scn->scn_zio_root);
 		scn->scn_zio_root = NULL;
+		if (err && SPA_EXITING(spa))
+			return;
 
 		/* calculate and dprintf the current memory usage */
 		(void) dsl_scan_should_clear(scn);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -819,13 +819,17 @@ dsl_scan_is_thorough_scrub(const dsl_scan_t *scn)
 static void
 dsl_errorscrub_sync_state(dsl_scan_t *scn, dmu_tx_t *tx)
 {
+	spa_t *spa = scn->scn_dp->dp_spa;
+
 	scn->errorscrub_phys.dep_cursor =
 	    zap_cursor_serialize(&scn->errorscrub_cursor);
 
-	VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+	int err = zap_update(scn->scn_dp->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_ERRORSCRUB, sizeof (uint64_t), ERRORSCRUB_PHYS_NUMINTS,
-	    &scn->errorscrub_phys, tx));
+	    &scn->errorscrub_phys, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -969,6 +973,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	dmu_object_type_t ot = 0;
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
+	int err;
 
 	ASSERT(!dsl_scan_is_running(scn));
 	ASSERT3U(setup_sync_arg->func, >, POOL_SCAN_NONE);
@@ -1066,8 +1071,11 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	if (spa_version(spa) < SPA_VERSION_DSL_SCRUB)
 		ot = DMU_OT_ZAP_OTHER;
 
-	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset,
-	    ot ? ot : DMU_OT_SCAN_QUEUE, DMU_OT_NONE, 0, tx);
+	err = zap_create(dp->dp_meta_objset,
+	    ot ? ot : DMU_OT_SCAN_QUEUE, DMU_OT_NONE, 0, tx,
+	    &scn->scn_phys.scn_queue_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	memcpy(&scn->scn_phys_cached, &scn->scn_phys, sizeof (scn->scn_phys));
 
@@ -1557,7 +1565,12 @@ dsl_scan_restart_resilver(dsl_pool_t *dp, uint64_t txg)
 	if (txg == 0) {
 		dmu_tx_t *tx;
 		tx = dmu_tx_create_dd(dp->dp_mos_dir);
-		VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+		int err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+		if (err && SPA_EXITING(dp->dp_spa)) {
+			dmu_tx_abort(tx);
+			return;
+		}
+		VERIFY0(err);
 
 		txg = dmu_tx_get_txg(tx);
 		dp->dp_scan->scn_restart_txg = txg;
@@ -1645,14 +1658,21 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 	spa_t *spa = dp->dp_spa;
 	dmu_object_type_t ot = (spa_version(spa) >= SPA_VERSION_DSL_SCRUB) ?
 	    DMU_OT_SCAN_QUEUE : DMU_OT_ZAP_OTHER;
+	int err;
 
 	ASSERT0(scn->scn_queues_pending);
 	ASSERT(scn->scn_phys.scn_queue_obj != 0);
 
-	VERIFY0(dmu_object_free(dp->dp_meta_objset,
-	    scn->scn_phys.scn_queue_obj, tx));
-	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset, ot,
-	    DMU_OT_NONE, 0, tx);
+	err = dmu_object_free(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
+	    tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+	err = zap_create(dp->dp_meta_objset, ot,
+	    DMU_OT_NONE, 0, tx, &scn->scn_phys.scn_queue_obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	for (scan_ds_t *sds = avl_first(&scn->scn_queue);
 	    sds != NULL; sds = AVL_NEXT(&scn->scn_queue, sds)) {
 		VERIFY0(zap_add_int_key(dp->dp_meta_objset,
@@ -3968,7 +3988,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bpobj_iterate(&dp->dp_free_bpobj,
 		    bpobj_dsl_scan_free_block_cb, scn, tx);
-		VERIFY0(zio_wait(scn->scn_zio_root));
+		int zioerr = zio_wait(scn->scn_zio_root);
+		if (zioerr && SPA_EXITING(spa)) {
+			if (err == 0)
+				err = zioerr;
+		} else {
+			VERIFY0(zioerr);
+		}
 		scn->scn_zio_root = NULL;
 
 		if (err != 0 && err != ERESTART)
@@ -3982,7 +4008,13 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bptree_iterate(dp->dp_meta_objset,
 		    dp->dp_bptree_obj, B_TRUE, dsl_scan_free_block_cb, scn, tx);
-		VERIFY0(zio_wait(scn->scn_zio_root));
+		int zioerr = zio_wait(scn->scn_zio_root);
+		if (zioerr && SPA_EXITING(spa)) {
+			if (err == 0)
+				err = zioerr;
+		} else {
+			VERIFY0(zioerr);
+		}
 		scn->scn_zio_root = NULL;
 
 		if (err == EIO || err == ECKSUM) {
@@ -4049,21 +4081,27 @@ dsl_process_async_destroys(dsl_pool_t *dp, dmu_tx_t *tx)
 		 * space to the dp_leak_dir.
 		 */
 		if (dp->dp_leak_dir == NULL) {
+			uint64_t object;
 			rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
-			(void) dsl_dir_create_sync(dp, dp->dp_root_dir,
-			    LEAK_DIR_NAME, tx);
-			VERIFY0(dsl_pool_open_special_dir(dp,
-			    LEAK_DIR_NAME, &dp->dp_leak_dir));
+			err = dsl_dir_create_sync(dp, dp->dp_root_dir,
+			    LEAK_DIR_NAME, tx, &object);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
+			if (!err)
+				err = dsl_pool_open_special_dir(dp,
+				    LEAK_DIR_NAME, &dp->dp_leak_dir);
 			rrw_exit(&dp->dp_config_rwlock, FTAG);
 		}
-		dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-		    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
-		dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
-		    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		if (!err) {
+			dsl_dir_diduse_space(dp->dp_leak_dir, DD_USED_HEAD,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+			    dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+			dsl_dir_diduse_space(dp->dp_free_dir, DD_USED_HEAD,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_used_bytes,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_compressed_bytes,
+			    -dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes, tx);
+		}
 	}
 
 	if (dp->dp_free_dir != NULL && !scn->scn_async_destroying &&

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -168,8 +168,9 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 		 * the userrefs zap object.
 		 */
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
-		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj =
-		    zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(ds)->ds_userrefs_obj));
+		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	} else {
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	}

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -158,7 +158,9 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
+	spa_t *spa = dp->dp_spa;
 	uint64_t zapobj;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -168,22 +170,30 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 		 * the userrefs zap object.
 		 */
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
-		VERIFY0(zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
-		    &dsl_dataset_phys(ds)->ds_userrefs_obj));
+		err = zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(ds)->ds_userrefs_obj);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	} else {
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	}
 	ds->ds_userrefs++;
 
-	VERIFY0(zap_add(mos, zapobj, htag, 8, 1, &now, tx));
+	err = zap_add(mos, zapobj, htag, 8, 1, &now, tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	if (minor != 0) {
 		char name[MAXNAMELEN];
 		nvlist_t *tags;
 
-		VERIFY0(dsl_pool_user_hold(dp, ds->ds_object,
-		    htag, now, tx));
+		err = dsl_pool_user_hold(dp, ds->ds_object,
+		    htag, now, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		(void) snprintf(name, sizeof (name), "%llx",
 		    (u_longlong_t)ds->ds_object);
 
@@ -253,8 +263,10 @@ dsl_onexit_hold_cleanup(spa_t *spa, nvlist_t *holds, minor_t minor)
 	    sizeof (ca->zhca_spaname));
 	ca->zhca_spa_load_guid = spa_load_guid(spa);
 	ca->zhca_holds = holds;
-	VERIFY0(zfs_onexit_add_cb(minor,
-	    dsl_dataset_user_release_onexit, ca, NULL));
+	int err = zfs_onexit_add_cb(minor,
+	    dsl_dataset_user_release_onexit, ca, NULL);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 void
@@ -276,8 +288,10 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_dataset_user_hold_arg_t *dduha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	nvlist_t *tmpholds;
 	uint64_t now = gethrestime_sec();
+	int err;
 
 	if (dduha->dduha_minor != 0)
 		tmpholds = fnvlist_alloc();
@@ -288,7 +302,10 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 	    pair = nvlist_next_nvpair(dduha->dduha_chkholds, pair)) {
 		dsl_dataset_t *ds;
 
-		VERIFY0(dsl_dataset_hold(dp, nvpair_name(pair), FTAG, &ds));
+		err = dsl_dataset_hold(dp, nvpair_name(pair), FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 		dsl_dataset_user_hold_sync_one_impl(tmpholds, ds,
 		    fnvpair_value_string(pair), dduha->dduha_minor, now, tx);
 		dsl_dataset_rele(ds, FTAG);
@@ -499,6 +516,7 @@ dsl_dataset_user_release_sync_one(dsl_dataset_t *ds, nvlist_t *holds,
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
+	spa_t *spa = dp->dp_spa;
 
 	for (nvpair_t *pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(holds, pair)) {
@@ -507,10 +525,13 @@ dsl_dataset_user_release_sync_one(dsl_dataset_t *ds, nvlist_t *holds,
 
 		/* Remove temporary hold if one exists. */
 		error = dsl_pool_user_release(dp, ds->ds_object, holdname, tx);
-		VERIFY(error == 0 || error == ENOENT);
+		if (!SPA_EXITING(spa))
+			VERIFY(error == 0 || error == ENOENT);
 
-		VERIFY0(zap_remove(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
-		    holdname, tx));
+		error = zap_remove(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
+		    holdname, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		ds->ds_userrefs--;
 
 		spa_history_log_internal_ds(ds, "release", tx,
@@ -524,6 +545,8 @@ dsl_dataset_user_release_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_user_release_arg_t *ddura = arg;
 	dsl_holdfunc_t *holdfunc = ddura->ddura_holdfunc;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -533,7 +556,10 @@ dsl_dataset_user_release_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_t *ds;
 		const char *name = nvpair_name(pair);
 
-		VERIFY0(holdfunc(dp, name, FTAG, &ds));
+		err = holdfunc(dp, name, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
 		dsl_dataset_user_release_sync_one(ds,
 		    fnvpair_value_nvlist(pair), tx);

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -148,7 +148,9 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
+	spa_t *spa = dp->dp_spa;
 	uint64_t zapobj;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -158,22 +160,30 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 		 * the userrefs zap object.
 		 */
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
-		VERIFY0(zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
-		    &dsl_dataset_phys(ds)->ds_userrefs_obj));
+		err = zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(ds)->ds_userrefs_obj);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	} else {
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	}
 	ds->ds_userrefs++;
 
-	VERIFY0(zap_add(mos, zapobj, htag, 8, 1, &now, tx));
+	err = zap_add(mos, zapobj, htag, 8, 1, &now, tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	if (minor != 0) {
 		char name[MAXNAMELEN];
 		nvlist_t *tags;
 
-		VERIFY0(dsl_pool_user_hold(dp, ds->ds_object,
-		    htag, now, tx));
+		err = dsl_pool_user_hold(dp, ds->ds_object,
+		    htag, now, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		(void) snprintf(name, sizeof (name), "%llx",
 		    (u_longlong_t)ds->ds_object);
 
@@ -243,8 +253,10 @@ dsl_onexit_hold_cleanup(spa_t *spa, nvlist_t *holds, minor_t minor)
 	    sizeof (ca->zhca_spaname));
 	ca->zhca_spa_load_guid = spa_load_guid(spa);
 	ca->zhca_holds = holds;
-	VERIFY0(zfs_onexit_add_cb(minor,
-	    dsl_dataset_user_release_onexit, ca, NULL));
+	int err = zfs_onexit_add_cb(minor,
+	    dsl_dataset_user_release_onexit, ca, NULL);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 void
@@ -266,8 +278,10 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_dataset_user_hold_arg_t *dduha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
 	nvlist_t *tmpholds;
 	uint64_t now = gethrestime_sec();
+	int err;
 
 	if (dduha->dduha_minor != 0)
 		tmpholds = fnvlist_alloc();
@@ -278,7 +292,10 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 	    pair = nvlist_next_nvpair(dduha->dduha_chkholds, pair)) {
 		dsl_dataset_t *ds;
 
-		VERIFY0(dsl_dataset_hold(dp, nvpair_name(pair), FTAG, &ds));
+		err = dsl_dataset_hold(dp, nvpair_name(pair), FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 		dsl_dataset_user_hold_sync_one_impl(tmpholds, ds,
 		    fnvpair_value_string(pair), dduha->dduha_minor, now, tx);
 		dsl_dataset_rele(ds, FTAG);
@@ -499,6 +516,7 @@ dsl_dataset_user_release_sync_one(dsl_dataset_t *ds, nvlist_t *holds,
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
+	spa_t *spa = dp->dp_spa;
 
 	for (nvpair_t *pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(holds, pair)) {
@@ -507,10 +525,13 @@ dsl_dataset_user_release_sync_one(dsl_dataset_t *ds, nvlist_t *holds,
 
 		/* Remove temporary hold if one exists. */
 		error = dsl_pool_user_release(dp, ds->ds_object, holdname, tx);
-		VERIFY(error == 0 || error == ENOENT);
+		if (!SPA_EXITING(spa))
+			VERIFY(error == 0 || error == ENOENT);
 
-		VERIFY0(zap_remove(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
-		    holdname, tx));
+		error = zap_remove(mos, dsl_dataset_phys(ds)->ds_userrefs_obj,
+		    holdname, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		ds->ds_userrefs--;
 
 		spa_history_log_internal_ds(ds, "release", tx,
@@ -524,6 +545,8 @@ dsl_dataset_user_release_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_user_release_arg_t *ddura = arg;
 	dsl_holdfunc_t *holdfunc = ddura->ddura_holdfunc;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	spa_t *spa = dp->dp_spa;
+	int err;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
@@ -533,7 +556,10 @@ dsl_dataset_user_release_sync(void *arg, dmu_tx_t *tx)
 		dsl_dataset_t *ds;
 		const char *name = nvpair_name(pair);
 
-		VERIFY0(holdfunc(dp, name, FTAG, &ds));
+		err = holdfunc(dp, name, FTAG, &ds);
+		if (err && SPA_EXITING(spa))
+			break;
+		VERIFY0(err);
 
 		dsl_dataset_user_release_sync_one(ds,
 		    fnvpair_value_nvlist(pair), tx);

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -158,8 +158,9 @@ dsl_dataset_user_hold_sync_one_impl(nvlist_t *tmpholds, dsl_dataset_t *ds,
 		 * the userrefs zap object.
 		 */
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
-		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj =
-		    zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(mos, DMU_OT_USERREFS, DMU_OT_NONE, 0, tx,
+		    &dsl_dataset_phys(ds)->ds_userrefs_obj));
+		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	} else {
 		zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	}

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -4048,7 +4048,7 @@ metaslab_unflushed_add(metaslab_t *msp, dmu_tx_t *tx)
 	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_frees));
 
 	mutex_enter(&spa->spa_flushed_ms_lock);
-	metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
+	(void) metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
 	metaslab_set_unflushed_dirty(msp, B_TRUE);
 	avl_add(&spa->spa_metaslabs_by_flushed, msp);
 	mutex_exit(&spa->spa_flushed_ms_lock);
@@ -4077,7 +4077,7 @@ metaslab_unflushed_bump(metaslab_t *msp, dmu_tx_t *tx, boolean_t dirty)
 	boolean_t ms_prev_flushed_dirty = metaslab_unflushed_dirty(msp);
 	mutex_enter(&spa->spa_flushed_ms_lock);
 	avl_remove(&spa->spa_metaslabs_by_flushed, msp);
-	metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
+	(void) metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
 	metaslab_set_unflushed_dirty(msp, dirty);
 	avl_add(&spa->spa_metaslabs_by_flushed, msp);
 	mutex_exit(&spa->spa_flushed_ms_lock);
@@ -4273,7 +4273,8 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa_meta_objset(spa);
 	zfs_range_tree_t *alloctree = msp->ms_allocating[txg & TXG_MASK];
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
+	int err = 0;
 
 	ASSERT(!vd->vdev_ishole);
 
@@ -4328,21 +4329,31 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	/*
 	 * Generate a log space map if one doesn't exist already.
 	 */
-	spa_generate_syncing_log_sm(spa, tx);
+	err = spa_generate_syncing_log_sm(spa, tx);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	if (msp->ms_sm == NULL) {
-		uint64_t new_object = space_map_alloc(mos,
+		uint64_t new_object;
+		err = space_map_alloc(mos,
 		    spa_feature_is_enabled(spa, SPA_FEATURE_LOG_SPACEMAP) ?
 		    zfs_metaslab_sm_blksz_with_log :
-		    zfs_metaslab_sm_blksz_no_log, tx);
+		    zfs_metaslab_sm_blksz_no_log, tx, &new_object);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
 		dmu_write(mos, vd->vdev_ms_array, sizeof (uint64_t) *
 		    msp->ms_id, sizeof (uint64_t), &new_object, tx,
 		    DMU_READ_NO_PREFETCH);
 
-		VERIFY0(space_map_open(&msp->ms_sm, mos, new_object,
-		    msp->ms_start, msp->ms_size, vd->vdev_ashift));
+		err = space_map_open(&msp->ms_sm, mos, new_object,
+		    msp->ms_start, msp->ms_size, vd->vdev_ashift);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		ASSERT(msp->ms_sm != NULL);
 
 		ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_allocs));
@@ -4354,12 +4365,19 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	    vd->vdev_checkpoint_sm == NULL) {
 		ASSERT(spa_has_checkpoint(spa));
 
-		uint64_t new_object = space_map_alloc(mos,
-		    zfs_vdev_standard_sm_blksz, tx);
+		uint64_t new_object;
+		err = space_map_alloc(mos,
+		    zfs_vdev_standard_sm_blksz, tx, &new_object);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
-		VERIFY0(space_map_open(&vd->vdev_checkpoint_sm,
-		    mos, new_object, 0, vd->vdev_asize, vd->vdev_ashift));
+		err = space_map_open(&vd->vdev_checkpoint_sm,
+		    mos, new_object, 0, vd->vdev_asize, vd->vdev_ashift);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		ASSERT3P(vd->vdev_checkpoint_sm, !=, NULL);
 
 		/*
@@ -4367,9 +4385,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		 * so it can be retrieved when the pool is reopened after an
 		 * export or through zdb.
 		 */
-		VERIFY0(zap_add(vd->vdev_spa->spa_meta_objset,
+		err = zap_add(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM,
-		    sizeof (new_object), 1, &new_object, tx));
+		    sizeof (new_object), 1, &new_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	mutex_enter(&msp->ms_sync_lock);
@@ -4537,12 +4558,41 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	 * vdev_ms_array.
 	 */
 	uint64_t object;
-	VERIFY0(dmu_read(mos, vd->vdev_ms_array,
-	    msp->ms_id * sizeof (uint64_t), sizeof (uint64_t), &object, 0));
+	err = dmu_read(mos, vd->vdev_ms_array,
+	    msp->ms_id * sizeof (uint64_t), sizeof (uint64_t), &object, 0);
+	if (err && SPA_EXITING(spa)) {
+		mutex_exit(&msp->ms_sync_lock);
+		goto spa_exiting;
+	}
+	VERIFY0(err);
+
 	VERIFY3U(object, ==, space_map_object(msp->ms_sm));
 
 	mutex_exit(&msp->ms_sync_lock);
 	dmu_tx_commit(tx);
+	return;
+
+spa_exiting:
+	if (tx)
+		dmu_tx_commit(tx);
+	mutex_enter(&msp->ms_sync_lock);
+	mutex_enter(&msp->ms_lock);
+	zfs_range_tree_vacate(alloctree, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_freeing, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_freed, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_trim, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocating[txg & TXG_MASK],
+	    NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocating[TXG_CLEAN(txg) & TXG_MASK],
+	    NULL, NULL);
+	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
+		zfs_range_tree_vacate(msp->ms_defer[t], NULL, NULL);
+	}
+	msp->ms_deferspace = 0;
+	mutex_exit(&msp->ms_lock);
+	mutex_exit(&msp->ms_sync_lock);
 }
 
 static void
@@ -6240,6 +6290,8 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 {
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
+	if (spa_exiting(spa))
+		return;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 	for (int i = 0; i < BP_GET_NDVAS(bp); i++) {
@@ -6349,12 +6401,13 @@ metaslab_set_unflushed_dirty(metaslab_t *ms, boolean_t dirty)
 	ms->ms_unflushed_dirty = dirty;
 }
 
-static void
+static int
 metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 {
 	vdev_t *vd = ms->ms_group->mg_vd;
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa_meta_objset(spa);
+	int err = 0;
 
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP));
 
@@ -6365,28 +6418,38 @@ metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 	uint64_t entry_offset = ms->ms_id * entry_size;
 
 	uint64_t object = 0;
-	int err = zap_lookup(mos, vd->vdev_top_zap,
+	err = zap_lookup(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
 	    &object);
 	if (err == ENOENT) {
-		object = dmu_object_alloc(mos, DMU_OTN_UINT64_METADATA,
-		    SPA_OLD_MAXBLOCKSIZE, DMU_OT_NONE, 0, tx);
-		VERIFY0(zap_add(mos, vd->vdev_top_zap,
+		err = dmu_object_alloc(mos, DMU_OTN_UINT64_METADATA,
+		    SPA_OLD_MAXBLOCKSIZE, DMU_OT_NONE, 0, tx, &object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = zap_add(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
-		    &object, tx));
+		    &object, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	} else {
+		if (err && SPA_EXITING(spa))
+			return (err);
 		VERIFY0(err);
 	}
 
 	dmu_write(spa_meta_objset(spa), object, entry_offset, entry_size,
 	    &entry, tx, DMU_READ_NO_PREFETCH);
+
+	return (err);
 }
 
-void
+int
 metaslab_set_unflushed_txg(metaslab_t *ms, uint64_t txg, dmu_tx_t *tx)
 {
 	ms->ms_unflushed_txg = txg;
-	metaslab_update_ondisk_flush_data(ms, tx);
+	return (metaslab_update_ondisk_flush_data(ms, tx));
 }
 
 boolean_t

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -475,7 +475,9 @@ metaslab_class_destroy(metaslab_class_t *mc)
 		avl_destroy(&mca->mca_tree);
 		mutex_destroy(&mca->mca_lock);
 		ASSERT0P(mca->mca_rotor);
-		ASSERT0(mca->mca_reserved);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(mca->mca_reserved);
+		}
 	}
 	mutex_destroy(&mc->mc_lock);
 	multilist_destroy(&mc->mc_metaslab_txg_list);
@@ -488,6 +490,9 @@ metaslab_class_validate(metaslab_class_t *mc)
 {
 #ifdef ZFS_DEBUG
 	spa_t *spa = mc->mc_spa;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Must hold one of the spa_config locks.
@@ -2148,6 +2153,9 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	if ((zfs_flags & ZFS_DEBUG_METASLAB_VERIFY) == 0)
 		return;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	/*
 	 * We can only verify the metaslab space when we're called
 	 * from syncing context with a loaded metaslab that has an
@@ -2317,9 +2325,13 @@ metaslab_aux_histograms_update_done(metaslab_t *msp, boolean_t defer_allowed)
 static void
 metaslab_verify_weight_and_frag(metaslab_t *msp)
 {
+	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
+
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
 	if ((zfs_flags & ZFS_DEBUG_METASLAB_VERIFY) == 0)
+		return;
+	if (SPA_EXITING(spa))
 		return;
 
 	/*
@@ -2543,16 +2555,18 @@ metaslab_load_impl(metaslab_t *msp)
 		error = space_map_load_length(msp->ms_sm, msp->ms_allocatable,
 		    SM_FREE, length);
 
-		/* Now, populate the size-sorted tree. */
-		metaslab_rt_create(msp->ms_allocatable, mrap);
-		msp->ms_allocatable->rt_ops = &metaslab_rt_ops;
-		msp->ms_allocatable->rt_arg = mrap;
+		if (error == 0) {
+			/* Now, populate the size-sorted tree. */
+			metaslab_rt_create(msp->ms_allocatable, mrap);
+			msp->ms_allocatable->rt_ops = &metaslab_rt_ops;
+			msp->ms_allocatable->rt_arg = mrap;
 
-		struct mssa_arg arg = {0};
-		arg.rt = msp->ms_allocatable;
-		arg.mra = mrap;
-		zfs_range_tree_walk(msp->ms_allocatable,
-		    metaslab_size_sorted_add, &arg);
+			struct mssa_arg arg = {0};
+			arg.rt = msp->ms_allocatable;
+			arg.mra = mrap;
+			zfs_range_tree_walk(msp->ms_allocatable,
+			    metaslab_size_sorted_add, &arg);
+		}
 	} else {
 		/*
 		 * Add the size-sorted tree first, since we don't need to load
@@ -3055,6 +3069,19 @@ metaslab_fini(metaslab_t *msp)
 	metaslab_group_remove(mg, msp);
 
 	mutex_enter(&msp->ms_lock);
+	if (SPA_EXITING(mg->mg_vd->vdev_spa)) {
+		/* Catch-all cleanup as required for forced exit. */
+		zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_freeing, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_freed, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
+		for (int t = 0; t < TXG_SIZE; t++)
+			zfs_range_tree_vacate(msp->ms_allocating[t], NULL,
+			    NULL);
+		for (int t = 0; t < TXG_DEFER_SIZE; t++)
+			zfs_range_tree_vacate(msp->ms_defer[t], NULL, NULL);
+		msp->ms_deferspace = 0;
+	}
 	VERIFY0P(msp->ms_group);
 
 	/*
@@ -3777,6 +3804,8 @@ metaslab_segment_may_passivate(metaslab_t *msp)
 static void
 metaslab_preload(void *arg)
 {
+	int err;
+
 	metaslab_t *msp = arg;
 	metaslab_class_t *mc = msp->ms_group->mg_class;
 	spa_t *spa = mc->mc_spa;
@@ -3785,8 +3814,11 @@ metaslab_preload(void *arg)
 	ASSERT(!MUTEX_HELD(&msp->ms_group->mg_lock));
 
 	mutex_enter(&msp->ms_lock);
-	(void) metaslab_load(msp);
-	metaslab_set_selected_txg(msp, spa_syncing_txg(spa));
+	err = metaslab_load(msp);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	if (!err)
+		metaslab_set_selected_txg(msp, spa_syncing_txg(spa));
 	mutex_exit(&msp->ms_lock);
 	spl_fstrans_unmark(cookie);
 }
@@ -3799,7 +3831,8 @@ metaslab_group_preload(metaslab_group_t *mg)
 	avl_tree_t *t = &mg->mg_metaslab_tree;
 	int m = 0;
 
-	if (spa_shutting_down(spa) || !metaslab_preload_enabled)
+	if (spa_shutting_down(spa) || !metaslab_preload_enabled ||
+	    SPA_EXITING(spa))
 		return;
 
 	mutex_enter(&mg->mg_lock);
@@ -4289,6 +4322,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		ASSERT0(zfs_range_tree_space(msp->ms_trim));
 		return;
 	}
+
+	/*
+	 * The pool is forcibly exiting. Just discard everything.
+	 */
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 
 	/*
 	 * Normally, we don't want to process a metaslab if there are no
@@ -5004,6 +5043,9 @@ find_valid_metaslab(metaslab_group_t *mg, uint64_t activation_weight,
 	for (; msp != NULL; msp = AVL_NEXT(t, msp)) {
 		int i;
 
+		if (tries > 0 && SPA_EXITING(mg->mg_vd->vdev_spa))
+			return (NULL);
+
 		if (!try_hard && tries > zfs_metaslab_find_max_tries) {
 			METASLABSTAT_BUMP(metaslabstat_too_many_tries);
 			return (NULL);
@@ -5131,6 +5173,9 @@ metaslab_group_alloc(metaslab_group_t *mg, zio_alloc_list_t *zal,
 	search->ms_allocator = -1;
 	search->ms_primary = B_TRUE;
 	for (;;) {
+		if (SPA_EXITING(mg->mg_vd->vdev_spa))
+			break;
+
 		boolean_t was_active = B_FALSE;
 
 		mutex_enter(&mg->mg_lock);
@@ -5540,6 +5585,8 @@ top:
 			return (0);
 		}
 next:
+		if (SPA_EXITING(spa))
+			break;
 		metaslab_class_rotate(mg, allocator, psize, B_FALSE);
 	} while ((mg = mg->mg_next) != rotor);
 
@@ -5548,13 +5595,16 @@ next:
 	 */
 	if (!try_hard && (zfs_metaslab_try_hard_before_gang ||
 	    GANG_ALLOCATION(flags) || (flags & METASLAB_ZIL) != 0 ||
-	    psize <= spa->spa_min_alloc)) {
+	    psize <= spa->spa_min_alloc) && !SPA_EXITING(spa)) {
 		METASLABSTAT_BUMP(metaslabstat_try_hard);
 		try_hard = B_TRUE;
 		goto top;
 	}
 
 	memset(&dva[d], 0, sizeof (dva_t));
+
+	if (SPA_EXITING(spa))
+		return (SET_ERROR(EIO));
 
 	metaslab_trace_add(zal, rotor, NULL, psize, d, TRACE_ENOSPC, allocator);
 	return (SET_ERROR(ENOSPC));
@@ -5602,9 +5652,12 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 
 	if (checkpoint) {
 		ASSERT(spa_has_checkpoint(spa));
-		zfs_range_tree_add(msp->ms_checkpointing, offset, asize);
+		if (!SPA_EXITING(spa))
+			zfs_range_tree_add(msp->ms_checkpointing, offset,
+			    asize);
 	} else {
-		zfs_range_tree_add(msp->ms_freeing, offset, asize);
+		if (!SPA_EXITING(spa))
+			zfs_range_tree_add(msp->ms_freeing, offset, asize);
 	}
 	mutex_exit(&msp->ms_lock);
 }
@@ -6258,6 +6311,8 @@ metaslab_check_free_impl(vdev_t *vd, uint64_t offset, uint64_t size)
 
 	msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
 
+	if (SPA_EXITING(spa))
+		return; /* skip checks */
 	mutex_enter(&msp->ms_lock);
 	if (msp->ms_loaded) {
 		zfs_range_tree_verify_not_present(msp->ms_allocatable,
@@ -6290,7 +6345,7 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 {
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
-	if (spa_exiting(spa))
+	if (SPA_EXITING(spa))
 		return;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -465,7 +465,9 @@ metaslab_class_destroy(metaslab_class_t *mc)
 		avl_destroy(&mca->mca_tree);
 		mutex_destroy(&mca->mca_lock);
 		ASSERT0P(mca->mca_rotor);
-		ASSERT0(mca->mca_reserved);
+		if (!SPA_EXITING(spa)) {
+			ASSERT0(mca->mca_reserved);
+		}
 	}
 	mutex_destroy(&mc->mc_lock);
 	multilist_destroy(&mc->mc_metaslab_txg_list);
@@ -478,6 +480,9 @@ metaslab_class_validate(metaslab_class_t *mc)
 {
 #ifdef ZFS_DEBUG
 	spa_t *spa = mc->mc_spa;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Must hold one of the spa_config locks.
@@ -2138,6 +2143,9 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	if ((zfs_flags & ZFS_DEBUG_METASLAB_VERIFY) == 0)
 		return;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	/*
 	 * We can only verify the metaslab space when we're called
 	 * from syncing context with a loaded metaslab that has an
@@ -2307,9 +2315,13 @@ metaslab_aux_histograms_update_done(metaslab_t *msp, boolean_t defer_allowed)
 static void
 metaslab_verify_weight_and_frag(metaslab_t *msp)
 {
+	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
+
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
 	if ((zfs_flags & ZFS_DEBUG_METASLAB_VERIFY) == 0)
+		return;
+	if (SPA_EXITING(spa))
 		return;
 
 	/*
@@ -2533,16 +2545,18 @@ metaslab_load_impl(metaslab_t *msp)
 		error = space_map_load_length(msp->ms_sm, msp->ms_allocatable,
 		    SM_FREE, length);
 
-		/* Now, populate the size-sorted tree. */
-		metaslab_rt_create(msp->ms_allocatable, mrap);
-		msp->ms_allocatable->rt_ops = &metaslab_rt_ops;
-		msp->ms_allocatable->rt_arg = mrap;
+		if (error == 0) {
+			/* Now, populate the size-sorted tree. */
+			metaslab_rt_create(msp->ms_allocatable, mrap);
+			msp->ms_allocatable->rt_ops = &metaslab_rt_ops;
+			msp->ms_allocatable->rt_arg = mrap;
 
-		struct mssa_arg arg = {0};
-		arg.rt = msp->ms_allocatable;
-		arg.mra = mrap;
-		zfs_range_tree_walk(msp->ms_allocatable,
-		    metaslab_size_sorted_add, &arg);
+			struct mssa_arg arg = {0};
+			arg.rt = msp->ms_allocatable;
+			arg.mra = mrap;
+			zfs_range_tree_walk(msp->ms_allocatable,
+			    metaslab_size_sorted_add, &arg);
+		}
 	} else {
 		/*
 		 * Add the size-sorted tree first, since we don't need to load
@@ -3045,6 +3059,19 @@ metaslab_fini(metaslab_t *msp)
 	metaslab_group_remove(mg, msp);
 
 	mutex_enter(&msp->ms_lock);
+	if (SPA_EXITING(mg->mg_vd->vdev_spa)) {
+		/* Catch-all cleanup as required for forced exit. */
+		zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_freeing, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_freed, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
+		for (int t = 0; t < TXG_SIZE; t++)
+			zfs_range_tree_vacate(msp->ms_allocating[t], NULL,
+			    NULL);
+		for (int t = 0; t < TXG_DEFER_SIZE; t++)
+			zfs_range_tree_vacate(msp->ms_defer[t], NULL, NULL);
+		msp->ms_deferspace = 0;
+	}
 	VERIFY0P(msp->ms_group);
 
 	/*
@@ -3767,6 +3794,8 @@ metaslab_segment_may_passivate(metaslab_t *msp)
 static void
 metaslab_preload(void *arg)
 {
+	int err;
+
 	metaslab_t *msp = arg;
 	metaslab_class_t *mc = msp->ms_group->mg_class;
 	spa_t *spa = mc->mc_spa;
@@ -3775,8 +3804,11 @@ metaslab_preload(void *arg)
 	ASSERT(!MUTEX_HELD(&msp->ms_group->mg_lock));
 
 	mutex_enter(&msp->ms_lock);
-	(void) metaslab_load(msp);
-	metaslab_set_selected_txg(msp, spa_syncing_txg(spa));
+	err = metaslab_load(msp);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	if (!err)
+		metaslab_set_selected_txg(msp, spa_syncing_txg(spa));
 	mutex_exit(&msp->ms_lock);
 	spl_fstrans_unmark(cookie);
 }
@@ -3789,7 +3821,8 @@ metaslab_group_preload(metaslab_group_t *mg)
 	avl_tree_t *t = &mg->mg_metaslab_tree;
 	int m = 0;
 
-	if (spa_shutting_down(spa) || !metaslab_preload_enabled)
+	if (spa_shutting_down(spa) || !metaslab_preload_enabled ||
+	    SPA_EXITING(spa))
 		return;
 
 	mutex_enter(&mg->mg_lock);
@@ -4279,6 +4312,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		ASSERT0(zfs_range_tree_space(msp->ms_trim));
 		return;
 	}
+
+	/*
+	 * The pool is forcibly exiting. Just discard everything.
+	 */
+	if (SPA_EXITING(spa))
+		goto spa_exiting;
 
 	/*
 	 * Normally, we don't want to process a metaslab if there are no
@@ -4994,6 +5033,9 @@ find_valid_metaslab(metaslab_group_t *mg, uint64_t activation_weight,
 	for (; msp != NULL; msp = AVL_NEXT(t, msp)) {
 		int i;
 
+		if (tries > 0 && SPA_EXITING(mg->mg_vd->vdev_spa))
+			return (NULL);
+
 		if (!try_hard && tries > zfs_metaslab_find_max_tries) {
 			METASLABSTAT_BUMP(metaslabstat_too_many_tries);
 			return (NULL);
@@ -5121,6 +5163,9 @@ metaslab_group_alloc(metaslab_group_t *mg, zio_alloc_list_t *zal,
 	search->ms_allocator = -1;
 	search->ms_primary = B_TRUE;
 	for (;;) {
+		if (SPA_EXITING(mg->mg_vd->vdev_spa))
+			break;
+
 		boolean_t was_active = B_FALSE;
 
 		mutex_enter(&mg->mg_lock);
@@ -5530,6 +5575,8 @@ top:
 			return (0);
 		}
 next:
+		if (SPA_EXITING(spa))
+			break;
 		metaslab_class_rotate(mg, allocator, psize, B_FALSE);
 	} while ((mg = mg->mg_next) != rotor);
 
@@ -5538,13 +5585,16 @@ next:
 	 */
 	if (!try_hard && (zfs_metaslab_try_hard_before_gang ||
 	    GANG_ALLOCATION(flags) || (flags & METASLAB_ZIL) != 0 ||
-	    psize <= spa->spa_min_alloc)) {
+	    psize <= spa->spa_min_alloc) && !SPA_EXITING(spa)) {
 		METASLABSTAT_BUMP(metaslabstat_try_hard);
 		try_hard = B_TRUE;
 		goto top;
 	}
 
 	memset(&dva[d], 0, sizeof (dva_t));
+
+	if (SPA_EXITING(spa))
+		return (SET_ERROR(EIO));
 
 	metaslab_trace_add(zal, rotor, NULL, psize, d, TRACE_ENOSPC, allocator);
 	return (SET_ERROR(ENOSPC));
@@ -5592,9 +5642,12 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 
 	if (checkpoint) {
 		ASSERT(spa_has_checkpoint(spa));
-		zfs_range_tree_add(msp->ms_checkpointing, offset, asize);
+		if (!SPA_EXITING(spa))
+			zfs_range_tree_add(msp->ms_checkpointing, offset,
+			    asize);
 	} else {
-		zfs_range_tree_add(msp->ms_freeing, offset, asize);
+		if (!SPA_EXITING(spa))
+			zfs_range_tree_add(msp->ms_freeing, offset, asize);
 	}
 	mutex_exit(&msp->ms_lock);
 }
@@ -6248,6 +6301,8 @@ metaslab_check_free_impl(vdev_t *vd, uint64_t offset, uint64_t size)
 
 	msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
 
+	if (SPA_EXITING(spa))
+		return; /* skip checks */
 	mutex_enter(&msp->ms_lock);
 	if (msp->ms_loaded) {
 		zfs_range_tree_verify_not_present(msp->ms_allocatable,
@@ -6280,7 +6335,7 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 {
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
-	if (spa_exiting(spa))
+	if (SPA_EXITING(spa))
 		return;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -4038,7 +4038,7 @@ metaslab_unflushed_add(metaslab_t *msp, dmu_tx_t *tx)
 	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_frees));
 
 	mutex_enter(&spa->spa_flushed_ms_lock);
-	metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
+	(void) metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
 	metaslab_set_unflushed_dirty(msp, B_TRUE);
 	avl_add(&spa->spa_metaslabs_by_flushed, msp);
 	mutex_exit(&spa->spa_flushed_ms_lock);
@@ -4067,7 +4067,7 @@ metaslab_unflushed_bump(metaslab_t *msp, dmu_tx_t *tx, boolean_t dirty)
 	boolean_t ms_prev_flushed_dirty = metaslab_unflushed_dirty(msp);
 	mutex_enter(&spa->spa_flushed_ms_lock);
 	avl_remove(&spa->spa_metaslabs_by_flushed, msp);
-	metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
+	(void) metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
 	metaslab_set_unflushed_dirty(msp, dirty);
 	avl_add(&spa->spa_metaslabs_by_flushed, msp);
 	mutex_exit(&spa->spa_flushed_ms_lock);
@@ -4263,7 +4263,8 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa_meta_objset(spa);
 	zfs_range_tree_t *alloctree = msp->ms_allocating[txg & TXG_MASK];
-	dmu_tx_t *tx;
+	dmu_tx_t *tx = NULL;
+	int err = 0;
 
 	ASSERT(!vd->vdev_ishole);
 
@@ -4318,21 +4319,31 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	/*
 	 * Generate a log space map if one doesn't exist already.
 	 */
-	spa_generate_syncing_log_sm(spa, tx);
+	err = spa_generate_syncing_log_sm(spa, tx);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	if (msp->ms_sm == NULL) {
-		uint64_t new_object = space_map_alloc(mos,
+		uint64_t new_object;
+		err = space_map_alloc(mos,
 		    spa_feature_is_enabled(spa, SPA_FEATURE_LOG_SPACEMAP) ?
 		    zfs_metaslab_sm_blksz_with_log :
-		    zfs_metaslab_sm_blksz_no_log, tx);
+		    zfs_metaslab_sm_blksz_no_log, tx, &new_object);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
 		dmu_write(mos, vd->vdev_ms_array, sizeof (uint64_t) *
 		    msp->ms_id, sizeof (uint64_t), &new_object, tx,
 		    DMU_READ_NO_PREFETCH);
 
-		VERIFY0(space_map_open(&msp->ms_sm, mos, new_object,
-		    msp->ms_start, msp->ms_size, vd->vdev_ashift));
+		err = space_map_open(&msp->ms_sm, mos, new_object,
+		    msp->ms_start, msp->ms_size, vd->vdev_ashift);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		ASSERT(msp->ms_sm != NULL);
 
 		ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_allocs));
@@ -4344,12 +4355,19 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	    vd->vdev_checkpoint_sm == NULL) {
 		ASSERT(spa_has_checkpoint(spa));
 
-		uint64_t new_object = space_map_alloc(mos,
-		    zfs_vdev_standard_sm_blksz, tx);
+		uint64_t new_object;
+		err = space_map_alloc(mos,
+		    zfs_vdev_standard_sm_blksz, tx, &new_object);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
-		VERIFY0(space_map_open(&vd->vdev_checkpoint_sm,
-		    mos, new_object, 0, vd->vdev_asize, vd->vdev_ashift));
+		err = space_map_open(&vd->vdev_checkpoint_sm,
+		    mos, new_object, 0, vd->vdev_asize, vd->vdev_ashift);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 		ASSERT3P(vd->vdev_checkpoint_sm, !=, NULL);
 
 		/*
@@ -4357,9 +4375,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		 * so it can be retrieved when the pool is reopened after an
 		 * export or through zdb.
 		 */
-		VERIFY0(zap_add(vd->vdev_spa->spa_meta_objset,
+		err = zap_add(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM,
-		    sizeof (new_object), 1, &new_object, tx));
+		    sizeof (new_object), 1, &new_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting;
+		VERIFY0(err);
 	}
 
 	mutex_enter(&msp->ms_sync_lock);
@@ -4527,12 +4548,41 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	 * vdev_ms_array.
 	 */
 	uint64_t object;
-	VERIFY0(dmu_read(mos, vd->vdev_ms_array,
-	    msp->ms_id * sizeof (uint64_t), sizeof (uint64_t), &object, 0));
+	err = dmu_read(mos, vd->vdev_ms_array,
+	    msp->ms_id * sizeof (uint64_t), sizeof (uint64_t), &object, 0);
+	if (err && SPA_EXITING(spa)) {
+		mutex_exit(&msp->ms_sync_lock);
+		goto spa_exiting;
+	}
+	VERIFY0(err);
+
 	VERIFY3U(object, ==, space_map_object(msp->ms_sm));
 
 	mutex_exit(&msp->ms_sync_lock);
 	dmu_tx_commit(tx);
+	return;
+
+spa_exiting:
+	if (tx)
+		dmu_tx_commit(tx);
+	mutex_enter(&msp->ms_sync_lock);
+	mutex_enter(&msp->ms_lock);
+	zfs_range_tree_vacate(alloctree, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_freeing, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_freed, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_trim, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocating[txg & TXG_MASK],
+	    NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocating[TXG_CLEAN(txg) & TXG_MASK],
+	    NULL, NULL);
+	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
+		zfs_range_tree_vacate(msp->ms_defer[t], NULL, NULL);
+	}
+	msp->ms_deferspace = 0;
+	mutex_exit(&msp->ms_lock);
+	mutex_exit(&msp->ms_sync_lock);
 }
 
 static void
@@ -6230,6 +6280,8 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 {
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
+	if (spa_exiting(spa))
+		return;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 	for (int i = 0; i < BP_GET_NDVAS(bp); i++) {
@@ -6339,12 +6391,13 @@ metaslab_set_unflushed_dirty(metaslab_t *ms, boolean_t dirty)
 	ms->ms_unflushed_dirty = dirty;
 }
 
-static void
+static int
 metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 {
 	vdev_t *vd = ms->ms_group->mg_vd;
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa_meta_objset(spa);
+	int err = 0;
 
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP));
 
@@ -6355,28 +6408,38 @@ metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 	uint64_t entry_offset = ms->ms_id * entry_size;
 
 	uint64_t object = 0;
-	int err = zap_lookup(mos, vd->vdev_top_zap,
+	err = zap_lookup(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
 	    &object);
 	if (err == ENOENT) {
-		object = dmu_object_alloc(mos, DMU_OTN_UINT64_METADATA,
-		    SPA_OLD_MAXBLOCKSIZE, DMU_OT_NONE, 0, tx);
-		VERIFY0(zap_add(mos, vd->vdev_top_zap,
+		err = dmu_object_alloc(mos, DMU_OTN_UINT64_METADATA,
+		    SPA_OLD_MAXBLOCKSIZE, DMU_OT_NONE, 0, tx, &object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = zap_add(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
-		    &object, tx));
+		    &object, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	} else {
+		if (err && SPA_EXITING(spa))
+			return (err);
 		VERIFY0(err);
 	}
 
 	dmu_write(spa_meta_objset(spa), object, entry_offset, entry_size,
 	    &entry, tx, DMU_READ_NO_PREFETCH);
+
+	return (err);
 }
 
-void
+int
 metaslab_set_unflushed_txg(metaslab_t *ms, uint64_t txg, dmu_tx_t *tx)
 {
 	ms->ms_unflushed_txg = txg;
-	metaslab_update_ondisk_flush_data(ms, tx);
+	return (metaslab_update_ondisk_flush_data(ms, tx));
 }
 
 boolean_t

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -5919,7 +5919,7 @@ metaslab_class_throttle_unreserve(metaslab_class_t *mc, int allocator,
 	ASSERT(mc->mc_alloc_throttle_enabled);
 	int64_t delta = copies * io_size;
 	return (atomic_add_64_nv(&mca->mca_reserved, -delta) <=
-	    mc->mc_alloc_max);
+	    mc->mc_alloc_max || SPA_EXITING(mc->mc_spa));
 }
 
 static int

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -425,9 +425,10 @@ sa_add_layout_entry(objset_t *os, const sa_attr_type_t *attrs, int attr_count,
 		char attr_name[8];
 
 		if (sa->sa_layout_attr_obj == 0) {
-			sa->sa_layout_attr_obj = zap_create_link(os,
+			VERIFY0(zap_create_link(os,
 			    DMU_OT_SA_ATTR_LAYOUTS,
-			    sa->sa_master_obj, SA_LAYOUTS, tx);
+			    sa->sa_master_obj, SA_LAYOUTS, tx,
+			    &sa->sa_layout_attr_obj));
 		}
 
 		(void) snprintf(attr_name, sizeof (attr_name),
@@ -1856,9 +1857,9 @@ sa_attr_register_sync(sa_handle_t *hdl, dmu_tx_t *tx)
 	}
 
 	if (sa->sa_reg_attr_obj == 0) {
-		sa->sa_reg_attr_obj = zap_create_link(hdl->sa_os,
+		VERIFY0(zap_create_link(hdl->sa_os,
 		    DMU_OT_SA_ATTR_REGISTRATION,
-		    sa->sa_master_obj, SA_REGISTRY, tx);
+		    sa->sa_master_obj, SA_REGISTRY, tx, &sa->sa_reg_attr_obj));
 	}
 	for (i = 0; i != sa->sa_num_attrs; i++) {
 		if (sa->sa_attr_table[i].sa_registered)

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -415,9 +415,10 @@ sa_add_layout_entry(objset_t *os, const sa_attr_type_t *attrs, int attr_count,
 		char attr_name[8];
 
 		if (sa->sa_layout_attr_obj == 0) {
-			sa->sa_layout_attr_obj = zap_create_link(os,
+			VERIFY0(zap_create_link(os,
 			    DMU_OT_SA_ATTR_LAYOUTS,
-			    sa->sa_master_obj, SA_LAYOUTS, tx);
+			    sa->sa_master_obj, SA_LAYOUTS, tx,
+			    &sa->sa_layout_attr_obj));
 		}
 
 		(void) snprintf(attr_name, sizeof (attr_name),
@@ -1846,9 +1847,9 @@ sa_attr_register_sync(sa_handle_t *hdl, dmu_tx_t *tx)
 	}
 
 	if (sa->sa_reg_attr_obj == 0) {
-		sa->sa_reg_attr_obj = zap_create_link(hdl->sa_os,
+		VERIFY0(zap_create_link(hdl->sa_os,
 		    DMU_OT_SA_ATTR_REGISTRATION,
-		    sa->sa_master_obj, SA_REGISTRY, tx);
+		    sa->sa_master_obj, SA_REGISTRY, tx, &sa->sa_reg_attr_obj));
 	}
 	for (i = 0; i != sa->sa_num_attrs; i++) {
 		if (sa->sa_attr_table[i].sa_registered)

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7715,6 +7715,36 @@ spa_tryimport(nvlist_t *tryconfig)
 	return (config);
 }
 
+void
+spa_initiate_forced_exit(spa_t *spa)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_suspend_lock));
+
+	if (spa_suspended(spa) && spa->spa_forced_exit_required) {
+		if (!spa->spa_forcibly_exiting) {
+			spa->spa_forcibly_exiting = B_TRUE;
+			cmn_err(CE_WARN, "Pool '%s' is now forcibly exiting",
+			    spa_name(spa));
+			zfs_dbgmsg("Pool '%s' is now forcibly exiting",
+			    spa_name(spa));
+		}
+		zio_resume_but_keep_suspended(spa);
+	}
+}
+
+void
+spa_set_forced_exit_required(spa_t *spa)
+{
+	mutex_enter(&spa->spa_suspend_lock);
+	if (!spa->spa_forced_exit_required) {
+		spa->spa_forced_exit_required = B_TRUE;
+		zfs_dbgmsg("Pool '%s' forced exit requirement has been set",
+		    spa_name(spa));
+	}
+	spa_initiate_forced_exit(spa);
+	mutex_exit(&spa->spa_suspend_lock);
+}
+
 /*
  * Pool export/destroy
  *
@@ -7731,6 +7761,9 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	int error = 0;
 	spa_t *spa;
 	hrtime_t export_start = gethrtime();
+	uint_t hardforce_ref_checks_left;
+
+	force = hardforce || force;
 
 	if (oldconfig)
 		*oldconfig = NULL;
@@ -7744,12 +7777,20 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		return (SET_ERROR(ENOENT));
 	}
 
+	if (spa_suspended(spa) && !hardforce) {
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(EAGAIN));
+	}
+
 	if (spa->spa_is_exporting) {
 		/* the pool is being exported by another thread */
 		spa_namespace_exit(FTAG);
 		return (SET_ERROR(ZFS_ERR_EXPORT_IN_PROGRESS));
 	}
 	spa->spa_is_exporting = B_TRUE;
+
+	if (hardforce)
+		spa_set_forced_exit_required(spa);
 
 	/*
 	 * Put a hold on the pool, drop the namespace lock, stop async tasks
@@ -7780,7 +7821,18 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 * so we have to force it to sync before checking spa_refcnt.
 	 */
 	if (spa->spa_sync_on) {
-		txg_wait_synced(spa->spa_dsl_pool, 0);
+		if (hardforce) {
+			txg_wait_synced(spa->spa_dsl_pool, 0);
+		} else if (txg_wait_synced_flags(spa->spa_dsl_pool, 0,
+		    TXG_WAIT_SUSPEND) != 0) {
+			/*
+			 * We want to release spa_namespace_lock instead of
+			 * holding it forever, so that hardforce can be asked to
+			 * do the trick.
+			 */
+			error = SET_ERROR(EAGAIN);
+			goto fail;
+		}
 		spa_evicting_os_wait(spa);
 	}
 
@@ -7789,7 +7841,36 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 * references.  If we are resetting a pool, allow references by
 	 * fault injection handlers.
 	 */
-	if (!spa_refcount_zero(spa) || (spa->spa_inject_ref != 0)) {
+	hardforce_ref_checks_left = TXG_SIZE * zfs_txg_timeout;
+	if (spa->spa_inject_ref != 0) {
+		/* No one is going to fight with zinject, even the hardforce */
+		goto open_refs;
+	}
+	while (hardforce && !spa_refcount_zero(spa) &&
+	    hardforce_ref_checks_left > 0 && !issig()) {
+		/*
+		 * Others might be stuck having spa references without a
+		 * chance to release them as we are holding spa_namespace_lock.
+		 * Wait for the last pool users to eject. The timeout is
+		 * arbitrary, waiting a little while is a UX improvement for
+		 * an operator, while waiting forever in the kernel would just
+		 * make a bad situation worse.
+		 */
+		hardforce_ref_checks_left--;
+		spa_namespace_exit(FTAG);
+		zfs_sleep_until(gethrtime() + SEC2NSEC(1));
+		spa_namespace_enter(FTAG);
+	}
+	if (!spa_refcount_zero(spa)) {
+open_refs:
+		zfs_dbgmsg("Pool '%s' cannot be exported due to open refs:"
+		    " spa_minref=%llu spa_refcount=%llu spa_inject_ref=%llu"
+		    " hardforce_ref_checks_left=%u",
+		    spa_name(spa),
+		    (u_longlong_t)spa->spa_minref,
+		    (u_longlong_t)zfs_refcount_count(&spa->spa_refcount),
+		    (u_longlong_t)spa->spa_inject_ref,
+		    hardforce_ref_checks_left);
 		error = SET_ERROR(EBUSY);
 		goto fail;
 	}
@@ -7835,7 +7916,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		 * so mark them all dirty.  spa_unload() will do the
 		 * final sync that pushes these changes out.
 		 */
-		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
+		if (new_state != POOL_STATE_UNINITIALIZED &&
+		    !spa_exiting(spa)) {
 			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 			spa->spa_state = new_state;
 			vdev_config_dirty(rvd);
@@ -7858,7 +7940,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		if (spa_should_flush_logs_on_unload(spa))
 			spa_unload_log_sm_flush_all(spa);
 
-		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
+		if (new_state != POOL_STATE_UNINITIALIZED &&
+		    !spa_exiting(spa)) {
 			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 			spa->spa_final_txg = spa_last_synced_txg(spa) +
 			    TXG_DEFER_SIZE + 1;
@@ -7890,8 +7973,7 @@ export_spa:
 	 */
 	spa_namespace_enter(FTAG);
 	if (new_state != POOL_STATE_UNINITIALIZED) {
-		if (!hardforce)
-			spa_write_cachefile(spa, B_TRUE, B_TRUE, B_FALSE);
+		spa_write_cachefile(spa, B_TRUE, B_TRUE, B_FALSE);
 		spa_remove(spa);
 	} else {
 		/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7297,7 +7297,9 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	 * Create the pool's history object.
 	 */
 	if (version >= SPA_VERSION_ZPOOL_HISTORY && !spa->spa_history)
-		spa_history_create_obj(spa, tx);
+		if (spa_history_create_obj(spa, tx) != 0) {
+			cmn_err(CE_PANIC, "failed to create history object");
+		}
 
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_POOL_CREATE);
 	spa_history_log_version(spa, "create", tx);
@@ -7305,9 +7307,12 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	/*
 	 * Create the pool config object.
 	 */
-	spa->spa_config_object = dmu_object_alloc(spa->spa_meta_objset,
+	if (dmu_object_alloc(spa->spa_meta_objset,
 	    DMU_OT_PACKED_NVLIST, SPA_CONFIG_BLOCKSIZE,
-	    DMU_OT_PACKED_NVLIST_SIZE, sizeof (uint64_t), tx);
+	    DMU_OT_PACKED_NVLIST_SIZE, sizeof (uint64_t), tx,
+	    &spa->spa_config_object) != 0) {
+		cmn_err(CE_PANIC, "failed to allocate object");
+	}
 
 	if (zap_add(spa->spa_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_CONFIG,
@@ -7335,7 +7340,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	 * because sync-to-convergence takes longer if the blocksize
 	 * keeps changing.
 	 */
-	obj = bpobj_alloc(spa->spa_meta_objset, 1 << 14, tx);
+	VERIFY0(bpobj_alloc(spa->spa_meta_objset, 1 << 14, tx, &obj));
 	dmu_object_set_compress(spa->spa_meta_objset, obj,
 	    ZIO_COMPRESS_OFF, tx);
 	if (zap_add(spa->spa_meta_objset,
@@ -10287,16 +10292,16 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	dmu_buf_rele(db, FTAG);
 }
 
-static void
+static int
 spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
     const char *config, const char *entry)
 {
 	nvlist_t *nvroot;
 	nvlist_t **list;
-	int i;
+	int i, err = 0;
 
 	if (!sav->sav_sync)
-		return;
+		return (0);
 
 	/*
 	 * Update the MOS nvlist describing the list of available devices.
@@ -10304,12 +10309,19 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 	 * valid and the vdevs are labeled appropriately.
 	 */
 	if (sav->sav_object == 0) {
-		sav->sav_object = dmu_object_alloc(spa->spa_meta_objset,
+		err = dmu_object_alloc(spa->spa_meta_objset,
 		    DMU_OT_PACKED_NVLIST, 1 << 14, DMU_OT_PACKED_NVLIST_SIZE,
-		    sizeof (uint64_t), tx);
-		VERIFY(zap_update(spa->spa_meta_objset,
+		    sizeof (uint64_t), tx, &sav->sav_object);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+
+		err = zap_update(spa->spa_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT, entry, sizeof (uint64_t), 1,
-		    &sav->sav_object, tx) == 0);
+		    &sav->sav_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	nvroot = fnvlist_alloc();
@@ -10331,7 +10343,10 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 	spa_sync_nvlist(spa, sav->sav_object, nvroot, tx);
 	nvlist_free(nvroot);
 
+out:
 	sav->sav_sync = B_FALSE;
+
+	return (err);
 }
 
 /*
@@ -10384,8 +10399,10 @@ spa_sync_config_object(spa_t *spa, dmu_tx_t *tx)
 
 	if (spa->spa_avz_action == AVZ_ACTION_REBUILD) {
 		/* Make and build the new AVZ */
-		uint64_t new_avz = zap_create(spa->spa_meta_objset,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+		uint64_t new_avz;
+		VERIFY0(zap_create(spa->spa_meta_objset,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx,
+		    &new_avz));
 		spa_avz_build(spa->spa_root_vdev, new_avz, tx);
 
 		/* Diff old AVZ with new one */
@@ -10446,9 +10463,9 @@ spa_sync_config_object(spa_t *spa, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_all_vdev_zaps == 0) {
-		spa->spa_all_vdev_zaps = zap_create_link(spa->spa_meta_objset,
+		VERIFY0(zap_create_link(spa->spa_meta_objset,
 		    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_VDEV_ZAP_MAP, tx);
+		    DMU_POOL_VDEV_ZAP_MAP, tx, &spa->spa_all_vdev_zaps));
 	}
 	spa->spa_avz_action = AVZ_ACTION_NONE;
 
@@ -10598,10 +10615,9 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * Set pool property values in the poolprops mos object.
 			 */
 			if (spa->spa_pool_props_object == 0) {
-				spa->spa_pool_props_object =
-				    zap_create_link(mos, DMU_OT_POOL_PROPS,
+				VERIFY0(zap_create_link(mos, DMU_OT_POOL_PROPS,
 				    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_PROPS,
-				    tx);
+				    tx, &spa->spa_pool_props_object));
 			}
 
 			/* normalize the property name */
@@ -10715,7 +10731,7 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 
 	if (spa->spa_ubsync.ub_version < SPA_VERSION_DIR_CLONES &&
 	    spa->spa_uberblock.ub_version >= SPA_VERSION_DIR_CLONES) {
-		dsl_pool_upgrade_dir_clones(dp, tx);
+		(void) dsl_pool_upgrade_dir_clones(dp, tx);
 
 		/* Keeping the freedir open increases spa_minref */
 		spa->spa_minref += 3;
@@ -10758,11 +10774,13 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	rrw_exit(&dp->dp_config_rwlock, FTAG);
 }
 
-static void
+static int
 vdev_indirect_state_sync_verify(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
 	vdev_indirect_mapping_t *vim __maybe_unused = vd->vdev_indirect_mapping;
 	vdev_indirect_births_t *vib __maybe_unused = vd->vdev_indirect_births;
+	int err = 0;
 
 	if (vd->vdev_ops == &vdev_indirect_ops) {
 		ASSERT(vim != NULL);
@@ -10770,7 +10788,10 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	}
 
 	uint64_t obsolete_sm_object = 0;
-	ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
 	if (obsolete_sm_object != 0) {
 		ASSERT(vd->vdev_obsolete_sm != NULL);
 		ASSERT(vd->vdev_removing ||
@@ -10790,6 +10811,8 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	 * tree must be empty when we start syncing.
 	 */
 	ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
+
+	return (err);
 }
 
 /*
@@ -10807,21 +10830,27 @@ spa_sync_adjust_vdev_max_queue_depth(spa_t *spa)
 	metaslab_class_balance(spa_dedup_class(spa), B_TRUE);
 }
 
-static void
+static int
 spa_sync_condense_indirect(spa_t *spa, dmu_tx_t *tx)
 {
 	ASSERT(spa_writeable(spa));
+	int err = 0;
 
 	vdev_t *rvd = spa->spa_root_vdev;
 	for (int c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *vd = rvd->vdev_child[c];
-		vdev_indirect_state_sync_verify(vd);
+		err = vdev_indirect_state_sync_verify(vd);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 
 		if (vdev_indirect_should_condense(vd)) {
-			spa_condense_indirect_start_sync(vd, tx);
+			err = spa_condense_indirect_start_sync(vd, tx);
 			break;
 		}
 	}
+
+	return (err);
 }
 
 static void
@@ -10836,9 +10865,9 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 		int pass = ++spa->spa_sync_pass;
 
 		spa_sync_config_object(spa, tx);
-		spa_sync_aux_dev(spa, &spa->spa_spares, tx,
+		(void) spa_sync_aux_dev(spa, &spa->spa_spares, tx,
 		    ZPOOL_CONFIG_SPARES, DMU_POOL_SPARES);
-		spa_sync_aux_dev(spa, &spa->spa_l2cache, tx,
+		(void) spa_sync_aux_dev(spa, &spa->spa_l2cache, tx,
 		    ZPOOL_CONFIG_L2CACHE, DMU_POOL_L2CACHE);
 		spa_errlog_sync(spa, txg);
 		dsl_pool_sync(dp, txg);
@@ -10862,7 +10891,7 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			    &spa->spa_deferred_bpobj, tx);
 		}
 
-		brt_sync(spa, txg);
+		(void) brt_sync(spa, txg);
 		ddt_sync(spa, txg);
 		dsl_scan_sync(dp, tx);
 		dsl_errorscrub_sync(dp, tx);
@@ -10874,7 +10903,7 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 		vdev_t *vd = NULL;
 		while ((vd = txg_list_remove(&spa->spa_vdev_txg_list, txg))
 		    != NULL)
-			vdev_sync(vd, txg);
+			(void) vdev_sync(vd, txg);
 
 		if (pass == 1) {
 			/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -8009,10 +8009,10 @@ fail:
  * Destroy a storage pool.
  */
 int
-spa_destroy(const char *pool)
+spa_destroy(const char *pool, boolean_t force, boolean_t hardforce)
 {
 	return (spa_export_common(pool, POOL_STATE_DESTROYED, NULL,
-	    B_FALSE, B_FALSE));
+	    force, hardforce));
 }
 
 /*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -347,6 +347,18 @@ static uint_t spa_note_txg_time = 10 * 60;
  */
 static uint_t spa_flush_txg_time = 10 * 60;
 
+#if ZFS_DEBUG
+/*
+ * The load guid of the spa which is forcibly exiting.
+ *
+ * Some functions do not have direct access to the spa_t reference, but they
+ * have spa load guid, e.g. ARC ones. And spa lookup by guid is not acceptable
+ * in many cases as it could be a deadlock waiting for spa_namespace_lock,
+ * while lockless lookup is dangerous.
+ */
+uint64_t spa_exiting_guid = 0;
+#endif
+
 /*
  * ==========================================================================
  * SPA properties routines
@@ -7728,6 +7740,9 @@ spa_initiate_forced_exit(spa_t *spa)
 	if (spa_suspended(spa) && spa->spa_forced_exit_required) {
 		if (!spa->spa_forcibly_exiting) {
 			spa->spa_forcibly_exiting = B_TRUE;
+#if ZFS_DEBUG
+			spa_exiting_guid = spa_load_guid(spa);
+#endif
 			cmn_err(CE_WARN, "Pool '%s' is now forcibly exiting",
 			    spa_name(spa));
 			zfs_dbgmsg("Pool '%s' is now forcibly exiting",
@@ -7989,6 +8004,14 @@ export_spa:
 		spa->spa_is_exporting = B_FALSE;
 		spa->spa_export_thread = NULL;
 	}
+
+#ifdef ZFS_DEBUG
+	/*
+	 * Now another spa can be marked for forced exit and be forcibly
+	 * exiting.
+	 */
+	spa_exiting_guid = 0;
+#endif
 
 	/*
 	 * Wake up any waiters in spa_lookup()

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1954,6 +1954,17 @@ spa_activate(spa_t *spa, spa_mode_t mode)
 	    defclsyspri, 1, INT_MAX, TASKQ_DYNAMIC | TASKQ_THREADS_CPU_PCT);
 }
 
+static void
+spa_metaslab_class_clear_stats(metaslab_class_t *mc)
+{
+	mc->mc_alloc = 0;
+	mc->mc_dalloc = 0;
+	mc->mc_deferred = 0;
+	mc->mc_ddeferred = 0;
+	mc->mc_space = 0;
+	mc->mc_dspace = 0;
+}
+
 /*
  * Opposite of spa_activate().
  */
@@ -2010,6 +2021,14 @@ spa_deactivate(spa_t *spa)
 		ASSERT3P(spa->spa_txg_zio[i], !=, NULL);
 		VERIFY0(zio_wait(spa->spa_txg_zio[i]));
 		spa->spa_txg_zio[i] = NULL;
+	}
+
+	if (spa_exiting(spa)) {
+		spa_metaslab_class_clear_stats(spa->spa_normal_class);
+		spa_metaslab_class_clear_stats(spa->spa_log_class);
+		spa_metaslab_class_clear_stats(spa->spa_embedded_log_class);
+		spa_metaslab_class_clear_stats(spa->spa_special_class);
+		spa_metaslab_class_clear_stats(spa->spa_dedup_class);
 	}
 
 	metaslab_class_destroy(spa->spa_normal_class);
@@ -2215,6 +2234,7 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg, boolean_t force)
 	dmu_tx_t *tx;
 	dsl_pool_t *dp = spa->spa_dsl_pool;
 	uint64_t idx = txg & TXG_MASK;
+	int err;
 
 	if (!spa_writeable(spa)) {
 		return;
@@ -2251,15 +2271,21 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg, boolean_t force)
 	spa->spa_last_flush_txg_time = curtime;
 	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);
 
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_MINUTES, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_minutes, tx));
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    &spa->spa_txg_log_time.dbr_minutes, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_DAYS, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_days, tx));
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    &spa->spa_txg_log_time.dbr_days, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_MONTHS, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_months, tx));
+	    &spa->spa_txg_log_time.dbr_months, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	dmu_tx_commit(tx);
 }
 
@@ -3252,7 +3278,7 @@ spa_livelist_delete_cb_check(void *arg, zthr_t *z)
 {
 	(void) z;
 	spa_t *spa = arg;
-	return (spa_livelist_delete_check(spa));
+	return (spa_livelist_delete_check(spa) && !SPA_EXITING(spa));
 }
 
 static int
@@ -3321,17 +3347,26 @@ livelist_delete_sync(void *arg, dmu_tx_t *tx)
 	uint64_t zap_obj = lda->zap_obj;
 	objset_t *mos = spa->spa_meta_objset;
 	uint64_t count;
+	int err;
 
 	/* free the livelist and decrement the feature count */
-	VERIFY0(zap_remove_int(mos, zap_obj, ll_obj, tx));
+	err = zap_remove_int(mos, zap_obj, ll_obj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	dsl_deadlist_free(mos, ll_obj, tx);
 	spa_feature_decr(spa, SPA_FEATURE_LIVELIST, tx);
-	VERIFY0(zap_count(mos, zap_obj, &count));
+	err = zap_count(mos, zap_obj, &count);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (count == 0) {
 		/* no more livelists to delete */
-		VERIFY0(zap_remove(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DELETED_CLONES, tx));
-		VERIFY0(zap_destroy(mos, zap_obj, tx));
+		err = zap_remove(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_DELETED_CLONES, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_destroy(mos, zap_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa->spa_livelists_to_delete = 0;
 		spa_notify_waiters(spa);
 	}
@@ -3350,22 +3385,36 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 	uint64_t ll_obj = 0, count;
 	objset_t *mos = spa->spa_meta_objset;
 	uint64_t zap_obj = spa->spa_livelists_to_delete;
+	int err;
 	/*
 	 * Determine the next livelist to delete. This function should only
 	 * be called if there is at least one deleted clone.
 	 */
-	VERIFY0(dsl_get_next_livelist_obj(mos, zap_obj, &ll_obj));
-	VERIFY0(zap_count(mos, ll_obj, &count));
+	err = dsl_get_next_livelist_obj(mos, zap_obj, &ll_obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+	err = zap_count(mos, ll_obj, &count);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	if (count > 0) {
 		dsl_deadlist_t *ll;
 		dsl_deadlist_entry_t *dle;
 		bplist_t to_free;
 		ll = kmem_zalloc(sizeof (dsl_deadlist_t), KM_SLEEP);
-		VERIFY0(dsl_deadlist_open(ll, mos, ll_obj));
+		err = dsl_deadlist_open(ll, mos, ll_obj);
+		if (err && SPA_EXITING(spa))
+			goto skip1;
+		VERIFY0(err);
 		dle = dsl_deadlist_first(ll);
+		if (dle == NULL && SPA_EXITING(spa))
+			goto skip2;
 		ASSERT3P(dle, !=, NULL);
+		if (SPA_EXITING(spa))
+			goto skip2;
 		bplist_create(&to_free);
-		int err = dsl_process_sub_livelist(&dle->dle_bpobj, &to_free,
+		err = dsl_process_sub_livelist(&dle->dle_bpobj, &to_free,
 		    z, NULL);
 		if (err == 0) {
 			sublist_delete_arg_t sync_arg = {
@@ -3378,15 +3427,20 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 			    " livelist %llu, %lld remaining",
 			    (u_longlong_t)dle->dle_bpobj.bpo_object,
 			    (u_longlong_t)ll_obj, (longlong_t)count - 1);
-			VERIFY0(dsl_sync_task(spa_name(spa), NULL,
+			err = dsl_sync_task(spa_name(spa), NULL,
 			    sublist_delete_sync, &sync_arg, 0,
-			    ZFS_SPACE_CHECK_DESTROY));
+			    ZFS_SPACE_CHECK_DESTROY);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		} else {
-			VERIFY3U(err, ==, EINTR);
+			if (!SPA_EXITING(spa))
+				VERIFY3U(err, ==, EINTR);
 		}
 		bplist_clear(&to_free);
 		bplist_destroy(&to_free);
+skip2:
 		dsl_deadlist_close(ll);
+skip1:
 		kmem_free(ll, sizeof (dsl_deadlist_t));
 	} else {
 		livelist_delete_arg_t sync_arg = {
@@ -3396,8 +3450,10 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 		};
 		zfs_dbgmsg("deletion of livelist %llu completed",
 		    (u_longlong_t)ll_obj);
-		VERIFY0(dsl_sync_task(spa_name(spa), NULL, livelist_delete_sync,
-		    &sync_arg, 0, ZFS_SPACE_CHECK_DESTROY));
+		err = dsl_sync_task(spa_name(spa), NULL, livelist_delete_sync,
+		    &sync_arg, 0, ZFS_SPACE_CHECK_DESTROY);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 }
 
@@ -10251,7 +10307,9 @@ spa_sync_frees(spa_t *spa, bplist_t *bpl, dmu_tx_t *tx)
 {
 	zio_t *zio = zio_root(spa, NULL, NULL, 0);
 	bplist_iterate(bpl, spa_free_sync_cb, zio, tx);
-	VERIFY0(zio_wait(zio));
+	int err = zio_wait(zio);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*
@@ -10277,9 +10335,15 @@ spa_sync_deferred_frees(spa_t *spa, dmu_tx_t *tx)
 	 * deferred frees from the previous TXG.
 	 */
 	zio_t *zio = zio_root(spa, NULL, NULL, 0);
-	VERIFY3U(bpobj_iterate(&spa->spa_deferred_bpobj,
-	    bpobj_spa_free_sync_cb, zio, tx), ==, 0);
-	VERIFY0(zio_wait(zio));
+
+	int err = bpobj_iterate(&spa->spa_deferred_bpobj,
+	    bpobj_spa_free_sync_cb, zio, tx);
+	if (!spa_exiting(spa))
+		VERIFY0(err);
+
+	err = zio_wait(zio);
+	if (!spa_exiting(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -10289,6 +10353,9 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	size_t bufsize;
 	size_t nvsize = 0;
 	dmu_buf_t *db;
+
+	if (spa_exiting(spa))
+		return;
 
 	VERIFY0(nvlist_size(nv, &nvsize, NV_ENCODE_XDR));
 
@@ -10545,6 +10612,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	nvpair_t *elem = NULL;
+	int err;
 
 	mutex_enter(&spa->spa_props_lock);
 
@@ -10638,9 +10706,12 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * Set pool property values in the poolprops mos object.
 			 */
 			if (spa->spa_pool_props_object == 0) {
-				VERIFY0(zap_create_link(mos, DMU_OT_POOL_PROPS,
+				err = zap_create_link(mos, DMU_OT_POOL_PROPS,
 				    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_PROPS,
-				    tx, &spa->spa_pool_props_object));
+				    tx, &spa->spa_pool_props_object);
+				if (err && SPA_EXITING(spa))
+					goto out;
+				VERIFY0(err);
 			}
 
 			/* normalize the property name */
@@ -10661,10 +10732,13 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 					    spa->spa_pool_props_object,
 					    propname, tx);
 				} else {
-					VERIFY0(zap_update(mos,
+					err = zap_update(mos,
 					    spa->spa_pool_props_object,
 					    propname, 1, strlen(strval) + 1,
-					    strval, tx));
+					    strval, tx);
+					if (err && SPA_EXITING(spa))
+						goto out;
+					VERIFY0(err);
 				}
 				spa_history_log_internal(spa, "set", tx,
 				    "%s=%s", elemname, strval);
@@ -10676,9 +10750,12 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 					VERIFY0(zpool_prop_index_to_string(
 					    prop, intval, &unused));
 				}
-				VERIFY0(zap_update(mos,
+				err = zap_update(mos,
 				    spa->spa_pool_props_object, propname,
-				    8, 1, &intval, tx));
+				    8, 1, &intval, tx);
+				if (err && SPA_EXITING(spa))
+					goto out;
+				VERIFY0(err);
 				spa_history_log_internal(spa, "set", tx,
 				    "%s=%lld", elemname,
 				    (longlong_t)intval);
@@ -10720,6 +10797,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 
 	}
 
+out:
 	mutex_exit(&spa->spa_props_lock);
 }
 
@@ -10733,6 +10811,11 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 static void
 spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 {
+	int err;
+
+	if (SPA_EXITING(spa))
+		return;
+
 	if (spa_sync_pass(spa) != 1)
 		return;
 
@@ -10788,10 +10871,12 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	 */
 	if (zap_contains(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_CHECKSUM_SALT) == ENOENT) {
-		VERIFY0(zap_add(spa->spa_meta_objset,
+		err = zap_add(spa->spa_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_CHECKSUM_SALT, 1,
 		    sizeof (spa->spa_cksum_salt.zcs_bytes),
-		    spa->spa_cksum_salt.zcs_bytes, tx));
+		    spa->spa_cksum_salt.zcs_bytes, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	rrw_exit(&dp->dp_config_rwlock, FTAG);
@@ -10833,7 +10918,8 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	 * happen in syncing context, the obsolete segments
 	 * tree must be empty when we start syncing.
 	 */
-	ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
+	if (!SPA_EXITING(spa))
+		ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
 
 	return (err);
 }
@@ -10910,11 +10996,12 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			 * we sync the deferred frees later in pass 1.
 			 */
 			ASSERT3U(pass, >, 1);
-			bplist_iterate(free_bpl, bpobj_enqueue_alloc_cb,
-			    &spa->spa_deferred_bpobj, tx);
+			if (!SPA_EXITING(spa))
+				bplist_iterate(free_bpl, bpobj_enqueue_alloc_cb,
+				    &spa->spa_deferred_bpobj, tx);
 		}
 
-		(void) brt_sync(spa, txg);
+		brt_sync(spa, txg);
 		ddt_sync(spa, txg);
 		dsl_scan_sync(dp, tx);
 		dsl_errorscrub_sync(dp, tx);
@@ -10973,7 +11060,8 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			break;
 		}
 
-		spa_sync_deferred_frees(spa, tx);
+		if (!SPA_EXITING(spa))
+			spa_sync_deferred_frees(spa, tx);
 	} while (dmu_objset_is_dirty(mos, txg));
 }
 
@@ -11035,7 +11123,7 @@ spa_sync_rewrite_vdev_config(spa_t *spa, dmu_tx_t *tx)
 
 		spa_config_exit(spa, SCL_STATE, FTAG);
 
-		if (error == 0)
+		if (error == 0 || SPA_EXITING(spa))
 			break;
 		zio_suspend(spa, NULL, ZIO_SUSPEND_IOERR);
 		zio_resume_wait(spa);
@@ -11134,9 +11222,11 @@ spa_sync(spa_t *spa, uint64_t txg)
 		}
 		if (i == rvd->vdev_children) {
 			spa->spa_deflate = TRUE;
-			VERIFY0(zap_add(spa->spa_meta_objset,
+			int err = zap_add(spa->spa_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_DEFLATE,
-			    sizeof (uint64_t), 1, &spa->spa_deflate, tx));
+			    sizeof (uint64_t), 1, &spa->spa_deflate, tx);
+			if (!spa_exiting(spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -11147,7 +11237,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 	spa_sync_iterate_to_convergence(spa, tx);
 
 #ifdef ZFS_DEBUG
-	if (!list_is_empty(&spa->spa_config_dirty_list)) {
+	if (!list_is_empty(&spa->spa_config_dirty_list) && !SPA_EXITING(spa)) {
 	/*
 	 * Make sure that the number of ZAPs for all the vdevs matches
 	 * the number of ZAPs in the per-vdev ZAP list. This only gets

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7435,7 +7435,9 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	 * Create the pool's history object.
 	 */
 	if (version >= SPA_VERSION_ZPOOL_HISTORY && !spa->spa_history)
-		spa_history_create_obj(spa, tx);
+		if (spa_history_create_obj(spa, tx) != 0) {
+			cmn_err(CE_PANIC, "failed to create history object");
+		}
 
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_POOL_CREATE);
 	spa_history_log_version(spa, "create", tx);
@@ -7443,9 +7445,12 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	/*
 	 * Create the pool config object.
 	 */
-	spa->spa_config_object = dmu_object_alloc(spa->spa_meta_objset,
+	if (dmu_object_alloc(spa->spa_meta_objset,
 	    DMU_OT_PACKED_NVLIST, SPA_CONFIG_BLOCKSIZE,
-	    DMU_OT_PACKED_NVLIST_SIZE, sizeof (uint64_t), tx);
+	    DMU_OT_PACKED_NVLIST_SIZE, sizeof (uint64_t), tx,
+	    &spa->spa_config_object) != 0) {
+		cmn_err(CE_PANIC, "failed to allocate object");
+	}
 
 	if (zap_add(spa->spa_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_CONFIG,
@@ -7473,7 +7478,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	 * because sync-to-convergence takes longer if the blocksize
 	 * keeps changing.
 	 */
-	obj = bpobj_alloc(spa->spa_meta_objset, 1 << 14, tx);
+	VERIFY0(bpobj_alloc(spa->spa_meta_objset, 1 << 14, tx, &obj));
 	dmu_object_set_compress(spa->spa_meta_objset, obj,
 	    ZIO_COMPRESS_OFF, tx);
 	if (zap_add(spa->spa_meta_objset,
@@ -10539,16 +10544,16 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	dmu_buf_rele(db, FTAG);
 }
 
-static void
+static int
 spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
     const char *config, const char *entry)
 {
 	nvlist_t *nvroot;
 	nvlist_t **list;
-	int i;
+	int i, err = 0;
 
 	if (!sav->sav_sync)
-		return;
+		return (0);
 
 	/*
 	 * Update the MOS nvlist describing the list of available devices.
@@ -10556,12 +10561,19 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 	 * valid and the vdevs are labeled appropriately.
 	 */
 	if (sav->sav_object == 0) {
-		sav->sav_object = dmu_object_alloc(spa->spa_meta_objset,
+		err = dmu_object_alloc(spa->spa_meta_objset,
 		    DMU_OT_PACKED_NVLIST, 1 << 14, DMU_OT_PACKED_NVLIST_SIZE,
-		    sizeof (uint64_t), tx);
-		VERIFY(zap_update(spa->spa_meta_objset,
+		    sizeof (uint64_t), tx, &sav->sav_object);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+
+		err = zap_update(spa->spa_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT, entry, sizeof (uint64_t), 1,
-		    &sav->sav_object, tx) == 0);
+		    &sav->sav_object, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	nvroot = fnvlist_alloc();
@@ -10583,7 +10595,10 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 	spa_sync_nvlist(spa, sav->sav_object, nvroot, tx);
 	nvlist_free(nvroot);
 
+out:
 	sav->sav_sync = B_FALSE;
+
+	return (err);
 }
 
 /*
@@ -10636,8 +10651,10 @@ spa_sync_config_object(spa_t *spa, dmu_tx_t *tx)
 
 	if (spa->spa_avz_action == AVZ_ACTION_REBUILD) {
 		/* Make and build the new AVZ */
-		uint64_t new_avz = zap_create(spa->spa_meta_objset,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
+		uint64_t new_avz;
+		VERIFY0(zap_create(spa->spa_meta_objset,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx,
+		    &new_avz));
 		spa_avz_build(spa->spa_root_vdev, new_avz, tx);
 
 		/* Diff old AVZ with new one */
@@ -10698,9 +10715,9 @@ spa_sync_config_object(spa_t *spa, dmu_tx_t *tx)
 	}
 
 	if (spa->spa_all_vdev_zaps == 0) {
-		spa->spa_all_vdev_zaps = zap_create_link(spa->spa_meta_objset,
+		VERIFY0(zap_create_link(spa->spa_meta_objset,
 		    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_VDEV_ZAP_MAP, tx);
+		    DMU_POOL_VDEV_ZAP_MAP, tx, &spa->spa_all_vdev_zaps));
 	}
 	spa->spa_avz_action = AVZ_ACTION_NONE;
 
@@ -10850,10 +10867,9 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * Set pool property values in the poolprops mos object.
 			 */
 			if (spa->spa_pool_props_object == 0) {
-				spa->spa_pool_props_object =
-				    zap_create_link(mos, DMU_OT_POOL_PROPS,
+				VERIFY0(zap_create_link(mos, DMU_OT_POOL_PROPS,
 				    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_PROPS,
-				    tx);
+				    tx, &spa->spa_pool_props_object));
 			}
 
 			/* normalize the property name */
@@ -10967,7 +10983,7 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 
 	if (spa->spa_ubsync.ub_version < SPA_VERSION_DIR_CLONES &&
 	    spa->spa_uberblock.ub_version >= SPA_VERSION_DIR_CLONES) {
-		dsl_pool_upgrade_dir_clones(dp, tx);
+		(void) dsl_pool_upgrade_dir_clones(dp, tx);
 
 		/* Keeping the freedir open increases spa_minref */
 		spa->spa_minref += 3;
@@ -11010,11 +11026,13 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	rrw_exit(&dp->dp_config_rwlock, FTAG);
 }
 
-static void
+static int
 vdev_indirect_state_sync_verify(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
 	vdev_indirect_mapping_t *vim __maybe_unused = vd->vdev_indirect_mapping;
 	vdev_indirect_births_t *vib __maybe_unused = vd->vdev_indirect_births;
+	int err = 0;
 
 	if (vd->vdev_ops == &vdev_indirect_ops) {
 		ASSERT(vim != NULL);
@@ -11022,7 +11040,10 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	}
 
 	uint64_t obsolete_sm_object = 0;
-	ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	ASSERT0(err);
 	if (obsolete_sm_object != 0) {
 		ASSERT(vd->vdev_obsolete_sm != NULL);
 		ASSERT(vd->vdev_removing ||
@@ -11042,6 +11063,8 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	 * tree must be empty when we start syncing.
 	 */
 	ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
+
+	return (err);
 }
 
 /*
@@ -11059,21 +11082,27 @@ spa_sync_adjust_vdev_max_queue_depth(spa_t *spa)
 	metaslab_class_balance(spa_dedup_class(spa), B_TRUE);
 }
 
-static void
+static int
 spa_sync_condense_indirect(spa_t *spa, dmu_tx_t *tx)
 {
 	ASSERT(spa_writeable(spa));
+	int err = 0;
 
 	vdev_t *rvd = spa->spa_root_vdev;
 	for (int c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *vd = rvd->vdev_child[c];
-		vdev_indirect_state_sync_verify(vd);
+		err = vdev_indirect_state_sync_verify(vd);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 
 		if (vdev_indirect_should_condense(vd)) {
-			spa_condense_indirect_start_sync(vd, tx);
+			err = spa_condense_indirect_start_sync(vd, tx);
 			break;
 		}
 	}
+
+	return (err);
 }
 
 static void
@@ -11088,9 +11117,9 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 		int pass = ++spa->spa_sync_pass;
 
 		spa_sync_config_object(spa, tx);
-		spa_sync_aux_dev(spa, &spa->spa_spares, tx,
+		(void) spa_sync_aux_dev(spa, &spa->spa_spares, tx,
 		    ZPOOL_CONFIG_SPARES, DMU_POOL_SPARES);
-		spa_sync_aux_dev(spa, &spa->spa_l2cache, tx,
+		(void) spa_sync_aux_dev(spa, &spa->spa_l2cache, tx,
 		    ZPOOL_CONFIG_L2CACHE, DMU_POOL_L2CACHE);
 		spa_errlog_sync(spa, txg);
 		dsl_pool_sync(dp, txg);
@@ -11114,7 +11143,7 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			    &spa->spa_deferred_bpobj, tx);
 		}
 
-		brt_sync(spa, txg);
+		(void) brt_sync(spa, txg);
 		ddt_sync(spa, txg);
 		dsl_scan_sync(dp, tx);
 		dsl_errorscrub_sync(dp, tx);
@@ -11126,7 +11155,7 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 		vdev_t *vd = NULL;
 		while ((vd = txg_list_remove(&spa->spa_vdev_txg_list, txg))
 		    != NULL)
-			vdev_sync(vd, txg);
+			(void) vdev_sync(vd, txg);
 
 		if (pass == 1) {
 			/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7853,6 +7853,36 @@ spa_tryimport(nvlist_t *tryconfig)
 	return (config);
 }
 
+void
+spa_initiate_forced_exit(spa_t *spa)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_suspend_lock));
+
+	if (spa_suspended(spa) && spa->spa_forced_exit_required) {
+		if (!spa->spa_forcibly_exiting) {
+			spa->spa_forcibly_exiting = B_TRUE;
+			cmn_err(CE_WARN, "Pool '%s' is now forcibly exiting",
+			    spa_name(spa));
+			zfs_dbgmsg("Pool '%s' is now forcibly exiting",
+			    spa_name(spa));
+		}
+		zio_resume_but_keep_suspended(spa);
+	}
+}
+
+void
+spa_set_forced_exit_required(spa_t *spa)
+{
+	mutex_enter(&spa->spa_suspend_lock);
+	if (!spa->spa_forced_exit_required) {
+		spa->spa_forced_exit_required = B_TRUE;
+		zfs_dbgmsg("Pool '%s' forced exit requirement has been set",
+		    spa_name(spa));
+	}
+	spa_initiate_forced_exit(spa);
+	mutex_exit(&spa->spa_suspend_lock);
+}
+
 /*
  * Pool export/destroy
  *
@@ -7869,6 +7899,9 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	int error = 0;
 	spa_t *spa;
 	hrtime_t export_start = gethrtime();
+	uint_t hardforce_ref_checks_left;
+
+	force = hardforce || force;
 
 	if (oldconfig)
 		*oldconfig = NULL;
@@ -7882,12 +7915,20 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		return (SET_ERROR(ENOENT));
 	}
 
+	if (spa_suspended(spa) && !hardforce) {
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(EAGAIN));
+	}
+
 	if (spa->spa_is_exporting) {
 		/* the pool is being exported by another thread */
 		spa_namespace_exit(FTAG);
 		return (SET_ERROR(ZFS_ERR_EXPORT_IN_PROGRESS));
 	}
 	spa->spa_is_exporting = B_TRUE;
+
+	if (hardforce)
+		spa_set_forced_exit_required(spa);
 
 	/*
 	 * Put a hold on the pool, drop the namespace lock, stop async tasks
@@ -7915,7 +7956,18 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 * so we have to force it to sync before checking spa_refcnt.
 	 */
 	if (spa->spa_sync_on) {
-		txg_wait_synced(spa->spa_dsl_pool, 0);
+		if (hardforce) {
+			txg_wait_synced(spa->spa_dsl_pool, 0);
+		} else if (txg_wait_synced_flags(spa->spa_dsl_pool, 0,
+		    TXG_WAIT_SUSPEND) != 0) {
+			/*
+			 * We want to release spa_namespace_lock instead of
+			 * holding it forever, so that hardforce can be asked to
+			 * do the trick.
+			 */
+			error = SET_ERROR(EAGAIN);
+			goto fail;
+		}
 		spa_evicting_os_wait(spa);
 	}
 
@@ -7924,7 +7976,36 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 * references.  If we are resetting a pool, allow references by
 	 * fault injection handlers.
 	 */
-	if (!spa_refcount_zero(spa) || (spa->spa_inject_ref != 0)) {
+	hardforce_ref_checks_left = TXG_SIZE * zfs_txg_timeout;
+	if (spa->spa_inject_ref != 0) {
+		/* No one is going to fight with zinject, even the hardforce */
+		goto open_refs;
+	}
+	while (hardforce && !spa_refcount_zero(spa) &&
+	    hardforce_ref_checks_left > 0 && !issig()) {
+		/*
+		 * Others might be stuck having spa references without a
+		 * chance to release them as we are holding spa_namespace_lock.
+		 * Wait for the last pool users to eject. The timeout is
+		 * arbitrary, waiting a little while is a UX improvement for
+		 * an operator, while waiting forever in the kernel would just
+		 * make a bad situation worse.
+		 */
+		hardforce_ref_checks_left--;
+		spa_namespace_exit(FTAG);
+		zfs_sleep_until(gethrtime() + SEC2NSEC(1));
+		spa_namespace_enter(FTAG);
+	}
+	if (!spa_refcount_zero(spa)) {
+open_refs:
+		zfs_dbgmsg("Pool '%s' cannot be exported due to open refs:"
+		    " spa_minref=%llu spa_refcount=%llu spa_inject_ref=%llu"
+		    " hardforce_ref_checks_left=%u",
+		    spa_name(spa),
+		    (u_longlong_t)spa->spa_minref,
+		    (u_longlong_t)zfs_refcount_count(&spa->spa_refcount),
+		    (u_longlong_t)spa->spa_inject_ref,
+		    hardforce_ref_checks_left);
 		error = SET_ERROR(EBUSY);
 		goto fail;
 	}
@@ -7975,7 +8056,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		 * so mark them all dirty.  spa_unload() will do the
 		 * final sync that pushes these changes out.
 		 */
-		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
+		if (new_state != POOL_STATE_UNINITIALIZED &&
+		    !spa_exiting(spa)) {
 			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 			spa->spa_state = new_state;
 			vdev_config_dirty(rvd);
@@ -7998,7 +8080,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		if (spa_should_flush_logs_on_unload(spa))
 			spa_unload_log_sm_flush_all(spa);
 
-		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
+		if (new_state != POOL_STATE_UNINITIALIZED &&
+		    !spa_exiting(spa)) {
 			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 			spa->spa_final_txg = spa_last_synced_txg(spa) +
 			    TXG_DEFER_SIZE + 1;
@@ -8030,8 +8113,7 @@ export_spa:
 	 */
 	spa_namespace_enter(FTAG);
 	if (new_state != POOL_STATE_UNINITIALIZED) {
-		if (!hardforce)
-			spa_write_cachefile(spa, B_TRUE, B_TRUE, B_FALSE);
+		spa_write_cachefile(spa, B_TRUE, B_TRUE, B_FALSE);
 		spa_remove(spa);
 	} else {
 		/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1944,6 +1944,17 @@ spa_activate(spa_t *spa, spa_mode_t mode)
 	    defclsyspri, 1, INT_MAX, TASKQ_DYNAMIC | TASKQ_THREADS_CPU_PCT);
 }
 
+static void
+spa_metaslab_class_clear_stats(metaslab_class_t *mc)
+{
+	mc->mc_alloc = 0;
+	mc->mc_dalloc = 0;
+	mc->mc_deferred = 0;
+	mc->mc_ddeferred = 0;
+	mc->mc_space = 0;
+	mc->mc_dspace = 0;
+}
+
 /*
  * Opposite of spa_activate().
  */
@@ -2000,6 +2011,14 @@ spa_deactivate(spa_t *spa)
 		ASSERT3P(spa->spa_txg_zio[i], !=, NULL);
 		VERIFY0(zio_wait(spa->spa_txg_zio[i]));
 		spa->spa_txg_zio[i] = NULL;
+	}
+
+	if (spa_exiting(spa)) {
+		spa_metaslab_class_clear_stats(spa->spa_normal_class);
+		spa_metaslab_class_clear_stats(spa->spa_log_class);
+		spa_metaslab_class_clear_stats(spa->spa_embedded_log_class);
+		spa_metaslab_class_clear_stats(spa->spa_special_class);
+		spa_metaslab_class_clear_stats(spa->spa_dedup_class);
 	}
 
 	metaslab_class_destroy(spa->spa_normal_class);
@@ -2205,6 +2224,7 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg, boolean_t force)
 	dmu_tx_t *tx;
 	dsl_pool_t *dp = spa->spa_dsl_pool;
 	uint64_t idx = txg & TXG_MASK;
+	int err;
 
 	if (!spa_writeable(spa)) {
 		return;
@@ -2241,15 +2261,21 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg, boolean_t force)
 	spa->spa_last_flush_txg_time = curtime;
 	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);
 
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_MINUTES, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_minutes, tx));
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    &spa->spa_txg_log_time.dbr_minutes, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_DAYS, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_days, tx));
-	VERIFY0(zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    &spa->spa_txg_log_time.dbr_days, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+	err = zap_update(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_TXG_LOG_TIME_MONTHS, RRD_ENTRY_SIZE, RRD_STRUCT_ELEM,
-	    &spa->spa_txg_log_time.dbr_months, tx));
+	    &spa->spa_txg_log_time.dbr_months, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	dmu_tx_commit(tx);
 }
 
@@ -3305,7 +3331,7 @@ spa_livelist_delete_cb_check(void *arg, zthr_t *z)
 {
 	(void) z;
 	spa_t *spa = arg;
-	return (spa_livelist_delete_check(spa));
+	return (spa_livelist_delete_check(spa) && !SPA_EXITING(spa));
 }
 
 static int
@@ -3374,17 +3400,26 @@ livelist_delete_sync(void *arg, dmu_tx_t *tx)
 	uint64_t zap_obj = lda->zap_obj;
 	objset_t *mos = spa->spa_meta_objset;
 	uint64_t count;
+	int err;
 
 	/* free the livelist and decrement the feature count */
-	VERIFY0(zap_remove_int(mos, zap_obj, ll_obj, tx));
+	err = zap_remove_int(mos, zap_obj, ll_obj, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	dsl_deadlist_free(mos, ll_obj, tx);
 	spa_feature_decr(spa, SPA_FEATURE_LIVELIST, tx);
-	VERIFY0(zap_count(mos, zap_obj, &count));
+	err = zap_count(mos, zap_obj, &count);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (count == 0) {
 		/* no more livelists to delete */
-		VERIFY0(zap_remove(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_DELETED_CLONES, tx));
-		VERIFY0(zap_destroy(mos, zap_obj, tx));
+		err = zap_remove(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_DELETED_CLONES, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+		err = zap_destroy(mos, zap_obj, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa->spa_livelists_to_delete = 0;
 		spa_notify_waiters(spa);
 	}
@@ -3403,22 +3438,36 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 	uint64_t ll_obj = 0, count;
 	objset_t *mos = spa->spa_meta_objset;
 	uint64_t zap_obj = spa->spa_livelists_to_delete;
+	int err;
 	/*
 	 * Determine the next livelist to delete. This function should only
 	 * be called if there is at least one deleted clone.
 	 */
-	VERIFY0(dsl_get_next_livelist_obj(mos, zap_obj, &ll_obj));
-	VERIFY0(zap_count(mos, ll_obj, &count));
+	err = dsl_get_next_livelist_obj(mos, zap_obj, &ll_obj);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+	err = zap_count(mos, ll_obj, &count);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	if (count > 0) {
 		dsl_deadlist_t *ll;
 		dsl_deadlist_entry_t *dle;
 		bplist_t to_free;
 		ll = kmem_zalloc(sizeof (dsl_deadlist_t), KM_SLEEP);
-		VERIFY0(dsl_deadlist_open(ll, mos, ll_obj));
+		err = dsl_deadlist_open(ll, mos, ll_obj);
+		if (err && SPA_EXITING(spa))
+			goto skip1;
+		VERIFY0(err);
 		dle = dsl_deadlist_first(ll);
+		if (dle == NULL && SPA_EXITING(spa))
+			goto skip2;
 		ASSERT3P(dle, !=, NULL);
+		if (SPA_EXITING(spa))
+			goto skip2;
 		bplist_create(&to_free);
-		int err = dsl_process_sub_livelist(&dle->dle_bpobj, &to_free,
+		err = dsl_process_sub_livelist(&dle->dle_bpobj, &to_free,
 		    z, NULL);
 		if (err == 0) {
 			sublist_delete_arg_t sync_arg = {
@@ -3431,15 +3480,20 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 			    " livelist %llu, %lld remaining",
 			    (u_longlong_t)dle->dle_bpobj.bpo_object,
 			    (u_longlong_t)ll_obj, (longlong_t)count - 1);
-			VERIFY0(dsl_sync_task(spa_name(spa), NULL,
+			err = dsl_sync_task(spa_name(spa), NULL,
 			    sublist_delete_sync, &sync_arg, 0,
-			    ZFS_SPACE_CHECK_DESTROY));
+			    ZFS_SPACE_CHECK_DESTROY);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		} else {
-			VERIFY3U(err, ==, EINTR);
+			if (!SPA_EXITING(spa))
+				VERIFY3U(err, ==, EINTR);
 		}
 		bplist_clear(&to_free);
 		bplist_destroy(&to_free);
+skip2:
 		dsl_deadlist_close(ll);
+skip1:
 		kmem_free(ll, sizeof (dsl_deadlist_t));
 	} else {
 		livelist_delete_arg_t sync_arg = {
@@ -3449,8 +3503,10 @@ spa_livelist_delete_cb(void *arg, zthr_t *z)
 		};
 		zfs_dbgmsg("deletion of livelist %llu completed",
 		    (u_longlong_t)ll_obj);
-		VERIFY0(dsl_sync_task(spa_name(spa), NULL, livelist_delete_sync,
-		    &sync_arg, 0, ZFS_SPACE_CHECK_DESTROY));
+		err = dsl_sync_task(spa_name(spa), NULL, livelist_delete_sync,
+		    &sync_arg, 0, ZFS_SPACE_CHECK_DESTROY);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 }
 
@@ -10503,7 +10559,9 @@ spa_sync_frees(spa_t *spa, bplist_t *bpl, dmu_tx_t *tx)
 {
 	zio_t *zio = zio_root(spa, NULL, NULL, 0);
 	bplist_iterate(bpl, spa_free_sync_cb, zio, tx);
-	VERIFY0(zio_wait(zio));
+	int err = zio_wait(zio);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*
@@ -10529,9 +10587,15 @@ spa_sync_deferred_frees(spa_t *spa, dmu_tx_t *tx)
 	 * deferred frees from the previous TXG.
 	 */
 	zio_t *zio = zio_root(spa, NULL, NULL, 0);
-	VERIFY3U(bpobj_iterate(&spa->spa_deferred_bpobj,
-	    bpobj_spa_free_sync_cb, zio, tx), ==, 0);
-	VERIFY0(zio_wait(zio));
+
+	int err = bpobj_iterate(&spa->spa_deferred_bpobj,
+	    bpobj_spa_free_sync_cb, zio, tx);
+	if (!spa_exiting(spa))
+		VERIFY0(err);
+
+	err = zio_wait(zio);
+	if (!spa_exiting(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -10541,6 +10605,9 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	size_t bufsize;
 	size_t nvsize = 0;
 	dmu_buf_t *db;
+
+	if (spa_exiting(spa))
+		return;
 
 	VERIFY0(nvlist_size(nv, &nvsize, NV_ENCODE_XDR));
 
@@ -10797,6 +10864,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	nvpair_t *elem = NULL;
+	int err;
 
 	mutex_enter(&spa->spa_props_lock);
 
@@ -10890,9 +10958,12 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * Set pool property values in the poolprops mos object.
 			 */
 			if (spa->spa_pool_props_object == 0) {
-				VERIFY0(zap_create_link(mos, DMU_OT_POOL_PROPS,
+				err = zap_create_link(mos, DMU_OT_POOL_PROPS,
 				    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_PROPS,
-				    tx, &spa->spa_pool_props_object));
+				    tx, &spa->spa_pool_props_object);
+				if (err && SPA_EXITING(spa))
+					goto out;
+				VERIFY0(err);
 			}
 
 			/* normalize the property name */
@@ -10913,10 +10984,13 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 					    spa->spa_pool_props_object,
 					    propname, tx);
 				} else {
-					VERIFY0(zap_update(mos,
+					err = zap_update(mos,
 					    spa->spa_pool_props_object,
 					    propname, 1, strlen(strval) + 1,
-					    strval, tx));
+					    strval, tx);
+					if (err && SPA_EXITING(spa))
+						goto out;
+					VERIFY0(err);
 				}
 				spa_history_log_internal(spa, "set", tx,
 				    "%s=%s", elemname, strval);
@@ -10928,9 +11002,12 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 					VERIFY0(zpool_prop_index_to_string(
 					    prop, intval, &unused));
 				}
-				VERIFY0(zap_update(mos,
+				err = zap_update(mos,
 				    spa->spa_pool_props_object, propname,
-				    8, 1, &intval, tx));
+				    8, 1, &intval, tx);
+				if (err && SPA_EXITING(spa))
+					goto out;
+				VERIFY0(err);
 				spa_history_log_internal(spa, "set", tx,
 				    "%s=%lld", elemname,
 				    (longlong_t)intval);
@@ -10972,6 +11049,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 
 	}
 
+out:
 	mutex_exit(&spa->spa_props_lock);
 }
 
@@ -10985,6 +11063,11 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 static void
 spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 {
+	int err;
+
+	if (SPA_EXITING(spa))
+		return;
+
 	if (spa_sync_pass(spa) != 1)
 		return;
 
@@ -11040,10 +11123,12 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	 */
 	if (zap_contains(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_CHECKSUM_SALT) == ENOENT) {
-		VERIFY0(zap_add(spa->spa_meta_objset,
+		err = zap_add(spa->spa_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_CHECKSUM_SALT, 1,
 		    sizeof (spa->spa_cksum_salt.zcs_bytes),
-		    spa->spa_cksum_salt.zcs_bytes, tx));
+		    spa->spa_cksum_salt.zcs_bytes, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	rrw_exit(&dp->dp_config_rwlock, FTAG);
@@ -11085,7 +11170,8 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	 * happen in syncing context, the obsolete segments
 	 * tree must be empty when we start syncing.
 	 */
-	ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
+	if (!SPA_EXITING(spa))
+		ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
 
 	return (err);
 }
@@ -11162,11 +11248,12 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			 * we sync the deferred frees later in pass 1.
 			 */
 			ASSERT3U(pass, >, 1);
-			bplist_iterate(free_bpl, bpobj_enqueue_alloc_cb,
-			    &spa->spa_deferred_bpobj, tx);
+			if (!SPA_EXITING(spa))
+				bplist_iterate(free_bpl, bpobj_enqueue_alloc_cb,
+				    &spa->spa_deferred_bpobj, tx);
 		}
 
-		(void) brt_sync(spa, txg);
+		brt_sync(spa, txg);
 		ddt_sync(spa, txg);
 		dsl_scan_sync(dp, tx);
 		dsl_errorscrub_sync(dp, tx);
@@ -11225,7 +11312,8 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 			break;
 		}
 
-		spa_sync_deferred_frees(spa, tx);
+		if (!SPA_EXITING(spa))
+			spa_sync_deferred_frees(spa, tx);
 	} while (dmu_objset_is_dirty(mos, txg));
 }
 
@@ -11322,7 +11410,7 @@ spa_sync_rewrite_vdev_config(spa_t *spa, dmu_tx_t *tx)
 
 		spa_config_exit(spa, SCL_STATE, FTAG);
 
-		if (error == 0)
+		if (error == 0 || SPA_EXITING(spa))
 			break;
 		zio_suspend(spa, NULL, ZIO_SUSPEND_IOERR);
 		zio_resume_wait(spa);
@@ -11421,9 +11509,11 @@ spa_sync(spa_t *spa, uint64_t txg)
 		}
 		if (i == rvd->vdev_children) {
 			spa->spa_deflate = TRUE;
-			VERIFY0(zap_add(spa->spa_meta_objset,
+			int err = zap_add(spa->spa_meta_objset,
 			    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_DEFLATE,
-			    sizeof (uint64_t), 1, &spa->spa_deflate, tx));
+			    sizeof (uint64_t), 1, &spa->spa_deflate, tx);
+			if (!spa_exiting(spa))
+				VERIFY0(err);
 		}
 	}
 
@@ -11434,7 +11524,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 	spa_sync_iterate_to_convergence(spa, tx);
 
 #ifdef ZFS_DEBUG
-	if (!list_is_empty(&spa->spa_config_dirty_list)) {
+	if (!list_is_empty(&spa->spa_config_dirty_list) && !SPA_EXITING(spa)) {
 	/*
 	 * Make sure that the number of ZAPs for all the vdevs matches
 	 * the number of ZAPs in the per-vdev ZAP list. This only gets

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -8149,10 +8149,10 @@ fail:
  * Destroy a storage pool.
  */
 int
-spa_destroy(const char *pool)
+spa_destroy(const char *pool, boolean_t force, boolean_t hardforce)
 {
 	return (spa_export_common(pool, POOL_STATE_DESTROYED, NULL,
-	    B_FALSE, B_FALSE));
+	    force, hardforce));
 }
 
 /*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -337,6 +337,18 @@ static uint_t spa_note_txg_time = 10 * 60;
  */
 static uint_t spa_flush_txg_time = 10 * 60;
 
+#if ZFS_DEBUG
+/*
+ * The load guid of the spa which is forcibly exiting.
+ *
+ * Some functions do not have direct access to the spa_t reference, but they
+ * have spa load guid, e.g. ARC ones. And spa lookup by guid is not acceptable
+ * in many cases as it could be a deadlock waiting for spa_namespace_lock,
+ * while lockless lookup is dangerous.
+ */
+uint64_t spa_exiting_guid = 0;
+#endif
+
 /*
  * ==========================================================================
  * SPA properties routines
@@ -7866,6 +7878,9 @@ spa_initiate_forced_exit(spa_t *spa)
 	if (spa_suspended(spa) && spa->spa_forced_exit_required) {
 		if (!spa->spa_forcibly_exiting) {
 			spa->spa_forcibly_exiting = B_TRUE;
+#if ZFS_DEBUG
+			spa_exiting_guid = spa_load_guid(spa);
+#endif
 			cmn_err(CE_WARN, "Pool '%s' is now forcibly exiting",
 			    spa_name(spa));
 			zfs_dbgmsg("Pool '%s' is now forcibly exiting",
@@ -8129,6 +8144,14 @@ export_spa:
 		spa->spa_is_exporting = B_FALSE;
 		spa->spa_export_thread = NULL;
 	}
+
+#ifdef ZFS_DEBUG
+	/*
+	 * Now another spa can be marked for forced exit and be forcibly
+	 * exiting.
+	 */
+	spa_exiting_guid = 0;
+#endif
 
 	/*
 	 * Wake up any waiters in spa_lookup()

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -345,6 +345,8 @@ spa_checkpoint_discard_thread_sync(void *arg, dmu_tx_t *tx)
 	    (u_longlong_t)words_after);
 
 	if (error != EINTR) {
+		if (SPA_EXITING(vd->vdev_spa))
+			goto skip;
 		if (error != 0) {
 			zfs_panic_recover("zfs: error %lld was returned "
 			    "while incrementally destroying the checkpoint "
@@ -355,12 +357,15 @@ spa_checkpoint_discard_thread_sync(void *arg, dmu_tx_t *tx)
 		ASSERT0(space_map_allocated(vd->vdev_checkpoint_sm));
 		ASSERT0(space_map_length(vd->vdev_checkpoint_sm));
 
+skip:
 		space_map_free(vd->vdev_checkpoint_sm, tx);
 		space_map_close(vd->vdev_checkpoint_sm);
 		vd->vdev_checkpoint_sm = NULL;
 
-		VERIFY0(zap_remove(spa_meta_objset(vd->vdev_spa),
-		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM, tx));
+		error = zap_remove(spa_meta_objset(vd->vdev_spa),
+		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM, tx);
+		if (!SPA_EXITING(vd->vdev_spa))
+			VERIFY0(error);
 	}
 }
 
@@ -391,6 +396,9 @@ spa_checkpoint_discard_thread_check(void *arg, zthr_t *zthr)
 		return (B_FALSE);
 
 	if (spa_has_checkpoint(spa))
+		return (B_FALSE);
+
+	if (SPA_EXITING(spa))
 		return (B_FALSE);
 
 	return (B_TRUE);
@@ -429,15 +437,22 @@ spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 			    checkpoint_sm->sm_dbuf, offset, size,
 			    B_TRUE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
 			if (error != 0) {
+				if (SPA_EXITING(spa))
+					return;
 				zfs_panic_recover("zfs: error %d was returned "
 				    "while prefetching checkpoint space map "
 				    "entries of vdev %llu\n",
 				    error, vd->vdev_id);
 			}
 
-			VERIFY0(dsl_sync_task(spa->spa_name, NULL,
+			error = dsl_sync_task(spa->spa_name, NULL,
 			    spa_checkpoint_discard_thread_sync, vd,
-			    0, ZFS_SPACE_CHECK_NONE));
+			    0, ZFS_SPACE_CHECK_NONE);
+			if (error && SPA_EXITING(spa)) {
+				dmu_buf_rele_array(dbp, numbufs, FTAG);
+				return;
+			}
+			VERIFY0(error);
 
 			dmu_buf_rele_array(dbp, numbufs, FTAG);
 		}
@@ -485,12 +500,16 @@ spa_checkpoint_sync(void *arg, dmu_tx_t *tx)
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	spa_t *spa = dp->dp_spa;
 	uberblock_t checkpoint = spa->spa_ubsync;
+	int err;
 
 	/*
 	 * At this point, there should not be a checkpoint in the MOS.
 	 */
-	ASSERT3U(zap_contains(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_ZPOOL_CHECKPOINT), ==, ENOENT);
+	err = zap_contains(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_ZPOOL_CHECKPOINT);
+	if (!(err == ENOENT) && SPA_EXITING(spa))
+		return;
+	ASSERT3U(err, ==, ENOENT);
 
 	ASSERT0(spa->spa_checkpoint_info.sci_timestamp);
 	ASSERT0(spa->spa_checkpoint_info.sci_dspace);
@@ -516,10 +535,13 @@ spa_checkpoint_sync(void *arg, dmu_tx_t *tx)
 	spa->spa_checkpoint_info.sci_timestamp = checkpoint.ub_timestamp;
 
 	checkpoint.ub_checkpoint_txg = checkpoint.ub_txg;
-	VERIFY0(zap_add(spa->spa_dsl_pool->dp_meta_objset,
+	err = zap_add(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT,
 	    sizeof (uint64_t), sizeof (uberblock_t) / sizeof (uint64_t),
-	    &checkpoint, tx));
+	    &checkpoint, tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	/*
 	 * Increment the feature refcount and thus activate the feature.
@@ -580,6 +602,7 @@ spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 {
 	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	int err = 0;
 
 	if (!spa_feature_is_active(spa, SPA_FEATURE_POOL_CHECKPOINT))
 		return (SET_ERROR(ZFS_ERR_NO_CHECKPOINT));
@@ -587,10 +610,12 @@ spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 	if (spa->spa_checkpoint_txg == 0)
 		return (SET_ERROR(ZFS_ERR_DISCARDING_CHECKPOINT));
 
-	VERIFY0(zap_contains(spa_meta_objset(spa),
-	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT));
+	err = zap_contains(spa_meta_objset(spa),
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
-	return (0);
+	return (err);
 }
 
 static void

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -335,6 +335,8 @@ spa_checkpoint_discard_thread_sync(void *arg, dmu_tx_t *tx)
 	    (u_longlong_t)words_after);
 
 	if (error != EINTR) {
+		if (SPA_EXITING(vd->vdev_spa))
+			goto skip;
 		if (error != 0) {
 			zfs_panic_recover("zfs: error %lld was returned "
 			    "while incrementally destroying the checkpoint "
@@ -345,12 +347,15 @@ spa_checkpoint_discard_thread_sync(void *arg, dmu_tx_t *tx)
 		ASSERT0(space_map_allocated(vd->vdev_checkpoint_sm));
 		ASSERT0(space_map_length(vd->vdev_checkpoint_sm));
 
+skip:
 		space_map_free(vd->vdev_checkpoint_sm, tx);
 		space_map_close(vd->vdev_checkpoint_sm);
 		vd->vdev_checkpoint_sm = NULL;
 
-		VERIFY0(zap_remove(spa_meta_objset(vd->vdev_spa),
-		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM, tx));
+		error = zap_remove(spa_meta_objset(vd->vdev_spa),
+		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM, tx);
+		if (!SPA_EXITING(vd->vdev_spa))
+			VERIFY0(error);
 	}
 }
 
@@ -381,6 +386,9 @@ spa_checkpoint_discard_thread_check(void *arg, zthr_t *zthr)
 		return (B_FALSE);
 
 	if (spa_has_checkpoint(spa))
+		return (B_FALSE);
+
+	if (SPA_EXITING(spa))
 		return (B_FALSE);
 
 	return (B_TRUE);
@@ -419,15 +427,22 @@ spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 			    checkpoint_sm->sm_dbuf, offset, size,
 			    B_TRUE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
 			if (error != 0) {
+				if (SPA_EXITING(spa))
+					return;
 				zfs_panic_recover("zfs: error %d was returned "
 				    "while prefetching checkpoint space map "
 				    "entries of vdev %llu\n",
 				    error, vd->vdev_id);
 			}
 
-			VERIFY0(dsl_sync_task(spa->spa_name, NULL,
+			error = dsl_sync_task(spa->spa_name, NULL,
 			    spa_checkpoint_discard_thread_sync, vd,
-			    0, ZFS_SPACE_CHECK_NONE));
+			    0, ZFS_SPACE_CHECK_NONE);
+			if (error && SPA_EXITING(spa)) {
+				dmu_buf_rele_array(dbp, numbufs, FTAG);
+				return;
+			}
+			VERIFY0(error);
 
 			dmu_buf_rele_array(dbp, numbufs, FTAG);
 		}
@@ -475,12 +490,16 @@ spa_checkpoint_sync(void *arg, dmu_tx_t *tx)
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	spa_t *spa = dp->dp_spa;
 	uberblock_t checkpoint = spa->spa_ubsync;
+	int err;
 
 	/*
 	 * At this point, there should not be a checkpoint in the MOS.
 	 */
-	ASSERT3U(zap_contains(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_ZPOOL_CHECKPOINT), ==, ENOENT);
+	err = zap_contains(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_ZPOOL_CHECKPOINT);
+	if (!(err == ENOENT) && SPA_EXITING(spa))
+		return;
+	ASSERT3U(err, ==, ENOENT);
 
 	ASSERT0(spa->spa_checkpoint_info.sci_timestamp);
 	ASSERT0(spa->spa_checkpoint_info.sci_dspace);
@@ -506,10 +525,13 @@ spa_checkpoint_sync(void *arg, dmu_tx_t *tx)
 	spa->spa_checkpoint_info.sci_timestamp = checkpoint.ub_timestamp;
 
 	checkpoint.ub_checkpoint_txg = checkpoint.ub_txg;
-	VERIFY0(zap_add(spa->spa_dsl_pool->dp_meta_objset,
+	err = zap_add(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT,
 	    sizeof (uint64_t), sizeof (uberblock_t) / sizeof (uint64_t),
-	    &checkpoint, tx));
+	    &checkpoint, tx);
+	if (err && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	/*
 	 * Increment the feature refcount and thus activate the feature.
@@ -570,6 +592,7 @@ spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 {
 	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	int err = 0;
 
 	if (!spa_feature_is_active(spa, SPA_FEATURE_POOL_CHECKPOINT))
 		return (SET_ERROR(ZFS_ERR_NO_CHECKPOINT));
@@ -577,10 +600,12 @@ spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 	if (spa->spa_checkpoint_txg == 0)
 		return (SET_ERROR(ZFS_ERR_DISCARDING_CHECKPOINT));
 
-	VERIFY0(zap_contains(spa_meta_objset(spa),
-	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT));
+	err = zap_contains(spa_meta_objset(spa),
+	    DMU_POOL_DIRECTORY_OBJECT, DMU_POOL_ZPOOL_CHECKPOINT);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
-	return (0);
+	return (err);
 }
 
 static void

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -166,6 +166,9 @@ spa_write_cachefile(spa_t *target, boolean_t removing, boolean_t postsysevent,
 	if (!(spa_mode_global & SPA_MODE_WRITE))
 		return;
 
+	if (spa_exiting(target))
+		return;
+
 	/*
 	 * Iterate over all cachefiles for the pool, past or present.  When the
 	 * cachefile is changed, the new one is pushed onto this list, allowing

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -156,6 +156,9 @@ spa_write_cachefile(spa_t *target, boolean_t removing, boolean_t postsysevent,
 	if (!(spa_mode_global & SPA_MODE_WRITE))
 		return;
 
+	if (spa_exiting(target))
+		return;
+
 	/*
 	 * Iterate over all cachefiles for the pool, past or present.  When the
 	 * cachefile is changed, the new one is pushed onto this list, allowing

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -814,8 +814,8 @@ sync_upgrade_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t *newobj,
 	zbookmark_phys_t zb;
 	uint64_t count;
 
-	*newobj = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-	    DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+	    DMU_OT_NONE, 0, tx, newobj));
 
 	/*
 	 * If we cannnot perform the upgrade we should clear the old on-disk
@@ -899,8 +899,8 @@ sync_upgrade_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t *newobj,
 		    head_ds, &err_obj);
 
 		if (error == ENOENT) {
-			err_obj = zap_create(spa->spa_meta_objset,
-			    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(spa->spa_meta_objset,
+			    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx, &err_obj));
 
 			(void) zap_update_int_key(spa->spa_meta_objset,
 			    *newobj, head_ds, err_obj, tx);
@@ -1175,8 +1175,8 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 
 	/* create log if necessary */
 	if (*obj == 0)
-		*obj = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+		    DMU_OT_NONE, 0, tx, obj));
 
 	/* add errors to the current log */
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG)) {
@@ -1212,8 +1212,9 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			    *obj, head_ds, &err_obj);
 
 			if (error == ENOENT) {
-				err_obj = zap_create(spa->spa_meta_objset,
-				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+				VERIFY0(zap_create(spa->spa_meta_objset,
+				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx,
+				    &err_obj));
 
 				(void) zap_update_int_key(spa->spa_meta_objset,
 				    *obj, head_ds, err_obj, tx);
@@ -1435,8 +1436,8 @@ swap_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t new_head, uint64_t
 	    &new_head_errlog);
 
 	if (error != 0) {
-		new_head_errlog = zap_create(spa->spa_meta_objset,
-		    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(spa->spa_meta_objset,
+		    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx, &new_head_errlog));
 
 		(void) zap_update_int_key(spa->spa_meta_objset, spa_err_obj,
 		    new_head, new_head_errlog, tx);

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -192,7 +192,7 @@ spa_log_error(spa_t *spa, const zbookmark_phys_t *zb, const uint64_t birth)
 	 * If we are trying to import a pool, ignore any errors, as we won't be
 	 * writing to the pool any time soon.
 	 */
-	if (spa_load_state(spa) == SPA_LOAD_TRYIMPORT)
+	if (spa_load_state(spa) == SPA_LOAD_TRYIMPORT || SPA_EXITING(spa))
 		return;
 
 	mutex_enter(&spa->spa_errlist_lock);
@@ -1169,14 +1169,22 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 	spa_error_entry_t *se;
 	char buf[NAME_MAX_LEN];
 	void *cookie;
+	int err;
 
 	if (avl_numnodes(t) == 0)
 		return;
 
+	if (SPA_EXITING(spa))
+		goto done;
+
 	/* create log if necessary */
-	if (*obj == 0)
-		VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-		    DMU_OT_NONE, 0, tx, obj));
+	if (*obj == 0) {
+		err = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+		    DMU_OT_NONE, 0, tx, obj);
+		if (err && SPA_EXITING(spa))
+			goto done;
+		VERIFY0(err);
+	}
 
 	/* add errors to the current log */
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG)) {
@@ -1184,8 +1192,11 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			bookmark_to_name(&se->se_bookmark, buf, sizeof (buf));
 
 			const char *name = se->se_name ? se->se_name : "";
-			(void) zap_update(spa->spa_meta_objset, *obj, buf, 1,
+			err = zap_update(spa->spa_meta_objset, *obj, buf, 1,
 			    strlen(name) + 1, name, tx);
+			if (err && SPA_EXITING(spa))
+				goto done;
+			VERIFY0(err);
 		}
 	} else {
 		for (se = avl_first(t); se != NULL; se = AVL_NEXT(t, se)) {
@@ -1196,7 +1207,7 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			zep.zb_birth = se->se_zep.zb_birth;
 
 			uint64_t head_ds = 0;
-			int error = get_head_ds(spa, se->se_bookmark.zb_objset,
+			err = get_head_ds(spa, se->se_bookmark.zb_objset,
 			    &head_ds);
 
 			/*
@@ -1204,28 +1215,41 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			 * to the filesystem stored in the bookmark of the
 			 * error block.
 			 */
-			if (error != 0)
+			if (err != 0)
 				head_ds = se->se_bookmark.zb_objset;
 
 			uint64_t err_obj;
-			error = zap_lookup_int_key(spa->spa_meta_objset,
+			err = zap_lookup_int_key(spa->spa_meta_objset,
 			    *obj, head_ds, &err_obj);
+			if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+				goto done;
 
-			if (error == ENOENT) {
-				VERIFY0(zap_create(spa->spa_meta_objset,
+			if (err == ENOENT) {
+				err = zap_create(spa->spa_meta_objset,
 				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx,
-				    &err_obj));
+				    &err_obj);
+				if (err && SPA_EXITING(spa))
+					goto done;
+				VERIFY0(err);
 
-				(void) zap_update_int_key(spa->spa_meta_objset,
+				err = zap_update_int_key(spa->spa_meta_objset,
 				    *obj, head_ds, err_obj, tx);
+				if (err && SPA_EXITING(spa))
+					goto done;
+				VERIFY0(err);
 			}
 			errphys_to_name(&zep, buf, sizeof (buf));
 
 			const char *name = se->se_name ? se->se_name : "";
-			(void) zap_update(spa->spa_meta_objset,
+			err = zap_update(spa->spa_meta_objset,
 			    err_obj, buf, 1, strlen(name) + 1, name, tx);
+			if (err && SPA_EXITING(spa))
+				goto done;
+			VERIFY0(err);
 		}
 	}
+
+done:
 	/* purge the error list */
 	cookie = NULL;
 	while ((se = avl_destroy_nodes(t, &cookie)) != NULL)
@@ -1266,6 +1290,9 @@ spa_errlog_sync(spa_t *spa, uint64_t txg)
 	dmu_tx_t *tx;
 	avl_tree_t scrub, last;
 	int scrub_finished;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	mutex_enter(&spa->spa_errlist_lock);
 

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -804,8 +804,8 @@ sync_upgrade_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t *newobj,
 	zbookmark_phys_t zb;
 	uint64_t count;
 
-	*newobj = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-	    DMU_OT_NONE, 0, tx);
+	VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+	    DMU_OT_NONE, 0, tx, newobj));
 
 	/*
 	 * If we cannnot perform the upgrade we should clear the old on-disk
@@ -889,8 +889,8 @@ sync_upgrade_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t *newobj,
 		    head_ds, &err_obj);
 
 		if (error == ENOENT) {
-			err_obj = zap_create(spa->spa_meta_objset,
-			    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+			VERIFY0(zap_create(spa->spa_meta_objset,
+			    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx, &err_obj));
 
 			(void) zap_update_int_key(spa->spa_meta_objset,
 			    *newobj, head_ds, err_obj, tx);
@@ -1165,8 +1165,8 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 
 	/* create log if necessary */
 	if (*obj == 0)
-		*obj = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+		    DMU_OT_NONE, 0, tx, obj));
 
 	/* add errors to the current log */
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG)) {
@@ -1202,8 +1202,9 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			    *obj, head_ds, &err_obj);
 
 			if (error == ENOENT) {
-				err_obj = zap_create(spa->spa_meta_objset,
-				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+				VERIFY0(zap_create(spa->spa_meta_objset,
+				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx,
+				    &err_obj));
 
 				(void) zap_update_int_key(spa->spa_meta_objset,
 				    *obj, head_ds, err_obj, tx);
@@ -1425,8 +1426,8 @@ swap_errlog(spa_t *spa, uint64_t spa_err_obj, uint64_t new_head, uint64_t
 	    &new_head_errlog);
 
 	if (error != 0) {
-		new_head_errlog = zap_create(spa->spa_meta_objset,
-		    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(spa->spa_meta_objset,
+		    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx, &new_head_errlog));
 
 		(void) zap_update_int_key(spa->spa_meta_objset, spa_err_obj,
 		    new_head, new_head_errlog, tx);

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -182,7 +182,7 @@ spa_log_error(spa_t *spa, const zbookmark_phys_t *zb, const uint64_t birth)
 	 * If we are trying to import a pool, ignore any errors, as we won't be
 	 * writing to the pool any time soon.
 	 */
-	if (spa_load_state(spa) == SPA_LOAD_TRYIMPORT)
+	if (spa_load_state(spa) == SPA_LOAD_TRYIMPORT || SPA_EXITING(spa))
 		return;
 
 	mutex_enter(&spa->spa_errlist_lock);
@@ -1159,14 +1159,22 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 	spa_error_entry_t *se;
 	char buf[NAME_MAX_LEN];
 	void *cookie;
+	int err;
 
 	if (avl_numnodes(t) == 0)
 		return;
 
+	if (SPA_EXITING(spa))
+		goto done;
+
 	/* create log if necessary */
-	if (*obj == 0)
-		VERIFY0(zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
-		    DMU_OT_NONE, 0, tx, obj));
+	if (*obj == 0) {
+		err = zap_create(spa->spa_meta_objset, DMU_OT_ERROR_LOG,
+		    DMU_OT_NONE, 0, tx, obj);
+		if (err && SPA_EXITING(spa))
+			goto done;
+		VERIFY0(err);
+	}
 
 	/* add errors to the current log */
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG)) {
@@ -1174,8 +1182,11 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			bookmark_to_name(&se->se_bookmark, buf, sizeof (buf));
 
 			const char *name = se->se_name ? se->se_name : "";
-			(void) zap_update(spa->spa_meta_objset, *obj, buf, 1,
+			err = zap_update(spa->spa_meta_objset, *obj, buf, 1,
 			    strlen(name) + 1, name, tx);
+			if (err && SPA_EXITING(spa))
+				goto done;
+			VERIFY0(err);
 		}
 	} else {
 		for (se = avl_first(t); se != NULL; se = AVL_NEXT(t, se)) {
@@ -1186,7 +1197,7 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			zep.zb_birth = se->se_zep.zb_birth;
 
 			uint64_t head_ds = 0;
-			int error = get_head_ds(spa, se->se_bookmark.zb_objset,
+			err = get_head_ds(spa, se->se_bookmark.zb_objset,
 			    &head_ds);
 
 			/*
@@ -1194,28 +1205,41 @@ sync_error_list(spa_t *spa, avl_tree_t *t, uint64_t *obj, dmu_tx_t *tx)
 			 * to the filesystem stored in the bookmark of the
 			 * error block.
 			 */
-			if (error != 0)
+			if (err != 0)
 				head_ds = se->se_bookmark.zb_objset;
 
 			uint64_t err_obj;
-			error = zap_lookup_int_key(spa->spa_meta_objset,
+			err = zap_lookup_int_key(spa->spa_meta_objset,
 			    *obj, head_ds, &err_obj);
+			if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa))
+				goto done;
 
-			if (error == ENOENT) {
-				VERIFY0(zap_create(spa->spa_meta_objset,
+			if (err == ENOENT) {
+				err = zap_create(spa->spa_meta_objset,
 				    DMU_OT_ERROR_LOG, DMU_OT_NONE, 0, tx,
-				    &err_obj));
+				    &err_obj);
+				if (err && SPA_EXITING(spa))
+					goto done;
+				VERIFY0(err);
 
-				(void) zap_update_int_key(spa->spa_meta_objset,
+				err = zap_update_int_key(spa->spa_meta_objset,
 				    *obj, head_ds, err_obj, tx);
+				if (err && SPA_EXITING(spa))
+					goto done;
+				VERIFY0(err);
 			}
 			errphys_to_name(&zep, buf, sizeof (buf));
 
 			const char *name = se->se_name ? se->se_name : "";
-			(void) zap_update(spa->spa_meta_objset,
+			err = zap_update(spa->spa_meta_objset,
 			    err_obj, buf, 1, strlen(name) + 1, name, tx);
+			if (err && SPA_EXITING(spa))
+				goto done;
+			VERIFY0(err);
 		}
 	}
+
+done:
 	/* purge the error list */
 	cookie = NULL;
 	while ((se = avl_destroy_nodes(t, &cookie)) != NULL)
@@ -1256,6 +1280,9 @@ spa_errlog_sync(spa_t *spa, uint64_t txg)
 	dmu_tx_t *tx;
 	avl_tree_t scrub, last;
 	int scrub_finished;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	mutex_enter(&spa->spa_errlist_lock);
 

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -84,27 +84,41 @@ spa_history_log_to_phys(uint64_t log_off, spa_history_phys_t *shpp)
 	    + shpp->sh_pool_create_len);
 }
 
-void
+int
 spa_history_create_obj(spa_t *spa, dmu_tx_t *tx)
 {
 	dmu_buf_t *dbp;
 	spa_history_phys_t *shpp;
 	objset_t *mos = spa->spa_meta_objset;
+	int err = 0;
 
 	ASSERT0(spa->spa_history);
-	spa->spa_history = dmu_object_alloc(mos, DMU_OT_SPA_HISTORY,
+	err = dmu_object_alloc(mos, DMU_OT_SPA_HISTORY,
 	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_SPA_HISTORY_OFFSETS,
-	    sizeof (spa_history_phys_t), tx);
+	    sizeof (spa_history_phys_t), tx, &spa->spa_history);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_HISTORY, sizeof (uint64_t), 1,
-	    &spa->spa_history, tx));
+	    &spa->spa_history, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
+	err = dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(dbp->db_size, >=, sizeof (spa_history_phys_t));
 
 	shpp = dbp->db_data;
 	dmu_buf_will_dirty(dbp, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	/*
 	 * Figure out maximum size of history log.  We set it at
@@ -115,7 +129,10 @@ spa_history_create_obj(spa_t *spa, dmu_tx_t *tx)
 	shpp->sh_phys_max_off = MIN(shpp->sh_phys_max_off, 1<<30);
 	shpp->sh_phys_max_off = MAX(shpp->sh_phys_max_off, 128<<10);
 
+out:
 	dmu_buf_rele(dbp, FTAG);
+
+	return (err);
 }
 
 /*
@@ -268,8 +285,14 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	 * history object, create it now.
 	 */
 	mutex_enter(&spa->spa_history_lock);
-	if (!spa->spa_history)
-		spa_history_create_obj(spa, tx);
+	if (!spa->spa_history) {
+		ret = spa_history_create_obj(spa, tx);
+		if (ret && SPA_EXITING(spa)) {
+			mutex_exit(&spa->spa_history_lock);
+			return;
+		}
+		VERIFY0(ret);
+	}
 	mutex_exit(&spa->spa_history_lock);
 
 	/*

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -273,7 +273,7 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	nvlist_t	*nvl = arg;
 	spa_t		*spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t	*mos = spa->spa_meta_objset;
-	dmu_buf_t	*dbp;
+	dmu_buf_t	*dbp = NULL;
 	spa_history_phys_t *shpp;
 	size_t		reclen;
 	uint64_t	le_len;
@@ -287,10 +287,8 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	mutex_enter(&spa->spa_history_lock);
 	if (!spa->spa_history) {
 		ret = spa_history_create_obj(spa, tx);
-		if (ret && SPA_EXITING(spa)) {
-			mutex_exit(&spa->spa_history_lock);
-			return;
-		}
+		if (ret && SPA_EXITING(spa))
+			goto spa_exiting;
 		VERIFY0(ret);
 	}
 	mutex_exit(&spa->spa_history_lock);
@@ -299,10 +297,17 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	 * Get the offset of where we need to write via the bonus buffer.
 	 * Update the offset when the write completes.
 	 */
-	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
+	ret = dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp);
+	if (ret && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(ret);
 	shpp = dbp->db_data;
 
 	dmu_buf_will_dirty(dbp, tx);
+	if (SPA_EXITING(spa)) {
+		ret = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 
 #ifdef ZFS_DEBUG
 	{
@@ -374,7 +379,10 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 
 	mutex_exit(&spa->spa_history_lock);
 	fnvlist_pack_free(record_packed, reclen);
-	dmu_buf_rele(dbp, FTAG);
+
+spa_exiting:
+	if (dbp != NULL)
+		dmu_buf_rele(dbp, FTAG);
 	fnvlist_free(nvl);
 }
 

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -263,7 +263,7 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	nvlist_t	*nvl = arg;
 	spa_t		*spa = dmu_tx_pool(tx)->dp_spa;
 	objset_t	*mos = spa->spa_meta_objset;
-	dmu_buf_t	*dbp;
+	dmu_buf_t	*dbp = NULL;
 	spa_history_phys_t *shpp;
 	size_t		reclen;
 	uint64_t	le_len;
@@ -279,7 +279,7 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 		ret = spa_history_create_obj(spa, tx);
 		if (ret && SPA_EXITING(spa)) {
 			mutex_exit(&spa->spa_history_lock);
-			return;
+			goto spa_exiting;
 		}
 		VERIFY0(ret);
 	}
@@ -289,10 +289,17 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	 * Get the offset of where we need to write via the bonus buffer.
 	 * Update the offset when the write completes.
 	 */
-	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
+	ret = dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp);
+	if (ret && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(ret);
 	shpp = dbp->db_data;
 
 	dmu_buf_will_dirty(dbp, tx);
+	if (SPA_EXITING(spa)) {
+		ret = SET_ERROR(EIO);
+		goto spa_exiting;
+	}
 
 #ifdef ZFS_DEBUG
 	{
@@ -364,7 +371,10 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 
 	mutex_exit(&spa->spa_history_lock);
 	fnvlist_pack_free(record_packed, reclen);
-	dmu_buf_rele(dbp, FTAG);
+
+spa_exiting:
+	if (dbp != NULL)
+		dmu_buf_rele(dbp, FTAG);
 	fnvlist_free(nvl);
 }
 

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -74,27 +74,41 @@ spa_history_log_to_phys(uint64_t log_off, spa_history_phys_t *shpp)
 	    + shpp->sh_pool_create_len);
 }
 
-void
+int
 spa_history_create_obj(spa_t *spa, dmu_tx_t *tx)
 {
 	dmu_buf_t *dbp;
 	spa_history_phys_t *shpp;
 	objset_t *mos = spa->spa_meta_objset;
+	int err = 0;
 
 	ASSERT0(spa->spa_history);
-	spa->spa_history = dmu_object_alloc(mos, DMU_OT_SPA_HISTORY,
+	err = dmu_object_alloc(mos, DMU_OT_SPA_HISTORY,
 	    SPA_OLD_MAXBLOCKSIZE, DMU_OT_SPA_HISTORY_OFFSETS,
-	    sizeof (spa_history_phys_t), tx);
+	    sizeof (spa_history_phys_t), tx, &spa->spa_history);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+	err = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_HISTORY, sizeof (uint64_t), 1,
-	    &spa->spa_history, tx));
+	    &spa->spa_history, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
+	err = dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(dbp->db_size, >=, sizeof (spa_history_phys_t));
 
 	shpp = dbp->db_data;
 	dmu_buf_will_dirty(dbp, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 
 	/*
 	 * Figure out maximum size of history log.  We set it at
@@ -105,7 +119,10 @@ spa_history_create_obj(spa_t *spa, dmu_tx_t *tx)
 	shpp->sh_phys_max_off = MIN(shpp->sh_phys_max_off, 1<<30);
 	shpp->sh_phys_max_off = MAX(shpp->sh_phys_max_off, 128<<10);
 
+out:
 	dmu_buf_rele(dbp, FTAG);
+
+	return (err);
 }
 
 /*
@@ -258,8 +275,14 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	 * history object, create it now.
 	 */
 	mutex_enter(&spa->spa_history_lock);
-	if (!spa->spa_history)
-		spa_history_create_obj(spa, tx);
+	if (!spa->spa_history) {
+		ret = spa_history_create_obj(spa, tx);
+		if (ret && SPA_EXITING(spa)) {
+			mutex_exit(&spa->spa_history_lock);
+			return;
+		}
+		VERIFY0(ret);
+	}
 	mutex_exit(&spa->spa_history_lock);
 
 	/*

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1106,7 +1106,8 @@ spa_cleanup_old_sm_logs(spa_t *spa, dmu_tx_t *tx)
 		ASSERT(avl_is_empty(&spa->spa_sm_logs_by_txg));
 		return;
 	}
-	VERIFY0(error);
+	if (!SPA_EXITING(spa))
+		VERIFY0(error);
 
 	metaslab_t *oldest = avl_first(&spa->spa_metaslabs_by_flushed);
 	uint64_t oldest_flushed_txg = metaslab_unflushed_txg(oldest);
@@ -1118,7 +1119,9 @@ spa_cleanup_old_sm_logs(spa_t *spa, dmu_tx_t *tx)
 		ASSERT0(sls->sls_mscount);
 		avl_remove(&spa->spa_sm_logs_by_txg, sls);
 		space_map_free_obj(mos, sls->sls_sm_obj, tx);
-		VERIFY0(zap_remove_int(mos, spacemap_zap, sls->sls_txg, tx));
+		error = zap_remove_int(mos, spacemap_zap, sls->sls_txg, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		spa_log_summary_decrement_blkcount(spa, sls->sls_nblocks);
 		spa->spa_unflushed_stats.sus_nblocks -= sls->sls_nblocks;
 		kmem_free(sls, sizeof (spa_log_sm_t));
@@ -1134,39 +1137,54 @@ spa_log_sm_alloc(uint64_t sm_obj, uint64_t txg)
 	return (sls);
 }
 
-void
+int
 spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 {
 	uint64_t txg = dmu_tx_get_txg(tx);
 	objset_t *mos = spa_meta_objset(spa);
+	int error = 0;
 
 	if (spa_syncing_log_sm(spa) != NULL)
-		return;
+		return (0);
 
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_LOG_SPACEMAP))
-		return;
+		return (0);
 
 	uint64_t spacemap_zap;
-	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
+	error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_LOG_SPACEMAP_ZAP, sizeof (spacemap_zap), 1, &spacemap_zap);
 	if (error == ENOENT) {
 		ASSERT(avl_is_empty(&spa->spa_sm_logs_by_txg));
 
-		error = 0;
-		spacemap_zap = zap_create(mos,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+		error = zap_create(mos,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx, &spacemap_zap);
+		if (error && SPA_EXITING(spa))
+			return (error);
+		VERIFY0(error);
+		error = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_LOG_SPACEMAP_ZAP, sizeof (spacemap_zap), 1,
-		    &spacemap_zap, tx));
+		    &spacemap_zap, tx);
+		if (error && SPA_EXITING(spa))
+			return (error);
 		spa_feature_incr(spa, SPA_FEATURE_LOG_SPACEMAP, tx);
 	}
+	if (error && SPA_EXITING(spa))
+		return (error);
 	VERIFY0(error);
 
 	uint64_t sm_obj;
-	ASSERT3U(zap_lookup_int_key(mos, spacemap_zap, txg, &sm_obj),
-	    ==, ENOENT);
-	sm_obj = space_map_alloc(mos, zfs_log_sm_blksz, tx);
-	VERIFY0(zap_add_int_key(mos, spacemap_zap, txg, sm_obj, tx));
+	error = zap_lookup_int_key(mos, spacemap_zap, txg, &sm_obj);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	ASSERT3U(error, ==, ENOENT);
+	error = space_map_alloc(mos, zfs_log_sm_blksz, tx, &sm_obj);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
+	error = zap_add_int_key(mos, spacemap_zap, txg, sm_obj, tx);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 	avl_add(&spa->spa_sm_logs_by_txg, spa_log_sm_alloc(sm_obj, txg));
 
 	/*
@@ -1176,10 +1194,15 @@ spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 	 * to being more restrictive (given that we're already going
 	 * to be using 2-word entries).
 	 */
-	VERIFY0(space_map_open(&spa->spa_syncing_log_sm, mos, sm_obj,
-	    0, UINT64_MAX, SPA_MINBLOCKSHIFT));
+	error = space_map_open(&spa->spa_syncing_log_sm, mos, sm_obj,
+	    0, UINT64_MAX, SPA_MINBLOCKSHIFT);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 
 	spa_log_sm_set_blocklimit(spa);
+
+	return (error);
 }
 
 /*

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -893,6 +893,9 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 	if (!spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP))
 		return;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	/*
 	 * If we don't have any metaslabs with unflushed changes
 	 * return immediately.
@@ -1074,10 +1077,12 @@ spa_sync_close_syncing_log_sm(spa_t *spa)
 	 * in spa_metaslabs_by_flushed is loading and we were
 	 * not able to flush any metaslabs the current TXG.
 	 */
-	ASSERT(sls->sls_nblocks != 0);
+	if (!SPA_EXITING(spa)) {
+		ASSERT(sls->sls_nblocks != 0);
 
-	spa_log_summary_add_incoming_blocks(spa, sls->sls_nblocks);
-	spa_log_summary_verify_counts(spa);
+		spa_log_summary_add_incoming_blocks(spa, sls->sls_nblocks);
+		spa_log_summary_verify_counts(spa);
+	}
 
 	space_map_close(spa->spa_syncing_log_sm);
 	spa->spa_syncing_log_sm = NULL;

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -883,6 +883,9 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 	if (!spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP))
 		return;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	/*
 	 * If we don't have any metaslabs with unflushed changes
 	 * return immediately.
@@ -1064,10 +1067,12 @@ spa_sync_close_syncing_log_sm(spa_t *spa)
 	 * in spa_metaslabs_by_flushed is loading and we were
 	 * not able to flush any metaslabs the current TXG.
 	 */
-	ASSERT(sls->sls_nblocks != 0);
+	if (!SPA_EXITING(spa)) {
+		ASSERT(sls->sls_nblocks != 0);
 
-	spa_log_summary_add_incoming_blocks(spa, sls->sls_nblocks);
-	spa_log_summary_verify_counts(spa);
+		spa_log_summary_add_incoming_blocks(spa, sls->sls_nblocks);
+		spa_log_summary_verify_counts(spa);
+	}
 
 	space_map_close(spa->spa_syncing_log_sm);
 	spa->spa_syncing_log_sm = NULL;

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1096,7 +1096,8 @@ spa_cleanup_old_sm_logs(spa_t *spa, dmu_tx_t *tx)
 		ASSERT(avl_is_empty(&spa->spa_sm_logs_by_txg));
 		return;
 	}
-	VERIFY0(error);
+	if (!SPA_EXITING(spa))
+		VERIFY0(error);
 
 	metaslab_t *oldest = avl_first(&spa->spa_metaslabs_by_flushed);
 	uint64_t oldest_flushed_txg = metaslab_unflushed_txg(oldest);
@@ -1108,7 +1109,9 @@ spa_cleanup_old_sm_logs(spa_t *spa, dmu_tx_t *tx)
 		ASSERT0(sls->sls_mscount);
 		avl_remove(&spa->spa_sm_logs_by_txg, sls);
 		space_map_free_obj(mos, sls->sls_sm_obj, tx);
-		VERIFY0(zap_remove_int(mos, spacemap_zap, sls->sls_txg, tx));
+		error = zap_remove_int(mos, spacemap_zap, sls->sls_txg, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(error);
 		spa_log_summary_decrement_blkcount(spa, sls->sls_nblocks);
 		spa->spa_unflushed_stats.sus_nblocks -= sls->sls_nblocks;
 		kmem_free(sls, sizeof (spa_log_sm_t));
@@ -1124,39 +1127,54 @@ spa_log_sm_alloc(uint64_t sm_obj, uint64_t txg)
 	return (sls);
 }
 
-void
+int
 spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 {
 	uint64_t txg = dmu_tx_get_txg(tx);
 	objset_t *mos = spa_meta_objset(spa);
+	int error = 0;
 
 	if (spa_syncing_log_sm(spa) != NULL)
-		return;
+		return (0);
 
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_LOG_SPACEMAP))
-		return;
+		return (0);
 
 	uint64_t spacemap_zap;
-	int error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
+	error = zap_lookup(mos, DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_LOG_SPACEMAP_ZAP, sizeof (spacemap_zap), 1, &spacemap_zap);
 	if (error == ENOENT) {
 		ASSERT(avl_is_empty(&spa->spa_sm_logs_by_txg));
 
-		error = 0;
-		spacemap_zap = zap_create(mos,
-		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx);
-		VERIFY0(zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
+		error = zap_create(mos,
+		    DMU_OTN_ZAP_METADATA, DMU_OT_NONE, 0, tx, &spacemap_zap);
+		if (error && SPA_EXITING(spa))
+			return (error);
+		VERIFY0(error);
+		error = zap_add(mos, DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_LOG_SPACEMAP_ZAP, sizeof (spacemap_zap), 1,
-		    &spacemap_zap, tx));
+		    &spacemap_zap, tx);
+		if (error && SPA_EXITING(spa))
+			return (error);
 		spa_feature_incr(spa, SPA_FEATURE_LOG_SPACEMAP, tx);
 	}
+	if (error && SPA_EXITING(spa))
+		return (error);
 	VERIFY0(error);
 
 	uint64_t sm_obj;
-	ASSERT3U(zap_lookup_int_key(mos, spacemap_zap, txg, &sm_obj),
-	    ==, ENOENT);
-	sm_obj = space_map_alloc(mos, zfs_log_sm_blksz, tx);
-	VERIFY0(zap_add_int_key(mos, spacemap_zap, txg, sm_obj, tx));
+	error = zap_lookup_int_key(mos, spacemap_zap, txg, &sm_obj);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	ASSERT3U(error, ==, ENOENT);
+	error = space_map_alloc(mos, zfs_log_sm_blksz, tx, &sm_obj);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
+	error = zap_add_int_key(mos, spacemap_zap, txg, sm_obj, tx);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 	avl_add(&spa->spa_sm_logs_by_txg, spa_log_sm_alloc(sm_obj, txg));
 
 	/*
@@ -1166,10 +1184,15 @@ spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 	 * to being more restrictive (given that we're already going
 	 * to be using 2-word entries).
 	 */
-	VERIFY0(space_map_open(&spa->spa_syncing_log_sm, mos, sm_obj,
-	    0, UINT64_MAX, SPA_MINBLOCKSHIFT));
+	error = space_map_open(&spa->spa_syncing_log_sm, mos, sm_obj,
+	    0, UINT64_MAX, SPA_MINBLOCKSHIFT);
+	if (error && SPA_EXITING(spa))
+		return (error);
+	VERIFY0(error);
 
 	spa_log_sm_set_blocklimit(spa);
+
+	return (error);
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -662,18 +662,21 @@ spa_namespace_broadcast(void)
 }
 
 /*
- * Lookup the named spa_t in the AVL tree.  The spa_namespace_lock must be held.
+ * Lookup the named spa_t in the AVL tree.  The spa_namespace_lock must be held
+ * or locked must be set to B_FALSE.
  * Returns NULL if no matching spa_t is found.
  */
-spa_t *
-spa_lookup(const char *name)
+static spa_t *
+spa_lookup_impl(const char *name, boolean_t locked)
 {
 	static spa_t search;	/* spa_t is large; don't allocate on stack */
 	spa_t *spa;
 	avl_index_t where;
 	char *cp;
 
-	ASSERT(spa_namespace_held());
+	if (locked) {
+		ASSERT(spa_namespace_held());
+	}
 
 retry:
 	(void) strlcpy(search.spa_name, name, sizeof (search.spa_name));
@@ -690,19 +693,33 @@ retry:
 	if (spa == NULL)
 		return (NULL);
 
-	/*
-	 * Avoid racing with import/export, which don't hold the namespace
-	 * lock for their entire duration.
-	 */
-	if ((spa->spa_load_thread != NULL &&
-	    spa->spa_load_thread != curthread) ||
-	    (spa->spa_export_thread != NULL &&
-	    spa->spa_export_thread != curthread)) {
-		spa_namespace_wait();
-		goto retry;
+	if (locked) {
+		/*
+		 * Avoid racing with import/export, which don't hold the
+		 * namespace lock for their entire duration.
+		 */
+		if ((spa->spa_load_thread != NULL &&
+		    spa->spa_load_thread != curthread) ||
+		    (spa->spa_export_thread != NULL &&
+		    spa->spa_export_thread != curthread)) {
+			spa_namespace_wait();
+			goto retry;
+		}
 	}
 
 	return (spa);
+}
+
+spa_t *
+spa_lookup(const char *name)
+{
+	return (spa_lookup_impl(name, B_TRUE));
+}
+
+spa_t *
+spa_lookup_lockless(const char *name)
+{
+	return (spa_lookup_impl(name, B_FALSE));
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2079,6 +2079,12 @@ spa_suspended(spa_t *spa)
 	return (spa->spa_suspended != ZIO_SUSPEND_NONE);
 }
 
+boolean_t
+spa_exiting(spa_t *spa)
+{
+	return (spa->spa_forcibly_exiting == B_TRUE);
+}
+
 uint64_t
 spa_version(spa_t *spa)
 {

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2069,6 +2069,12 @@ spa_suspended(spa_t *spa)
 	return (spa->spa_suspended != ZIO_SUSPEND_NONE);
 }
 
+boolean_t
+spa_exiting(spa_t *spa)
+{
+	return (spa->spa_forcibly_exiting == B_TRUE);
+}
+
 uint64_t
 spa_version(spa_t *spa)
 {

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -652,18 +652,21 @@ spa_namespace_broadcast(void)
 }
 
 /*
- * Lookup the named spa_t in the AVL tree.  The spa_namespace_lock must be held.
+ * Lookup the named spa_t in the AVL tree.  The spa_namespace_lock must be held
+ * or locked must be set to B_FALSE.
  * Returns NULL if no matching spa_t is found.
  */
-spa_t *
-spa_lookup(const char *name)
+static spa_t *
+spa_lookup_impl(const char *name, boolean_t locked)
 {
 	static spa_t search;	/* spa_t is large; don't allocate on stack */
 	spa_t *spa;
 	avl_index_t where;
 	char *cp;
 
-	ASSERT(spa_namespace_held());
+	if (locked) {
+		ASSERT(spa_namespace_held());
+	}
 
 retry:
 	(void) strlcpy(search.spa_name, name, sizeof (search.spa_name));
@@ -680,19 +683,33 @@ retry:
 	if (spa == NULL)
 		return (NULL);
 
-	/*
-	 * Avoid racing with import/export, which don't hold the namespace
-	 * lock for their entire duration.
-	 */
-	if ((spa->spa_load_thread != NULL &&
-	    spa->spa_load_thread != curthread) ||
-	    (spa->spa_export_thread != NULL &&
-	    spa->spa_export_thread != curthread)) {
-		spa_namespace_wait();
-		goto retry;
+	if (locked) {
+		/*
+		 * Avoid racing with import/export, which don't hold the
+		 * namespace lock for their entire duration.
+		 */
+		if ((spa->spa_load_thread != NULL &&
+		    spa->spa_load_thread != curthread) ||
+		    (spa->spa_export_thread != NULL &&
+		    spa->spa_export_thread != curthread)) {
+			spa_namespace_wait();
+			goto retry;
+		}
 	}
 
 	return (spa);
+}
+
+spa_t *
+spa_lookup(const char *name)
+{
+	return (spa_lookup_impl(name, B_TRUE));
+}
+
+spa_t *
+spa_lookup_lockless(const char *name)
+{
+	return (spa_lookup_impl(name, B_FALSE));
 }
 
 /*

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -861,6 +861,7 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 	objset_t *os = sm->sm_os;
 	spa_t *spa = dmu_objset_spa(os);
 	dmu_object_info_t doi;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(os)));
 	ASSERT(dmu_tx_is_syncing(tx));
@@ -890,10 +891,19 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 		space_map_free(sm, tx);
 		dmu_buf_rele(sm->sm_dbuf, sm);
 
-		sm->sm_object = space_map_alloc(sm->sm_os, blocksize, tx);
-		VERIFY0(space_map_open_impl(sm));
+		err = space_map_alloc(sm->sm_os, blocksize, tx, &sm->sm_object);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
+		err = space_map_open_impl(sm);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	} else {
-		VERIFY0(dmu_free_range(os, space_map_object(sm), 0, -1ULL, tx));
+		err = dmu_free_range(os, space_map_object(sm), 0, -1ULL, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 
 		/*
 		 * If the spacemap is reallocated, its histogram
@@ -909,11 +919,10 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 	sm->sm_phys->smp_alloc = 0;
 }
 
-uint64_t
-space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = dmu_objset_spa(os);
-	uint64_t object;
 	int bonuslen;
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
@@ -924,10 +933,8 @@ space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
 		bonuslen = SPACE_MAP_SIZE_V0;
 	}
 
-	object = dmu_object_alloc_ibs(os, DMU_OT_SPACE_MAP, blocksize,
-	    space_map_ibs, DMU_OT_SPACE_MAP_HEADER, bonuslen, tx);
-
-	return (object);
+	return (dmu_object_alloc_ibs(os, DMU_OT_SPACE_MAP, blocksize,
+	    space_map_ibs, DMU_OT_SPACE_MAP_HEADER, bonuslen, tx, objectp));
 }
 
 void

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -30,6 +30,7 @@
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dnode.h>
 #include <sys/dsl_pool.h>
@@ -401,6 +402,8 @@ static int
 space_map_load_callback(space_map_entry_t *sme, void *arg)
 {
 	space_map_load_arg_t *smla = arg;
+	if (SPA_EXITING(smla->smla_sm->sm_os->os_spa))
+		return (SET_ERROR(EIO));
 	if (sme->sme_type == smla->smla_type) {
 		VERIFY3U(zfs_range_tree_space(smla->smla_rt) + sme->sme_run, <=,
 		    smla->smla_sm->sm_size);
@@ -595,10 +598,17 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			dmu_buf_rele(db, tag);
 
 			uint64_t next_word_offset = sm->sm_phys->smp_length;
-			VERIFY0(dmu_buf_hold(sm->sm_os,
+			int err = dmu_buf_hold(sm->sm_os,
 			    space_map_object(sm), next_word_offset,
-			    tag, &db, DMU_READ_PREFETCH));
+			    tag, &db, DMU_READ_PREFETCH);
+			if (SPA_EXITING(sm->sm_os->os_spa))
+				return;
+			VERIFY0(err);
 			dmu_buf_will_dirty(db, tx);
+			if (SPA_EXITING(sm->sm_os->os_spa)) {
+				dmu_buf_rele(db, tag);
+				return;
+			}
 
 			/* update caller's dbuf */
 			*dbp = db;
@@ -674,8 +684,11 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 {
 	spa_t *spa = tx->tx_pool->dp_spa;
 	dmu_buf_t *db;
+	int err;
 
 	space_map_write_intro_debug(sm, maptype, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 #ifdef ZFS_DEBUG
 	/*
@@ -694,11 +707,18 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	 * start appending to it.
 	 */
 	uint64_t next_word_offset = sm->sm_phys->smp_length;
-	VERIFY0(dmu_buf_hold(sm->sm_os, space_map_object(sm),
-	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH));
+	err = dmu_buf_hold(sm->sm_os, space_map_object(sm),
+	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		dmu_buf_rele(db, FTAG);
+		return;
+	}
 
 	zfs_btree_t *t = &rt->rt_root;
 	zfs_btree_index_t where;
@@ -735,6 +755,10 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 		space_map_write_seg(sm, zfs_rs_get_start(rs, rt),
 		    zfs_rs_get_end(rs, rt), maptype, vdev_id, words, &db,
 		    FTAG, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(db, FTAG);
+			return;
+		}
 	}
 
 	dmu_buf_rele(db, FTAG);
@@ -762,7 +786,11 @@ space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(sm->sm_os)));
 	VERIFY3U(space_map_object(sm), !=, 0);
 
+	spa_t *spa = sm->sm_os->os_spa;
+
 	dmu_buf_will_dirty(sm->sm_dbuf, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * This field is no longer necessary since the in-core space map
@@ -785,6 +813,8 @@ space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	uint64_t rt_space = zfs_range_tree_space(rt);
 
 	space_map_write_impl(sm, rt, maptype, vdev_id, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Ensure that the space_map's accounting wasn't changed
@@ -940,18 +970,26 @@ space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 void
 space_map_free_obj(objset_t *os, uint64_t smobj, dmu_tx_t *tx)
 {
+	int err;
+
 	spa_t *spa = dmu_objset_spa(os);
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
 		dmu_object_info_t doi;
 
-		VERIFY0(dmu_object_info(os, smobj, &doi));
+		err = dmu_object_info(os, smobj, &doi);
+		if (SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		if (doi.doi_bonus_size != SPACE_MAP_SIZE_V0) {
 			spa_feature_decr(spa,
 			    SPA_FEATURE_SPACEMAP_HISTOGRAM, tx);
 		}
 	}
 
-	VERIFY0(dmu_object_free(os, smobj, tx));
+	err = dmu_object_free(os, smobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 }
 
 void

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -851,6 +851,7 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 	objset_t *os = sm->sm_os;
 	spa_t *spa = dmu_objset_spa(os);
 	dmu_object_info_t doi;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(os)));
 	ASSERT(dmu_tx_is_syncing(tx));
@@ -880,10 +881,19 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 		space_map_free(sm, tx);
 		dmu_buf_rele(sm->sm_dbuf, sm);
 
-		sm->sm_object = space_map_alloc(sm->sm_os, blocksize, tx);
-		VERIFY0(space_map_open_impl(sm));
+		err = space_map_alloc(sm->sm_os, blocksize, tx, &sm->sm_object);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
+		err = space_map_open_impl(sm);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 	} else {
-		VERIFY0(dmu_free_range(os, space_map_object(sm), 0, -1ULL, tx));
+		err = dmu_free_range(os, space_map_object(sm), 0, -1ULL, tx);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 
 		/*
 		 * If the spacemap is reallocated, its histogram
@@ -899,11 +909,10 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 	sm->sm_phys->smp_alloc = 0;
 }
 
-uint64_t
-space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
+int
+space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = dmu_objset_spa(os);
-	uint64_t object;
 	int bonuslen;
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
@@ -914,10 +923,8 @@ space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx)
 		bonuslen = SPACE_MAP_SIZE_V0;
 	}
 
-	object = dmu_object_alloc_ibs(os, DMU_OT_SPACE_MAP, blocksize,
-	    space_map_ibs, DMU_OT_SPACE_MAP_HEADER, bonuslen, tx);
-
-	return (object);
+	return (dmu_object_alloc_ibs(os, DMU_OT_SPACE_MAP, blocksize,
+	    space_map_ibs, DMU_OT_SPACE_MAP_HEADER, bonuslen, tx, objectp));
 }
 
 void

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -20,6 +20,7 @@
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dnode.h>
 #include <sys/dsl_pool.h>
@@ -391,6 +392,8 @@ static int
 space_map_load_callback(space_map_entry_t *sme, void *arg)
 {
 	space_map_load_arg_t *smla = arg;
+	if (SPA_EXITING(smla->smla_sm->sm_os->os_spa))
+		return (SET_ERROR(EIO));
 	if (sme->sme_type == smla->smla_type) {
 		VERIFY3U(zfs_range_tree_space(smla->smla_rt) + sme->sme_run, <=,
 		    smla->smla_sm->sm_size);
@@ -585,10 +588,17 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			dmu_buf_rele(db, tag);
 
 			uint64_t next_word_offset = sm->sm_phys->smp_length;
-			VERIFY0(dmu_buf_hold(sm->sm_os,
+			int err = dmu_buf_hold(sm->sm_os,
 			    space_map_object(sm), next_word_offset,
-			    tag, &db, DMU_READ_PREFETCH));
+			    tag, &db, DMU_READ_PREFETCH);
+			if (SPA_EXITING(sm->sm_os->os_spa))
+				return;
+			VERIFY0(err);
 			dmu_buf_will_dirty(db, tx);
+			if (SPA_EXITING(sm->sm_os->os_spa)) {
+				dmu_buf_rele(db, tag);
+				return;
+			}
 
 			/* update caller's dbuf */
 			*dbp = db;
@@ -664,8 +674,11 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 {
 	spa_t *spa = tx->tx_pool->dp_spa;
 	dmu_buf_t *db;
+	int err;
 
 	space_map_write_intro_debug(sm, maptype, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 #ifdef ZFS_DEBUG
 	/*
@@ -684,11 +697,18 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	 * start appending to it.
 	 */
 	uint64_t next_word_offset = sm->sm_phys->smp_length;
-	VERIFY0(dmu_buf_hold(sm->sm_os, space_map_object(sm),
-	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH));
+	err = dmu_buf_hold(sm->sm_os, space_map_object(sm),
+	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		dmu_buf_rele(db, FTAG);
+		return;
+	}
 
 	zfs_btree_t *t = &rt->rt_root;
 	zfs_btree_index_t where;
@@ -725,6 +745,10 @@ space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 		space_map_write_seg(sm, zfs_rs_get_start(rs, rt),
 		    zfs_rs_get_end(rs, rt), maptype, vdev_id, words, &db,
 		    FTAG, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(db, FTAG);
+			return;
+		}
 	}
 
 	dmu_buf_rele(db, FTAG);
@@ -752,7 +776,11 @@ space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(sm->sm_os)));
 	VERIFY3U(space_map_object(sm), !=, 0);
 
+	spa_t *spa = sm->sm_os->os_spa;
+
 	dmu_buf_will_dirty(sm->sm_dbuf, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * This field is no longer necessary since the in-core space map
@@ -775,6 +803,8 @@ space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
 	uint64_t rt_space = zfs_range_tree_space(rt);
 
 	space_map_write_impl(sm, rt, maptype, vdev_id, tx);
+	if (SPA_EXITING(spa))
+		return;
 
 	/*
 	 * Ensure that the space_map's accounting wasn't changed
@@ -930,18 +960,26 @@ space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx, uint64_t *objectp)
 void
 space_map_free_obj(objset_t *os, uint64_t smobj, dmu_tx_t *tx)
 {
+	int err;
+
 	spa_t *spa = dmu_objset_spa(os);
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
 		dmu_object_info_t doi;
 
-		VERIFY0(dmu_object_info(os, smobj, &doi));
+		err = dmu_object_info(os, smobj, &doi);
+		if (SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
 		if (doi.doi_bonus_size != SPACE_MAP_SIZE_V0) {
 			spa_feature_decr(spa,
 			    SPA_FEATURE_SPACEMAP_HISTOGRAM, tx);
 		}
 	}
 
-	VERIFY0(dmu_object_free(os, smobj, tx));
+	err = dmu_object_free(os, smobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 }
 
 void

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -559,7 +559,7 @@ txg_sync_thread(void *arg)
 		 * harder to detect if another host is changing it when
 		 * resuming after a MMP suspend.
 		 */
-		if (spa_suspended(spa))
+		if (spa_suspended(spa) && !SPA_EXITING(spa))
 			continue;
 
 		/*
@@ -751,6 +751,10 @@ txg_wait_synced_flags(dsl_pool_t *dp, uint64_t txg, txg_wait_flag_t flags)
 				error = SET_ERROR(EINTR);
 				break;
 			}
+		} else if (flags & TXG_WAIT_SUSPEND) {
+			(void) cv_timedwait_io(&tx->tx_sync_done_cv,
+			    &tx->tx_sync_lock, ddi_get_lbolt() +
+			    SEC_TO_TICK(2 * zfs_txg_timeout));
 		} else {
 			/* Uninterruptable wait, until the condvar fires */
 			cv_wait_io(&tx->tx_sync_done_cv, &tx->tx_sync_lock);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -531,6 +531,8 @@ txg_sync_thread(void *arg)
 	start = delta = 0;
 	for (;;) {
 		clock_t timeout = zfs_txg_timeout * hz;
+		if (SPA_EXITING(spa))
+			timeout = 1 * hz;
 		clock_t timer;
 		uint64_t txg;
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -549,7 +549,7 @@ txg_sync_thread(void *arg)
 		 * harder to detect if another host is changing it when
 		 * resuming after a MMP suspend.
 		 */
-		if (spa_suspended(spa))
+		if (spa_suspended(spa) && !SPA_EXITING(spa))
 			continue;
 
 		/*
@@ -741,6 +741,10 @@ txg_wait_synced_flags(dsl_pool_t *dp, uint64_t txg, txg_wait_flag_t flags)
 				error = SET_ERROR(EINTR);
 				break;
 			}
+		} else if (flags & TXG_WAIT_SUSPEND) {
+			(void) cv_timedwait_io(&tx->tx_sync_done_cv,
+			    &tx->tx_sync_lock, ddi_get_lbolt() +
+			    SEC_TO_TICK(2 * zfs_txg_timeout));
 		} else {
 			/* Uninterruptable wait, until the condvar fires */
 			cv_wait_io(&tx->tx_sync_done_cv, &tx->tx_sync_lock);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -521,6 +521,8 @@ txg_sync_thread(void *arg)
 	start = delta = 0;
 	for (;;) {
 		clock_t timeout = zfs_txg_timeout * hz;
+		if (SPA_EXITING(spa))
+			timeout = 1 * hz;
 		clock_t timer;
 		uint64_t txg;
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3596,13 +3596,14 @@ vdev_dtl_load(vdev_t *vd)
 	return (error);
 }
 
-static void
+static int
 vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
 	const char *string;
+	int err = 0;
 
 	ASSERT(alloc_bias != VDEV_BIAS_NONE);
 
@@ -3612,12 +3613,17 @@ vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
 	    (alloc_bias == VDEV_BIAS_DEDUP) ? VDEV_ALLOC_BIAS_DEDUP : NULL;
 
 	ASSERT(string != NULL);
-	VERIFY0(zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
-	    1, strlen(string) + 1, string, tx));
+	err = zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
+	    1, strlen(string) + 1, string, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (alloc_bias == VDEV_BIAS_SPECIAL || alloc_bias == VDEV_BIAS_DEDUP) {
 		spa_activate_allocation_classes(spa, tx);
 	}
+
+	return (err);
 }
 
 void
@@ -3630,46 +3636,73 @@ vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 	    zapobj, tx));
 }
 
-uint64_t
-vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx)
+int
+vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = vd->vdev_spa;
-	uint64_t zap = zap_create(spa->spa_meta_objset, DMU_OTN_ZAP_METADATA,
-	    DMU_OT_NONE, 0, tx);
+	int err = zap_create(spa->spa_meta_objset, DMU_OTN_ZAP_METADATA,
+	    DMU_OT_NONE, 0, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	ASSERT(zap != 0);
-	VERIFY0(zap_add_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
-	    zap, tx));
+	ASSERT(*objectp != 0);
+	err = zap_add_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
+	    *objectp, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	return (zap);
+	return (err);
 }
 
-void
+int
 vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 {
+	spa_t *spa = vd->vdev_spa;
+	int err = 0;
+
 	if (vd->vdev_ops != &vdev_hole_ops &&
 	    vd->vdev_ops != &vdev_missing_ops &&
 	    vd->vdev_ops != &vdev_root_ops &&
 	    !vd->vdev_top->vdev_removing) {
 		if (vd->vdev_ops->vdev_op_leaf && vd->vdev_leaf_zap == 0) {
-			vd->vdev_leaf_zap = vdev_create_link_zap(vd, tx);
+			err = vdev_create_link_zap(vd, tx, &vd->vdev_leaf_zap);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
 		}
 		if (vd == vd->vdev_top && vd->vdev_top_zap == 0) {
-			vd->vdev_top_zap = vdev_create_link_zap(vd, tx);
-			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE)
-				vdev_zap_allocation_data(vd, tx);
+			err = vdev_create_link_zap(vd, tx, &vd->vdev_top_zap);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
+			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
+				err = vdev_zap_allocation_data(vd, tx);
+				if (err && SPA_EXITING(spa))
+					return (err);
+				VERIFY0(err);
+			}
 		}
 	}
 	if (vd->vdev_ops == &vdev_root_ops && vd->vdev_root_zap == 0 &&
 	    spa_feature_is_enabled(vd->vdev_spa, SPA_FEATURE_AVZ_V2)) {
 		if (!spa_feature_is_active(vd->vdev_spa, SPA_FEATURE_AVZ_V2))
 			spa_feature_incr(vd->vdev_spa, SPA_FEATURE_AVZ_V2, tx);
-		vd->vdev_root_zap = vdev_create_link_zap(vd, tx);
+		err = vdev_create_link_zap(vd, tx, &vd->vdev_root_zap);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 
 	for (uint64_t i = 0; i < vd->vdev_children; i++) {
-		vdev_construct_zaps(vd->vdev_child[i], tx);
+		err = vdev_construct_zaps(vd->vdev_child[i], tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
+
+	return (err);
 }
 
 static void
@@ -3681,6 +3714,7 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 	zfs_range_tree_t *rtsync;
 	dmu_tx_t *tx;
 	uint64_t object = space_map_object(vd->vdev_dtl_sm);
+	int err = 0;
 
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
@@ -3712,11 +3746,18 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 	if (vd->vdev_dtl_sm == NULL) {
 		uint64_t new_object;
 
-		new_object = space_map_alloc(mos, zfs_vdev_dtl_sm_blksz, tx);
+		err = space_map_alloc(mos, zfs_vdev_dtl_sm_blksz, tx,
+		    &new_object);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
-		VERIFY0(space_map_open(&vd->vdev_dtl_sm, mos, new_object,
-		    0, -1ULL, 0));
+		err = space_map_open(&vd->vdev_dtl_sm, mos, new_object,
+		    0, -1ULL, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT(vd->vdev_dtl_sm != NULL);
 	}
 
@@ -3745,6 +3786,7 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 		vdev_config_dirty(vd->vdev_top);
 	}
 
+out:
 	dmu_tx_commit(tx);
 }
 
@@ -4288,12 +4330,13 @@ vdev_sync_done(vdev_t *vd, uint64_t txg)
 	}
 }
 
-void
+int
 vdev_sync(vdev_t *vd, uint64_t txg)
 {
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *lvd;
 	metaslab_t *msp;
+	int err = 0;
 
 	ASSERT3U(txg, ==, spa->spa_syncing_txg);
 	dmu_tx_t *tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
@@ -4311,7 +4354,7 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 			ASSERT(txg_list_empty(&vd->vdev_ms_list, txg));
 			ASSERT(txg_list_empty(&vd->vdev_dtl_list, txg));
 			dmu_tx_commit(tx);
-			return;
+			return (0);
 		}
 	}
 
@@ -4321,29 +4364,40 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 	    !vd->vdev_removing) {
 		ASSERT(vd == vd->vdev_top);
 		ASSERT0(vd->vdev_indirect_config.vic_mapping_object);
-		vd->vdev_ms_array = dmu_object_alloc(spa->spa_meta_objset,
-		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx);
+		err = dmu_object_alloc(spa->spa_meta_objset,
+		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx,
+		    &vd->vdev_ms_array);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		ASSERT(vd->vdev_ms_array != 0);
 		vdev_config_dirty(vd);
 	}
+skip:
 
 	while ((msp = txg_list_remove(&vd->vdev_ms_list, txg)) != NULL) {
-		metaslab_sync(msp, txg);
+		if (!err)
+			metaslab_sync(msp, txg);
 		(void) txg_list_add(&vd->vdev_ms_list, msp, TXG_CLEAN(txg));
 	}
 
-	while ((lvd = txg_list_remove(&vd->vdev_dtl_list, txg)) != NULL)
-		vdev_dtl_sync(lvd, txg);
+	while ((lvd = txg_list_remove(&vd->vdev_dtl_list, txg)) != NULL) {
+		if (!err)
+			vdev_dtl_sync(lvd, txg);
+	}
 
 	/*
 	 * If this is an empty log device being removed, destroy the
 	 * metadata associated with it.
 	 */
-	if (vd->vdev_islog && vd->vdev_stat.vs_alloc == 0 && vd->vdev_removing)
+	if (!err && vd->vdev_islog && vd->vdev_stat.vs_alloc == 0 &&
+	    vd->vdev_removing)
 		vdev_remove_empty_log(vd, txg);
 
 	(void) txg_list_add(&spa->spa_vdev_txg_list, vd, TXG_CLEAN(txg));
 	dmu_tx_commit(tx);
+
+	return (err);
 }
 uint64_t
 vdev_asize_to_psize_txg(vdev_t *vd, uint64_t asize, uint64_t txg)

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1208,6 +1208,9 @@ vdev_free(vdev_t *vd)
 		vd->vdev_log_mg = NULL;
 	}
 
+	if (SPA_EXITING(spa))
+		vdev_clear_stats(vd);
+
 	ASSERT0(vd->vdev_stat.vs_space);
 	ASSERT0(vd->vdev_stat.vs_dspace);
 	ASSERT0(vd->vdev_stat.vs_alloc);
@@ -1270,6 +1273,8 @@ vdev_free(vdev_t *vd)
 		space_map_close(vd->vdev_obsolete_sm);
 		vd->vdev_obsolete_sm = NULL;
 	}
+	if (SPA_EXITING(spa))
+		zfs_range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
 	zfs_range_tree_destroy(vd->vdev_obsolete_segments);
 	rw_destroy(&vd->vdev_indirect_rwlock);
 	mutex_destroy(&vd->vdev_obsolete_lock);
@@ -3630,10 +3635,18 @@ void
 vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
+	int err;
 
-	VERIFY0(zap_destroy(spa->spa_meta_objset, zapobj, tx));
-	VERIFY0(zap_remove_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
-	    zapobj, tx));
+	err = zap_destroy(spa->spa_meta_objset, zapobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
+	err = zap_remove_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
+	    zapobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 }
 
 int
@@ -4229,13 +4242,19 @@ vdev_destroy_ms_flush_data(vdev_t *vd, dmu_tx_t *tx)
 	uint64_t object = 0;
 	int err = zap_lookup(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1, &object);
+	if (!(err == ENOENT || err == 0) && SPA_EXITING(vd->vdev_spa))
+		return;
 	if (err == ENOENT)
 		return;
 	VERIFY0(err);
 
-	VERIFY0(dmu_object_free(mos, object, tx));
-	VERIFY0(zap_remove(mos, vd->vdev_top_zap,
-	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, tx));
+	err = dmu_object_free(mos, object, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
+	err = zap_remove(mos, vd->vdev_top_zap,
+	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
 }
 
 /*
@@ -4245,6 +4264,8 @@ vdev_destroy_ms_flush_data(vdev_t *vd, dmu_tx_t *tx)
 void
 vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 {
+	int err;
+
 	if (vd->vdev_ms_array == 0)
 		return;
 
@@ -4252,8 +4273,11 @@ vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 	uint64_t array_count = vd->vdev_asize >> vd->vdev_ms_shift;
 	size_t array_bytes = array_count * sizeof (uint64_t);
 	uint64_t *smobj_array = kmem_alloc(array_bytes, KM_SLEEP);
-	VERIFY0(dmu_read(mos, vd->vdev_ms_array, 0,
-	    array_bytes, smobj_array, 0));
+	err = dmu_read(mos, vd->vdev_ms_array, 0,
+	    array_bytes, smobj_array, 0);
+	if (err && SPA_EXITING(vd->vdev_spa))
+		goto skip;
+	VERIFY0(err);
 
 	for (uint64_t i = 0; i < array_count; i++) {
 		uint64_t smobj = smobj_array[i];
@@ -4263,8 +4287,11 @@ vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 		space_map_free_obj(mos, smobj, tx);
 	}
 
+skip:
 	kmem_free(smobj_array, array_bytes);
-	VERIFY0(dmu_object_free(mos, vd->vdev_ms_array, tx));
+	err = dmu_object_free(mos, vd->vdev_ms_array, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
 	vdev_destroy_ms_flush_data(vd, tx);
 	vd->vdev_ms_array = 0;
 }

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1204,6 +1204,9 @@ vdev_free(vdev_t *vd)
 		vd->vdev_log_mg = NULL;
 	}
 
+	if (SPA_EXITING(spa))
+		vdev_clear_stats(vd);
+
 	ASSERT0(vd->vdev_stat.vs_space);
 	ASSERT0(vd->vdev_stat.vs_dspace);
 	ASSERT0(vd->vdev_stat.vs_alloc);
@@ -1266,6 +1269,8 @@ vdev_free(vdev_t *vd)
 		space_map_close(vd->vdev_obsolete_sm);
 		vd->vdev_obsolete_sm = NULL;
 	}
+	if (SPA_EXITING(spa))
+		zfs_range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
 	zfs_range_tree_destroy(vd->vdev_obsolete_segments);
 	rw_destroy(&vd->vdev_indirect_rwlock);
 	mutex_destroy(&vd->vdev_obsolete_lock);
@@ -3706,10 +3711,18 @@ void
 vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
+	int err;
 
-	VERIFY0(zap_destroy(spa->spa_meta_objset, zapobj, tx));
-	VERIFY0(zap_remove_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
-	    zapobj, tx));
+	err = zap_destroy(spa->spa_meta_objset, zapobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
+
+	err = zap_remove_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
+	    zapobj, tx);
+	if (SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 }
 
 int
@@ -4306,13 +4319,19 @@ vdev_destroy_ms_flush_data(vdev_t *vd, dmu_tx_t *tx)
 	uint64_t object = 0;
 	int err = zap_lookup(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1, &object);
+	if (!(err == ENOENT || err == 0) && SPA_EXITING(vd->vdev_spa))
+		return;
 	if (err == ENOENT)
 		return;
 	VERIFY0(err);
 
-	VERIFY0(dmu_object_free(mos, object, tx));
-	VERIFY0(zap_remove(mos, vd->vdev_top_zap,
-	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, tx));
+	err = dmu_object_free(mos, object, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
+	err = zap_remove(mos, vd->vdev_top_zap,
+	    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
 }
 
 /*
@@ -4322,6 +4341,8 @@ vdev_destroy_ms_flush_data(vdev_t *vd, dmu_tx_t *tx)
 void
 vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 {
+	int err;
+
 	if (vd->vdev_ms_array == 0)
 		return;
 
@@ -4329,8 +4350,11 @@ vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 	uint64_t array_count = vd->vdev_asize >> vd->vdev_ms_shift;
 	size_t array_bytes = array_count * sizeof (uint64_t);
 	uint64_t *smobj_array = kmem_alloc(array_bytes, KM_SLEEP);
-	VERIFY0(dmu_read(mos, vd->vdev_ms_array, 0,
-	    array_bytes, smobj_array, 0));
+	err = dmu_read(mos, vd->vdev_ms_array, 0,
+	    array_bytes, smobj_array, 0);
+	if (err && SPA_EXITING(vd->vdev_spa))
+		goto skip;
+	VERIFY0(err);
 
 	for (uint64_t i = 0; i < array_count; i++) {
 		uint64_t smobj = smobj_array[i];
@@ -4340,8 +4364,11 @@ vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 		space_map_free_obj(mos, smobj, tx);
 	}
 
+skip:
 	kmem_free(smobj_array, array_bytes);
-	VERIFY0(dmu_object_free(mos, vd->vdev_ms_array, tx));
+	err = dmu_object_free(mos, vd->vdev_ms_array, tx);
+	if (!SPA_EXITING(vd->vdev_spa))
+		VERIFY0(err);
 	vdev_destroy_ms_flush_data(vd, tx);
 	vd->vdev_ms_array = 0;
 }

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3672,13 +3672,14 @@ vdev_dtl_load(vdev_t *vd)
 	return (error);
 }
 
-static void
+static int
 vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
 	const char *string;
+	int err = 0;
 
 	ASSERT(alloc_bias != VDEV_BIAS_NONE);
 
@@ -3688,12 +3689,17 @@ vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
 	    (alloc_bias == VDEV_BIAS_DEDUP) ? VDEV_ALLOC_BIAS_DEDUP : NULL;
 
 	ASSERT(string != NULL);
-	VERIFY0(zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
-	    1, strlen(string) + 1, string, tx));
+	err = zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
+	    1, strlen(string) + 1, string, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (alloc_bias == VDEV_BIAS_SPECIAL || alloc_bias == VDEV_BIAS_DEDUP) {
 		spa_activate_allocation_classes(spa, tx);
 	}
+
+	return (err);
 }
 
 void
@@ -3706,46 +3712,73 @@ vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 	    zapobj, tx));
 }
 
-uint64_t
-vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx)
+int
+vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx, uint64_t *objectp)
 {
 	spa_t *spa = vd->vdev_spa;
-	uint64_t zap = zap_create(spa->spa_meta_objset, DMU_OTN_ZAP_METADATA,
-	    DMU_OT_NONE, 0, tx);
+	int err = zap_create(spa->spa_meta_objset, DMU_OTN_ZAP_METADATA,
+	    DMU_OT_NONE, 0, tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	ASSERT(zap != 0);
-	VERIFY0(zap_add_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
-	    zap, tx));
+	ASSERT(*objectp != 0);
+	err = zap_add_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
+	    *objectp, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	return (zap);
+	return (err);
 }
 
-void
+int
 vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 {
+	spa_t *spa = vd->vdev_spa;
+	int err = 0;
+
 	if (vd->vdev_ops != &vdev_hole_ops &&
 	    vd->vdev_ops != &vdev_missing_ops &&
 	    vd->vdev_ops != &vdev_root_ops &&
 	    !vd->vdev_top->vdev_removing) {
 		if (vd->vdev_ops->vdev_op_leaf && vd->vdev_leaf_zap == 0) {
-			vd->vdev_leaf_zap = vdev_create_link_zap(vd, tx);
+			err = vdev_create_link_zap(vd, tx, &vd->vdev_leaf_zap);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
 		}
 		if (vd == vd->vdev_top && vd->vdev_top_zap == 0) {
-			vd->vdev_top_zap = vdev_create_link_zap(vd, tx);
-			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE)
-				vdev_zap_allocation_data(vd, tx);
+			err = vdev_create_link_zap(vd, tx, &vd->vdev_top_zap);
+			if (err && SPA_EXITING(spa))
+				return (err);
+			VERIFY0(err);
+			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
+				err = vdev_zap_allocation_data(vd, tx);
+				if (err && SPA_EXITING(spa))
+					return (err);
+				VERIFY0(err);
+			}
 		}
 	}
 	if (vd->vdev_ops == &vdev_root_ops && vd->vdev_root_zap == 0 &&
 	    spa_feature_is_enabled(vd->vdev_spa, SPA_FEATURE_AVZ_V2)) {
 		if (!spa_feature_is_active(vd->vdev_spa, SPA_FEATURE_AVZ_V2))
 			spa_feature_incr(vd->vdev_spa, SPA_FEATURE_AVZ_V2, tx);
-		vd->vdev_root_zap = vdev_create_link_zap(vd, tx);
+		err = vdev_create_link_zap(vd, tx, &vd->vdev_root_zap);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 
 	for (uint64_t i = 0; i < vd->vdev_children; i++) {
-		vdev_construct_zaps(vd->vdev_child[i], tx);
+		err = vdev_construct_zaps(vd->vdev_child[i], tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
+
+	return (err);
 }
 
 static void
@@ -3757,6 +3790,7 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 	zfs_range_tree_t *rtsync;
 	dmu_tx_t *tx;
 	uint64_t object = space_map_object(vd->vdev_dtl_sm);
+	int err = 0;
 
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
@@ -3788,11 +3822,18 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 	if (vd->vdev_dtl_sm == NULL) {
 		uint64_t new_object;
 
-		new_object = space_map_alloc(mos, zfs_vdev_dtl_sm_blksz, tx);
+		err = space_map_alloc(mos, zfs_vdev_dtl_sm_blksz, tx,
+		    &new_object);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		VERIFY3U(new_object, !=, 0);
 
-		VERIFY0(space_map_open(&vd->vdev_dtl_sm, mos, new_object,
-		    0, -1ULL, 0));
+		err = space_map_open(&vd->vdev_dtl_sm, mos, new_object,
+		    0, -1ULL, 0);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 		ASSERT(vd->vdev_dtl_sm != NULL);
 	}
 
@@ -3821,6 +3862,7 @@ vdev_dtl_sync(vdev_t *vd, uint64_t txg)
 		vdev_config_dirty(vd->vdev_top);
 	}
 
+out:
 	dmu_tx_commit(tx);
 }
 
@@ -4365,12 +4407,13 @@ vdev_sync_done(vdev_t *vd, uint64_t txg)
 	}
 }
 
-void
+int
 vdev_sync(vdev_t *vd, uint64_t txg)
 {
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *lvd;
 	metaslab_t *msp;
+	int err = 0;
 
 	ASSERT3U(txg, ==, spa->spa_syncing_txg);
 	dmu_tx_t *tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
@@ -4388,7 +4431,7 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 			ASSERT(txg_list_empty(&vd->vdev_ms_list, txg));
 			ASSERT(txg_list_empty(&vd->vdev_dtl_list, txg));
 			dmu_tx_commit(tx);
-			return;
+			return (0);
 		}
 	}
 
@@ -4398,29 +4441,40 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 	    !vd->vdev_removing) {
 		ASSERT(vd == vd->vdev_top);
 		ASSERT0(vd->vdev_indirect_config.vic_mapping_object);
-		vd->vdev_ms_array = dmu_object_alloc(spa->spa_meta_objset,
-		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx);
+		err = dmu_object_alloc(spa->spa_meta_objset,
+		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx,
+		    &vd->vdev_ms_array);
+		if (err && SPA_EXITING(spa))
+			goto skip;
+		VERIFY0(err);
 		ASSERT(vd->vdev_ms_array != 0);
 		vdev_config_dirty(vd);
 	}
+skip:
 
 	while ((msp = txg_list_remove(&vd->vdev_ms_list, txg)) != NULL) {
-		metaslab_sync(msp, txg);
+		if (!err)
+			metaslab_sync(msp, txg);
 		(void) txg_list_add(&vd->vdev_ms_list, msp, TXG_CLEAN(txg));
 	}
 
-	while ((lvd = txg_list_remove(&vd->vdev_dtl_list, txg)) != NULL)
-		vdev_dtl_sync(lvd, txg);
+	while ((lvd = txg_list_remove(&vd->vdev_dtl_list, txg)) != NULL) {
+		if (!err)
+			vdev_dtl_sync(lvd, txg);
+	}
 
 	/*
 	 * If this is an empty log device being removed, destroy the
 	 * metadata associated with it.
 	 */
-	if (vd->vdev_islog && vd->vdev_stat.vs_alloc == 0 && vd->vdev_removing)
+	if (!err && vd->vdev_islog && vd->vdev_stat.vs_alloc == 0 &&
+	    vd->vdev_removing)
 		vdev_remove_empty_log(vd, txg);
 
 	(void) txg_list_add(&spa->spa_vdev_txg_list, vd, TXG_CLEAN(txg));
 	dmu_tx_commit(tx);
+
+	return (err);
 }
 uint64_t
 vdev_asize_to_psize_txg(vdev_t *vd, uint64_t asize, uint64_t txg)

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -52,6 +52,8 @@ static taskq_t *vdev_file_taskq;
 static uint_t vdev_file_logical_ashift = SPA_MINBLOCKSHIFT;
 static uint_t vdev_file_physical_ashift = SPA_MINBLOCKSHIFT;
 
+volatile int vdev_file_constant_error = 0;
+
 void
 vdev_file_init(void)
 {
@@ -220,6 +222,11 @@ vdev_file_io_strategy(void *arg)
 	ssize_t size;
 	int err;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	off = zio->io_offset;
 	size = zio->io_size;
 	resid = 0;
@@ -239,6 +246,7 @@ vdev_file_io_strategy(void *arg)
 	if (resid != 0 && zio->io_error == 0)
 		zio->io_error = SET_ERROR(ENOSPC);
 
+out:
 	zio_delay_interrupt(zio);
 }
 
@@ -248,8 +256,14 @@ vdev_file_io_fsync(void *arg)
 	zio_t *zio = (zio_t *)arg;
 	vdev_file_t *vf = zio->io_vd->vdev_tsd;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	zio->io_error = zfs_file_fsync(vf->vf_file, O_SYNC | O_DSYNC);
 
+out:
 	zio_interrupt(zio);
 }
 
@@ -259,9 +273,15 @@ vdev_file_io_deallocate(void *arg)
 	zio_t *zio = (zio_t *)arg;
 	vdev_file_t *vf = zio->io_vd->vdev_tsd;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	zio->io_error = zfs_file_deallocate(vf->vf_file,
 	    zio->io_offset, zio->io_size);
 
+out:
 	zio_interrupt(zio);
 }
 

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -43,6 +43,8 @@ static taskq_t *vdev_file_taskq;
 static uint_t vdev_file_logical_ashift = SPA_MINBLOCKSHIFT;
 static uint_t vdev_file_physical_ashift = SPA_MINBLOCKSHIFT;
 
+volatile int vdev_file_constant_error = 0;
+
 void
 vdev_file_init(void)
 {
@@ -212,6 +214,11 @@ vdev_file_io_strategy(void *arg)
 	ssize_t size;
 	int err;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	off = zio->io_offset;
 	size = zio->io_size;
 	resid = 0;
@@ -231,6 +238,7 @@ vdev_file_io_strategy(void *arg)
 	if (resid != 0 && zio->io_error == 0)
 		zio->io_error = SET_ERROR(ENOSPC);
 
+out:
 	zio_delay_interrupt(zio);
 }
 
@@ -240,8 +248,14 @@ vdev_file_io_fsync(void *arg)
 	zio_t *zio = (zio_t *)arg;
 	vdev_file_t *vf = zio->io_vd->vdev_tsd;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	zio->io_error = zfs_file_fsync(vf->vf_file, O_SYNC | O_DSYNC);
 
+out:
 	zio_interrupt(zio);
 }
 
@@ -251,9 +265,15 @@ vdev_file_io_deallocate(void *arg)
 	zio_t *zio = (zio_t *)arg;
 	vdev_file_t *vf = zio->io_vd->vdev_tsd;
 
+	if (vdev_file_constant_error) {
+		zio->io_error = SET_ERROR(vdev_file_constant_error);
+		goto out;
+	}
+
 	zio->io_error = zfs_file_deallocate(vf->vf_file,
 	    zio->io_offset, zio->io_size);
 
+out:
 	zio_interrupt(zio);
 }
 

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -326,6 +326,9 @@ vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset, uint64_t size)
 {
 	spa_t *spa = vd->vdev_spa;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
 	ASSERT(size > 0);
@@ -357,13 +360,22 @@ spa_vdev_indirect_mark_obsolete(spa_t *spa, uint64_t vdev_id, uint64_t offset,
 	vdev_indirect_mark_obsolete(vd, offset, size);
 }
 
-static spa_condensing_indirect_t *
-spa_condensing_indirect_create(spa_t *spa)
+static int
+spa_condensing_indirect_create(spa_t *spa, spa_condensing_indirect_t **scip)
 {
-	spa_condensing_indirect_phys_t *scip =
+	int err = 0;
+	spa_condensing_indirect_phys_t *sciphys =
 	    &spa->spa_condensing_indirect_phys;
 	spa_condensing_indirect_t *sci = kmem_zalloc(sizeof (*sci), KM_SLEEP);
 	objset_t *mos = spa->spa_meta_objset;
+
+	err = vdev_indirect_mapping_open(mos, sciphys->scip_next_mapping_object,
+	    &sci->sci_new_mapping);
+	if (err && SPA_EXITING(spa)) {
+		kmem_free(sci, sizeof (*sci));
+		return (err);
+	}
+	VERIFY0(err);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
 		list_create(&sci->sci_new_mapping_entries[i],
@@ -371,10 +383,9 @@ spa_condensing_indirect_create(spa_t *spa)
 		    offsetof(vdev_indirect_mapping_entry_t, vime_node));
 	}
 
-	sci->sci_new_mapping =
-	    vdev_indirect_mapping_open(mos, scip->scip_next_mapping_object);
+	*scip = sci;
 
-	return (sci);
+	return (err);
 }
 
 static void
@@ -813,7 +824,11 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	VERIFY0(err);
 
 	ASSERT0P(spa->spa_condensing_indirect);
-	spa->spa_condensing_indirect = spa_condensing_indirect_create(spa);
+	err = spa_condensing_indirect_create(spa,
+	    &spa->spa_condensing_indirect);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	zfs_dbgmsg("starting condense of vdev %llu in txg %llu: "
 	    "posm=%llu nm=%llu",
@@ -900,10 +915,10 @@ spa_condense_init(spa_t *spa)
 	    &spa->spa_condensing_indirect_phys);
 	if (error == 0) {
 		if (spa_writeable(spa)) {
-			spa->spa_condensing_indirect =
-			    spa_condensing_indirect_create(spa);
+			error = spa_condensing_indirect_create(spa,
+			    &spa->spa_condensing_indirect);
 		}
-		return (0);
+		return (error);
 	} else if (error == ENOENT) {
 		return (0);
 	} else {

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -394,6 +394,7 @@ vdev_indirect_should_condense(vdev_t *vd)
 {
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(spa->spa_dsl_pool));
 
@@ -409,6 +410,9 @@ vdev_indirect_should_condense(vdev_t *vd)
 	if (spa_shutting_down(spa))
 		return (B_FALSE);
 
+	if (SPA_EXITING(spa))
+		return (B_FALSE);
+
 	/*
 	 * The mapping object size must not change while we are
 	 * condensing, so we can only condense indirect vdevs
@@ -422,7 +426,10 @@ vdev_indirect_should_condense(vdev_t *vd)
 	 * point in condensing.
 	 */
 	uint64_t obsolete_sm_obj __maybe_unused;
-	ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_obj));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_obj);
+	if (err && SPA_EXITING(spa))
+		return (B_FALSE);
+	ASSERT0(err);
 	if (vd->vdev_obsolete_sm == NULL) {
 		ASSERT0(obsolete_sm_obj);
 		return (B_FALSE);
@@ -753,12 +760,13 @@ spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 /*
  * Sync task to begin the condensing process.
  */
-void
+int
 spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	spa_condensing_indirect_phys_t *scip =
 	    &spa->spa_condensing_indirect_phys;
+	int err = 0;
 
 	ASSERT0(scip->scip_next_mapping_object);
 	ASSERT0(scip->scip_prev_obsolete_sm_object);
@@ -769,12 +777,18 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	ASSERT(vdev_indirect_mapping_num_entries(vd->vdev_indirect_mapping));
 
 	uint64_t obsolete_sm_obj;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_obj));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(obsolete_sm_obj, !=, 0);
 
 	scip->scip_vdev = vd->vdev_id;
-	scip->scip_next_mapping_object =
-	    vdev_indirect_mapping_alloc(spa->spa_meta_objset, tx);
+	err = vdev_indirect_mapping_alloc(spa->spa_meta_objset, tx,
+	    &scip->scip_next_mapping_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	scip->scip_prev_obsolete_sm_object = obsolete_sm_obj;
 
@@ -784,13 +798,19 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	 */
 	space_map_close(vd->vdev_obsolete_sm);
 	vd->vdev_obsolete_sm = NULL;
-	VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-	    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx));
+	err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+	    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(spa->spa_dsl_pool->dp_meta_objset,
+	err = zap_add(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_CONDENSING_INDIRECT, sizeof (uint64_t),
-	    sizeof (*scip) / sizeof (uint64_t), scip, tx));
+	    sizeof (*scip) / sizeof (uint64_t), scip, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ASSERT0P(spa->spa_condensing_indirect);
 	spa->spa_condensing_indirect = spa_condensing_indirect_create(spa);
@@ -802,6 +822,8 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	    (u_longlong_t)scip->scip_next_mapping_object);
 
 	zthr_wakeup(spa->spa_condense_zthr);
+
+	return (err);
 }
 
 /*
@@ -810,11 +832,12 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
  *
  * If the obsolete space map doesn't exist yet, create and open it.
  */
-void
+int
 vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
+	int err = 0;
 
 	ASSERT3U(vic->vic_mapping_object, !=, 0);
 	ASSERT(zfs_range_tree_space(vd->vdev_obsolete_segments) > 0);
@@ -822,22 +845,38 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	ASSERT(spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS));
 
 	uint64_t obsolete_sm_object;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (obsolete_sm_object == 0) {
-		obsolete_sm_object = space_map_alloc(spa->spa_meta_objset,
-		    zfs_vdev_standard_sm_blksz, tx);
+		err = space_map_alloc(spa->spa_meta_objset,
+		    zfs_vdev_standard_sm_blksz, tx, &obsolete_sm_object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 
 		ASSERT(vd->vdev_top_zap != 0);
-		VERIFY0(zap_add(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+		err = zap_add(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM,
-		    sizeof (obsolete_sm_object), 1, &obsolete_sm_object, tx));
-		ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+		    sizeof (obsolete_sm_object), 1, &obsolete_sm_object, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+
+		err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		ASSERT3U(obsolete_sm_object, !=, 0);
 
 		spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
-		VERIFY0(space_map_open(&vd->vdev_obsolete_sm,
+		err = space_map_open(&vd->vdev_obsolete_sm,
 		    spa->spa_meta_objset, obsolete_sm_object,
-		    0, vd->vdev_asize, 0));
+		    0, vd->vdev_asize, 0);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 
 	ASSERT(vd->vdev_obsolete_sm != NULL);
@@ -847,6 +886,8 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	space_map_write(vd->vdev_obsolete_sm,
 	    vd->vdev_obsolete_segments, SM_ALLOC, SM_NO_VDEVID, tx);
 	zfs_range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
+
+	return (err);
 }
 
 int

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -390,6 +390,7 @@ vdev_indirect_should_condense(vdev_t *vd)
 {
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	ASSERT(dsl_pool_sync_context(spa->spa_dsl_pool));
 
@@ -405,6 +406,9 @@ vdev_indirect_should_condense(vdev_t *vd)
 	if (spa_shutting_down(spa))
 		return (B_FALSE);
 
+	if (SPA_EXITING(spa))
+		return (B_FALSE);
+
 	/*
 	 * The mapping object size must not change while we are
 	 * condensing, so we can only condense indirect vdevs
@@ -418,7 +422,10 @@ vdev_indirect_should_condense(vdev_t *vd)
 	 * point in condensing.
 	 */
 	uint64_t obsolete_sm_obj __maybe_unused;
-	ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_obj));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_obj);
+	if (err && SPA_EXITING(spa))
+		return (B_FALSE);
+	ASSERT0(err);
 	if (vd->vdev_obsolete_sm == NULL) {
 		ASSERT0(obsolete_sm_obj);
 		return (B_FALSE);
@@ -749,12 +756,13 @@ spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 /*
  * Sync task to begin the condensing process.
  */
-void
+int
 spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	spa_condensing_indirect_phys_t *scip =
 	    &spa->spa_condensing_indirect_phys;
+	int err = 0;
 
 	ASSERT0(scip->scip_next_mapping_object);
 	ASSERT0(scip->scip_prev_obsolete_sm_object);
@@ -765,12 +773,18 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	ASSERT(vdev_indirect_mapping_num_entries(vd->vdev_indirect_mapping));
 
 	uint64_t obsolete_sm_obj;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_obj));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_obj);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	ASSERT3U(obsolete_sm_obj, !=, 0);
 
 	scip->scip_vdev = vd->vdev_id;
-	scip->scip_next_mapping_object =
-	    vdev_indirect_mapping_alloc(spa->spa_meta_objset, tx);
+	err = vdev_indirect_mapping_alloc(spa->spa_meta_objset, tx,
+	    &scip->scip_next_mapping_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	scip->scip_prev_obsolete_sm_object = obsolete_sm_obj;
 
@@ -780,13 +794,19 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	 */
 	space_map_close(vd->vdev_obsolete_sm);
 	vd->vdev_obsolete_sm = NULL;
-	VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-	    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx));
+	err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+	    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
-	VERIFY0(zap_add(spa->spa_dsl_pool->dp_meta_objset,
+	err = zap_add(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_CONDENSING_INDIRECT, sizeof (uint64_t),
-	    sizeof (*scip) / sizeof (uint64_t), scip, tx));
+	    sizeof (*scip) / sizeof (uint64_t), scip, tx);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	ASSERT0P(spa->spa_condensing_indirect);
 	spa->spa_condensing_indirect = spa_condensing_indirect_create(spa);
@@ -798,6 +818,8 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	    (u_longlong_t)scip->scip_next_mapping_object);
 
 	zthr_wakeup(spa->spa_condense_zthr);
+
+	return (err);
 }
 
 /*
@@ -806,11 +828,12 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
  *
  * If the obsolete space map doesn't exist yet, create and open it.
  */
-void
+int
 vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
+	int err = 0;
 
 	ASSERT3U(vic->vic_mapping_object, !=, 0);
 	ASSERT(zfs_range_tree_space(vd->vdev_obsolete_segments) > 0);
@@ -818,22 +841,38 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	ASSERT(spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS));
 
 	uint64_t obsolete_sm_object;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 	if (obsolete_sm_object == 0) {
-		obsolete_sm_object = space_map_alloc(spa->spa_meta_objset,
-		    zfs_vdev_standard_sm_blksz, tx);
+		err = space_map_alloc(spa->spa_meta_objset,
+		    zfs_vdev_standard_sm_blksz, tx, &obsolete_sm_object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 
 		ASSERT(vd->vdev_top_zap != 0);
-		VERIFY0(zap_add(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+		err = zap_add(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM,
-		    sizeof (obsolete_sm_object), 1, &obsolete_sm_object, tx));
-		ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+		    sizeof (obsolete_sm_object), 1, &obsolete_sm_object, tx);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+
+		err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		ASSERT3U(obsolete_sm_object, !=, 0);
 
 		spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
-		VERIFY0(space_map_open(&vd->vdev_obsolete_sm,
+		err = space_map_open(&vd->vdev_obsolete_sm,
 		    spa->spa_meta_objset, obsolete_sm_object,
-		    0, vd->vdev_asize, 0));
+		    0, vd->vdev_asize, 0);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 	}
 
 	ASSERT(vd->vdev_obsolete_sm != NULL);
@@ -843,6 +882,8 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	space_map_write(vd->vdev_obsolete_sm,
 	    vd->vdev_obsolete_segments, SM_ALLOC, SM_NO_VDEVID, tx);
 	zfs_range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
+
+	return (err);
 }
 
 int

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -322,6 +322,9 @@ vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset, uint64_t size)
 {
 	spa_t *spa = vd->vdev_spa;
 
+	if (SPA_EXITING(spa))
+		return;
+
 	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
 	ASSERT(size > 0);
@@ -353,13 +356,22 @@ spa_vdev_indirect_mark_obsolete(spa_t *spa, uint64_t vdev_id, uint64_t offset,
 	vdev_indirect_mark_obsolete(vd, offset, size);
 }
 
-static spa_condensing_indirect_t *
-spa_condensing_indirect_create(spa_t *spa)
+static int
+spa_condensing_indirect_create(spa_t *spa, spa_condensing_indirect_t **scip)
 {
-	spa_condensing_indirect_phys_t *scip =
+	int err = 0;
+	spa_condensing_indirect_phys_t *sciphys =
 	    &spa->spa_condensing_indirect_phys;
 	spa_condensing_indirect_t *sci = kmem_zalloc(sizeof (*sci), KM_SLEEP);
 	objset_t *mos = spa->spa_meta_objset;
+
+	err = vdev_indirect_mapping_open(mos, sciphys->scip_next_mapping_object,
+	    &sci->sci_new_mapping);
+	if (err && SPA_EXITING(spa)) {
+		kmem_free(sci, sizeof (*sci));
+		return (err);
+	}
+	VERIFY0(err);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
 		list_create(&sci->sci_new_mapping_entries[i],
@@ -367,10 +379,9 @@ spa_condensing_indirect_create(spa_t *spa)
 		    offsetof(vdev_indirect_mapping_entry_t, vime_node));
 	}
 
-	sci->sci_new_mapping =
-	    vdev_indirect_mapping_open(mos, scip->scip_next_mapping_object);
+	*scip = sci;
 
-	return (sci);
+	return (err);
 }
 
 static void
@@ -809,7 +820,11 @@ spa_condense_indirect_start_sync(vdev_t *vd, dmu_tx_t *tx)
 	VERIFY0(err);
 
 	ASSERT0P(spa->spa_condensing_indirect);
-	spa->spa_condensing_indirect = spa_condensing_indirect_create(spa);
+	err = spa_condensing_indirect_create(spa,
+	    &spa->spa_condensing_indirect);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	zfs_dbgmsg("starting condense of vdev %llu in txg %llu: "
 	    "posm=%llu nm=%llu",
@@ -896,10 +911,10 @@ spa_condense_init(spa_t *spa)
 	    &spa->spa_condensing_indirect_phys);
 	if (error == 0) {
 		if (spa_writeable(spa)) {
-			spa->spa_condensing_indirect =
-			    spa_condensing_indirect_create(spa);
+			error = spa_condensing_indirect_create(spa,
+			    &spa->spa_condensing_indirect);
 		}
-		return (0);
+		return (error);
 	} else if (error == ENOENT) {
 		return (0);
 	} else {

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -21,6 +21,7 @@
 #include <sys/dmu_tx.h>
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dsl_pool.h>
 #include <sys/vdev_indirect_births.h>
 
@@ -98,27 +99,45 @@ vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 	    tx, objectp));
 }
 
-vdev_indirect_births_t *
-vdev_indirect_births_open(objset_t *os, uint64_t births_object)
+int
+vdev_indirect_births_open(objset_t *os, uint64_t births_object,
+    vdev_indirect_births_t **vibp)
 {
+	spa_t *spa = os->os_spa;
+	int err = 0;
 	vdev_indirect_births_t *vib = kmem_zalloc(sizeof (*vib), KM_SLEEP);
 
 	vib->vib_objset = os;
 	vib->vib_object = births_object;
 
-	VERIFY0(dmu_bonus_hold(os, vib->vib_object, vib, &vib->vib_dbuf));
+	err = dmu_bonus_hold(os, vib->vib_object, vib, &vib->vib_dbuf);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	vib->vib_phys = vib->vib_dbuf->db_data;
 
 	if (vib->vib_phys->vib_count > 0) {
 		uint64_t births_size = vdev_indirect_births_size_impl(vib);
 		vib->vib_entries = vmem_alloc(births_size, KM_SLEEP);
-		VERIFY0(dmu_read(vib->vib_objset, vib->vib_object, 0,
-		    births_size, vib->vib_entries, DMU_READ_PREFETCH));
+		err = dmu_read(vib->vib_objset, vib->vib_object, 0,
+		    births_size, vib->vib_entries, DMU_READ_PREFETCH);
+		if (err && SPA_EXITING(spa)) {
+			vmem_free(vib->vib_entries, births_size);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 	}
 
 	ASSERT(vdev_indirect_births_verify(vib));
+	*vibp = vib;
 
-	return (vib);
+	return (err);
+
+spa_exiting:
+	if (vib->vib_dbuf)
+		dmu_buf_rele(vib->vib_dbuf, vib);
+	kmem_free(vib, sizeof (*vib));
+	return (err);
 }
 
 void

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -87,15 +87,15 @@ vdev_indirect_births_close(vdev_indirect_births_t *vib)
 	kmem_free(vib, sizeof (*vib));
 }
 
-uint64_t
-vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx)
+int
+vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
 
 	return (dmu_object_alloc(os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
 	    DMU_OTN_UINT64_METADATA, sizeof (vdev_indirect_birth_phys_t),
-	    tx));
+	    tx, objectp));
 }
 
 vdev_indirect_births_t *

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -83,15 +83,15 @@ vdev_indirect_births_close(vdev_indirect_births_t *vib)
 	kmem_free(vib, sizeof (*vib));
 }
 
-uint64_t
-vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx)
+int
+vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
 
 	return (dmu_object_alloc(os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
 	    DMU_OTN_UINT64_METADATA, sizeof (vdev_indirect_birth_phys_t),
-	    tx));
+	    tx, objectp));
 }
 
 vdev_indirect_births_t *

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -17,6 +17,7 @@
 #include <sys/dmu_tx.h>
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dsl_pool.h>
 #include <sys/vdev_indirect_births.h>
 
@@ -94,27 +95,45 @@ vdev_indirect_births_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 	    tx, objectp));
 }
 
-vdev_indirect_births_t *
-vdev_indirect_births_open(objset_t *os, uint64_t births_object)
+int
+vdev_indirect_births_open(objset_t *os, uint64_t births_object,
+    vdev_indirect_births_t **vibp)
 {
+	spa_t *spa = os->os_spa;
+	int err = 0;
 	vdev_indirect_births_t *vib = kmem_zalloc(sizeof (*vib), KM_SLEEP);
 
 	vib->vib_objset = os;
 	vib->vib_object = births_object;
 
-	VERIFY0(dmu_bonus_hold(os, vib->vib_object, vib, &vib->vib_dbuf));
+	err = dmu_bonus_hold(os, vib->vib_object, vib, &vib->vib_dbuf);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	vib->vib_phys = vib->vib_dbuf->db_data;
 
 	if (vib->vib_phys->vib_count > 0) {
 		uint64_t births_size = vdev_indirect_births_size_impl(vib);
 		vib->vib_entries = vmem_alloc(births_size, KM_SLEEP);
-		VERIFY0(dmu_read(vib->vib_objset, vib->vib_object, 0,
-		    births_size, vib->vib_entries, DMU_READ_PREFETCH));
+		err = dmu_read(vib->vib_objset, vib->vib_object, 0,
+		    births_size, vib->vib_entries, DMU_READ_PREFETCH);
+		if (err && SPA_EXITING(spa)) {
+			vmem_free(vib->vib_entries, births_size);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 	}
 
 	ASSERT(vdev_indirect_births_verify(vib));
+	*vibp = vib;
 
-	return (vib);
+	return (err);
+
+spa_exiting:
+	if (vib->vib_dbuf)
+		dmu_buf_rele(vib->vib_dbuf, vib);
+	kmem_free(vib, sizeof (*vib));
+	return (err);
 }
 
 void

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -356,18 +356,28 @@ vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 }
 
 
-vdev_indirect_mapping_t *
-vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
+int
+vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object,
+    vdev_indirect_mapping_t **vimp)
 {
+	spa_t *spa = os->os_spa;
 	vdev_indirect_mapping_t *vim = kmem_zalloc(sizeof (*vim), KM_SLEEP);
 	dmu_object_info_t doi;
-	VERIFY0(dmu_object_info(os, mapping_object, &doi));
+	int err = 0;
+
+	err = dmu_object_info(os, mapping_object, &doi);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	vim->vim_objset = os;
 	vim->vim_object = mapping_object;
 
-	VERIFY0(dmu_bonus_hold(os, vim->vim_object, vim,
-	    &vim->vim_dbuf));
+	err = dmu_bonus_hold(os, vim->vim_object, vim,
+	    &vim->vim_dbuf);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	vim->vim_phys = vim->vim_dbuf->db_data;
 
 	vim->vim_havecounts =
@@ -376,27 +386,49 @@ vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
 	if (vim->vim_phys->vimp_num_entries > 0) {
 		uint64_t map_size = vdev_indirect_mapping_size(vim);
 		vim->vim_entries = vmem_alloc(map_size, KM_SLEEP);
-		VERIFY0(dmu_read(os, vim->vim_object, 0, map_size,
-		    vim->vim_entries, DMU_READ_PREFETCH));
+		err = dmu_read(os, vim->vim_object, 0, map_size,
+		    vim->vim_entries, DMU_READ_PREFETCH);
+		if (err && SPA_EXITING(spa)) {
+			vmem_free(vim->vim_entries, map_size);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 	}
 
 	ASSERT(vdev_indirect_mapping_verify(vim));
+	*vimp = vim;
 
-	return (vim);
+	return (err);
+
+spa_exiting:
+	if (vim->vim_dbuf)
+		dmu_buf_rele(vim->vim_dbuf, vim);
+	kmem_free(vim, sizeof (*vim));
+	return (err);
 }
 
 void
 vdev_indirect_mapping_free(objset_t *os, uint64_t object, dmu_tx_t *tx)
 {
-	vdev_indirect_mapping_t *vim = vdev_indirect_mapping_open(os, object);
+	spa_t *spa = os->os_spa;
+	vdev_indirect_mapping_t *vim;
+	int err;
+
+	err = vdev_indirect_mapping_open(os, object, &vim);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (vim->vim_havecounts) {
-		VERIFY0(dmu_object_free(os, vim->vim_phys->vimp_counts_object,
-		    tx));
+		err = dmu_object_free(os, vim->vim_phys->vimp_counts_object,
+		    tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa_feature_decr(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 	}
 	vdev_indirect_mapping_close(vim);
 
-	VERIFY0(dmu_object_free(os, object, tx));
+	err = dmu_object_free(os, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -307,37 +307,52 @@ vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim)
 	kmem_free(vim, sizeof (*vim));
 }
 
-uint64_t
-vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx)
+int
+vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t object;
 	ASSERT(dmu_tx_is_syncing(tx));
+	spa_t *spa = os->os_spa;
 	uint64_t bonus_size = VDEV_INDIRECT_MAPPING_SIZE_V0;
+	int err = 0;
 
 	if (spa_feature_is_enabled(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		bonus_size = sizeof (vdev_indirect_mapping_phys_t);
 	}
 
-	object = dmu_object_alloc(os,
+	err = dmu_object_alloc(os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
 	    DMU_OTN_UINT64_METADATA, bonus_size,
-	    tx);
+	    tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (spa_feature_is_enabled(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		dmu_buf_t *dbuf;
 		vdev_indirect_mapping_phys_t *vimp;
 
-		VERIFY0(dmu_bonus_hold(os, object, FTAG, &dbuf));
+		err = dmu_bonus_hold(os, *objectp, FTAG, &dbuf);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		dmu_buf_will_dirty(dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			return (SET_ERROR(EIO));
+		}
 		vimp = dbuf->db_data;
-		vimp->vimp_counts_object = dmu_object_alloc(os,
+		err = dmu_object_alloc(os,
 		    DMU_OTN_UINT32_METADATA, SPA_OLD_MAXBLOCKSIZE,
-		    DMU_OT_NONE, 0, tx);
+		    DMU_OT_NONE, 0, tx, &vimp->vimp_counts_object);
+		if (err && SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			return (err);
+		}
 		spa_feature_incr(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 		dmu_buf_rele(dbuf, FTAG);
 	}
 
-	return (object);
+	return (err);
 }
 
 

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -352,18 +352,28 @@ vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 }
 
 
-vdev_indirect_mapping_t *
-vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
+int
+vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object,
+    vdev_indirect_mapping_t **vimp)
 {
+	spa_t *spa = os->os_spa;
 	vdev_indirect_mapping_t *vim = kmem_zalloc(sizeof (*vim), KM_SLEEP);
 	dmu_object_info_t doi;
-	VERIFY0(dmu_object_info(os, mapping_object, &doi));
+	int err = 0;
+
+	err = dmu_object_info(os, mapping_object, &doi);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 
 	vim->vim_objset = os;
 	vim->vim_object = mapping_object;
 
-	VERIFY0(dmu_bonus_hold(os, vim->vim_object, vim,
-	    &vim->vim_dbuf));
+	err = dmu_bonus_hold(os, vim->vim_object, vim,
+	    &vim->vim_dbuf);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting;
+	VERIFY0(err);
 	vim->vim_phys = vim->vim_dbuf->db_data;
 
 	vim->vim_havecounts =
@@ -372,27 +382,49 @@ vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
 	if (vim->vim_phys->vimp_num_entries > 0) {
 		uint64_t map_size = vdev_indirect_mapping_size(vim);
 		vim->vim_entries = vmem_alloc(map_size, KM_SLEEP);
-		VERIFY0(dmu_read(os, vim->vim_object, 0, map_size,
-		    vim->vim_entries, DMU_READ_PREFETCH));
+		err = dmu_read(os, vim->vim_object, 0, map_size,
+		    vim->vim_entries, DMU_READ_PREFETCH);
+		if (err && SPA_EXITING(spa)) {
+			vmem_free(vim->vim_entries, map_size);
+			goto spa_exiting;
+		}
+		VERIFY0(err);
 	}
 
 	ASSERT(vdev_indirect_mapping_verify(vim));
+	*vimp = vim;
 
-	return (vim);
+	return (err);
+
+spa_exiting:
+	if (vim->vim_dbuf)
+		dmu_buf_rele(vim->vim_dbuf, vim);
+	kmem_free(vim, sizeof (*vim));
+	return (err);
 }
 
 void
 vdev_indirect_mapping_free(objset_t *os, uint64_t object, dmu_tx_t *tx)
 {
-	vdev_indirect_mapping_t *vim = vdev_indirect_mapping_open(os, object);
+	spa_t *spa = os->os_spa;
+	vdev_indirect_mapping_t *vim;
+	int err;
+
+	err = vdev_indirect_mapping_open(os, object, &vim);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (vim->vim_havecounts) {
-		VERIFY0(dmu_object_free(os, vim->vim_phys->vimp_counts_object,
-		    tx));
+		err = dmu_object_free(os, vim->vim_phys->vimp_counts_object,
+		    tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		spa_feature_decr(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 	}
 	vdev_indirect_mapping_close(vim);
 
-	VERIFY0(dmu_object_free(os, object, tx));
+	err = dmu_object_free(os, object, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -303,37 +303,52 @@ vdev_indirect_mapping_close(vdev_indirect_mapping_t *vim)
 	kmem_free(vim, sizeof (*vim));
 }
 
-uint64_t
-vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx)
+int
+vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t object;
 	ASSERT(dmu_tx_is_syncing(tx));
+	spa_t *spa = os->os_spa;
 	uint64_t bonus_size = VDEV_INDIRECT_MAPPING_SIZE_V0;
+	int err = 0;
 
 	if (spa_feature_is_enabled(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		bonus_size = sizeof (vdev_indirect_mapping_phys_t);
 	}
 
-	object = dmu_object_alloc(os,
+	err = dmu_object_alloc(os,
 	    DMU_OTN_UINT64_METADATA, SPA_OLD_MAXBLOCKSIZE,
 	    DMU_OTN_UINT64_METADATA, bonus_size,
-	    tx);
+	    tx, objectp);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	if (spa_feature_is_enabled(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		dmu_buf_t *dbuf;
 		vdev_indirect_mapping_phys_t *vimp;
 
-		VERIFY0(dmu_bonus_hold(os, object, FTAG, &dbuf));
+		err = dmu_bonus_hold(os, *objectp, FTAG, &dbuf);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
 		dmu_buf_will_dirty(dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			return (SET_ERROR(EIO));
+		}
 		vimp = dbuf->db_data;
-		vimp->vimp_counts_object = dmu_object_alloc(os,
+		err = dmu_object_alloc(os,
 		    DMU_OTN_UINT32_METADATA, SPA_OLD_MAXBLOCKSIZE,
-		    DMU_OT_NONE, 0, tx);
+		    DMU_OT_NONE, 0, tx, &vimp->vimp_counts_object);
+		if (err && SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			return (err);
+		}
 		spa_feature_incr(os->os_spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 		dmu_buf_rele(dbuf, FTAG);
 	}
 
-	return (object);
+	return (err);
 }
 
 

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -78,25 +78,33 @@ vdev_initialize_zap_update_sync(void *arg, dmu_tx_t *tx)
 
 	VERIFY(vd->vdev_leaf_zap != 0);
 
+	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = vd->vdev_spa->spa_meta_objset;
+	int err;
 
 	if (last_offset > 0) {
 		vd->vdev_initialize_last_offset = last_offset;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_INITIALIZE_LAST_OFFSET,
-		    sizeof (last_offset), 1, &last_offset, tx));
+		    sizeof (last_offset), 1, &last_offset, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 	if (vd->vdev_initialize_action_time > 0) {
 		uint64_t val = (uint64_t)vd->vdev_initialize_action_time;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME, sizeof (val),
-		    1, &val, tx));
+		    1, &val, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	uint64_t initialize_state = vd->vdev_initialize_state;
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+	err = zap_update(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_STATE, sizeof (initialize_state), 1,
-	    &initialize_state, tx));
+	    &initialize_state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -116,30 +124,38 @@ vdev_initialize_zap_remove_sync(void *arg, dmu_tx_t *tx)
 	vd->vdev_initialize_last_offset = 0;
 	vd->vdev_initialize_action_time = 0;
 
+	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = vd->vdev_spa->spa_meta_objset;
 	int error;
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_LAST_OFFSET, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_STATE, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 }
 
-static void
+static int
 vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 {
 	ASSERT(MUTEX_HELD(&vd->vdev_initialize_lock));
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	if (new_state == vd->vdev_initialize_state)
-		return;
+		return (0);
 
 	/*
 	 * Copy the vd's guid, this will be freed by the sync task.
@@ -158,7 +174,13 @@ vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 	vd->vdev_initialize_state = new_state;
 
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
-	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+	err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+	if (err && SPA_EXITING(spa)) {
+		dmu_tx_abort(tx);
+		kmem_free(guid, sizeof (uint64_t));
+		goto out;
+	}
+	VERIFY0(err);
 
 	if (new_state != VDEV_INITIALIZE_NONE) {
 		dsl_sync_task_nowait(spa_get_dsl(spa),
@@ -197,8 +219,11 @@ vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 
 	dmu_tx_commit(tx);
 
+out:
 	if (new_state != VDEV_INITIALIZE_ACTIVE)
 		spa_notify_waiters(spa);
+
+	return (err);
 }
 
 static void
@@ -239,6 +264,7 @@ static int
 vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 {
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	/* Limit inflight initializing I/Os */
 	mutex_enter(&vd->vdev_initialize_io_lock);
@@ -250,7 +276,17 @@ vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 	mutex_exit(&vd->vdev_initialize_io_lock);
 
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
-	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+	err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+	if (err && SPA_EXITING(spa)) {
+		dmu_tx_abort(tx);
+		mutex_enter(&vd->vdev_initialize_io_lock);
+		if (vd->vdev_initialize_inflight > 0)
+			vd->vdev_initialize_inflight--;
+		cv_broadcast(&vd->vdev_initialize_io_cv);
+		mutex_exit(&vd->vdev_initialize_io_lock);
+		return (err);
+	}
+	VERIFY0(err);
 	uint64_t txg = dmu_tx_get_txg(tx);
 
 	spa_config_enter(spa, SCL_STATE_ALL, vd, RW_READER);
@@ -289,7 +325,7 @@ vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 
 	dmu_tx_commit(tx);
 
-	return (0);
+	return (err);
 }
 
 /*
@@ -385,9 +421,10 @@ vdev_initialize_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 	}
 }
 
-static void
+static int
 vdev_initialize_calculate_progress(vdev_t *vd)
 {
+	int err = 0;
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
 	ASSERT(vd->vdev_leaf_zap != 0);
@@ -439,7 +476,12 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		 * metaslab. Load it and walk the free tree for more accurate
 		 * progress estimation.
 		 */
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(vd->vdev_spa)) {
+			mutex_exit(&msp->ms_lock);
+			break;
+		}
+		VERIFY0(err);
 
 		zfs_btree_index_t where;
 		zfs_range_tree_t *rt = msp->ms_allocatable;
@@ -455,6 +497,8 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		}
 		mutex_exit(&msp->ms_lock);
 	}
+
+	return (err);
 }
 
 static int
@@ -477,7 +521,9 @@ vdev_initialize_load(vdev_t *vd)
 		}
 	}
 
-	vdev_initialize_calculate_progress(vd);
+	if (!err)
+		err = vdev_initialize_calculate_progress(vd);
+
 	return (err);
 }
 
@@ -537,7 +583,12 @@ vdev_initialize_thread(void *arg)
 	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
 	vd->vdev_initialize_last_offset = 0;
-	VERIFY0(vdev_initialize_load(vd));
+	error = vdev_initialize_load(vd);
+	if (error && SPA_EXITING(spa)) {
+		spa_config_exit(spa, SCL_CONFIG, FTAG);
+		goto out;
+	}
+	VERIFY0(error);
 
 	abd_t *deadbeef = vdev_initialize_block_alloc();
 
@@ -548,6 +599,7 @@ vdev_initialize_thread(void *arg)
 	for (uint64_t i = 0; !vd->vdev_detached &&
 	    i < vd->vdev_top->vdev_ms_count; i++) {
 		metaslab_t *msp = vd->vdev_top->vdev_ms[i];
+		boolean_t sync = B_TRUE;
 		boolean_t unload_when_done = B_FALSE;
 
 		/*
@@ -555,7 +607,10 @@ vdev_initialize_thread(void *arg)
 		 * first pass, calculate our progress.
 		 */
 		if (vd->vdev_top->vdev_ms_count != ms_count) {
-			vdev_initialize_calculate_progress(vd);
+			error = vdev_initialize_calculate_progress(vd);
+			if (error && SPA_EXITING(spa))
+				break;
+			VERIFY0(error);
 			ms_count = vd->vdev_top->vdev_ms_count;
 		}
 
@@ -564,14 +619,20 @@ vdev_initialize_thread(void *arg)
 		mutex_enter(&msp->ms_lock);
 		if (!msp->ms_loaded && !msp->ms_loading)
 			unload_when_done = B_TRUE;
-		VERIFY0(metaslab_load(msp));
-
-		zfs_range_tree_walk(msp->ms_allocatable,
-		    vdev_initialize_range_add, vd);
+		error = metaslab_load(msp);
+		if (error && SPA_EXITING(spa)) {
+			sync = B_FALSE;
+			unload_when_done = B_FALSE;
+		} else {
+			VERIFY0(error);
+			zfs_range_tree_walk(msp->ms_allocatable,
+			    vdev_initialize_range_add, vd);
+		}
 		mutex_exit(&msp->ms_lock);
 
-		error = vdev_initialize_ranges(vd, deadbeef);
-		metaslab_enable(msp, B_TRUE, unload_when_done);
+		if (!error)
+			error = vdev_initialize_ranges(vd, deadbeef);
+		metaslab_enable(msp, sync, unload_when_done);
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
 		zfs_range_tree_vacate(vd->vdev_initialize_tree, NULL, NULL);
@@ -594,10 +655,10 @@ vdev_initialize_thread(void *arg)
 	mutex_enter(&vd->vdev_initialize_lock);
 	if (!vd->vdev_initialize_exit_wanted) {
 		if (vdev_writeable(vd)) {
-			vdev_initialize_change_state(vd,
+			(void) vdev_initialize_change_state(vd,
 			    VDEV_INITIALIZE_COMPLETE);
 		} else if (vd->vdev_faulted) {
-			vdev_initialize_change_state(vd,
+			(void) vdev_initialize_change_state(vd,
 			    VDEV_INITIALIZE_CANCELED);
 		}
 	}
@@ -613,6 +674,7 @@ vdev_initialize_thread(void *arg)
 	 */
 	mutex_exit(&vd->vdev_initialize_lock);
 	txg_wait_synced(spa_get_dsl(spa), 0);
+out:
 	mutex_enter(&vd->vdev_initialize_lock);
 
 	vd->vdev_initialize_thread = NULL;
@@ -658,7 +720,7 @@ vdev_uninitialize(vdev_t *vd)
 	ASSERT(!vd->vdev_initialize_exit_wanted);
 	ASSERT(!vd->vdev_top->vdev_removing);
 
-	vdev_initialize_change_state(vd, VDEV_INITIALIZE_NONE);
+	(void) vdev_initialize_change_state(vd, VDEV_INITIALIZE_NONE);
 }
 
 /*
@@ -722,7 +784,7 @@ vdev_initialize_stop(vdev_t *vd, vdev_initializing_state_t tgt_state,
 		return;
 	}
 
-	vdev_initialize_change_state(vd, tgt_state);
+	(void) vdev_initialize_change_state(vd, tgt_state);
 	vd->vdev_initialize_exit_wanted = B_TRUE;
 
 	if (vd_list == NULL) {
@@ -781,6 +843,7 @@ vdev_initialize_stop_all(vdev_t *vd, vdev_initializing_state_t tgt_state)
 void
 vdev_initialize_restart(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
 	ASSERT(spa_namespace_held() ||
 	    vd->vdev_spa->spa_load_thread == curthread);
 	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
@@ -791,20 +854,24 @@ vdev_initialize_restart(vdev_t *vd)
 		int err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_INITIALIZE_STATE,
 		    sizeof (initialize_state), 1, &initialize_state);
-		ASSERT(err == 0 || err == ENOENT);
+		if (!SPA_EXITING(spa))
+			ASSERT(err == 0 || err == ENOENT);
 		vd->vdev_initialize_state = initialize_state;
 
 		uint64_t timestamp = 0;
 		err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME,
 		    sizeof (timestamp), 1, &timestamp);
-		ASSERT(err == 0 || err == ENOENT);
+		if (!SPA_EXITING(spa))
+			ASSERT(err == 0 || err == ENOENT);
 		vd->vdev_initialize_action_time = timestamp;
 
 		if ((vd->vdev_initialize_state == VDEV_INITIALIZE_SUSPENDED ||
 		    vd->vdev_offline) && !vd->vdev_top->vdev_rz_expanding) {
 			/* load progress for reporting, but don't resume */
-			VERIFY0(vdev_initialize_load(vd));
+			err = vdev_initialize_load(vd);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		} else if (vd->vdev_initialize_state ==
 		    VDEV_INITIALIZE_ACTIVE && vdev_writeable(vd) &&
 		    !vd->vdev_top->vdev_removing &&

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -68,30 +68,40 @@ vdev_initialize_zap_update_sync(void *arg, dmu_tx_t *tx)
 
 	VERIFY(vd->vdev_leaf_zap != 0);
 
+	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = vd->vdev_spa->spa_meta_objset;
+	int err;
 
 	if (last_offset > 0) {
 		vd->vdev_initialize_last_offset = last_offset;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_INITIALIZE_LAST_OFFSET,
-		    sizeof (last_offset), 1, &last_offset, tx));
+		    sizeof (last_offset), 1, &last_offset, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 	if (vd->vdev_initialize_action_time > 0) {
 		uint64_t val = (uint64_t)vd->vdev_initialize_action_time;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME, sizeof (val),
-		    1, &val, tx));
+		    1, &val, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	uint64_t initialize_state = vd->vdev_initialize_state;
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+	err = zap_update(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_STATE, sizeof (initialize_state), 1,
-	    &initialize_state, tx));
+	    &initialize_state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t initialize_value = vd->vdev_initialize_value;
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+	err = zap_update(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_VALUE, sizeof (initialize_value), 1,
-	    &initialize_value, tx));
+	    &initialize_value, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -111,19 +121,26 @@ vdev_initialize_zap_remove_sync(void *arg, dmu_tx_t *tx)
 	vd->vdev_initialize_last_offset = 0;
 	vd->vdev_initialize_action_time = 0;
 
+	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = vd->vdev_spa->spa_meta_objset;
 	int error;
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_LAST_OFFSET, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_STATE, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
 	    VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME, tx);
+	if (!(error == 0 || error == ENOENT) && SPA_EXITING(spa))
+		return;
 	VERIFY(error == 0 || error == ENOENT);
 
 	error = zap_remove(mos, vd->vdev_leaf_zap,
@@ -131,14 +148,15 @@ vdev_initialize_zap_remove_sync(void *arg, dmu_tx_t *tx)
 	VERIFY(error == 0 || error == ENOENT);
 }
 
-static void
+static int
 vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 {
 	ASSERT(MUTEX_HELD(&vd->vdev_initialize_lock));
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	if (new_state == vd->vdev_initialize_state)
-		return;
+		return (0);
 
 	/*
 	 * Copy the vd's guid, this will be freed by the sync task.
@@ -157,7 +175,13 @@ vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 	vd->vdev_initialize_state = new_state;
 
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
-	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+	err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+	if (err && SPA_EXITING(spa)) {
+		dmu_tx_abort(tx);
+		kmem_free(guid, sizeof (uint64_t));
+		goto out;
+	}
+	VERIFY0(err);
 
 	if (new_state != VDEV_INITIALIZE_NONE) {
 		dsl_sync_task_nowait(spa_get_dsl(spa),
@@ -196,8 +220,11 @@ vdev_initialize_change_state(vdev_t *vd, vdev_initializing_state_t new_state)
 
 	dmu_tx_commit(tx);
 
+out:
 	if (new_state != VDEV_INITIALIZE_ACTIVE)
 		spa_notify_waiters(spa);
+
+	return (err);
 }
 
 static void
@@ -238,6 +265,7 @@ static int
 vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 {
 	spa_t *spa = vd->vdev_spa;
+	int err = 0;
 
 	/* Limit inflight initializing I/Os */
 	mutex_enter(&vd->vdev_initialize_io_lock);
@@ -249,7 +277,17 @@ vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 	mutex_exit(&vd->vdev_initialize_io_lock);
 
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
-	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
+	err = dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND);
+	if (err && SPA_EXITING(spa)) {
+		dmu_tx_abort(tx);
+		mutex_enter(&vd->vdev_initialize_io_lock);
+		if (vd->vdev_initialize_inflight > 0)
+			vd->vdev_initialize_inflight--;
+		cv_broadcast(&vd->vdev_initialize_io_cv);
+		mutex_exit(&vd->vdev_initialize_io_lock);
+		return (err);
+	}
+	VERIFY0(err);
 	uint64_t txg = dmu_tx_get_txg(tx);
 
 	spa_config_enter(spa, SCL_STATE_ALL, vd, RW_READER);
@@ -288,7 +326,7 @@ vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
 
 	dmu_tx_commit(tx);
 
-	return (0);
+	return (err);
 }
 
 /*
@@ -384,9 +422,10 @@ vdev_initialize_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 	}
 }
 
-static void
+static int
 vdev_initialize_calculate_progress(vdev_t *vd)
 {
+	int err = 0;
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
 	ASSERT(vd->vdev_leaf_zap != 0);
@@ -438,7 +477,12 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		 * metaslab. Load it and walk the free tree for more accurate
 		 * progress estimation.
 		 */
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(vd->vdev_spa)) {
+			mutex_exit(&msp->ms_lock);
+			break;
+		}
+		VERIFY0(err);
 
 		zfs_btree_index_t where;
 		zfs_range_tree_t *rt = msp->ms_allocatable;
@@ -454,6 +498,8 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		}
 		mutex_exit(&msp->ms_lock);
 	}
+
+	return (err);
 }
 
 static int
@@ -476,7 +522,9 @@ vdev_initialize_load(vdev_t *vd)
 		}
 	}
 
-	vdev_initialize_calculate_progress(vd);
+	if (!err)
+		err = vdev_initialize_calculate_progress(vd);
+
 	return (err);
 }
 
@@ -536,7 +584,12 @@ vdev_initialize_thread(void *arg)
 	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
 	vd->vdev_initialize_last_offset = 0;
-	VERIFY0(vdev_initialize_load(vd));
+	error = vdev_initialize_load(vd);
+	if (error && SPA_EXITING(spa)) {
+		spa_config_exit(spa, SCL_CONFIG, FTAG);
+		goto out;
+	}
+	VERIFY0(error);
 
 	abd_t *deadbeef =
 	    vdev_initialize_block_alloc(vd->vdev_initialize_value);
@@ -548,6 +601,7 @@ vdev_initialize_thread(void *arg)
 	for (uint64_t i = 0; !vd->vdev_detached &&
 	    i < vd->vdev_top->vdev_ms_count; i++) {
 		metaslab_t *msp = vd->vdev_top->vdev_ms[i];
+		boolean_t sync = B_TRUE;
 		boolean_t unload_when_done = B_FALSE;
 
 		/*
@@ -555,7 +609,10 @@ vdev_initialize_thread(void *arg)
 		 * first pass, calculate our progress.
 		 */
 		if (vd->vdev_top->vdev_ms_count != ms_count) {
-			vdev_initialize_calculate_progress(vd);
+			error = vdev_initialize_calculate_progress(vd);
+			if (error && SPA_EXITING(spa))
+				break;
+			VERIFY0(error);
 			ms_count = vd->vdev_top->vdev_ms_count;
 		}
 
@@ -564,14 +621,20 @@ vdev_initialize_thread(void *arg)
 		mutex_enter(&msp->ms_lock);
 		if (!msp->ms_loaded && !msp->ms_loading)
 			unload_when_done = B_TRUE;
-		VERIFY0(metaslab_load(msp));
-
-		zfs_range_tree_walk(msp->ms_allocatable,
-		    vdev_initialize_range_add, vd);
+		error = metaslab_load(msp);
+		if (error && SPA_EXITING(spa)) {
+			sync = B_FALSE;
+			unload_when_done = B_FALSE;
+		} else {
+			VERIFY0(error);
+			zfs_range_tree_walk(msp->ms_allocatable,
+			    vdev_initialize_range_add, vd);
+		}
 		mutex_exit(&msp->ms_lock);
 
-		error = vdev_initialize_ranges(vd, deadbeef);
-		metaslab_enable(msp, B_TRUE, unload_when_done);
+		if (!error)
+			error = vdev_initialize_ranges(vd, deadbeef);
+		metaslab_enable(msp, sync, unload_when_done);
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
 		zfs_range_tree_vacate(vd->vdev_initialize_tree, NULL, NULL);
@@ -594,10 +657,10 @@ vdev_initialize_thread(void *arg)
 	mutex_enter(&vd->vdev_initialize_lock);
 	if (!vd->vdev_initialize_exit_wanted) {
 		if (vdev_writeable(vd)) {
-			vdev_initialize_change_state(vd,
+			(void) vdev_initialize_change_state(vd,
 			    VDEV_INITIALIZE_COMPLETE);
 		} else if (vd->vdev_faulted) {
-			vdev_initialize_change_state(vd,
+			(void) vdev_initialize_change_state(vd,
 			    VDEV_INITIALIZE_CANCELED);
 		}
 	}
@@ -613,6 +676,7 @@ vdev_initialize_thread(void *arg)
 	 */
 	mutex_exit(&vd->vdev_initialize_lock);
 	txg_wait_synced(spa_get_dsl(spa), 0);
+out:
 	mutex_enter(&vd->vdev_initialize_lock);
 
 	vd->vdev_initialize_thread = NULL;
@@ -673,7 +737,7 @@ vdev_uninitialize(vdev_t *vd)
 	ASSERT(!vd->vdev_initialize_exit_wanted);
 	ASSERT(!vd->vdev_top->vdev_removing);
 
-	vdev_initialize_change_state(vd, VDEV_INITIALIZE_NONE);
+	(void) vdev_initialize_change_state(vd, VDEV_INITIALIZE_NONE);
 }
 
 /*
@@ -737,7 +801,7 @@ vdev_initialize_stop(vdev_t *vd, vdev_initializing_state_t tgt_state,
 		return;
 	}
 
-	vdev_initialize_change_state(vd, tgt_state);
+	(void) vdev_initialize_change_state(vd, tgt_state);
 	vd->vdev_initialize_exit_wanted = B_TRUE;
 
 	if (vd_list == NULL) {
@@ -796,6 +860,7 @@ vdev_initialize_stop_all(vdev_t *vd, vdev_initializing_state_t tgt_state)
 void
 vdev_initialize_restart(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
 	ASSERT(spa_namespace_held() ||
 	    vd->vdev_spa->spa_load_thread == curthread);
 	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
@@ -806,14 +871,16 @@ vdev_initialize_restart(vdev_t *vd)
 		int err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_INITIALIZE_STATE,
 		    sizeof (initialize_state), 1, &initialize_state);
-		ASSERT(err == 0 || err == ENOENT);
+		if (!SPA_EXITING(spa))
+			ASSERT(err == 0 || err == ENOENT);
 		vd->vdev_initialize_state = initialize_state;
 
 		uint64_t timestamp = 0;
 		err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME,
 		    sizeof (timestamp), 1, &timestamp);
-		ASSERT(err == 0 || err == ENOENT);
+		if (!SPA_EXITING(spa))
+			ASSERT(err == 0 || err == ENOENT);
 		vd->vdev_initialize_action_time = timestamp;
 
 		/*
@@ -831,7 +898,9 @@ vdev_initialize_restart(vdev_t *vd)
 		if ((vd->vdev_initialize_state == VDEV_INITIALIZE_SUSPENDED ||
 		    vd->vdev_offline) && !vd->vdev_top->vdev_rz_expanding) {
 			/* load progress for reporting, but don't resume */
-			VERIFY0(vdev_initialize_load(vd));
+			err = vdev_initialize_load(vd);
+			if (!SPA_EXITING(spa))
+				VERIFY0(err);
 		} else if (vd->vdev_initialize_state ==
 		    VDEV_INITIALIZE_ACTIVE && vdev_writeable(vd) &&
 		    !vd->vdev_top->vdev_removing &&

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -211,6 +211,14 @@ vdev_label_write(zio_t *zio, vdev_t *vd, int l, abd_t *buf, uint64_t offset,
 	    spa_config_held(zio->io_spa, SCL_STATE, RW_WRITER) == SCL_STATE);
 	ASSERT(flags & ZIO_FLAG_CONFIG_WRITER);
 
+	if (SPA_EXITING(zio->io_spa)) {
+		zio_t *nio = zio_null(zio, zio->io_spa, NULL, done, private,
+		    ZIO_FLAG_CANFAIL);
+		nio->io_error = SET_ERROR(EIO);
+		zio_nowait(nio);
+		return;
+	}
+
 	zio_nowait(zio_write_phys(zio, vd,
 	    vdev_label_offset(vd->vdev_psize, l, offset),
 	    size, buf, ZIO_CHECKSUM_LABEL, done, private,
@@ -2129,6 +2137,8 @@ retry:
 	 */
 	if (error != 0) {
 		if ((flags & ZIO_FLAG_IO_RETRY) != 0)
+			return (error);
+		if (SPA_EXITING(spa))
 			return (error);
 		flags |= ZIO_FLAG_IO_RETRY;
 	}

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -201,6 +201,14 @@ vdev_label_write(zio_t *zio, vdev_t *vd, int l, abd_t *buf, uint64_t offset,
 	    spa_config_held(zio->io_spa, SCL_STATE, RW_WRITER) == SCL_STATE);
 	ASSERT(flags & ZIO_FLAG_CONFIG_WRITER);
 
+	if (SPA_EXITING(zio->io_spa)) {
+		zio_t *nio = zio_null(zio, zio->io_spa, NULL, done, private,
+		    ZIO_FLAG_CANFAIL);
+		nio->io_error = SET_ERROR(EIO);
+		zio_nowait(nio);
+		return;
+	}
+
 	zio_nowait(zio_write_phys(zio, vd,
 	    vdev_label_offset(vd->vdev_psize, l, offset),
 	    size, buf, ZIO_CHECKSUM_LABEL, done, private,
@@ -2154,6 +2162,8 @@ retry:
 	 */
 	if (error != 0) {
 		if ((flags & ZIO_FLAG_IO_RETRY) != 0)
+			return (error);
+		if (SPA_EXITING(spa))
 			return (error);
 		flags |= ZIO_FLAG_IO_RETRY;
 	}

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -783,7 +783,8 @@ vdev_mirror_io_done(zio_t *zio)
 	    (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)) {
 		zio_dio_chksum_verify_error_report(zio);
 		zio->io_error = vdev_mirror_worst_error(mm);
-		ASSERT3U(zio->io_error, ==, ECKSUM);
+		if (!SPA_EXITING(zio->io_spa))
+			ASSERT3U(zio->io_error, ==, ECKSUM);
 		return;
 	}
 

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -773,7 +773,8 @@ vdev_mirror_io_done(zio_t *zio)
 	    (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)) {
 		zio_dio_chksum_verify_error_report(zio);
 		zio->io_error = vdev_mirror_worst_error(mm);
-		ASSERT3U(zio->io_error, ==, ECKSUM);
+		if (!SPA_EXITING(zio->io_spa))
+			ASSERT3U(zio->io_error, ==, ECKSUM);
 		return;
 	}
 

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -4205,9 +4205,11 @@ raidz_reflow_sync(void *arg, dmu_tx_t *tx)
 	mutex_exit(&vre->vre_lock);
 
 	vdev_t *vd = vdev_lookup_top(spa, vre->vre_vdev_id);
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	int err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_BYTES_COPIED,
-	    sizeof (vre->vre_bytes_copied), 1, &vre->vre_bytes_copied, tx));
+	    sizeof (vre->vre_bytes_copied), 1, &vre->vre_bytes_copied, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -4217,6 +4219,7 @@ raidz_reflow_complete_sync(void *arg, dmu_tx_t *tx)
 	vdev_raidz_expand_t *vre = spa->spa_raidz_expand;
 	vdev_t *raidvd = vdev_lookup_top(spa, vre->vre_vdev_id);
 	vdev_raidz_t *vdrz = raidvd->vdev_tsd;
+	int err;
 
 	for (int i = 0; i < TXG_SIZE; i++)
 		VERIFY0(vre->vre_offset_pertxg[i]);
@@ -4249,14 +4252,18 @@ raidz_reflow_complete_sync(void *arg, dmu_tx_t *tx)
 	vre->vre_state = DSS_FINISHED;
 
 	uint64_t state = vre->vre_state;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_STATE,
-	    sizeof (state), 1, &state, tx));
+	    sizeof (state), 1, &state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t end_time = vre->vre_end_time;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_END_TIME,
-	    sizeof (end_time), 1, &end_time, tx));
+	    sizeof (end_time), 1, &end_time, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa->spa_uberblock.ub_raidz_reflow_info = 0;
 
@@ -4962,6 +4969,7 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 {
 	spa_t *spa = arg;
 	vdev_raidz_expand_t *vre = spa->spa_raidz_expand;
+	int err;
 
 	if (RRSS_GET_STATE(&spa->spa_ubsync) == RRSS_SCRATCH_VALID)
 		vre->vre_offset = 0;
@@ -5009,7 +5017,13 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 			continue;
 		}
 
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(spa)) {
+			mutex_exit(&msp->ms_lock);
+			metaslab_enable(msp, B_FALSE, B_FALSE);
+			break;
+		}
+		VERIFY0(err);
 
 		/*
 		 * We want to copy everything except the free (allocatable)
@@ -5140,7 +5154,7 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 	 */
 	txg_wait_synced(spa->spa_dsl_pool, 0);
 
-	if (!zthr_iscancelled(zthr) &&
+	if (!zthr_iscancelled(zthr) && !SPA_EXITING(spa) &&
 	    vre->vre_offset == raidvd->vdev_ms_count << raidvd->vdev_ms_shift) {
 		/*
 		 * We are not being canceled or paused, so the reflow must be
@@ -5232,6 +5246,7 @@ vdev_raidz_attach_sync(void *arg, dmu_tx_t *tx)
 	spa_t *spa = new_child->vdev_spa;
 	vdev_t *raidvd = new_child->vdev_parent;
 	vdev_raidz_t *vdrz = raidvd->vdev_tsd;
+	int err;
 	ASSERT3P(raidvd->vdev_ops, ==, &vdev_raidz_ops);
 	ASSERT3P(raidvd->vdev_top, ==, raidvd);
 	ASSERT3U(raidvd->vdev_children, >, vdrz->vd_original_width);
@@ -5262,14 +5277,18 @@ vdev_raidz_attach_sync(void *arg, dmu_tx_t *tx)
 	vdrz->vn_vre.vre_bytes_copied = 0;
 
 	uint64_t state = vdrz->vn_vre.vre_state;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_STATE,
-	    sizeof (state), 1, &state, tx));
+	    sizeof (state), 1, &state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t start_time = vdrz->vn_vre.vre_start_time;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_START_TIME,
-	    sizeof (start_time), 1, &start_time, tx));
+	    sizeof (start_time), 1, &start_time, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	(void) zap_remove(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_END_TIME, tx);

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -4195,9 +4195,11 @@ raidz_reflow_sync(void *arg, dmu_tx_t *tx)
 	mutex_exit(&vre->vre_lock);
 
 	vdev_t *vd = vdev_lookup_top(spa, vre->vre_vdev_id);
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	int err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_BYTES_COPIED,
-	    sizeof (vre->vre_bytes_copied), 1, &vre->vre_bytes_copied, tx));
+	    sizeof (vre->vre_bytes_copied), 1, &vre->vre_bytes_copied, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static void
@@ -4207,6 +4209,7 @@ raidz_reflow_complete_sync(void *arg, dmu_tx_t *tx)
 	vdev_raidz_expand_t *vre = spa->spa_raidz_expand;
 	vdev_t *raidvd = vdev_lookup_top(spa, vre->vre_vdev_id);
 	vdev_raidz_t *vdrz = raidvd->vdev_tsd;
+	int err;
 
 	for (int i = 0; i < TXG_SIZE; i++)
 		VERIFY0(vre->vre_offset_pertxg[i]);
@@ -4239,14 +4242,18 @@ raidz_reflow_complete_sync(void *arg, dmu_tx_t *tx)
 	vre->vre_state = DSS_FINISHED;
 
 	uint64_t state = vre->vre_state;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_STATE,
-	    sizeof (state), 1, &state, tx));
+	    sizeof (state), 1, &state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t end_time = vre->vre_end_time;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    vd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_END_TIME,
-	    sizeof (end_time), 1, &end_time, tx));
+	    sizeof (end_time), 1, &end_time, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa->spa_uberblock.ub_raidz_reflow_info = 0;
 
@@ -4952,6 +4959,7 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 {
 	spa_t *spa = arg;
 	vdev_raidz_expand_t *vre = spa->spa_raidz_expand;
+	int err;
 
 	if (RRSS_GET_STATE(&spa->spa_ubsync) == RRSS_SCRATCH_VALID)
 		vre->vre_offset = 0;
@@ -4999,7 +5007,13 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 			continue;
 		}
 
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(spa)) {
+			mutex_exit(&msp->ms_lock);
+			metaslab_enable(msp, B_FALSE, B_FALSE);
+			break;
+		}
+		VERIFY0(err);
 
 		/*
 		 * We want to copy everything except the free (allocatable)
@@ -5130,7 +5144,7 @@ spa_raidz_expand_thread(void *arg, zthr_t *zthr)
 	 */
 	txg_wait_synced(spa->spa_dsl_pool, 0);
 
-	if (!zthr_iscancelled(zthr) &&
+	if (!zthr_iscancelled(zthr) && !SPA_EXITING(spa) &&
 	    vre->vre_offset == raidvd->vdev_ms_count << raidvd->vdev_ms_shift) {
 		/*
 		 * We are not being canceled or paused, so the reflow must be
@@ -5222,6 +5236,7 @@ vdev_raidz_attach_sync(void *arg, dmu_tx_t *tx)
 	spa_t *spa = new_child->vdev_spa;
 	vdev_t *raidvd = new_child->vdev_parent;
 	vdev_raidz_t *vdrz = raidvd->vdev_tsd;
+	int err;
 	ASSERT3P(raidvd->vdev_ops, ==, &vdev_raidz_ops);
 	ASSERT3P(raidvd->vdev_top, ==, raidvd);
 	ASSERT3U(raidvd->vdev_children, >, vdrz->vd_original_width);
@@ -5251,14 +5266,18 @@ vdev_raidz_attach_sync(void *arg, dmu_tx_t *tx)
 	vdrz->vn_vre.vre_bytes_copied = 0;
 
 	uint64_t state = vdrz->vn_vre.vre_state;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_STATE,
-	    sizeof (state), 1, &state, tx));
+	    sizeof (state), 1, &state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t start_time = vdrz->vn_vre.vre_start_time;
-	VERIFY0(zap_update(spa->spa_meta_objset,
+	err = zap_update(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_START_TIME,
-	    sizeof (start_time), 1, &start_time, tx));
+	    sizeof (start_time), 1, &start_time, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	(void) zap_remove(spa->spa_meta_objset,
 	    raidvd->vdev_top_zap, VDEV_TOP_ZAP_RAIDZ_EXPAND_END_TIME, tx);

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -196,6 +196,7 @@ vdev_rebuild_update_sync(void *arg, dmu_tx_t *tx)
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
 	uint64_t txg = dmu_tx_get_txg(tx);
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 
@@ -207,9 +208,11 @@ vdev_rebuild_update_sync(void *arg, dmu_tx_t *tx)
 	vrp->vrp_scan_time_ms = vr->vr_prev_scan_time_ms +
 	    NSEC2MSEC(gethrtime() - vr->vr_pass_start_time);
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	mutex_exit(&vd->vdev_rebuild_lock);
 }
@@ -225,6 +228,8 @@ vdev_rebuild_initiate_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	boolean_t needed;
+	int err;
 
 	ASSERT(vd->vdev_rebuilding);
 
@@ -246,11 +251,20 @@ vdev_rebuild_initiate_sync(void *arg, dmu_tx_t *tx)
 	 * be useful because it would allow us to rebuild the space used by
 	 * pool checkpoints.
 	 */
-	VERIFY(vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg));
+	needed = vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg);
+	if (SPA_EXITING(spa)) {
+		vrp->vrp_rebuild_state = VDEV_REBUILD_NONE;
+		vd->vdev_rebuilding = B_TRUE;
+		mutex_exit(&vd->vdev_rebuild_lock);
+		return;
+	}
+	VERIFY(needed);
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_history_log_internal(spa, "rebuild", tx,
 	    "vdev_id=%llu vdev_guid=%llu started",
@@ -308,6 +322,7 @@ vdev_rebuild_complete_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 
@@ -324,9 +339,11 @@ vdev_rebuild_complete_sync(void *arg, dmu_tx_t *tx)
 	vrp->vrp_rebuild_state = VDEV_REBUILD_COMPLETE;
 	vrp->vrp_end_time = gethrestime_sec();
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	vdev_dtl_reassess(vd, tx->tx_txg, vrp->vrp_max_txg, B_TRUE, B_TRUE);
 	spa_feature_decr(vd->vdev_spa, SPA_FEATURE_DEVICE_REBUILD, tx);
@@ -372,14 +389,17 @@ vdev_rebuild_cancel_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 	vrp->vrp_rebuild_state = VDEV_REBUILD_CANCELED;
 	vrp->vrp_end_time = gethrestime_sec();
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_feature_decr(vd->vdev_spa, SPA_FEATURE_DEVICE_REBUILD, tx);
 
@@ -403,6 +423,7 @@ vdev_rebuild_cancel_sync(void *arg, dmu_tx_t *tx)
 static void
 vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 {
+	int err;
 	int vdev_id = (uintptr_t)arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
@@ -427,9 +448,11 @@ vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 	/* See vdev_rebuild_initiate_sync comment */
 	VERIFY(vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg));
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_history_log_internal(spa, "rebuild",  tx,
 	    "vdev_id=%llu vdev_guid=%llu reset",
@@ -450,6 +473,7 @@ vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 void
 vdev_rebuild_clear_sync(void *arg, dmu_tx_t *tx)
 {
+	int err;
 	int vdev_id = (uintptr_t)arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
@@ -470,9 +494,11 @@ vdev_rebuild_clear_sync(void *arg, dmu_tx_t *tx)
 
 	if (vd->vdev_top_zap != 0 && zap_contains(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS) == 0) {
-		VERIFY0(zap_update(mos, vd->vdev_top_zap,
+		err = zap_update(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-		    REBUILD_PHYS_ENTRIES, vrp, tx));
+		    REBUILD_PHYS_ENTRIES, vrp, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	mutex_exit(&vd->vdev_rebuild_lock);
@@ -815,6 +841,11 @@ vdev_rebuild_thread(void *arg)
 		metaslab_t *msp = vd->vdev_ms[i];
 		vr->vr_scan_msp = msp;
 
+		if (SPA_EXITING(spa)) {
+			error = EIO;
+			break;
+		}
+
 		/*
 		 * Calculate the max number of in-flight bytes for top-level
 		 * vdev scanning operations (minimum 1MB, maximum 1/2 of
@@ -871,8 +902,11 @@ vdev_rebuild_thread(void *arg)
 		 * unflushed frees.  This is the minimum range to be rebuilt.
 		 */
 		if (msp->ms_sm != NULL) {
-			VERIFY0(space_map_load(msp->ms_sm,
-			    vr->vr_scan_tree, SM_ALLOC));
+			error = space_map_load(msp->ms_sm,
+			    vr->vr_scan_tree, SM_ALLOC);
+			if (error && SPA_EXITING(spa))
+				goto skip;
+			VERIFY0(error);
 
 			for (int i = 0; i < TXG_SIZE; i++) {
 				ASSERT0(zfs_range_tree_space(
@@ -893,6 +927,7 @@ vdev_rebuild_thread(void *arg)
 			    vrp->vrp_last_offset);
 		}
 
+skip:
 		mutex_exit(&msp->ms_lock);
 		mutex_exit(&msp->ms_sync_lock);
 
@@ -909,7 +944,8 @@ vdev_rebuild_thread(void *arg)
 		/*
 		 * Walk the allocated space map and issue the rebuild I/O.
 		 */
-		error = vdev_rebuild_ranges(vr);
+		if (!error)
+			error = vdev_rebuild_ranges(vr);
 		zfs_range_tree_vacate(vr->vr_scan_tree, NULL, NULL);
 
 		/*

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -186,6 +186,7 @@ vdev_rebuild_update_sync(void *arg, dmu_tx_t *tx)
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
 	uint64_t txg = dmu_tx_get_txg(tx);
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 
@@ -197,9 +198,11 @@ vdev_rebuild_update_sync(void *arg, dmu_tx_t *tx)
 	vrp->vrp_scan_time_ms = vr->vr_prev_scan_time_ms +
 	    NSEC2MSEC(gethrtime() - vr->vr_pass_start_time);
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	mutex_exit(&vd->vdev_rebuild_lock);
 }
@@ -215,6 +218,8 @@ vdev_rebuild_initiate_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	boolean_t needed;
+	int err;
 
 	ASSERT(vd->vdev_rebuilding);
 
@@ -236,11 +241,20 @@ vdev_rebuild_initiate_sync(void *arg, dmu_tx_t *tx)
 	 * be useful because it would allow us to rebuild the space used by
 	 * pool checkpoints.
 	 */
-	VERIFY(vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg));
+	needed = vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg);
+	if (SPA_EXITING(spa)) {
+		vrp->vrp_rebuild_state = VDEV_REBUILD_NONE;
+		vd->vdev_rebuilding = B_TRUE;
+		mutex_exit(&vd->vdev_rebuild_lock);
+		return;
+	}
+	VERIFY(needed);
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_history_log_internal(spa, "rebuild", tx,
 	    "vdev_id=%llu vdev_guid=%llu started",
@@ -298,6 +312,7 @@ vdev_rebuild_complete_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 
@@ -314,9 +329,11 @@ vdev_rebuild_complete_sync(void *arg, dmu_tx_t *tx)
 	vrp->vrp_rebuild_state = VDEV_REBUILD_COMPLETE;
 	vrp->vrp_end_time = gethrestime_sec();
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	vdev_dtl_reassess(vd, tx->tx_txg, vrp->vrp_max_txg, B_TRUE, B_TRUE);
 	spa_feature_decr(vd->vdev_spa, SPA_FEATURE_DEVICE_REBUILD, tx);
@@ -362,14 +379,17 @@ vdev_rebuild_cancel_sync(void *arg, dmu_tx_t *tx)
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp = &vr->vr_rebuild_phys;
+	int err;
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 	vrp->vrp_rebuild_state = VDEV_REBUILD_CANCELED;
 	vrp->vrp_end_time = gethrestime_sec();
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_feature_decr(vd->vdev_spa, SPA_FEATURE_DEVICE_REBUILD, tx);
 
@@ -393,6 +413,7 @@ vdev_rebuild_cancel_sync(void *arg, dmu_tx_t *tx)
 static void
 vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 {
+	int err;
 	int vdev_id = (uintptr_t)arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
@@ -417,9 +438,11 @@ vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 	/* See vdev_rebuild_initiate_sync comment */
 	VERIFY(vdev_resilver_needed(vd, &vrp->vrp_min_txg, &vrp->vrp_max_txg));
 
-	VERIFY0(zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+	err = zap_update(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-	    REBUILD_PHYS_ENTRIES, vrp, tx));
+	    REBUILD_PHYS_ENTRIES, vrp, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	spa_history_log_internal(spa, "rebuild",  tx,
 	    "vdev_id=%llu vdev_guid=%llu reset",
@@ -440,6 +463,7 @@ vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 void
 vdev_rebuild_clear_sync(void *arg, dmu_tx_t *tx)
 {
+	int err;
 	int vdev_id = (uintptr_t)arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	vdev_t *vd = vdev_lookup_top(spa, vdev_id);
@@ -460,9 +484,11 @@ vdev_rebuild_clear_sync(void *arg, dmu_tx_t *tx)
 
 	if (vd->vdev_top_zap != 0 && zap_contains(mos, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS) == 0) {
-		VERIFY0(zap_update(mos, vd->vdev_top_zap,
+		err = zap_update(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
-		    REBUILD_PHYS_ENTRIES, vrp, tx));
+		    REBUILD_PHYS_ENTRIES, vrp, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	mutex_exit(&vd->vdev_rebuild_lock);
@@ -805,6 +831,11 @@ vdev_rebuild_thread(void *arg)
 		metaslab_t *msp = vd->vdev_ms[i];
 		vr->vr_scan_msp = msp;
 
+		if (SPA_EXITING(spa)) {
+			error = EIO;
+			break;
+		}
+
 		/*
 		 * Calculate the max number of in-flight bytes for top-level
 		 * vdev scanning operations (minimum 1MB, maximum 1/2 of
@@ -861,8 +892,11 @@ vdev_rebuild_thread(void *arg)
 		 * unflushed frees.  This is the minimum range to be rebuilt.
 		 */
 		if (msp->ms_sm != NULL) {
-			VERIFY0(space_map_load(msp->ms_sm,
-			    vr->vr_scan_tree, SM_ALLOC));
+			error = space_map_load(msp->ms_sm,
+			    vr->vr_scan_tree, SM_ALLOC);
+			if (error && SPA_EXITING(spa))
+				goto skip;
+			VERIFY0(error);
 
 			for (int i = 0; i < TXG_SIZE; i++) {
 				ASSERT0(zfs_range_tree_space(
@@ -883,6 +917,7 @@ vdev_rebuild_thread(void *arg)
 			    vrp->vrp_last_offset);
 		}
 
+skip:
 		mutex_exit(&msp->ms_lock);
 		mutex_exit(&msp->ms_sync_lock);
 
@@ -899,7 +934,8 @@ vdev_rebuild_thread(void *arg)
 		/*
 		 * Walk the allocated space map and issue the rebuild I/O.
 		 */
-		error = vdev_rebuild_ranges(vr);
+		if (!error)
+			error = vdev_rebuild_ranges(vr);
 		zfs_range_tree_vacate(vr->vr_scan_tree, NULL, NULL);
 
 		/*

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -183,11 +183,13 @@ static int spa_vdev_remove_cancel_impl(spa_t *spa);
 static void
 spa_sync_removing_state(spa_t *spa, dmu_tx_t *tx)
 {
-	VERIFY0(zap_update(spa->spa_dsl_pool->dp_meta_objset,
+	int err = zap_update(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_REMOVING, sizeof (uint64_t),
 	    sizeof (spa->spa_removing_phys) / sizeof (uint64_t),
-	    &spa->spa_removing_phys, tx));
+	    &spa->spa_removing_phys, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static nvlist_t *
@@ -454,6 +456,7 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	objset_t *mos = spa->spa_dsl_pool->dp_meta_objset;
 	spa_vdev_removal_t *svr = NULL;
 	uint64_t txg __maybe_unused = dmu_tx_get_txg(tx);
+	int err;
 
 	ASSERT0(vdev_get_nparity(vd));
 	svr = spa_vdev_removal_create(vd);
@@ -470,20 +473,35 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 		 */
 		spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 		uint64_t one = 1;
-		VERIFY0(zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
+		err = zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, sizeof (one), 1,
-		    &one, tx));
+		    &one, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting1;
+		VERIFY0(err);
 		boolean_t are_precise __maybe_unused;
 		ASSERT0(vdev_obsolete_counts_are_precise(vd, &are_precise));
 		ASSERT3B(are_precise, ==, B_TRUE);
 	}
 
-	VERIFY0(vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object));
-	vd->vdev_indirect_mapping =
-	    vdev_indirect_mapping_open(mos, vic->vic_mapping_object);
-	VERIFY0(vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object));
-	vd->vdev_indirect_births =
-	    vdev_indirect_births_open(mos, vic->vic_births_object);
+	err = vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_mapping_open(mos, vic->vic_mapping_object,
+	    &vd->vdev_indirect_mapping);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_births_open(mos, vic->vic_births_object,
+	    &vd->vdev_indirect_births);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
 	spa->spa_removing_phys.sr_removing_vdev = vd->vdev_id;
 	spa->spa_removing_phys.sr_start_time = gethrestime_sec();
 	spa->spa_removing_phys.sr_end_time = 0;
@@ -533,12 +551,22 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	 * modified all blocks of the object.)
 	 */
 	dmu_object_info_t doi;
-	VERIFY0(dmu_object_info(mos, DMU_POOL_DIRECTORY_OBJECT, &doi));
+	err = dmu_object_info(mos, DMU_POOL_DIRECTORY_OBJECT, &doi);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting2;
+	VERIFY0(err);
 	for (uint64_t offset = 0; offset < doi.doi_max_offset; ) {
 		dmu_buf_t *dbuf;
-		VERIFY0(dmu_buf_hold(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    offset, FTAG, &dbuf, 0));
+		err = dmu_buf_hold(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    offset, FTAG, &dbuf, 0);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting2;
+		VERIFY0(err);
 		dmu_buf_will_dirty(dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			goto spa_exiting2;
+		}
 		offset += dbuf->db_size;
 		dmu_buf_rele(dbuf, FTAG);
 	}
@@ -569,6 +597,13 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	spa->spa_vdev_removal = svr;
 	svr->svr_thread = thread_create(NULL, 0,
 	    spa_vdev_remove_thread, spa, 0, &p0, TS_RUN, minclsyspri);
+	return;
+
+spa_exiting2:
+	vdev_indirect_births_close(vd->vdev_indirect_births);
+
+spa_exiting1:
+	spa_vdev_removal_destroy(svr);
 }
 
 /*
@@ -623,10 +658,20 @@ spa_remove_init(spa_t *spa)
 		ASSERT3U(svr->svr_vdev_id, ==, vd->vdev_id);
 		ASSERT(vd->vdev_removing);
 
-		vd->vdev_indirect_mapping = vdev_indirect_mapping_open(
-		    spa->spa_meta_objset, vic->vic_mapping_object);
-		vd->vdev_indirect_births = vdev_indirect_births_open(
-		    spa->spa_meta_objset, vic->vic_births_object);
+		error = vdev_indirect_mapping_open(spa->spa_meta_objset,
+		    vic->vic_mapping_object, &vd->vdev_indirect_mapping);
+		if (error && SPA_EXITING(spa)) {
+spa_exiting1:
+			spa_vdev_removal_destroy(svr);
+			spa_config_exit(spa, SCL_STATE, FTAG);
+			return (error);
+		}
+		VERIFY0(error);
+		error = vdev_indirect_births_open(spa->spa_meta_objset,
+		    vic->vic_births_object, &vd->vdev_indirect_births);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting1;
+		VERIFY0(error);
 		spa_config_exit(spa, SCL_STATE, FTAG);
 
 		spa->spa_vdev_removal = svr;
@@ -640,10 +685,19 @@ spa_remove_init(spa_t *spa)
 		vdev_indirect_config_t *vic = &vd->vdev_indirect_config;
 
 		ASSERT3P(vd->vdev_ops, ==, &vdev_indirect_ops);
-		vd->vdev_indirect_mapping = vdev_indirect_mapping_open(
-		    spa->spa_meta_objset, vic->vic_mapping_object);
-		vd->vdev_indirect_births = vdev_indirect_births_open(
-		    spa->spa_meta_objset, vic->vic_births_object);
+		error = vdev_indirect_mapping_open(spa->spa_meta_objset,
+		    vic->vic_mapping_object, &vd->vdev_indirect_mapping);
+		if (error && SPA_EXITING(spa)) {
+spa_exiting2:
+			spa_config_exit(spa, SCL_STATE, FTAG);
+			return (error);
+		}
+		VERIFY0(error);
+		error = vdev_indirect_births_open(spa->spa_meta_objset,
+		    vic->vic_births_object, &vd->vdev_indirect_births);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting2;
+		VERIFY0(error);
 
 		indirect_vdev_id = vic->vic_prev_indirect_vdev;
 	}
@@ -936,6 +990,9 @@ vdev_mapping_sync(void *arg, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
 	uint64_t txg = dmu_tx_get_txg(tx);
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	ASSERT(vic->vic_mapping_object != 0);
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
@@ -1693,8 +1750,18 @@ again:
 		 * to finish loading the spacemap, and then take the
 		 * appropriate action (see free_from_removing_vdev()).
 		 */
-		if (msp->ms_sm != NULL)
-			VERIFY0(space_map_load(msp->ms_sm, segs, SM_ALLOC));
+		if (msp->ms_sm != NULL) {
+			int err = space_map_load(msp->ms_sm, segs, SM_ALLOC);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&msp->ms_lock);
+				mutex_exit(&msp->ms_sync_lock);
+				zfs_range_tree_vacate(segs, NULL, NULL);
+				mutex_enter(&svr->svr_lock);
+				svr->svr_thread_exit = B_TRUE;
+				break;
+			}
+			VERIFY0(err);
+		}
 
 		/*
 		 * We could not hold svr_lock while loading space map, or we
@@ -1827,7 +1894,10 @@ again:
 		 * error was encountered.  The removal process must be
 		 * cancelled or this damage may become permanent.
 		 */
-		if (zfs_removal_ignore_errors == 0 &&
+		if (SPA_EXITING(spa)) {
+			zfs_dbgmsg("canceling removal due to spa_exiting");
+			spa_vdev_remove_cancel_impl(spa);
+		} else if (zfs_removal_ignore_errors == 0 &&
 		    (vca.vca_read_error_bytes > 0 ||
 		    vca.vca_write_error_bytes > 0)) {
 			zfs_dbgmsg("canceling removal due to IO errors: "
@@ -1907,29 +1977,38 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic = &vd->vdev_indirect_config;
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 	objset_t *mos = spa->spa_meta_objset;
+	int err;
 
 	ASSERT0P(svr->svr_thread);
 
 	spa_feature_decr(spa, SPA_FEATURE_DEVICE_REMOVAL, tx);
 
-	boolean_t are_precise;
-	VERIFY0(vdev_obsolete_counts_are_precise(vd, &are_precise));
+	boolean_t are_precise = B_FALSE;
+	err = vdev_obsolete_counts_are_precise(vd, &are_precise);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (are_precise) {
 		spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
-		VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, tx));
+		err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
-	uint64_t obsolete_sm_object;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	uint64_t obsolete_sm_object = 0;
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (obsolete_sm_object != 0) {
 		ASSERT(vd->vdev_obsolete_sm != NULL);
 		ASSERT3U(obsolete_sm_object, ==,
 		    space_map_object(vd->vdev_obsolete_sm));
 
 		space_map_free(vd->vdev_obsolete_sm, tx);
-		VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx));
+		err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		space_map_close(vd->vdev_obsolete_sm);
 		vd->vdev_obsolete_sm = NULL;
 		spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
@@ -1957,13 +2036,21 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 		 * Assert nothing in flight -- ms_*tree is empty.
 		 */
 		for (int i = 0; i < TXG_SIZE; i++)
-			ASSERT0(zfs_range_tree_space(msp->ms_allocating[i]));
+			ASSERT0(zfs_range_tree_space(
+			    msp->ms_allocating[i]));
 		for (int i = 0; i < TXG_DEFER_SIZE; i++)
 			ASSERT0(zfs_range_tree_space(msp->ms_defer[i]));
 		ASSERT0(zfs_range_tree_space(msp->ms_freed));
 
-		if (msp->ms_sm != NULL)
-			VERIFY0(space_map_load(msp->ms_sm, segs, SM_ALLOC));
+		if (msp->ms_sm != NULL) {
+			err = space_map_load(msp->ms_sm, segs, SM_ALLOC);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&msp->ms_lock);
+				zfs_range_tree_vacate(segs, NULL, NULL);
+				break;
+			}
+			VERIFY0(err);
+		}
 
 		zfs_range_tree_walk(msp->ms_unflushed_allocs,
 		    zfs_range_tree_add, segs);
@@ -2195,6 +2282,8 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 	ASSERT(spa_namespace_held());
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
+	if (SPA_EXITING(spa))
+		goto skip;
 	/* The top ZAP should have been destroyed by vdev_remove_empty. */
 	ASSERT0(vd->vdev_top_zap);
 	/* The leaf ZAP should have been destroyed by vdev_dtl_sync. */
@@ -2202,12 +2291,14 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 
 	(void) vdev_label_init(vd, 0, VDEV_LABEL_REMOVE);
 
+skip:
 	if (list_link_active(&vd->vdev_state_dirty_node))
 		vdev_state_clean(vd);
 	if (list_link_active(&vd->vdev_config_dirty_node))
 		vdev_config_clean(vd);
 
-	ASSERT0(vd->vdev_stat.vs_alloc);
+	if (!SPA_EXITING(spa))
+		ASSERT0(vd->vdev_stat.vs_alloc);
 
 	/*
 	 * Clean up the vdev namespace.

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -478,10 +478,10 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 		ASSERT3B(are_precise, ==, B_TRUE);
 	}
 
-	vic->vic_mapping_object = vdev_indirect_mapping_alloc(mos, tx);
+	VERIFY0(vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object));
 	vd->vdev_indirect_mapping =
 	    vdev_indirect_mapping_open(mos, vic->vic_mapping_object);
-	vic->vic_births_object = vdev_indirect_births_alloc(mos, tx);
+	VERIFY0(vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object));
 	vd->vdev_indirect_births =
 	    vdev_indirect_births_open(mos, vic->vic_births_object);
 	spa->spa_removing_phys.sr_removing_vdev = vd->vdev_id;

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -173,11 +173,13 @@ static int spa_vdev_remove_cancel_impl(spa_t *spa);
 static void
 spa_sync_removing_state(spa_t *spa, dmu_tx_t *tx)
 {
-	VERIFY0(zap_update(spa->spa_dsl_pool->dp_meta_objset,
+	int err = zap_update(spa->spa_dsl_pool->dp_meta_objset,
 	    DMU_POOL_DIRECTORY_OBJECT,
 	    DMU_POOL_REMOVING, sizeof (uint64_t),
 	    sizeof (spa->spa_removing_phys) / sizeof (uint64_t),
-	    &spa->spa_removing_phys, tx));
+	    &spa->spa_removing_phys, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 static nvlist_t *
@@ -444,6 +446,7 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	objset_t *mos = spa->spa_dsl_pool->dp_meta_objset;
 	spa_vdev_removal_t *svr = NULL;
 	uint64_t txg __maybe_unused = dmu_tx_get_txg(tx);
+	int err;
 
 	ASSERT0(vdev_get_nparity(vd));
 	svr = spa_vdev_removal_create(vd);
@@ -460,20 +463,35 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 		 */
 		spa_feature_incr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
 		uint64_t one = 1;
-		VERIFY0(zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
+		err = zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, sizeof (one), 1,
-		    &one, tx));
+		    &one, tx);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting1;
+		VERIFY0(err);
 		boolean_t are_precise __maybe_unused;
 		ASSERT0(vdev_obsolete_counts_are_precise(vd, &are_precise));
 		ASSERT3B(are_precise, ==, B_TRUE);
 	}
 
-	VERIFY0(vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object));
-	vd->vdev_indirect_mapping =
-	    vdev_indirect_mapping_open(mos, vic->vic_mapping_object);
-	VERIFY0(vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object));
-	vd->vdev_indirect_births =
-	    vdev_indirect_births_open(mos, vic->vic_births_object);
+	err = vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_mapping_open(mos, vic->vic_mapping_object,
+	    &vd->vdev_indirect_mapping);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
+	err = vdev_indirect_births_open(mos, vic->vic_births_object,
+	    &vd->vdev_indirect_births);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting1;
+	VERIFY0(err);
 	spa->spa_removing_phys.sr_removing_vdev = vd->vdev_id;
 	spa->spa_removing_phys.sr_start_time = gethrestime_sec();
 	spa->spa_removing_phys.sr_end_time = 0;
@@ -523,12 +541,22 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	 * modified all blocks of the object.)
 	 */
 	dmu_object_info_t doi;
-	VERIFY0(dmu_object_info(mos, DMU_POOL_DIRECTORY_OBJECT, &doi));
+	err = dmu_object_info(mos, DMU_POOL_DIRECTORY_OBJECT, &doi);
+	if (err && SPA_EXITING(spa))
+		goto spa_exiting2;
+	VERIFY0(err);
 	for (uint64_t offset = 0; offset < doi.doi_max_offset; ) {
 		dmu_buf_t *dbuf;
-		VERIFY0(dmu_buf_hold(mos, DMU_POOL_DIRECTORY_OBJECT,
-		    offset, FTAG, &dbuf, 0));
+		err = dmu_buf_hold(mos, DMU_POOL_DIRECTORY_OBJECT,
+		    offset, FTAG, &dbuf, 0);
+		if (err && SPA_EXITING(spa))
+			goto spa_exiting2;
+		VERIFY0(err);
 		dmu_buf_will_dirty(dbuf, tx);
+		if (SPA_EXITING(spa)) {
+			dmu_buf_rele(dbuf, FTAG);
+			goto spa_exiting2;
+		}
 		offset += dbuf->db_size;
 		dmu_buf_rele(dbuf, FTAG);
 	}
@@ -559,6 +587,13 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	spa->spa_vdev_removal = svr;
 	svr->svr_thread = thread_create(NULL, 0,
 	    spa_vdev_remove_thread, spa, 0, &p0, TS_RUN, minclsyspri);
+	return;
+
+spa_exiting2:
+	vdev_indirect_births_close(vd->vdev_indirect_births);
+
+spa_exiting1:
+	spa_vdev_removal_destroy(svr);
 }
 
 /*
@@ -613,10 +648,20 @@ spa_remove_init(spa_t *spa)
 		ASSERT3U(svr->svr_vdev_id, ==, vd->vdev_id);
 		ASSERT(vd->vdev_removing);
 
-		vd->vdev_indirect_mapping = vdev_indirect_mapping_open(
-		    spa->spa_meta_objset, vic->vic_mapping_object);
-		vd->vdev_indirect_births = vdev_indirect_births_open(
-		    spa->spa_meta_objset, vic->vic_births_object);
+		error = vdev_indirect_mapping_open(spa->spa_meta_objset,
+		    vic->vic_mapping_object, &vd->vdev_indirect_mapping);
+		if (error && SPA_EXITING(spa)) {
+spa_exiting1:
+			spa_vdev_removal_destroy(svr);
+			spa_config_exit(spa, SCL_STATE, FTAG);
+			return (error);
+		}
+		VERIFY0(error);
+		error = vdev_indirect_births_open(spa->spa_meta_objset,
+		    vic->vic_births_object, &vd->vdev_indirect_births);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting1;
+		VERIFY0(error);
 		spa_config_exit(spa, SCL_STATE, FTAG);
 
 		spa->spa_vdev_removal = svr;
@@ -630,10 +675,19 @@ spa_remove_init(spa_t *spa)
 		vdev_indirect_config_t *vic = &vd->vdev_indirect_config;
 
 		ASSERT3P(vd->vdev_ops, ==, &vdev_indirect_ops);
-		vd->vdev_indirect_mapping = vdev_indirect_mapping_open(
-		    spa->spa_meta_objset, vic->vic_mapping_object);
-		vd->vdev_indirect_births = vdev_indirect_births_open(
-		    spa->spa_meta_objset, vic->vic_births_object);
+		error = vdev_indirect_mapping_open(spa->spa_meta_objset,
+		    vic->vic_mapping_object, &vd->vdev_indirect_mapping);
+		if (error && SPA_EXITING(spa)) {
+spa_exiting2:
+			spa_config_exit(spa, SCL_STATE, FTAG);
+			return (error);
+		}
+		VERIFY0(error);
+		error = vdev_indirect_births_open(spa->spa_meta_objset,
+		    vic->vic_births_object, &vd->vdev_indirect_births);
+		if (error && SPA_EXITING(spa))
+			goto spa_exiting2;
+		VERIFY0(error);
 
 		indirect_vdev_id = vic->vic_prev_indirect_vdev;
 	}
@@ -926,6 +980,9 @@ vdev_mapping_sync(void *arg, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
 	uint64_t txg = dmu_tx_get_txg(tx);
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
+
+	if (SPA_EXITING(spa))
+		return;
 
 	ASSERT(vic->vic_mapping_object != 0);
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
@@ -1683,8 +1740,18 @@ again:
 		 * to finish loading the spacemap, and then take the
 		 * appropriate action (see free_from_removing_vdev()).
 		 */
-		if (msp->ms_sm != NULL)
-			VERIFY0(space_map_load(msp->ms_sm, segs, SM_ALLOC));
+		if (msp->ms_sm != NULL) {
+			int err = space_map_load(msp->ms_sm, segs, SM_ALLOC);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&msp->ms_lock);
+				mutex_exit(&msp->ms_sync_lock);
+				zfs_range_tree_vacate(segs, NULL, NULL);
+				mutex_enter(&svr->svr_lock);
+				svr->svr_thread_exit = B_TRUE;
+				break;
+			}
+			VERIFY0(err);
+		}
 
 		/*
 		 * We could not hold svr_lock while loading space map, or we
@@ -1831,7 +1898,10 @@ again:
 		 * error was encountered.  The removal process must be
 		 * cancelled or this damage may become permanent.
 		 */
-		if (zfs_removal_ignore_errors == 0 &&
+		if (SPA_EXITING(spa)) {
+			zfs_dbgmsg("canceling removal due to spa_exiting");
+			spa_vdev_remove_cancel_impl(spa);
+		} else if (zfs_removal_ignore_errors == 0 &&
 		    (vca.vca_read_error_bytes > 0 ||
 		    vca.vca_write_error_bytes > 0)) {
 			zfs_dbgmsg("canceling removal due to IO errors: "
@@ -1911,29 +1981,38 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic = &vd->vdev_indirect_config;
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 	objset_t *mos = spa->spa_meta_objset;
+	int err;
 
 	ASSERT0P(svr->svr_thread);
 
 	spa_feature_decr(spa, SPA_FEATURE_DEVICE_REMOVAL, tx);
 
-	boolean_t are_precise;
-	VERIFY0(vdev_obsolete_counts_are_precise(vd, &are_precise));
+	boolean_t are_precise = B_FALSE;
+	err = vdev_obsolete_counts_are_precise(vd, &are_precise);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (are_precise) {
 		spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
-		VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, tx));
+		err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_OBSOLETE_COUNTS_ARE_PRECISE, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
-	uint64_t obsolete_sm_object;
-	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	uint64_t obsolete_sm_object = 0;
+	err = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 	if (obsolete_sm_object != 0) {
 		ASSERT(vd->vdev_obsolete_sm != NULL);
 		ASSERT3U(obsolete_sm_object, ==,
 		    space_map_object(vd->vdev_obsolete_sm));
 
 		space_map_free(vd->vdev_obsolete_sm, tx);
-		VERIFY0(zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
-		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx));
+		err = zap_remove(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		space_map_close(vd->vdev_obsolete_sm);
 		vd->vdev_obsolete_sm = NULL;
 		spa_feature_decr(spa, SPA_FEATURE_OBSOLETE_COUNTS, tx);
@@ -1961,13 +2040,21 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 		 * Assert nothing in flight -- ms_*tree is empty.
 		 */
 		for (int i = 0; i < TXG_SIZE; i++)
-			ASSERT0(zfs_range_tree_space(msp->ms_allocating[i]));
+			ASSERT0(zfs_range_tree_space(
+			    msp->ms_allocating[i]));
 		for (int i = 0; i < TXG_DEFER_SIZE; i++)
 			ASSERT0(zfs_range_tree_space(msp->ms_defer[i]));
 		ASSERT0(zfs_range_tree_space(msp->ms_freed));
 
-		if (msp->ms_sm != NULL)
-			VERIFY0(space_map_load(msp->ms_sm, segs, SM_ALLOC));
+		if (msp->ms_sm != NULL) {
+			err = space_map_load(msp->ms_sm, segs, SM_ALLOC);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&msp->ms_lock);
+				zfs_range_tree_vacate(segs, NULL, NULL);
+				break;
+			}
+			VERIFY0(err);
+		}
 
 		zfs_range_tree_walk(msp->ms_unflushed_allocs,
 		    zfs_range_tree_add, segs);
@@ -2199,6 +2286,8 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 	ASSERT(spa_namespace_held());
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
+	if (SPA_EXITING(spa))
+		goto skip;
 	/* The top ZAP should have been destroyed by vdev_remove_empty. */
 	ASSERT0(vd->vdev_top_zap);
 	/* The leaf ZAP should have been destroyed by vdev_dtl_sync. */
@@ -2206,12 +2295,14 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 
 	(void) vdev_label_init(vd, 0, VDEV_LABEL_REMOVE);
 
+skip:
 	if (list_link_active(&vd->vdev_state_dirty_node))
 		vdev_state_clean(vd);
 	if (list_link_active(&vd->vdev_config_dirty_node))
 		vdev_config_clean(vd);
 
-	ASSERT0(vd->vdev_stat.vs_alloc);
+	if (!SPA_EXITING(spa))
+		ASSERT0(vd->vdev_stat.vs_alloc);
 
 	/*
 	 * Clean up the vdev namespace.

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -468,10 +468,10 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 		ASSERT3B(are_precise, ==, B_TRUE);
 	}
 
-	vic->vic_mapping_object = vdev_indirect_mapping_alloc(mos, tx);
+	VERIFY0(vdev_indirect_mapping_alloc(mos, tx, &vic->vic_mapping_object));
 	vd->vdev_indirect_mapping =
 	    vdev_indirect_mapping_open(mos, vic->vic_mapping_object);
-	vic->vic_births_object = vdev_indirect_births_alloc(mos, tx);
+	VERIFY0(vdev_indirect_births_alloc(mos, tx, &vic->vic_births_object));
 	vd->vdev_indirect_births =
 	    vdev_indirect_births_open(mos, vic->vic_births_object);
 	spa->spa_removing_phys.sr_removing_vdev = vd->vdev_id;

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -223,6 +223,8 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 	 */
 	uint64_t guid = *(uint64_t *)arg;
 	uint64_t txg = dmu_tx_get_txg(tx);
+	int err;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	kmem_free(arg, sizeof (uint64_t));
 
 	vdev_t *vd = spa_lookup_by_guid(tx->tx_pool->dp_spa, guid, B_FALSE);
@@ -243,16 +245,20 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 			last_offset = 0;
 
 		vd->vdev_trim_last_offset = last_offset;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_TRIM_LAST_OFFSET,
-		    sizeof (last_offset), 1, &last_offset, tx));
+		    sizeof (last_offset), 1, &last_offset, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (vd->vdev_trim_action_time > 0) {
 		uint64_t val = (uint64_t)vd->vdev_trim_action_time;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_TRIM_ACTION_TIME, sizeof (val),
-		    1, &val, tx));
+		    1, &val, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (vd->vdev_trim_rate > 0) {
@@ -261,28 +267,35 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 		if (rate == UINT64_MAX)
 			rate = 0;
 
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
-		    VDEV_LEAF_ZAP_TRIM_RATE, sizeof (rate), 1, &rate, tx));
+		err = zap_update(mos, vd->vdev_leaf_zap,
+		    VDEV_LEAF_ZAP_TRIM_RATE, sizeof (rate), 1, &rate, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	uint64_t partial = vd->vdev_trim_partial;
 	if (partial == UINT64_MAX)
 		partial = 0;
 
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_PARTIAL,
-	    sizeof (partial), 1, &partial, tx));
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_PARTIAL,
+	    sizeof (partial), 1, &partial, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t secure = vd->vdev_trim_secure;
 	if (secure == UINT64_MAX)
 		secure = 0;
 
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_SECURE,
-	    sizeof (secure), 1, &secure, tx));
-
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_SECURE,
+	    sizeof (secure), 1, &secure, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t trim_state = vd->vdev_trim_state;
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
-	    sizeof (trim_state), 1, &trim_state, tx));
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
+	    sizeof (trim_state), 1, &trim_state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*
@@ -510,7 +523,8 @@ vdev_trim_range(trim_args_t *ta, uint64_t start, uint64_t size)
 	 */
 	if (ta->trim_type == TRIM_TYPE_MANUAL) {
 		while (vd->vdev_trim_rate != 0 && !vdev_trim_should_stop(vd) &&
-		    vdev_trim_calculate_rate(ta) > vd->vdev_trim_rate) {
+		    vdev_trim_calculate_rate(ta) > vd->vdev_trim_rate &&
+		    !SPA_EXITING(spa)) {
 			cv_timedwait_idle(&vd->vdev_trim_io_cv,
 			    &vd->vdev_trim_io_lock, ddi_get_lbolt() +
 			    MSEC_TO_TICK(10));
@@ -677,6 +691,8 @@ vdev_trim_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 static void
 vdev_trim_calculate_progress(vdev_t *vd)
 {
+	int err;
+
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
 	ASSERT(vd->vdev_leaf_zap != 0);
@@ -728,7 +744,12 @@ vdev_trim_calculate_progress(vdev_t *vd)
 		 * metaslab.  Load it and walk the free tree for more
 		 * accurate progress estimation.
 		 */
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(vd->vdev_spa)) {
+			mutex_exit(&msp->ms_lock);
+			return;
+		}
+		VERIFY0(err);
 
 		zfs_range_tree_t *rt = msp->ms_allocatable;
 		zfs_btree_t *bt = &rt->rt_root;
@@ -846,10 +867,11 @@ vdev_trim_range_add(void *arg, uint64_t start, uint64_t size)
 {
 	trim_args_t *ta = arg;
 	vdev_t *vd = ta->trim_vdev;
+	spa_t *spa = vd->vdev_spa;
 	zfs_range_seg64_t logical_rs;
 	logical_rs.rs_start = start;
 	logical_rs.rs_end = start + size;
-
+	int err;
 	/*
 	 * Every range to be trimmed must be part of ms_allocatable.
 	 * When ZFS_DEBUG_TRIM is set load the metaslab to verify this
@@ -857,7 +879,12 @@ vdev_trim_range_add(void *arg, uint64_t start, uint64_t size)
 	 */
 	if (zfs_flags & ZFS_DEBUG_TRIM) {
 		metaslab_t *msp = ta->trim_msp;
-		VERIFY0(metaslab_load(msp));
+
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
+
 		VERIFY3B(msp->ms_loaded, ==, B_TRUE);
 		VERIFY(zfs_range_tree_contains(msp->ms_allocatable, start,
 		    size));
@@ -897,7 +924,12 @@ vdev_trim_thread(void *arg)
 	vd->vdev_trim_partial = 0;
 	vd->vdev_trim_secure = 0;
 
-	VERIFY0(vdev_trim_load(vd));
+	error = vdev_trim_load(vd);
+	if (error && SPA_EXITING(spa)) {
+		spa_config_exit(spa, SCL_CONFIG, FTAG);
+		goto out;
+	}
+	VERIFY0(error);
 
 	ta.trim_vdev = vd;
 	ta.trim_extent_bytes_max = zfs_trim_extent_bytes_max;
@@ -935,7 +967,14 @@ vdev_trim_thread(void *arg)
 		spa_config_exit(spa, SCL_CONFIG, FTAG);
 		metaslab_disable(msp);
 		mutex_enter(&msp->ms_lock);
-		VERIFY0(metaslab_load(msp));
+		error = metaslab_load(msp);
+		if (error && SPA_EXITING(spa)) {
+			mutex_exit(&msp->ms_lock);
+			metaslab_enable(msp, B_FALSE, B_FALSE);
+			spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+			break;
+		}
+		VERIFY0(error);
 
 		/*
 		 * If a partial TRIM was requested skip metaslabs which have
@@ -991,6 +1030,7 @@ vdev_trim_thread(void *arg)
 	 */
 	mutex_exit(&vd->vdev_trim_lock);
 	txg_wait_synced(spa_get_dsl(spa), 0);
+out:
 	mutex_enter(&vd->vdev_trim_lock);
 
 	vd->vdev_trim_thread = NULL;
@@ -1156,6 +1196,8 @@ vdev_trim_stop_all(vdev_t *vd, vdev_trim_state_t tgt_state)
 void
 vdev_trim_restart(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
+
 	ASSERT(spa_namespace_held() ||
 	    vd->vdev_spa->spa_load_thread == curthread);
 	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
@@ -1166,25 +1208,44 @@ vdev_trim_restart(vdev_t *vd)
 		int err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
 		    sizeof (trim_state), 1, &trim_state);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa)) {
+			mutex_exit(&vd->vdev_trim_lock);
+			return;
+		}
 		ASSERT(err == 0 || err == ENOENT);
-		vd->vdev_trim_state = trim_state;
 
 		uint64_t timestamp = 0;
 		err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_ACTION_TIME,
 		    sizeof (timestamp), 1, &timestamp);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa)) {
+			mutex_exit(&vd->vdev_trim_lock);
+			return;
+		}
 		ASSERT(err == 0 || err == ENOENT);
+
+		vd->vdev_trim_state = trim_state;
 		vd->vdev_trim_action_time = timestamp;
 
 		if ((vd->vdev_trim_state == VDEV_TRIM_SUSPENDED ||
 		    vd->vdev_offline) && !vd->vdev_top->vdev_rz_expanding) {
 			/* load progress for reporting, but don't resume */
-			VERIFY0(vdev_trim_load(vd));
+			err = vdev_trim_load(vd);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&vd->vdev_trim_lock);
+				return; // set back orig state & timestamp?
+			}
+			VERIFY0(err);
 		} else if (vd->vdev_trim_state == VDEV_TRIM_ACTIVE &&
 		    vdev_writeable(vd) && !vd->vdev_top->vdev_removing &&
 		    !vd->vdev_top->vdev_rz_expanding &&
 		    vd->vdev_trim_thread == NULL) {
-			VERIFY0(vdev_trim_load(vd));
+			err = vdev_trim_load(vd);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&vd->vdev_trim_lock);
+				return; // set back orig state & timestamp?
+			}
+			VERIFY0(err);
 			vdev_trim(vd, vd->vdev_trim_rate,
 			    vd->vdev_trim_partial, vd->vdev_trim_secure);
 		}
@@ -1225,6 +1286,7 @@ vdev_autotrim_thread(void *arg)
 	vdev_t *vd = arg;
 	spa_t *spa = vd->vdev_spa;
 	int shift = 0;
+	int err;
 
 	mutex_enter(&vd->vdev_autotrim_lock);
 	ASSERT3P(vd->vdev_top, ==, vd);
@@ -1413,10 +1475,13 @@ vdev_autotrim_thread(void *arg)
 			 */
 			if (zfs_flags & ZFS_DEBUG_TRIM) {
 				mutex_enter(&msp->ms_lock);
-				VERIFY0(metaslab_load(msp));
-				VERIFY3P(tap[0].trim_msp, ==, msp);
-				zfs_range_tree_walk(trim_tree,
-				    vdev_trim_range_verify, &tap[0]);
+				err = metaslab_load(msp);
+				if (!SPA_EXITING(spa)) {
+					VERIFY0(err);
+					VERIFY3P(tap[0].trim_msp, ==, msp);
+					zfs_range_tree_walk(trim_tree,
+					    vdev_trim_range_verify, &tap[0]);
+				}
 				mutex_exit(&msp->ms_lock);
 			}
 

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -213,6 +213,8 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 	 */
 	uint64_t guid = *(uint64_t *)arg;
 	uint64_t txg = dmu_tx_get_txg(tx);
+	int err;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	kmem_free(arg, sizeof (uint64_t));
 
 	vdev_t *vd = spa_lookup_by_guid(tx->tx_pool->dp_spa, guid, B_FALSE);
@@ -233,16 +235,20 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 			last_offset = 0;
 
 		vd->vdev_trim_last_offset = last_offset;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_TRIM_LAST_OFFSET,
-		    sizeof (last_offset), 1, &last_offset, tx));
+		    sizeof (last_offset), 1, &last_offset, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (vd->vdev_trim_action_time > 0) {
 		uint64_t val = (uint64_t)vd->vdev_trim_action_time;
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
+		err = zap_update(mos, vd->vdev_leaf_zap,
 		    VDEV_LEAF_ZAP_TRIM_ACTION_TIME, sizeof (val),
-		    1, &val, tx));
+		    1, &val, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	if (vd->vdev_trim_rate > 0) {
@@ -251,28 +257,35 @@ vdev_trim_zap_update_sync(void *arg, dmu_tx_t *tx)
 		if (rate == UINT64_MAX)
 			rate = 0;
 
-		VERIFY0(zap_update(mos, vd->vdev_leaf_zap,
-		    VDEV_LEAF_ZAP_TRIM_RATE, sizeof (rate), 1, &rate, tx));
+		err = zap_update(mos, vd->vdev_leaf_zap,
+		    VDEV_LEAF_ZAP_TRIM_RATE, sizeof (rate), 1, &rate, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
 	uint64_t partial = vd->vdev_trim_partial;
 	if (partial == UINT64_MAX)
 		partial = 0;
 
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_PARTIAL,
-	    sizeof (partial), 1, &partial, tx));
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_PARTIAL,
+	    sizeof (partial), 1, &partial, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t secure = vd->vdev_trim_secure;
 	if (secure == UINT64_MAX)
 		secure = 0;
 
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_SECURE,
-	    sizeof (secure), 1, &secure, tx));
-
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_SECURE,
+	    sizeof (secure), 1, &secure, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 
 	uint64_t trim_state = vd->vdev_trim_state;
-	VERIFY0(zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
-	    sizeof (trim_state), 1, &trim_state, tx));
+	err = zap_update(mos, vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
+	    sizeof (trim_state), 1, &trim_state, tx);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*
@@ -500,7 +513,8 @@ vdev_trim_range(trim_args_t *ta, uint64_t start, uint64_t size)
 	 */
 	if (ta->trim_type == TRIM_TYPE_MANUAL) {
 		while (vd->vdev_trim_rate != 0 && !vdev_trim_should_stop(vd) &&
-		    vdev_trim_calculate_rate(ta) > vd->vdev_trim_rate) {
+		    vdev_trim_calculate_rate(ta) > vd->vdev_trim_rate &&
+		    !SPA_EXITING(spa)) {
 			cv_timedwait_idle(&vd->vdev_trim_io_cv,
 			    &vd->vdev_trim_io_lock, ddi_get_lbolt() +
 			    MSEC_TO_TICK(10));
@@ -667,6 +681,8 @@ vdev_trim_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 static void
 vdev_trim_calculate_progress(vdev_t *vd)
 {
+	int err;
+
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
 	ASSERT(vd->vdev_leaf_zap != 0);
@@ -718,7 +734,12 @@ vdev_trim_calculate_progress(vdev_t *vd)
 		 * metaslab.  Load it and walk the free tree for more
 		 * accurate progress estimation.
 		 */
-		VERIFY0(metaslab_load(msp));
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(vd->vdev_spa)) {
+			mutex_exit(&msp->ms_lock);
+			return;
+		}
+		VERIFY0(err);
 
 		zfs_range_tree_t *rt = msp->ms_allocatable;
 		zfs_btree_t *bt = &rt->rt_root;
@@ -836,10 +857,11 @@ vdev_trim_range_add(void *arg, uint64_t start, uint64_t size)
 {
 	trim_args_t *ta = arg;
 	vdev_t *vd = ta->trim_vdev;
+	spa_t *spa = vd->vdev_spa;
 	zfs_range_seg64_t logical_rs;
 	logical_rs.rs_start = start;
 	logical_rs.rs_end = start + size;
-
+	int err;
 	/*
 	 * Every range to be trimmed must be part of ms_allocatable.
 	 * When ZFS_DEBUG_TRIM is set load the metaslab to verify this
@@ -847,7 +869,12 @@ vdev_trim_range_add(void *arg, uint64_t start, uint64_t size)
 	 */
 	if (zfs_flags & ZFS_DEBUG_TRIM) {
 		metaslab_t *msp = ta->trim_msp;
-		VERIFY0(metaslab_load(msp));
+
+		err = metaslab_load(msp);
+		if (err && SPA_EXITING(spa))
+			return;
+		VERIFY0(err);
+
 		VERIFY3B(msp->ms_loaded, ==, B_TRUE);
 		VERIFY(zfs_range_tree_contains(msp->ms_allocatable, start,
 		    size));
@@ -887,7 +914,12 @@ vdev_trim_thread(void *arg)
 	vd->vdev_trim_partial = 0;
 	vd->vdev_trim_secure = 0;
 
-	VERIFY0(vdev_trim_load(vd));
+	error = vdev_trim_load(vd);
+	if (error && SPA_EXITING(spa)) {
+		spa_config_exit(spa, SCL_CONFIG, FTAG);
+		goto out;
+	}
+	VERIFY0(error);
 
 	ta.trim_vdev = vd;
 	ta.trim_extent_bytes_max = zfs_trim_extent_bytes_max;
@@ -925,7 +957,14 @@ vdev_trim_thread(void *arg)
 		spa_config_exit(spa, SCL_CONFIG, FTAG);
 		metaslab_disable(msp);
 		mutex_enter(&msp->ms_lock);
-		VERIFY0(metaslab_load(msp));
+		error = metaslab_load(msp);
+		if (error && SPA_EXITING(spa)) {
+			mutex_exit(&msp->ms_lock);
+			metaslab_enable(msp, B_FALSE, B_FALSE);
+			spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+			break;
+		}
+		VERIFY0(error);
 
 		/*
 		 * If a partial TRIM was requested skip metaslabs which have
@@ -981,6 +1020,7 @@ vdev_trim_thread(void *arg)
 	 */
 	mutex_exit(&vd->vdev_trim_lock);
 	txg_wait_synced(spa_get_dsl(spa), 0);
+out:
 	mutex_enter(&vd->vdev_trim_lock);
 
 	vd->vdev_trim_thread = NULL;
@@ -1147,6 +1187,8 @@ vdev_trim_stop_all(vdev_t *vd, vdev_trim_state_t tgt_state)
 void
 vdev_trim_restart(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
+
 	ASSERT(spa_namespace_held() ||
 	    vd->vdev_spa->spa_load_thread == curthread);
 	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
@@ -1157,25 +1199,44 @@ vdev_trim_restart(vdev_t *vd)
 		int err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_STATE,
 		    sizeof (trim_state), 1, &trim_state);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa)) {
+			mutex_exit(&vd->vdev_trim_lock);
+			return;
+		}
 		ASSERT(err == 0 || err == ENOENT);
-		vd->vdev_trim_state = trim_state;
 
 		uint64_t timestamp = 0;
 		err = zap_lookup(vd->vdev_spa->spa_meta_objset,
 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_ACTION_TIME,
 		    sizeof (timestamp), 1, &timestamp);
+		if (!(err == 0 || err == ENOENT) && SPA_EXITING(spa)) {
+			mutex_exit(&vd->vdev_trim_lock);
+			return;
+		}
 		ASSERT(err == 0 || err == ENOENT);
+
+		vd->vdev_trim_state = trim_state;
 		vd->vdev_trim_action_time = timestamp;
 
 		if ((vd->vdev_trim_state == VDEV_TRIM_SUSPENDED ||
 		    vd->vdev_offline) && !vd->vdev_top->vdev_rz_expanding) {
 			/* load progress for reporting, but don't resume */
-			VERIFY0(vdev_trim_load(vd));
+			err = vdev_trim_load(vd);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&vd->vdev_trim_lock);
+				return; // set back orig state & timestamp?
+			}
+			VERIFY0(err);
 		} else if (vd->vdev_trim_state == VDEV_TRIM_ACTIVE &&
 		    vdev_writeable(vd) && !vd->vdev_top->vdev_removing &&
 		    !vd->vdev_top->vdev_rz_expanding &&
 		    vd->vdev_trim_thread == NULL) {
-			VERIFY0(vdev_trim_load(vd));
+			err = vdev_trim_load(vd);
+			if (err && SPA_EXITING(spa)) {
+				mutex_exit(&vd->vdev_trim_lock);
+				return; // set back orig state & timestamp?
+			}
+			VERIFY0(err);
 			vdev_trim(vd, vd->vdev_trim_rate,
 			    vd->vdev_trim_partial, vd->vdev_trim_secure);
 		}
@@ -1216,6 +1277,7 @@ vdev_autotrim_thread(void *arg)
 	vdev_t *vd = arg;
 	spa_t *spa = vd->vdev_spa;
 	int shift = 0;
+	int err;
 
 	mutex_enter(&vd->vdev_autotrim_lock);
 	ASSERT3P(vd->vdev_top, ==, vd);
@@ -1404,10 +1466,13 @@ vdev_autotrim_thread(void *arg)
 			 */
 			if (zfs_flags & ZFS_DEBUG_TRIM) {
 				mutex_enter(&msp->ms_lock);
-				VERIFY0(metaslab_load(msp));
-				VERIFY3P(tap[0].trim_msp, ==, msp);
-				zfs_range_tree_walk(trim_tree,
-				    vdev_trim_range_verify, &tap[0]);
+				err = metaslab_load(msp);
+				if (!SPA_EXITING(spa)) {
+					VERIFY0(err);
+					VERIFY3P(tap[0].trim_msp, ==, msp);
+					zfs_range_tree_walk(trim_tree,
+					    vdev_trim_range_verify, &tap[0]);
+				}
 				mutex_exit(&msp->ms_lock);
 			}
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -31,6 +31,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/btree.h>
 #include <sys/zap.h>
@@ -39,117 +40,141 @@
 
 /* zap_create */
 
-static uint64_t
+static int
 zap_create_impl(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t obj;
+	spa_t *spa = os->os_spa;
+	int err = 0;
 
 	ASSERT3U(DMU_OT_BYTESWAP(ot), ==, DMU_BSWAP_ZAP);
 
 	if (allocated_dnode == NULL) {
 		dnode_t *dn;
-		obj = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
+		err = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
 		    indirect_blockshift, bonustype, bonuslen, dnodesize,
-		    &dn, FTAG, tx);
-		mzap_create_impl(dn, normflags, flags, tx);
+		    &dn, FTAG, tx, objectp);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = mzap_create_impl(dn, normflags, flags, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dnode_rele(dn, FTAG);
 	} else {
-		obj = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
+		err = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
 		    indirect_blockshift, bonustype, bonuslen, dnodesize,
-		    allocated_dnode, tag, tx);
-		mzap_create_impl(*allocated_dnode, normflags, flags, tx);
+		    allocated_dnode, tag, tx, objectp);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = mzap_create_impl(*allocated_dnode, normflags, flags, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
-	return (obj);
+	return (err);
 }
 
-uint64_t
+int
 zap_create(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
-	return (zap_create_norm(os, 0, ot, bonustype, bonuslen, tx));
+	return (zap_create_norm(os, 0, ot, bonustype, bonuslen, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_norm_dnsize(os, 0, ot, bonustype, bonuslen,
-	    dnodesize, tx));
+	    dnodesize, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (zap_create_norm_dnsize(os, normflags, ot, bonustype, bonuslen,
-	    0, tx));
+	    0, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_norm_dnsize(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, 0, ot, 0, 0,
-	    bonustype, bonuslen, dnodesize, NULL, NULL, tx));
+	    bonustype, bonuslen, dnodesize, NULL, NULL, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (zap_create_flags_dnsize(os, normflags, flags, ot,
-	    leaf_blockshift, indirect_blockshift, bonustype, bonuslen, 0, tx));
+	    leaf_blockshift, indirect_blockshift, bonustype, bonuslen, 0, tx,
+	    objectp));
 }
 
-uint64_t
+int
 zap_create_flags_dnsize(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, flags, ot, leaf_blockshift,
 	    indirect_blockshift, bonustype, bonuslen, dnodesize, NULL, NULL,
-	    tx));
+	    tx, objectp));
 }
 
 /* zap_crate_hold */
 
-uint64_t
+int
 zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, flags, ot, leaf_blockshift,
 	    indirect_blockshift, bonustype, bonuslen, dnodesize,
-	    allocated_dnode, tag, tx));
+	    allocated_dnode, tag, tx, objectp));
 }
 
 /* zap_create_link */
 
-uint64_t
+int
 zap_create_link(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
-    const char *name, dmu_tx_t *tx)
+    const char *name, dmu_tx_t *tx, uint64_t *objectp)
 {
-	return (zap_create_link_dnsize(os, ot, parent_obj, name, 0, tx));
+	return (zap_create_link_dnsize(os, ot, parent_obj, name, 0, tx,
+	    objectp));
 }
 
-uint64_t
+int
 zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
-    const char *name, int dnodesize, dmu_tx_t *tx)
+    const char *name, int dnodesize, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t new_obj;
+	int err = 0;
 
-	new_obj = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx);
-	VERIFY(new_obj != 0);
-	VERIFY0(zap_add(os, parent_obj, name, sizeof (uint64_t), 1, &new_obj,
-	    tx));
+	err = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx, objectp);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
+	VERIFY(*objectp != 0);
 
-	return (new_obj);
+	err = zap_add(os, parent_obj, name, sizeof (uint64_t), 1, objectp,
+	    tx);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 /* zap_create_claim */
@@ -197,11 +222,11 @@ zap_create_claim_norm_dnsize(objset_t *os, uint64_t obj, int normflags,
 	if (error != 0)
 		return (error);
 
-	mzap_create_impl(dn, normflags, 0, tx);
+	error = mzap_create_impl(dn, normflags, 0, tx);
 
 	dnode_rele(dn, FTAG);
 
-	return (0);
+	return (error);
 }
 
 /* zap_destroy */

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -21,6 +21,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/btree.h>
 #include <sys/zap.h>
@@ -29,117 +30,141 @@
 
 /* zap_create */
 
-static uint64_t
+static int
 zap_create_impl(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t obj;
+	spa_t *spa = os->os_spa;
+	int err = 0;
 
 	ASSERT3U(DMU_OT_BYTESWAP(ot), ==, DMU_BSWAP_ZAP);
 
 	if (allocated_dnode == NULL) {
 		dnode_t *dn;
-		obj = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
+		err = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
 		    indirect_blockshift, bonustype, bonuslen, dnodesize,
-		    &dn, FTAG, tx);
-		mzap_create_impl(dn, normflags, flags, tx);
+		    &dn, FTAG, tx, objectp);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = mzap_create_impl(dn, normflags, flags, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 		dnode_rele(dn, FTAG);
 	} else {
-		obj = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
+		err = dmu_object_alloc_hold(os, ot, 1ULL << leaf_blockshift,
 		    indirect_blockshift, bonustype, bonuslen, dnodesize,
-		    allocated_dnode, tag, tx);
-		mzap_create_impl(*allocated_dnode, normflags, flags, tx);
+		    allocated_dnode, tag, tx, objectp);
+		if (err && SPA_EXITING(spa))
+			return (err);
+		VERIFY0(err);
+		err = mzap_create_impl(*allocated_dnode, normflags, flags, tx);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
 	}
 
-	return (obj);
+	return (err);
 }
 
-uint64_t
+int
 zap_create(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
-	return (zap_create_norm(os, 0, ot, bonustype, bonuslen, tx));
+	return (zap_create_norm(os, 0, ot, bonustype, bonuslen, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_dnsize(objset_t *os, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_norm_dnsize(os, 0, ot, bonustype, bonuslen,
-	    dnodesize, tx));
+	    dnodesize, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_norm(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (zap_create_norm_dnsize(os, normflags, ot, bonustype, bonuslen,
-	    0, tx));
+	    0, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_norm_dnsize(objset_t *os, int normflags, dmu_object_type_t ot,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, 0, ot, 0, 0,
-	    bonustype, bonuslen, dnodesize, NULL, NULL, tx));
+	    bonustype, bonuslen, dnodesize, NULL, NULL, tx, objectp));
 }
 
-uint64_t
+int
 zap_create_flags(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, dmu_tx_t *tx, uint64_t *objectp)
 {
 	return (zap_create_flags_dnsize(os, normflags, flags, ot,
-	    leaf_blockshift, indirect_blockshift, bonustype, bonuslen, 0, tx));
+	    leaf_blockshift, indirect_blockshift, bonustype, bonuslen, 0, tx,
+	    objectp));
 }
 
-uint64_t
+int
 zap_create_flags_dnsize(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
-    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx)
+    dmu_object_type_t bonustype, int bonuslen, int dnodesize, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, flags, ot, leaf_blockshift,
 	    indirect_blockshift, bonustype, bonuslen, dnodesize, NULL, NULL,
-	    tx));
+	    tx, objectp));
 }
 
 /* zap_crate_hold */
 
-uint64_t
+int
 zap_create_hold(objset_t *os, int normflags, zap_flags_t flags,
     dmu_object_type_t ot, int leaf_blockshift, int indirect_blockshift,
     dmu_object_type_t bonustype, int bonuslen, int dnodesize,
-    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx)
+    dnode_t **allocated_dnode, const void *tag, dmu_tx_t *tx,
+    uint64_t *objectp)
 {
 	return (zap_create_impl(os, normflags, flags, ot, leaf_blockshift,
 	    indirect_blockshift, bonustype, bonuslen, dnodesize,
-	    allocated_dnode, tag, tx));
+	    allocated_dnode, tag, tx, objectp));
 }
 
 /* zap_create_link */
 
-uint64_t
+int
 zap_create_link(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
-    const char *name, dmu_tx_t *tx)
+    const char *name, dmu_tx_t *tx, uint64_t *objectp)
 {
-	return (zap_create_link_dnsize(os, ot, parent_obj, name, 0, tx));
+	return (zap_create_link_dnsize(os, ot, parent_obj, name, 0, tx,
+	    objectp));
 }
 
-uint64_t
+int
 zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
-    const char *name, int dnodesize, dmu_tx_t *tx)
+    const char *name, int dnodesize, dmu_tx_t *tx, uint64_t *objectp)
 {
-	uint64_t new_obj;
+	int err = 0;
 
-	new_obj = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx);
-	VERIFY(new_obj != 0);
-	VERIFY0(zap_add(os, parent_obj, name, sizeof (uint64_t), 1, &new_obj,
-	    tx));
+	err = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx, objectp);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
+	VERIFY(*objectp != 0);
 
-	return (new_obj);
+	err = zap_add(os, parent_obj, name, sizeof (uint64_t), 1, objectp,
+	    tx);
+	if (err && SPA_EXITING(os->os_spa))
+		return (err);
+	VERIFY0(err);
+
+	return (err);
 }
 
 /* zap_create_claim */
@@ -187,11 +212,11 @@ zap_create_claim_norm_dnsize(objset_t *os, uint64_t obj, int normflags,
 	if (error != 0)
 		return (error);
 
-	mzap_create_impl(dn, normflags, 0, tx);
+	error = mzap_create_impl(dn, normflags, 0, tx);
 
 	dnode_rele(dn, FTAG);
 
-	return (0);
+	return (error);
 }
 
 /* zap_destroy */

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -45,6 +45,7 @@
 
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_znode.h>
@@ -544,6 +545,10 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	    blkid << bs, NULL, &db, DMU_READ_NO_PREFETCH);
 	if (err != 0)
 		return (err);
+	if (SPA_EXITING(zap->zap_objset->os_spa)) {
+		dmu_buf_rele(db, NULL);
+		return (SET_ERROR(EIO));
+	}
 
 	ASSERT3U(db->db_object, ==, zap->zap_object);
 	ASSERT3U(db->db_offset, ==, blkid << bs);
@@ -560,8 +565,14 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	 * Must lock before dirtying, otherwise zap_leaf_phys(l) could change,
 	 * causing ASSERT below to fail.
 	 */
-	if (lt == RW_WRITER)
+	if (lt == RW_WRITER) {
 		dmu_buf_will_dirty(db, tx);
+		if (SPA_EXITING(zap->zap_objset->os_spa)) {
+			dmu_buf_rele(db, NULL);
+			*lp = NULL;
+			return (SET_ERROR(EIO));
+		}
+	}
 	ASSERT3U(l->l_blkid, ==, blkid);
 	ASSERT3P(l->l_dbuf, ==, db);
 	ASSERT3U(zap_leaf_phys(l)->l_hdr.lh_block_type, ==, ZBT_LEAF);

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -35,6 +35,7 @@
 
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_znode.h>
@@ -534,6 +535,10 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	    blkid << bs, NULL, &db, DMU_READ_NO_PREFETCH);
 	if (err != 0)
 		return (err);
+	if (SPA_EXITING(zap->zap_objset->os_spa)) {
+		dmu_buf_rele(db, NULL);
+		return (SET_ERROR(EIO));
+	}
 
 	ASSERT3U(db->db_object, ==, zap->zap_object);
 	ASSERT3U(db->db_offset, ==, blkid << bs);
@@ -550,8 +555,14 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	 * Must lock before dirtying, otherwise zap_leaf_phys(l) could change,
 	 * causing ASSERT below to fail.
 	 */
-	if (lt == RW_WRITER)
+	if (lt == RW_WRITER) {
 		dmu_buf_will_dirty(db, tx);
+		if (SPA_EXITING(zap->zap_objset->os_spa)) {
+			dmu_buf_rele(db, NULL);
+			*lp = NULL;
+			return (SET_ERROR(EIO));
+		}
+	}
 	ASSERT3U(l->l_blkid, ==, blkid);
 	ASSERT3P(l->l_dbuf, ==, db);
 	ASSERT3U(zap_leaf_phys(l)->l_hdr.lh_block_type, ==, ZBT_LEAF);

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -31,6 +31,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/dsl_dataset.h>
 #include <sys/zap.h>
@@ -292,6 +293,7 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 	ASSERT0(db->db_offset);
 	objset_t *os = dmu_buf_get_objset(db);
 	uint64_t obj = db->db_object;
+	int err;
 
 	*zapp = NULL;
 
@@ -331,8 +333,13 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 	zap->zap_objset = os;
 	zap->zap_dnode = dn;
 
-	if (lt == RW_WRITER)
+	if (lt == RW_WRITER) {
 		dmu_buf_will_dirty(db, tx);
+		if (SPA_EXITING(os->os_spa)) {
+			rw_exit(&zap->zap_rwlock);
+			return (SET_ERROR(EIO));
+		}
+	}
 
 	ASSERT3P(zap->zap_dbuf, ==, db);
 
@@ -345,12 +352,17 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 			dprintf("upgrading obj %llu: num_entries=%u\n",
 			    (u_longlong_t)obj, zap->zap_m.zap_num_entries);
 			*zapp = zap;
-			int err = mzap_upgrade(zapp, tx, 0);
+			err = mzap_upgrade(zapp, tx, 0);
 			if (err != 0)
 				rw_exit(&zap->zap_rwlock);
 			return (err);
 		}
-		VERIFY0(dmu_object_set_blocksize(os, obj, newsz, 0, tx));
+		err = dmu_object_set_blocksize(os, obj, newsz, 0, tx);
+		if (err && SPA_EXITING(os->os_spa)) {
+			rw_exit(&zap->zap_rwlock);
+			return (SET_ERROR(EIO));
+		}
+		VERIFY0(err);
 		zap->zap_m.zap_num_chunks =
 		    db->db_size / MZAP_ENT_LEN - 1;
 

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -21,6 +21,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dnode.h>
 #include <sys/dsl_dataset.h>
 #include <sys/zap.h>
@@ -282,6 +283,7 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 	ASSERT0(db->db_offset);
 	objset_t *os = dmu_buf_get_objset(db);
 	uint64_t obj = db->db_object;
+	int err;
 
 	*zapp = NULL;
 
@@ -321,8 +323,13 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 	zap->zap_objset = os;
 	zap->zap_dnode = dn;
 
-	if (lt == RW_WRITER)
+	if (lt == RW_WRITER) {
 		dmu_buf_will_dirty(db, tx);
+		if (SPA_EXITING(os->os_spa)) {
+			rw_exit(&zap->zap_rwlock);
+			return (SET_ERROR(EIO));
+		}
+	}
 
 	ASSERT3P(zap->zap_dbuf, ==, db);
 
@@ -335,12 +342,17 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
 			dprintf("upgrading obj %llu: num_entries=%u\n",
 			    (u_longlong_t)obj, zap->zap_m.zap_num_entries);
 			*zapp = zap;
-			int err = mzap_upgrade(zapp, tx, 0);
+			err = mzap_upgrade(zapp, tx, 0);
 			if (err != 0)
 				rw_exit(&zap->zap_rwlock);
 			return (err);
 		}
-		VERIFY0(dmu_object_set_blocksize(os, obj, newsz, 0, tx));
+		err = dmu_object_set_blocksize(os, obj, newsz, 0, tx);
+		if (err && SPA_EXITING(os->os_spa)) {
+			rw_exit(&zap->zap_rwlock);
+			return (SET_ERROR(EIO));
+		}
+		VERIFY0(err);
 		zap->zap_m.zap_num_chunks =
 		    db->db_size / MZAP_ENT_LEN - 1;
 

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -361,13 +361,15 @@ mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
 		    mze->mze_name, (u_longlong_t)mze->mze_value);
 		zap_name_init_str(zn, mze->mze_name, 0);
 		/* If we fail here, we would end up losing entries */
-		VERIFY0(fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd,
-		    tx));
+		err = fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd, tx);
+		if (err && SPA_EXITING(zap->zap_objset->os_spa))
+			break;
+		VERIFY0(err);
 	}
 	zap_name_free(zn);
 	vmem_free(mzp, sz);
 	*zapp = zap;
-	return (0);
+	return (err);
 }
 
 /*
@@ -391,10 +393,19 @@ int
 mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
+	spa_t *spa = dn->dn_objset->os_spa;
+	int err = 0;
 
-	VERIFY0(dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH));
+	err = dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		dmu_buf_rele(db, FTAG);
+		return (SET_ERROR(EIO));
+	}
 	mzap_phys_t *zp = db->db_data;
 	zp->mz_block_type = ZBT_MICRO;
 	zp->mz_salt =
@@ -404,15 +415,23 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	if (flags != 0) {
 		zap_t *zap;
 		/* Only fat zap supports flags; upgrade immediately. */
-		VERIFY0(zap_lock_by_dnode(dn, tx,
-		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap));
-		VERIFY0(mzap_upgrade(&zap, tx, flags));
+		err = zap_lock_by_dnode(dn, tx,
+		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+
+		err = mzap_upgrade(&zap, tx, flags);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+
 		zap_unlock(zap, FTAG);
 	}
 
+out:
 	dmu_buf_rele(db, FTAG);
 
-	return (0);
+	return (err);
 }
 
 /*

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -387,7 +387,7 @@ mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
  * The *_NF* (Normalization Form) flags are mutually exclusive; at most one
  * of them may be supplied.
  */
-void
+int
 mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
@@ -411,6 +411,8 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	}
 
 	dmu_buf_rele(db, FTAG);
+
+	return (0);
 }
 
 /*

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -351,13 +351,15 @@ mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
 		    mze->mze_name, (u_longlong_t)mze->mze_value);
 		zap_name_init_str(zn, mze->mze_name, 0);
 		/* If we fail here, we would end up losing entries */
-		VERIFY0(fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd,
-		    tx));
+		err = fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd, tx);
+		if (err && SPA_EXITING(zap->zap_objset->os_spa))
+			break;
+		VERIFY0(err);
 	}
 	zap_name_free(zn);
 	vmem_free(mzp, sz);
 	*zapp = zap;
-	return (0);
+	return (err);
 }
 
 /*
@@ -381,10 +383,19 @@ int
 mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
+	spa_t *spa = dn->dn_objset->os_spa;
+	int err = 0;
 
-	VERIFY0(dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH));
+	err = dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH);
+	if (err && SPA_EXITING(spa))
+		return (err);
+	VERIFY0(err);
 
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		dmu_buf_rele(db, FTAG);
+		return (SET_ERROR(EIO));
+	}
 	mzap_phys_t *zp = db->db_data;
 	zp->mz_block_type = ZBT_MICRO;
 	zp->mz_salt =
@@ -394,15 +405,23 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	if (flags != 0) {
 		zap_t *zap;
 		/* Only fat zap supports flags; upgrade immediately. */
-		VERIFY0(zap_lock_by_dnode(dn, tx,
-		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap));
-		VERIFY0(mzap_upgrade(&zap, tx, flags));
+		err = zap_lock_by_dnode(dn, tx,
+		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+
+		err = mzap_upgrade(&zap, tx, flags);
+		if (!SPA_EXITING(spa))
+			VERIFY0(err);
+
 		zap_unlock(zap, FTAG);
 	}
 
+out:
 	dmu_buf_rele(db, FTAG);
 
-	return (0);
+	return (err);
 }
 
 /*

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -377,7 +377,7 @@ mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
  * The *_NF* (Normalization Form) flags are mutually exclusive; at most one
  * of them may be supplied.
  */
-void
+int
 mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t *db;
@@ -401,6 +401,8 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	}
 
 	dmu_buf_rele(db, FTAG);
+
+	return (0);
 }
 
 /*

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -369,10 +369,10 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 		uint64_t enabling_txg = dmu_tx_get_txg(tx);
 
 		if (spa->spa_feat_enabled_txg_obj == 0ULL) {
-			spa->spa_feat_enabled_txg_obj =
-			    zap_create_link(spa->spa_meta_objset,
+			VERIFY0(zap_create_link(spa->spa_meta_objset,
 			    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-			    DMU_POOL_FEATURE_ENABLED_TXG, tx);
+			    DMU_POOL_FEATURE_ENABLED_TXG, tx,
+			    &spa->spa_feat_enabled_txg_obj));
 		}
 		spa_feature_incr(spa, SPA_FEATURE_ENABLED_TXG, tx);
 
@@ -450,15 +450,15 @@ spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 	ASSERT((!spa->spa_sync_on && tx->tx_txg == TXG_INITIAL) ||
 	    dsl_pool_sync_context(spa_get_dsl(spa)));
 
-	spa->spa_feat_for_read_obj = zap_create_link(spa->spa_meta_objset,
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_READ, tx);
-	spa->spa_feat_for_write_obj = zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj));
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_WRITE, tx);
-	spa->spa_feat_desc_obj = zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj));
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURE_DESCRIPTIONS, tx);
+	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj));
 }
 
 /*

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -309,8 +309,11 @@ feature_sync(spa_t *spa, zfeature_info_t *feature, uint64_t refcount,
 	uint64_t zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
 	ASSERT(MUTEX_HELD(&spa->spa_feat_stats_lock));
-	VERIFY0(zap_update(spa->spa_meta_objset, zapobj, feature->fi_guid,
-	    sizeof (uint64_t), 1, &refcount, tx));
+	int err = zap_update(spa->spa_meta_objset, zapobj, feature->fi_guid,
+	    sizeof (uint64_t), 1, &refcount, tx);
+	if (err != 0 && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	/*
 	 * feature_sync is called directly from zhack, allowing the
@@ -443,6 +446,8 @@ feature_do_action(spa_t *spa, spa_feature_t fid, feature_action_t action,
 void
 spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 {
+	int err;
+
 	/*
 	 * We create feature flags ZAP objects in two instances: during pool
 	 * creation and during pool upgrade.
@@ -450,15 +455,23 @@ spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 	ASSERT((!spa->spa_sync_on && tx->tx_txg == TXG_INITIAL) ||
 	    dsl_pool_sync_context(spa_get_dsl(spa)));
 
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj));
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj));
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj));
+	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -359,10 +359,10 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 		uint64_t enabling_txg = dmu_tx_get_txg(tx);
 
 		if (spa->spa_feat_enabled_txg_obj == 0ULL) {
-			spa->spa_feat_enabled_txg_obj =
-			    zap_create_link(spa->spa_meta_objset,
+			VERIFY0(zap_create_link(spa->spa_meta_objset,
 			    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-			    DMU_POOL_FEATURE_ENABLED_TXG, tx);
+			    DMU_POOL_FEATURE_ENABLED_TXG, tx,
+			    &spa->spa_feat_enabled_txg_obj));
 		}
 		spa_feature_incr(spa, SPA_FEATURE_ENABLED_TXG, tx);
 
@@ -440,15 +440,15 @@ spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 	ASSERT((!spa->spa_sync_on && tx->tx_txg == TXG_INITIAL) ||
 	    dsl_pool_sync_context(spa_get_dsl(spa)));
 
-	spa->spa_feat_for_read_obj = zap_create_link(spa->spa_meta_objset,
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_READ, tx);
-	spa->spa_feat_for_write_obj = zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj));
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_WRITE, tx);
-	spa->spa_feat_desc_obj = zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj));
+	VERIFY0(zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURE_DESCRIPTIONS, tx);
+	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj));
 }
 
 /*

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -299,8 +299,11 @@ feature_sync(spa_t *spa, zfeature_info_t *feature, uint64_t refcount,
 	uint64_t zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
 	ASSERT(MUTEX_HELD(&spa->spa_feat_stats_lock));
-	VERIFY0(zap_update(spa->spa_meta_objset, zapobj, feature->fi_guid,
-	    sizeof (uint64_t), 1, &refcount, tx));
+	int err = zap_update(spa->spa_meta_objset, zapobj, feature->fi_guid,
+	    sizeof (uint64_t), 1, &refcount, tx);
+	if (err != 0 && SPA_EXITING(spa))
+		return;
+	VERIFY0(err);
 
 	/*
 	 * feature_sync is called directly from zhack, allowing the
@@ -433,6 +436,8 @@ feature_do_action(spa_t *spa, spa_feature_t fid, feature_action_t action,
 void
 spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 {
+	int err;
+
 	/*
 	 * We create feature flags ZAP objects in two instances: during pool
 	 * creation and during pool upgrade.
@@ -440,15 +445,23 @@ spa_feature_create_zap_objects(spa_t *spa, dmu_tx_t *tx)
 	ASSERT((!spa->spa_sync_on && tx->tx_txg == TXG_INITIAL) ||
 	    dsl_pool_sync_context(spa_get_dsl(spa)));
 
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj));
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_READ, tx, &spa->spa_feat_for_read_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj));
-	VERIFY0(zap_create_link(spa->spa_meta_objset,
+	    DMU_POOL_FEATURES_FOR_WRITE, tx, &spa->spa_feat_for_write_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
+
+	err = zap_create_link(spa->spa_meta_objset,
 	    DMU_OTN_ZAP_METADATA, DMU_POOL_DIRECTORY_OBJECT,
-	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj));
+	    DMU_POOL_FEATURE_DESCRIPTIONS, tx, &spa->spa_feat_desc_obj);
+	if (!SPA_EXITING(spa))
+		VERIFY0(err);
 }
 
 /*

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -25,6 +25,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/avl.h>
 #include <sys/zap.h>
 #include <sys/nvpair.h>
@@ -211,20 +212,21 @@ zfs_fuid_init(zfsvfs_t *zfsvfs)
 /*
  * sync out AVL trees to persistent storage.
  */
-void
+int
 zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 {
+	spa_t *spa = zfsvfs->z_os->os_spa;
 	nvlist_t *nvp;
 	nvlist_t **fuids;
 	size_t nvsize = 0;
 	char *packed;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	fuid_domain_t *domnode;
 	int numnodes;
-	int i;
+	int i, err = 0;
 
 	if (!zfsvfs->z_fuid_dirty) {
-		return;
+		return (err);
 	}
 
 	rw_enter(&zfsvfs->z_fuid_lock, RW_WRITER);
@@ -233,12 +235,18 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	 * First see if table needs to be created?
 	 */
 	if (zfsvfs->z_fuid_obj == 0) {
-		zfsvfs->z_fuid_obj = dmu_object_alloc(zfsvfs->z_os,
+		err = dmu_object_alloc(zfsvfs->z_os,
 		    DMU_OT_FUID, 1 << 14, DMU_OT_FUID_SIZE,
-		    sizeof (uint64_t), tx);
-		VERIFY(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
+		    sizeof (uint64_t), tx, &zfsvfs->z_fuid_obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    ZFS_FUID_TABLES, sizeof (uint64_t), 1,
-		    &zfsvfs->z_fuid_obj, tx) == 0);
+		    &zfsvfs->z_fuid_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	VERIFY0(nvlist_alloc(&nvp, NV_UNIQUE_NAME, KM_SLEEP));
@@ -267,13 +275,24 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	dmu_write(zfsvfs->z_os, zfsvfs->z_fuid_obj, 0,
 	    zfsvfs->z_fuid_size, packed, tx, DMU_READ_NO_PREFETCH);
 	kmem_free(packed, zfsvfs->z_fuid_size);
-	VERIFY0(dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db));
+	err = dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	*(uint64_t *)db->db_data = zfsvfs->z_fuid_size;
-	dmu_buf_rele(db, FTAG);
 
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
 	zfsvfs->z_fuid_dirty = B_FALSE;
 	rw_exit(&zfsvfs->z_fuid_lock);
+
+	return (err);
 }
 
 /*

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -15,6 +15,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/avl.h>
 #include <sys/zap.h>
 #include <sys/nvpair.h>
@@ -201,20 +202,21 @@ zfs_fuid_init(zfsvfs_t *zfsvfs)
 /*
  * sync out AVL trees to persistent storage.
  */
-void
+int
 zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 {
+	spa_t *spa = zfsvfs->z_os->os_spa;
 	nvlist_t *nvp;
 	nvlist_t **fuids;
 	size_t nvsize = 0;
 	char *packed;
-	dmu_buf_t *db;
+	dmu_buf_t *db = NULL;
 	fuid_domain_t *domnode;
 	int numnodes;
-	int i;
+	int i, err = 0;
 
 	if (!zfsvfs->z_fuid_dirty) {
-		return;
+		return (err);
 	}
 
 	rw_enter(&zfsvfs->z_fuid_lock, RW_WRITER);
@@ -223,12 +225,18 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	 * First see if table needs to be created?
 	 */
 	if (zfsvfs->z_fuid_obj == 0) {
-		zfsvfs->z_fuid_obj = dmu_object_alloc(zfsvfs->z_os,
+		err = dmu_object_alloc(zfsvfs->z_os,
 		    DMU_OT_FUID, 1 << 14, DMU_OT_FUID_SIZE,
-		    sizeof (uint64_t), tx);
-		VERIFY(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
+		    sizeof (uint64_t), tx, &zfsvfs->z_fuid_obj);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
+		err = zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    ZFS_FUID_TABLES, sizeof (uint64_t), 1,
-		    &zfsvfs->z_fuid_obj, tx) == 0);
+		    &zfsvfs->z_fuid_obj, tx);
+		if (err && SPA_EXITING(spa))
+			goto out;
+		VERIFY0(err);
 	}
 
 	VERIFY0(nvlist_alloc(&nvp, NV_UNIQUE_NAME, KM_SLEEP));
@@ -257,13 +265,24 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	dmu_write(zfsvfs->z_os, zfsvfs->z_fuid_obj, 0,
 	    zfsvfs->z_fuid_size, packed, tx, DMU_READ_NO_PREFETCH);
 	kmem_free(packed, zfsvfs->z_fuid_size);
-	VERIFY0(dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db));
+	err = dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db);
+	if (err && SPA_EXITING(spa))
+		goto out;
+	VERIFY0(err);
 	dmu_buf_will_dirty(db, tx);
+	if (SPA_EXITING(spa)) {
+		err = SET_ERROR(EIO);
+		goto out;
+	}
 	*(uint64_t *)db->db_data = zfsvfs->z_fuid_size;
-	dmu_buf_rele(db, FTAG);
 
+out:
+	if (db)
+		dmu_buf_rele(db, FTAG);
 	zfsvfs->z_fuid_dirty = B_FALSE;
 	rw_exit(&zfsvfs->z_fuid_lock);
+
+	return (err);
 }
 
 /*

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1817,7 +1817,7 @@ zfs_ioc_pool_create(zfs_cmd_t *zc)
 	 */
 	if (!error && (error = zfs_set_prop_nvlist(spa_name,
 	    ZPROP_SRC_LOCAL, rootprops, NULL)) != 0) {
-		(void) spa_destroy(spa_name);
+		(void) spa_destroy(spa_name, B_FALSE, B_FALSE);
 		unload_wkey = B_FALSE; /* spa_destroy() unloads wrapping keys */
 	}
 
@@ -1835,8 +1835,13 @@ static int
 zfs_ioc_pool_destroy(zfs_cmd_t *zc)
 {
 	int error;
-	zfs_log_history(zc);
-	error = spa_destroy(zc->zc_name);
+	boolean_t force = (boolean_t)zc->zc_cookie;
+	boolean_t hardforce = (boolean_t)zc->zc_guid;
+
+	if (!hardforce)
+		zfs_log_history(zc);
+
+	error = spa_destroy(zc->zc_name, force, hardforce);
 
 	return (error);
 }
@@ -8301,7 +8306,7 @@ zfs_ioctl_init(void)
 	 * does the logging of those commands.
 	 */
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_DESTROY, zfs_ioc_pool_destroy,
-	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_EXPORT, zfs_ioc_pool_export,
 	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1885,10 +1885,73 @@ zfs_ioc_pool_export(zfs_cmd_t *zc)
 	boolean_t force = (boolean_t)zc->zc_cookie;
 	boolean_t hardforce = (boolean_t)zc->zc_guid;
 
-	zfs_log_history(zc);
+	if (!hardforce)
+		zfs_log_history(zc);
+
 	error = spa_export(zc->zc_name, NULL, force, hardforce);
 
 	return (error);
+}
+
+static int
+zfs_ioc_pool_set_forced_exit_required(zfs_cmd_t *zc)
+{
+	spa_t *spa;
+	boolean_t locked = B_FALSE;
+
+	zfs_dbgmsg("Pool '%s' forced exit requirement has been requested.",
+	    zc->zc_name);
+
+	/*
+	 * The trade-off reasoning.
+	 *
+	 * The spa_lookup() is required to find the targeted pool and
+	 * kick-off the forced exit.
+	 *
+	 * The problem is that there are other places in the code which may
+	 * hold spa_namespace_lock while sleeping for something else like
+	 * txg_wait_synced, etc. We could locate such places, add complexity
+	 * or workarounds to allow forced exit break through, but there are at
+	 * least two open issues left:
+	 * - Newly added code may easily forget about fragile nature of such
+	 *   forced exit, what could be spotted too late when a specific
+	 *   production case fails to use forced exit.
+	 * - While we are targeting a specific pool for forced exit, the
+	 *   global spa_namespace_lock may be held by a thread working with
+	 *   another pool, and sleep for its own reasons or issues which are
+	 *   unrelated to the pool we target.
+	 *
+	 * The forced exit is meant to be used for an exceptional situation
+	 * like a suspended pool blocking administrative operations over the
+	 * rest of the pools. In such cases users are not expected to change
+	 * the spa namespace while doing the things like forced export.
+	 * Otherwise, panics are possible, but such way it provides a
+	 * possibility to avoid system reboot what anyway is the only option
+	 * if the forced exit feature is not available.
+	 */
+	hrtime_t threshold = gethrtime() + SEC2NSEC(10);
+	while (!locked && gethrtime() < threshold)
+		locked = spa_namespace_tryenter(FTAG);
+
+	if (locked) {
+		spa = spa_lookup(zc->zc_name);
+	} else {
+		zfs_dbgmsg("Decided to go without spa_namespace_lock for "
+		    "hardforced exit of '%s' pool", zc->zc_name);
+		spa = spa_lookup_lockless(zc->zc_name);
+	}
+	if (spa == NULL) {
+		if (locked)
+			spa_namespace_exit(FTAG);
+		return (SET_ERROR(ENOENT));
+	}
+
+	spa_set_forced_exit_required(spa);
+
+	if (locked)
+		spa_namespace_exit(FTAG);
+
+	return (0);
 }
 
 static int
@@ -8231,7 +8294,11 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_DESTROY, zfs_ioc_pool_destroy,
 	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_EXPORT, zfs_ioc_pool_export,
-	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
+
+	zfs_ioctl_register_pool(ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED,
+	    zfs_ioc_pool_set_forced_exit_required,
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_STATS, zfs_ioc_pool_stats,
 	    zfs_secpolicy_read, B_FALSE, POOL_CHECK_NONE);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6624,6 +6624,15 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 		spa_namespace_exit(FTAG);
 		return (SET_ERROR(EIO));
 	}
+	if (spa->spa_forced_exit_required) {
+		/*
+		 * Do not restart activities for the pool destined to exit
+		 * abnormally, otherwise it's a bigger mess than we have
+		 * already.
+		 */
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(EIO));
+	}
 	if (spa_get_log_state(spa) == SPA_LOG_MISSING) {
 		/* we need to let spa_open/spa_load clear the chains */
 		spa_set_log_state(spa, SPA_LOG_CLEAR);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1887,10 +1887,73 @@ zfs_ioc_pool_export(zfs_cmd_t *zc)
 	boolean_t force = (boolean_t)zc->zc_cookie;
 	boolean_t hardforce = (boolean_t)zc->zc_guid;
 
-	zfs_log_history(zc);
+	if (!hardforce)
+		zfs_log_history(zc);
+
 	error = spa_export(zc->zc_name, NULL, force, hardforce);
 
 	return (error);
+}
+
+static int
+zfs_ioc_pool_set_forced_exit_required(zfs_cmd_t *zc)
+{
+	spa_t *spa;
+	boolean_t locked = B_FALSE;
+
+	zfs_dbgmsg("Pool '%s' forced exit requirement has been requested.",
+	    zc->zc_name);
+
+	/*
+	 * The trade-off reasoning.
+	 *
+	 * The spa_lookup() is required to find the targeted pool and
+	 * kick-off the forced exit.
+	 *
+	 * The problem is that there are other places in the code which may
+	 * hold spa_namespace_lock while sleeping for something else like
+	 * txg_wait_synced, etc. We could locate such places, add complexity
+	 * or workarounds to allow forced exit break through, but there are at
+	 * least two open issues left:
+	 * - Newly added code may easily forget about fragile nature of such
+	 *   forced exit, what could be spotted too late when a specific
+	 *   production case fails to use forced exit.
+	 * - While we are targeting a specific pool for forced exit, the
+	 *   global spa_namespace_lock may be held by a thread working with
+	 *   another pool, and sleep for its own reasons or issues which are
+	 *   unrelated to the pool we target.
+	 *
+	 * The forced exit is meant to be used for an exceptional situation
+	 * like a suspended pool blocking administrative operations over the
+	 * rest of the pools. In such cases users are not expected to change
+	 * the spa namespace while doing the things like forced export.
+	 * Otherwise, panics are possible, but such way it provides a
+	 * possibility to avoid system reboot what anyway is the only option
+	 * if the forced exit feature is not available.
+	 */
+	hrtime_t threshold = gethrtime() + SEC2NSEC(10);
+	while (!locked && gethrtime() < threshold)
+		locked = spa_namespace_tryenter(FTAG);
+
+	if (locked) {
+		spa = spa_lookup(zc->zc_name);
+	} else {
+		zfs_dbgmsg("Decided to go without spa_namespace_lock for "
+		    "hardforced exit of '%s' pool", zc->zc_name);
+		spa = spa_lookup_lockless(zc->zc_name);
+	}
+	if (spa == NULL) {
+		if (locked)
+			spa_namespace_exit(FTAG);
+		return (SET_ERROR(ENOENT));
+	}
+
+	spa_set_forced_exit_required(spa);
+
+	if (locked)
+		spa_namespace_exit(FTAG);
+
+	return (0);
 }
 
 static int
@@ -8258,7 +8321,11 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_DESTROY, zfs_ioc_pool_destroy,
 	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_EXPORT, zfs_ioc_pool_export,
-	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
+
+	zfs_ioctl_register_pool(ZFS_IOC_POOL_SET_FORCED_EXIT_REQUIRED,
+	    zfs_ioc_pool_set_forced_exit_required,
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_STATS, zfs_ioc_pool_stats,
 	    zfs_secpolicy_read, B_FALSE, POOL_CHECK_NONE);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1819,7 +1819,7 @@ zfs_ioc_pool_create(zfs_cmd_t *zc)
 	 */
 	if (!error && (error = zfs_set_prop_nvlist(spa_name,
 	    ZPROP_SRC_LOCAL, rootprops, NULL)) != 0) {
-		(void) spa_destroy(spa_name);
+		(void) spa_destroy(spa_name, B_FALSE, B_FALSE);
 		unload_wkey = B_FALSE; /* spa_destroy() unloads wrapping keys */
 	}
 
@@ -1837,8 +1837,13 @@ static int
 zfs_ioc_pool_destroy(zfs_cmd_t *zc)
 {
 	int error;
-	zfs_log_history(zc);
-	error = spa_destroy(zc->zc_name);
+	boolean_t force = (boolean_t)zc->zc_cookie;
+	boolean_t hardforce = (boolean_t)zc->zc_guid;
+
+	if (!hardforce)
+		zfs_log_history(zc);
+
+	error = spa_destroy(zc->zc_name, force, hardforce);
 
 	return (error);
 }
@@ -8328,7 +8333,7 @@ zfs_ioctl_init(void)
 	 * does the logging of those commands.
 	 */
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_DESTROY, zfs_ioc_pool_destroy,
-	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_EXPORT, zfs_ioc_pool_export,
 	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6649,6 +6649,15 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 		spa_namespace_exit(FTAG);
 		return (SET_ERROR(EIO));
 	}
+	if (spa->spa_forced_exit_required) {
+		/*
+		 * Do not restart activities for the pool destined to exit
+		 * abnormally, otherwise it's a bigger mess than we have
+		 * already.
+		 */
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(EIO));
+	}
 	if (spa_get_log_state(spa) == SPA_LOG_MISSING) {
 		/* we need to let spa_open/spa_load clear the chains */
 		spa_set_log_state(spa, SPA_LOG_CLEAR);

--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -376,8 +376,8 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 
 	mutex_enter(&zfsvfs->z_lock);
 	if (*objp == 0) {
-		*objp = zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
+		    DMU_OT_NONE, 0, tx, objp));
 		VERIFY0(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    zfs_userquota_prop_prefixes[type], 8, 1, objp, tx));
 	}
@@ -392,7 +392,7 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 	}
 	ASSERT0(err);
 	if (fuid_dirtied)
-		zfs_fuid_sync(zfsvfs, tx);
+		err = zfs_fuid_sync(zfsvfs, tx);
 	dmu_tx_commit(tx);
 	return (err);
 }

--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -366,8 +366,8 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 
 	mutex_enter(&zfsvfs->z_lock);
 	if (*objp == 0) {
-		*objp = zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
-		    DMU_OT_NONE, 0, tx);
+		VERIFY0(zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
+		    DMU_OT_NONE, 0, tx, objp));
 		VERIFY0(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    zfs_userquota_prop_prefixes[type], 8, 1, objp, tx));
 	}
@@ -382,7 +382,7 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 	}
 	ASSERT0(err);
 	if (fuid_dirtied)
-		zfs_fuid_sync(zfsvfs, tx);
+		err = zfs_fuid_sync(zfsvfs, tx);
 	dmu_tx_commit(tx);
 	return (err);
 }

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -127,7 +127,7 @@ zfs_fsync(znode_t *zp, int syncflag, cred_t *cr)
 		error = zil_commit(zfsvfs->z_log, zp->z_id);
 		zfs_exit(zfsvfs, FTAG);
 	}
-	return (error);
+	return (error ? error : zfsvfs_error(zfsvfs));
 }
 
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -112,7 +112,7 @@ zfs_fsync(znode_t *zp, int syncflag, cred_t *cr)
 		error = zil_commit(zfsvfs->z_log, zp->z_id);
 		zfs_exit(zfsvfs, FTAG);
 	}
-	return (error);
+	return (error ? error : zfsvfs_error(zfsvfs));
 }
 
 

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -869,8 +869,10 @@ static void
 zil_free_lwb(zilog_t *zilog, lwb_t *lwb)
 {
 	ASSERT(MUTEX_HELD(&zilog->zl_lock));
-	ASSERT(lwb->lwb_state == LWB_STATE_NEW ||
-	    lwb->lwb_state == LWB_STATE_FLUSH_DONE);
+	ASSERTF(lwb->lwb_state == LWB_STATE_NEW ||
+	    lwb->lwb_state == LWB_STATE_FLUSH_DONE ||
+	    lwb->lwb_flags & LWB_FLAG_CRASHED,
+	    "lwb_state=%d", lwb->lwb_state);
 	ASSERT0P(lwb->lwb_child_zio);
 	ASSERT0P(lwb->lwb_write_zio);
 	ASSERT0P(lwb->lwb_root_zio);
@@ -1065,7 +1067,8 @@ zil_create(zilog_t *zilog)
 	    dmu_objset_type(zilog->zl_os) != DMU_OST_ZVOL,
 	    dsl_dataset_feature_is_active(ds, SPA_FEATURE_ZILSAXATTR));
 
-	ASSERT(error != 0 || memcmp(&blk, &zh->zh_log, sizeof (blk)) == 0);
+	ASSERT(error != 0 || memcmp(&blk, &zh->zh_log, sizeof (blk)) == 0 ||
+	    SPA_EXITING(zilog->zl_spa));
 	IMPLY(error == 0, lwb != NULL);
 
 	return (lwb);
@@ -1593,6 +1596,7 @@ zil_lwb_write_done(zio_t *zio)
 	void *cookie = NULL;
 	zil_vdev_node_t *zv;
 	lwb_t *nlwb = NULL;
+	zio_t *nio;
 
 	ASSERT3S(spa_config_held(spa, SCL_STATE, RW_READER), !=, 0);
 
@@ -1619,8 +1623,11 @@ zil_lwb_write_done(zio_t *zio)
 	}
 	mutex_exit(&zilog->zl_lock);
 
-	if (avl_numnodes(t) == 0)
+	if (avl_numnodes(t) == 0) {
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		return;
+	}
 
 	/*
 	 * If there was an IO error, we're not going to call zio_flush()
@@ -1643,6 +1650,8 @@ zil_lwb_write_done(zio_t *zio)
 	if (zio->io_error != 0 || (lwb->lwb_flags & LWB_FLAG_CRASHED)) {
 		while ((zv = avl_destroy_nodes(t, &cookie)) != NULL)
 			kmem_free(zv, sizeof (*zv));
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		return;
 	}
 
@@ -1681,6 +1690,14 @@ zil_lwb_write_done(zio_t *zio)
 		}
 		kmem_free(zv, sizeof (*zv));
 	}
+
+	return;
+
+spa_exiting:
+	nio = zio_null(lwb->lwb_root_zio, spa, NULL, NULL, NULL,
+	    ZIO_FLAG_CANFAIL);
+	nio->io_error = SET_ERROR(EIO);
+	zio_nowait(nio);
 }
 
 /*
@@ -2020,8 +2037,26 @@ next_lwb:
 		    zil_lwb_write_done, lwb, ZIO_FLAG_CANFAIL);
 		lwb->lwb_write_zio->io_error = lwb->lwb_error;
 	}
-	if (lwb->lwb_child_zio)
+	if (lwb->lwb_child_zio) {
 		zio_add_child(lwb->lwb_write_zio, lwb->lwb_child_zio);
+		/*
+		 * We are adding a child which is probably done already having
+		 * an error, which is not going to be absorbed by parent.
+		 * Here we ignore ZIO_FLAG_DONT_PROPAGATE.
+		 *
+		 * XXX: Should it be integrated into common zio_add_child()?
+		 */
+		zio_t *cio = lwb->lwb_child_zio;
+		int io_error = 0;
+		mutex_enter(&cio->io_lock);
+		io_error = cio->io_error;
+		mutex_exit(&cio->io_lock);
+		if (io_error) {
+			zio_t *nio = zio_null(lwb->lwb_write_zio, spa, NULL,
+			    NULL, NULL, ZIO_FLAG_CANFAIL);
+			nio->io_error = io_error;
+		}
+	}
 
 	/*
 	 * Open transaction to allocate the next block pointer.
@@ -2521,7 +2556,11 @@ zil_lwb_commit(zilog_t *zilog, lwb_t *lwb, itx_t *itx)
 					 * immediately.
 					 */
 					zil_crash(zilog);
+					/* please zil_free_lwb() */
+					lwb->lwb_child_zio = NULL;
 					return (error);
+				} else if (SPA_EXITING(zilog->zl_spa)) {
+					lwb->lwb_error = SET_ERROR(EIO);
 				}
 				zfs_fallthrough;
 			}
@@ -3459,7 +3498,7 @@ out:
 	mutex_exit(&zilog->zl_issuer_lock);
 	int err = 0;
 	while ((lwb = list_remove_head(&ilwbs)) != NULL) {
-		if (err == 0)
+		if (err == 0 || SPA_EXITING(zilog->zl_spa))
 			err = zil_lwb_write_issue(zilog, lwb);
 	}
 	list_destroy(&ilwbs);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -857,6 +857,7 @@ zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, int min_sz, int sz,
 	lwb->lwb_issued_txg = 0;
 	lwb->lwb_alloc_txg = txg;
 	lwb->lwb_max_txg = 0;
+	lwb->lwb_max_lr_seq = 0;
 
 	mutex_enter(&zilog->zl_lock);
 	list_insert_tail(&zilog->zl_lwb_list, lwb);
@@ -1502,7 +1503,10 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 		 * writes succeeded, because ztest wants to ASSERT that
 		 * it got the whole log chain.
 		 */
-		zilog->zl_commit_lr_seq = zilog->zl_lr_seq;
+		if (zio->io_error == 0 &&
+		    lwb->lwb_max_lr_seq > zilog->zl_commit_lr_seq &&
+		    !SPA_EXITING(zio->io_spa))
+			zilog->zl_commit_lr_seq = lwb->lwb_max_lr_seq;
 	}
 
 	while ((itx = list_remove_head(&lwb->lwb_itxs)) != NULL)
@@ -2577,6 +2581,9 @@ zil_lwb_commit(zilog_t *zilog, lwb_t *lwb, itx_t *itx)
 	lwb->lwb_nfilled += reclen + dlen;
 	ASSERT3S(lwb->lwb_nfilled, <=, lwb->lwb_nused);
 	ASSERT0(P2PHASE(lwb->lwb_nfilled, sizeof (uint64_t)));
+
+	if (lr->lrc_seq > lwb->lwb_max_lr_seq)
+		lwb->lwb_max_lr_seq = lr->lrc_seq;
 
 	return (0);
 }

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -859,8 +859,10 @@ static void
 zil_free_lwb(zilog_t *zilog, lwb_t *lwb)
 {
 	ASSERT(MUTEX_HELD(&zilog->zl_lock));
-	ASSERT(lwb->lwb_state == LWB_STATE_NEW ||
-	    lwb->lwb_state == LWB_STATE_FLUSH_DONE);
+	ASSERTF(lwb->lwb_state == LWB_STATE_NEW ||
+	    lwb->lwb_state == LWB_STATE_FLUSH_DONE ||
+	    lwb->lwb_flags & LWB_FLAG_CRASHED,
+	    "lwb_state=%d", lwb->lwb_state);
 	ASSERT0P(lwb->lwb_child_zio);
 	ASSERT0P(lwb->lwb_write_zio);
 	ASSERT0P(lwb->lwb_root_zio);
@@ -1055,7 +1057,8 @@ zil_create(zilog_t *zilog)
 	    dmu_objset_type(zilog->zl_os) != DMU_OST_ZVOL,
 	    dsl_dataset_feature_is_active(ds, SPA_FEATURE_ZILSAXATTR));
 
-	ASSERT(error != 0 || memcmp(&blk, &zh->zh_log, sizeof (blk)) == 0);
+	ASSERT(error != 0 || memcmp(&blk, &zh->zh_log, sizeof (blk)) == 0 ||
+	    SPA_EXITING(zilog->zl_spa));
 	IMPLY(error == 0, lwb != NULL);
 
 	return (lwb);
@@ -1583,6 +1586,7 @@ zil_lwb_write_done(zio_t *zio)
 	void *cookie = NULL;
 	zil_vdev_node_t *zv;
 	lwb_t *nlwb = NULL;
+	zio_t *nio;
 
 	ASSERT3S(spa_config_held(spa, SCL_STATE, RW_READER), !=, 0);
 
@@ -1609,8 +1613,11 @@ zil_lwb_write_done(zio_t *zio)
 	}
 	mutex_exit(&zilog->zl_lock);
 
-	if (avl_numnodes(t) == 0)
+	if (avl_numnodes(t) == 0) {
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		return;
+	}
 
 	/*
 	 * If there was an IO error, we're not going to call zio_flush()
@@ -1633,6 +1640,8 @@ zil_lwb_write_done(zio_t *zio)
 	if (zio->io_error != 0 || (lwb->lwb_flags & LWB_FLAG_CRASHED)) {
 		while ((zv = avl_destroy_nodes(t, &cookie)) != NULL)
 			kmem_free(zv, sizeof (*zv));
+		if (SPA_EXITING(spa))
+			goto spa_exiting;
 		return;
 	}
 
@@ -1671,6 +1680,14 @@ zil_lwb_write_done(zio_t *zio)
 		}
 		kmem_free(zv, sizeof (*zv));
 	}
+
+	return;
+
+spa_exiting:
+	nio = zio_null(lwb->lwb_root_zio, spa, NULL, NULL, NULL,
+	    ZIO_FLAG_CANFAIL);
+	nio->io_error = SET_ERROR(EIO);
+	zio_nowait(nio);
 }
 
 /*
@@ -2010,8 +2027,26 @@ next_lwb:
 		    zil_lwb_write_done, lwb, ZIO_FLAG_CANFAIL);
 		lwb->lwb_write_zio->io_error = lwb->lwb_error;
 	}
-	if (lwb->lwb_child_zio)
+	if (lwb->lwb_child_zio) {
 		zio_add_child(lwb->lwb_write_zio, lwb->lwb_child_zio);
+		/*
+		 * We are adding a child which is probably done already having
+		 * an error, which is not going to be absorbed by parent.
+		 * Here we ignore ZIO_FLAG_DONT_PROPAGATE.
+		 *
+		 * XXX: Should it be integrated into common zio_add_child()?
+		 */
+		zio_t *cio = lwb->lwb_child_zio;
+		int io_error = 0;
+		mutex_enter(&cio->io_lock);
+		io_error = cio->io_error;
+		mutex_exit(&cio->io_lock);
+		if (io_error) {
+			zio_t *nio = zio_null(lwb->lwb_write_zio, spa, NULL,
+			    NULL, NULL, ZIO_FLAG_CANFAIL);
+			nio->io_error = io_error;
+		}
+	}
 
 	/*
 	 * Open transaction to allocate the next block pointer.
@@ -2511,7 +2546,11 @@ zil_lwb_commit(zilog_t *zilog, lwb_t *lwb, itx_t *itx)
 					 * immediately.
 					 */
 					zil_crash(zilog);
+					/* please zil_free_lwb() */
+					lwb->lwb_child_zio = NULL;
 					return (error);
+				} else if (SPA_EXITING(zilog->zl_spa)) {
+					lwb->lwb_error = SET_ERROR(EIO);
 				}
 				zfs_fallthrough;
 			}
@@ -3449,7 +3488,7 @@ out:
 	mutex_exit(&zilog->zl_issuer_lock);
 	int err = 0;
 	while ((lwb = list_remove_head(&ilwbs)) != NULL) {
-		if (err == 0)
+		if (err == 0 || SPA_EXITING(zilog->zl_spa))
 			err = zil_lwb_write_issue(zilog, lwb);
 	}
 	list_destroy(&ilwbs);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -847,6 +847,7 @@ zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, int min_sz, int sz,
 	lwb->lwb_issued_txg = 0;
 	lwb->lwb_alloc_txg = txg;
 	lwb->lwb_max_txg = 0;
+	lwb->lwb_max_lr_seq = 0;
 
 	mutex_enter(&zilog->zl_lock);
 	list_insert_tail(&zilog->zl_lwb_list, lwb);
@@ -1492,7 +1493,10 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 		 * writes succeeded, because ztest wants to ASSERT that
 		 * it got the whole log chain.
 		 */
-		zilog->zl_commit_lr_seq = zilog->zl_lr_seq;
+		if (zio->io_error == 0 &&
+		    lwb->lwb_max_lr_seq > zilog->zl_commit_lr_seq &&
+		    !SPA_EXITING(zio->io_spa))
+			zilog->zl_commit_lr_seq = lwb->lwb_max_lr_seq;
 	}
 
 	while ((itx = list_remove_head(&lwb->lwb_itxs)) != NULL)
@@ -2567,6 +2571,9 @@ zil_lwb_commit(zilog_t *zilog, lwb_t *lwb, itx_t *itx)
 	lwb->lwb_nfilled += reclen + dlen;
 	ASSERT3S(lwb->lwb_nfilled, <=, lwb->lwb_nused);
 	ASSERT0(P2PHASE(lwb->lwb_nfilled, sizeof (uint64_t)));
+
+	if (lr->lrc_seq > lwb->lwb_max_lr_seq)
+		lwb->lwb_max_lr_seq = lr->lrc_seq;
 
 	return (0);
 }

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4455,7 +4455,8 @@ again:
 	/*
 	 * Fall back to some other class when this one is full.
 	 */
-	if (error == ENOSPC && (newmc = spa_preferred_class(spa, zio)) != mc) {
+	if (error == ENOSPC && (newmc = spa_preferred_class(spa, zio)) != mc &&
+	    !SPA_EXITING(spa)) {
 		/*
 		 * If we are holding old class reservation, drop it.
 		 * Dispatch the next ZIO(s) there if some are waiting.
@@ -4495,7 +4496,8 @@ again:
 		goto again;
 	}
 
-	if (error == ENOSPC && zio->io_size > spa->spa_min_alloc) {
+	if (error == ENOSPC && zio->io_size > spa->spa_min_alloc &&
+	    !SPA_EXITING(spa)) {
 		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
 			zfs_dbgmsg("%s: metaslab allocation failure, "
 			    "trying ganging: zio %px, size %llu, error %d",
@@ -4516,6 +4518,8 @@ again:
 			    error);
 		}
 		zio->io_error = error;
+		if (error && SPA_EXITING(spa))
+			zio->io_pipeline = ZIO_INTERLOCK_PIPELINE;
 	} else if (zio->io_prop.zp_rewrite) {
 		/*
 		 * For rewrite operations, preserve the logical birth time
@@ -5516,8 +5520,10 @@ zio_ready(zio_t *zio)
 			if (metaslab_class_throttle_unreserve(
 			    zio->io_metaslab_class, zio->io_allocator,
 			    zio->io_prop.zp_copies, zio->io_size)) {
-				zio_allocate_dispatch(zio->io_metaslab_class,
-				    zio->io_allocator);
+				if (!SPA_EXITING(zio->io_spa))
+					zio_allocate_dispatch(
+					    zio->io_metaslab_class,
+					    zio->io_allocator);
 			}
 		}
 	}
@@ -5604,8 +5610,9 @@ zio_dva_throttle_done(zio_t *zio)
 
 	if (metaslab_class_throttle_unreserve(pio->io_metaslab_class,
 	    pio->io_allocator, 1, pio->io_size)) {
-		zio_allocate_dispatch(zio->io_metaslab_class,
-		    pio->io_allocator);
+		if (!SPA_EXITING(zio->io_spa))
+			zio_allocate_dispatch(zio->io_metaslab_class,
+			    pio->io_allocator);
 	}
 }
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -146,6 +146,10 @@ static const int zio_buf_debug_limit = 16384;
 static const int zio_buf_debug_limit = 0;
 #endif
 
+#ifndef _KERNEL
+boolean_t zio_flush_err_propagation = B_FALSE;
+#endif
+
 typedef struct zio_stats {
 	kstat_named_t ziostat_total_allocations;
 	kstat_named_t ziostat_alloc_class_fallbacks;
@@ -1725,8 +1729,13 @@ zio_vdev_delegated_io(vdev_t *vd, uint64_t offset, abd_t *data, uint64_t size,
 void
 zio_flush(zio_t *pio, vdev_t *vd)
 {
-	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_PROPAGATE |
-	    ZIO_FLAG_DONT_RETRY;
+#ifdef _KERNEL
+	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_RETRY
+	    | ZIO_FLAG_DONT_PROPAGATE;
+#else
+	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_RETRY
+	    | (zio_flush_err_propagation ? 0 : ZIO_FLAG_DONT_PROPAGATE);
+#endif
 
 	if (vd->vdev_nowritecache)
 		return;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2522,8 +2522,8 @@ zio_wait(zio_t *zio)
 		error = cv_timedwait_io(&zio->io_cv, &zio->io_lock,
 		    ddi_get_lbolt() + timeout);
 
-		if (zfs_deadman_enabled && error == -1 &&
-		    gethrtime() - zio->io_queued_timestamp >
+		if (!SPA_EXITING(zio->io_spa) && zfs_deadman_enabled &&
+		    error == -1 && gethrtime() - zio->io_queued_timestamp >
 		    spa_deadman_ziotime(zio->io_spa)) {
 			mutex_exit(&zio->io_lock);
 			timeout = MSEC_TO_TICK(zfs_deadman_checktime_ms);
@@ -2598,6 +2598,21 @@ zio_reexecute(void *arg)
 	pio->io_flags |= ZIO_FLAG_REEXECUTED;
 	pio->io_pipeline_trace = 0;
 	pio->io_error = 0;
+
+	if (SPA_EXITING(pio->io_spa)) {
+		pio->io_post = ZIO_POST_CANCELLED;
+		/*
+		 * This pool is being forcibly exiting; skip everything and
+		 * finish as soon as possible.
+		 *
+		 * Note: even MUST_SUCCEED ones are going to fail to
+		 * communicate the actual state of the things.
+		 */
+		pio->io_pipeline = ZIO_STAGE_DONE;
+		pio->io_stage = ZIO_STAGE_OPEN;
+		pio->io_error = SET_ERROR(EIO);
+	}
+
 	pio->io_state[ZIO_WAIT_READY] = (pio->io_stage >= ZIO_STAGE_READY) ||
 	    (pio->io_pipeline & ZIO_STAGE_READY) == 0;
 	pio->io_state[ZIO_WAIT_DONE] = (pio->io_stage >= ZIO_STAGE_DONE);
@@ -2665,9 +2680,11 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 		    "failure and the failure mode property for this pool "
 		    "is set to panic.", spa_name(spa));
 
-	if (reason != ZIO_SUSPEND_MMP) {
+	if (reason != ZIO_SUSPEND_MMP && !SPA_EXITING(spa)) {
 		cmn_err(CE_WARN, "Pool '%s' has encountered an uncorrectable "
-		    "I/O failure and has been suspended.", spa_name(spa));
+		    "I/O failure and has been suspended "
+		    "(spa_last_synced_txg=%llu).", spa_name(spa),
+		    (u_longlong_t)spa_last_synced_txg(spa));
 	}
 
 	(void) zfs_ereport_post(FM_EREPORT_ZFS_IO_FAILURE, spa, NULL,
@@ -2690,6 +2707,13 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 		ASSERT(zio->io_stage == ZIO_STAGE_DONE);
 		zio_add_child(spa->spa_suspend_zio_root, zio);
 	}
+
+	/*
+	 * After the initiation of forced exit there may be newcomers here.
+	 * Make them follow the same path, i.e. re-execute as cancelled I/O
+	 * without actual suspension.
+	 */
+	spa_initiate_forced_exit(spa);
 
 	mutex_exit(&spa->spa_suspend_lock);
 
@@ -2726,9 +2750,41 @@ void
 zio_resume_wait(spa_t *spa)
 {
 	mutex_enter(&spa->spa_suspend_lock);
-	while (spa_suspended(spa))
+	while (spa_suspended(spa) && !SPA_EXITING(spa))
 		cv_wait(&spa->spa_suspend_cv, &spa->spa_suspend_lock);
 	mutex_exit(&spa->spa_suspend_lock);
+}
+
+static void
+zio_wait_godfather(void *arg)
+{
+	zio_t *pio = arg;
+
+	if (pio == NULL)
+		return;
+
+	ASSERT(pio->io_flags & ZIO_FLAG_GODFATHER);
+
+	zio_reexecute(pio);
+	zio_wait(pio);
+}
+
+void
+zio_resume_but_keep_suspended(spa_t *spa)
+{
+	zio_t *pio;
+
+	ASSERT(MUTEX_HELD(&spa->spa_suspend_lock));
+
+	pio = spa->spa_suspend_zio_root;
+	spa->spa_suspend_zio_root = NULL;
+	cv_broadcast(&spa->spa_suspend_cv); /* wake resume waiters */
+
+	if (pio != NULL) {
+		spa_taskq_dispatch(spa,
+		    ZIO_TYPE_CLAIM, ZIO_TASKQ_ISSUE,
+		    zio_wait_godfather, pio, B_FALSE);
+	}
 }
 
 /*
@@ -5560,6 +5616,7 @@ zio_done(zio_t *zio)
 	const uint64_t psize = zio->io_size;
 	zio_t *pio, *pio_next;
 	zio_link_t *zl = NULL;
+	const boolean_t cancelled = zio->io_post & ZIO_POST_CANCELLED;
 
 	/*
 	 * If our children haven't all completed,
@@ -5583,7 +5640,7 @@ zio_done(zio_t *zio)
 		for (int w = 0; w < ZIO_WAIT_TYPES; w++)
 			ASSERT0(zio->io_children[c][w]);
 
-	if (zio->io_bp != NULL && !BP_IS_EMBEDDED(zio->io_bp)) {
+	if (!cancelled && zio->io_bp != NULL && !BP_IS_EMBEDDED(zio->io_bp)) {
 		ASSERT(memcmp(zio->io_bp, &zio->io_bp_copy,
 		    sizeof (blkptr_t)) == 0 ||
 		    (zio->io_bp == zio_unique_parent(zio)->io_bp));
@@ -5611,7 +5668,7 @@ zio_done(zio_t *zio)
 	 * If the I/O on the transformed data was successful, generate any
 	 * checksum reports now while we still have the transformed data.
 	 */
-	if (zio->io_error == 0) {
+	if (!cancelled && zio->io_error == 0) {
 		while (zio->io_cksum_report != NULL) {
 			zio_cksum_report_t *zcr = zio->io_cksum_report;
 			uint64_t align = zcr->zcr_align;
@@ -5648,14 +5705,15 @@ zio_done(zio_t *zio)
 	    !(zio->io_flags & ZIO_FLAG_RAW))
 		zio->io_error = 0;
 
-	vdev_stat_update(zio, psize);
+	if (!cancelled)
+		vdev_stat_update(zio, psize);
 
 	/*
 	 * If this I/O is attached to a particular vdev is slow, exceeding
 	 * 30 seconds to complete, post an error described the I/O delay.
 	 * We ignore these errors if the device is currently unavailable.
 	 */
-	if (zio->io_delay >= MSEC2NSEC(zio_slow_io_ms)) {
+	if (!cancelled && zio->io_delay >= MSEC2NSEC(zio_slow_io_ms)) {
 		if (zio->io_vd != NULL && !vdev_is_dead(zio->io_vd)) {
 			/*
 			 * We want to only increment our slow IO counters if
@@ -5682,7 +5740,7 @@ zio_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error) {
+	if (!cancelled && zio->io_error) {
 		/*
 		 * If this I/O is attached to a particular vdev,
 		 * generate an error message describing the I/O failure
@@ -5719,7 +5777,7 @@ zio_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error && zio == zio->io_logical) {
+	if (!cancelled && zio->io_error && zio == zio->io_logical) {
 
 		/*
 		 * A DDT child tried to create a mixed gang/non-gang BP. We're
@@ -5758,6 +5816,12 @@ zio_done(zio_t *zio)
 		    !(zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND)))
 			zio->io_post |= ZIO_POST_SUSPEND;
 
+		if ((zio->io_post & ZIO_POST_REEXECUTE) &&
+		    SPA_EXITING(zio->io_spa)) {
+			zio->io_post &= ~ZIO_POST_REEXECUTE;
+			zio->io_post |= ZIO_POST_SUSPEND;
+		}
+
 		/*
 		 * Here is a possibly good place to attempt to do
 		 * either combinatorial reconstruction or error correction
@@ -5775,7 +5839,7 @@ zio_done(zio_t *zio)
 	 */
 	zio_inherit_child_errors(zio, ZIO_CHILD_LOGICAL);
 
-	if ((zio->io_error ||
+	if ((cancelled || zio->io_error ||
 	    (zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND))) &&
 	    IO_IS_ALLOCATING(zio) && zio->io_gang_leader == zio &&
 	    !(zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)))
@@ -5790,7 +5854,8 @@ zio_done(zio_t *zio)
 	    (zio->io_post & ZIO_POST_SUSPEND))
 		zio->io_post &= ~ZIO_POST_SUSPEND;
 
-	if (zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND)) {
+	if (zio->io_post &
+	    (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND|ZIO_POST_CANCELLED)) {
 		/*
 		 * A Direct I/O operation that has a checksum verify error
 		 * should not attempt to reexecute. Instead, the error should
@@ -5844,7 +5909,15 @@ zio_done(zio_t *zio)
 			}
 		}
 
-		if ((pio = zio_unique_parent(zio)) != NULL) {
+		if (zio->io_post & ZIO_POST_CANCELLED) {
+			/*
+			 * This zio had been marked for reexecute previously,
+			 * and upon reexecution, found the pool being forcibly
+			 * exiting. Reset error back as it could be altered.
+			 */
+			zio->io_error = SET_ERROR(EIO);
+			goto finish;
+		} else if ((pio = zio_unique_parent(zio)) != NULL) {
 			/*
 			 * We're not a root i/o, so there's nothing to do
 			 * but notify our parent.  Don't propagate errors
@@ -5876,10 +5949,14 @@ zio_done(zio_t *zio)
 		return (NULL);
 	}
 
+finish:
 	ASSERT(list_is_empty(&zio->io_child_list));
-	ASSERT0(zio->io_post & ZIO_POST_REEXECUTE);
-	ASSERT0(zio->io_post & ZIO_POST_SUSPEND);
-	ASSERT(zio->io_error == 0 || (zio->io_flags & ZIO_FLAG_CANFAIL));
+	if (!(zio->io_post & ZIO_POST_CANCELLED)) {
+		ASSERT0(zio->io_post & ZIO_POST_REEXECUTE);
+		ASSERT0(zio->io_post & ZIO_POST_SUSPEND);
+		ASSERT(zio->io_error == 0 ||
+		    (zio->io_flags & ZIO_FLAG_CANFAIL));
+	}
 
 	/*
 	 * Report any checksum errors, since the I/O is complete.
@@ -5888,7 +5965,8 @@ zio_done(zio_t *zio)
 		zio_cksum_report_t *zcr = zio->io_cksum_report;
 		zio->io_cksum_report = zcr->zcr_next;
 		zcr->zcr_next = NULL;
-		zcr->zcr_finish(zcr, NULL);
+		if (!SPA_EXITING(zio->io_spa))
+			zcr->zcr_finish(zcr, NULL);
 		zfs_ereport_free_checksum(zcr);
 	}
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -136,6 +136,10 @@ static const int zio_buf_debug_limit = 16384;
 static const int zio_buf_debug_limit = 0;
 #endif
 
+#ifndef _KERNEL
+boolean_t zio_flush_err_propagation = B_FALSE;
+#endif
+
 typedef struct zio_stats {
 	kstat_named_t ziostat_total_allocations;
 	kstat_named_t ziostat_alloc_class_fallbacks;
@@ -1715,8 +1719,13 @@ zio_vdev_delegated_io(vdev_t *vd, uint64_t offset, abd_t *data, uint64_t size,
 void
 zio_flush(zio_t *pio, vdev_t *vd)
 {
-	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_PROPAGATE |
-	    ZIO_FLAG_DONT_RETRY;
+#ifdef _KERNEL
+	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_RETRY
+	    | ZIO_FLAG_DONT_PROPAGATE;
+#else
+	const zio_flag_t flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_RETRY
+	    | (zio_flush_err_propagation ? 0 : ZIO_FLAG_DONT_PROPAGATE);
+#endif
 
 	if (vd->vdev_nowritecache)
 		return;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4318,7 +4318,7 @@ zio_io_to_allocate(metaslab_class_allocator_t *mca, boolean_t *more)
 	 */
 	if (!metaslab_class_throttle_reserve(zio->io_metaslab_class,
 	    zio->io_allocator, zio->io_prop.zp_copies, zio->io_size,
-	    B_FALSE, more)) {
+	    B_FALSE || SPA_EXITING(zio->io_spa), more)) {
 		return (NULL);
 	}
 	zio->io_flags |= ZIO_FLAG_ALLOC_THROTTLED;
@@ -4474,7 +4474,8 @@ again:
 	/*
 	 * Fall back to some other class when this one is full.
 	 */
-	if (error == ENOSPC && (newmc = spa_preferred_class(spa, zio)) != mc) {
+	if (error == ENOSPC && (newmc = spa_preferred_class(spa, zio)) != mc &&
+	    !SPA_EXITING(spa)) {
 		/*
 		 * If we are holding old class reservation, drop it.
 		 * Dispatch the next ZIO(s) there if some are waiting.
@@ -4514,7 +4515,8 @@ again:
 		goto again;
 	}
 
-	if (error == ENOSPC && zio->io_size > spa->spa_min_alloc) {
+	if (error == ENOSPC && zio->io_size > spa->spa_min_alloc &&
+	    !SPA_EXITING(spa)) {
 		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
 			zfs_dbgmsg("%s: metaslab allocation failure, "
 			    "trying ganging: zio %px, size %llu, error %d",
@@ -4535,6 +4537,8 @@ again:
 			    error);
 		}
 		zio->io_error = error;
+		if (error && SPA_EXITING(spa))
+			zio->io_pipeline = ZIO_INTERLOCK_PIPELINE;
 	} else if (zio->io_prop.zp_rewrite) {
 		/*
 		 * For rewrite operations, preserve the logical birth time
@@ -5588,7 +5592,8 @@ zio_dva_throttle_done(zio_t *zio)
 	const void *tag = pio;
 	uint64_t size = pio->io_size;
 
-	ASSERT3P(zio->io_bp, !=, NULL);
+	if (!SPA_EXITING(zio->io_spa))
+		ASSERT3P(zio->io_bp, !=, NULL);
 	ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
 	ASSERT3U(zio->io_priority, ==, ZIO_PRIORITY_ASYNC_WRITE);
 	ASSERT3U(zio->io_child_type, ==, ZIO_CHILD_VDEV);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2526,8 +2526,8 @@ zio_wait(zio_t *zio)
 		error = cv_timedwait_io(&zio->io_cv, &zio->io_lock,
 		    ddi_get_lbolt() + timeout);
 
-		if (zfs_deadman_enabled && error == -1 &&
-		    gethrtime() - zio->io_queued_timestamp >
+		if (!SPA_EXITING(zio->io_spa) && zfs_deadman_enabled &&
+		    error == -1 && gethrtime() - zio->io_queued_timestamp >
 		    spa_deadman_ziotime(zio->io_spa)) {
 			mutex_exit(&zio->io_lock);
 			timeout = MSEC_TO_TICK(zfs_deadman_checktime_ms);
@@ -2602,6 +2602,21 @@ zio_reexecute(void *arg)
 	pio->io_flags |= ZIO_FLAG_REEXECUTED;
 	pio->io_pipeline_trace = 0;
 	pio->io_error = 0;
+
+	if (SPA_EXITING(pio->io_spa)) {
+		pio->io_post = ZIO_POST_CANCELLED;
+		/*
+		 * This pool is being forcibly exiting; skip everything and
+		 * finish as soon as possible.
+		 *
+		 * Note: even MUST_SUCCEED ones are going to fail to
+		 * communicate the actual state of the things.
+		 */
+		pio->io_pipeline = ZIO_STAGE_DONE;
+		pio->io_stage = ZIO_STAGE_OPEN;
+		pio->io_error = SET_ERROR(EIO);
+	}
+
 	pio->io_state[ZIO_WAIT_READY] = (pio->io_stage >= ZIO_STAGE_READY) ||
 	    (pio->io_pipeline & ZIO_STAGE_READY) == 0;
 	pio->io_state[ZIO_WAIT_DONE] = (pio->io_stage >= ZIO_STAGE_DONE);
@@ -2669,9 +2684,11 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 		    "failure and the failure mode property for this pool "
 		    "is set to panic.", spa_name(spa));
 
-	if (reason != ZIO_SUSPEND_MMP) {
+	if (reason != ZIO_SUSPEND_MMP && !SPA_EXITING(spa)) {
 		cmn_err(CE_WARN, "Pool '%s' has encountered an uncorrectable "
-		    "I/O failure and has been suspended.", spa_name(spa));
+		    "I/O failure and has been suspended "
+		    "(spa_last_synced_txg=%llu).", spa_name(spa),
+		    (u_longlong_t)spa_last_synced_txg(spa));
 	}
 
 	(void) zfs_ereport_post(FM_EREPORT_ZFS_IO_FAILURE, spa, NULL,
@@ -2694,6 +2711,13 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 		ASSERT(zio->io_stage == ZIO_STAGE_DONE);
 		zio_add_child(spa->spa_suspend_zio_root, zio);
 	}
+
+	/*
+	 * After the initiation of forced exit there may be newcomers here.
+	 * Make them follow the same path, i.e. re-execute as cancelled I/O
+	 * without actual suspension.
+	 */
+	spa_initiate_forced_exit(spa);
 
 	mutex_exit(&spa->spa_suspend_lock);
 
@@ -2730,9 +2754,41 @@ void
 zio_resume_wait(spa_t *spa)
 {
 	mutex_enter(&spa->spa_suspend_lock);
-	while (spa_suspended(spa))
+	while (spa_suspended(spa) && !SPA_EXITING(spa))
 		cv_wait(&spa->spa_suspend_cv, &spa->spa_suspend_lock);
 	mutex_exit(&spa->spa_suspend_lock);
+}
+
+static void
+zio_wait_godfather(void *arg)
+{
+	zio_t *pio = arg;
+
+	if (pio == NULL)
+		return;
+
+	ASSERT(pio->io_flags & ZIO_FLAG_GODFATHER);
+
+	zio_reexecute(pio);
+	zio_wait(pio);
+}
+
+void
+zio_resume_but_keep_suspended(spa_t *spa)
+{
+	zio_t *pio;
+
+	ASSERT(MUTEX_HELD(&spa->spa_suspend_lock));
+
+	pio = spa->spa_suspend_zio_root;
+	spa->spa_suspend_zio_root = NULL;
+	cv_broadcast(&spa->spa_suspend_cv); /* wake resume waiters */
+
+	if (pio != NULL) {
+		spa_taskq_dispatch(spa,
+		    ZIO_TYPE_CLAIM, ZIO_TASKQ_ISSUE,
+		    zio_wait_godfather, pio, B_FALSE);
+	}
 }
 
 /*
@@ -5581,6 +5637,7 @@ zio_done(zio_t *zio)
 	const uint64_t psize = zio->io_size;
 	zio_t *pio, *pio_next;
 	zio_link_t *zl = NULL;
+	const boolean_t cancelled = zio->io_post & ZIO_POST_CANCELLED;
 
 	/*
 	 * If our children haven't all completed,
@@ -5604,7 +5661,7 @@ zio_done(zio_t *zio)
 		for (int w = 0; w < ZIO_WAIT_TYPES; w++)
 			ASSERT0(zio->io_children[c][w]);
 
-	if (zio->io_bp != NULL && !BP_IS_EMBEDDED(zio->io_bp)) {
+	if (!cancelled && zio->io_bp != NULL && !BP_IS_EMBEDDED(zio->io_bp)) {
 		ASSERT(memcmp(zio->io_bp, &zio->io_bp_copy,
 		    sizeof (blkptr_t)) == 0 ||
 		    (zio->io_bp == zio_unique_parent(zio)->io_bp));
@@ -5632,7 +5689,7 @@ zio_done(zio_t *zio)
 	 * If the I/O on the transformed data was successful, generate any
 	 * checksum reports now while we still have the transformed data.
 	 */
-	if (zio->io_error == 0) {
+	if (!cancelled && zio->io_error == 0) {
 		while (zio->io_cksum_report != NULL) {
 			zio_cksum_report_t *zcr = zio->io_cksum_report;
 			uint64_t align = zcr->zcr_align;
@@ -5669,14 +5726,15 @@ zio_done(zio_t *zio)
 	    !(zio->io_flags & ZIO_FLAG_RAW))
 		zio->io_error = 0;
 
-	vdev_stat_update(zio, psize);
+	if (!cancelled)
+		vdev_stat_update(zio, psize);
 
 	/*
 	 * If this I/O is attached to a particular vdev is slow, exceeding
 	 * 30 seconds to complete, post an error described the I/O delay.
 	 * We ignore these errors if the device is currently unavailable.
 	 */
-	if (zio->io_delay >= MSEC2NSEC(zio_slow_io_ms)) {
+	if (!cancelled && zio->io_delay >= MSEC2NSEC(zio_slow_io_ms)) {
 		if (zio->io_vd != NULL && !vdev_is_dead(zio->io_vd)) {
 			/*
 			 * We want to only increment our slow IO counters if
@@ -5703,7 +5761,7 @@ zio_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error) {
+	if (!cancelled && zio->io_error) {
 		/*
 		 * If this I/O is attached to a particular vdev,
 		 * generate an error message describing the I/O failure
@@ -5740,7 +5798,7 @@ zio_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error && zio == zio->io_logical) {
+	if (!cancelled && zio->io_error && zio == zio->io_logical) {
 
 		/*
 		 * A DDT child tried to create a mixed gang/non-gang BP. We're
@@ -5779,6 +5837,12 @@ zio_done(zio_t *zio)
 		    !(zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND)))
 			zio->io_post |= ZIO_POST_SUSPEND;
 
+		if ((zio->io_post & ZIO_POST_REEXECUTE) &&
+		    SPA_EXITING(zio->io_spa)) {
+			zio->io_post &= ~ZIO_POST_REEXECUTE;
+			zio->io_post |= ZIO_POST_SUSPEND;
+		}
+
 		/*
 		 * Here is a possibly good place to attempt to do
 		 * either combinatorial reconstruction or error correction
@@ -5796,7 +5860,7 @@ zio_done(zio_t *zio)
 	 */
 	zio_inherit_child_errors(zio, ZIO_CHILD_LOGICAL);
 
-	if ((zio->io_error ||
+	if ((cancelled || zio->io_error ||
 	    (zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND))) &&
 	    IO_IS_ALLOCATING(zio) && zio->io_gang_leader == zio &&
 	    !(zio->io_flags & (ZIO_FLAG_IO_REWRITE | ZIO_FLAG_NOPWRITE)))
@@ -5811,7 +5875,8 @@ zio_done(zio_t *zio)
 	    (zio->io_post & ZIO_POST_SUSPEND))
 		zio->io_post &= ~ZIO_POST_SUSPEND;
 
-	if (zio->io_post & (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND)) {
+	if (zio->io_post &
+	    (ZIO_POST_REEXECUTE|ZIO_POST_SUSPEND|ZIO_POST_CANCELLED)) {
 		/*
 		 * A Direct I/O operation that has a checksum verify error
 		 * should not attempt to reexecute. Instead, the error should
@@ -5865,7 +5930,15 @@ zio_done(zio_t *zio)
 			}
 		}
 
-		if ((pio = zio_unique_parent(zio)) != NULL) {
+		if (zio->io_post & ZIO_POST_CANCELLED) {
+			/*
+			 * This zio had been marked for reexecute previously,
+			 * and upon reexecution, found the pool being forcibly
+			 * exiting. Reset error back as it could be altered.
+			 */
+			zio->io_error = SET_ERROR(EIO);
+			goto finish;
+		} else if ((pio = zio_unique_parent(zio)) != NULL) {
 			/*
 			 * We're not a root i/o, so there's nothing to do
 			 * but notify our parent.  Don't propagate errors
@@ -5897,10 +5970,14 @@ zio_done(zio_t *zio)
 		return (NULL);
 	}
 
+finish:
 	ASSERT(list_is_empty(&zio->io_child_list));
-	ASSERT0(zio->io_post & ZIO_POST_REEXECUTE);
-	ASSERT0(zio->io_post & ZIO_POST_SUSPEND);
-	ASSERT(zio->io_error == 0 || (zio->io_flags & ZIO_FLAG_CANFAIL));
+	if (!(zio->io_post & ZIO_POST_CANCELLED)) {
+		ASSERT0(zio->io_post & ZIO_POST_REEXECUTE);
+		ASSERT0(zio->io_post & ZIO_POST_SUSPEND);
+		ASSERT(zio->io_error == 0 ||
+		    (zio->io_flags & ZIO_FLAG_CANFAIL));
+	}
 
 	/*
 	 * Report any checksum errors, since the I/O is complete.
@@ -5909,7 +5986,8 @@ zio_done(zio_t *zio)
 		zio_cksum_report_t *zcr = zio->io_cksum_report;
 		zio->io_cksum_report = zcr->zcr_next;
 		zcr->zcr_next = NULL;
-		zcr->zcr_finish(zcr, NULL);
+		if (!SPA_EXITING(zio->io_spa))
+			zcr->zcr_finish(zcr, NULL);
 		zfs_ereport_free_checksum(zcr);
 	}
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -463,6 +463,12 @@ tags = ['functional', 'cli_root', 'zpool_events']
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_003_neg', 'zpool_export_004_pos',
+    'zpool_export_hardforce_001_pos',
+    'zpool_export_hardforce_002_pos',
+    'zpool_export_hardforce_003_pos',
+    'zpool_export_hardforce_004_pos',
+    'zpool_export_hardforce_005_pos',
+    'zpool_export_hardforce_006_pos',
     'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -469,6 +469,8 @@ tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_hardforce_004_pos',
     'zpool_export_hardforce_005_pos',
     'zpool_export_hardforce_006_pos',
+    'zpool_export_hardforce_send_001_pos',
+    'zpool_export_hardforce_send_002_pos',
     'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -469,6 +469,8 @@ tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_hardforce_004_pos',
     'zpool_export_hardforce_005_pos',
     'zpool_export_hardforce_006_pos',
+    'zpool_export_hardforce_receive_001_pos',
+    'zpool_export_hardforce_receive_002_pos',
     'zpool_export_hardforce_send_001_pos',
     'zpool_export_hardforce_send_002_pos',
     'zpool_export_parallel_pos', 'zpool_export_parallel_admin']

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -445,6 +445,10 @@ tags = ['functional', 'cli_root', 'zpool_create']
 
 [tests/functional/cli_root/zpool_destroy]
 tests = ['zpool_destroy_001_pos', 'zpool_destroy_002_pos',
+    'zpool_destroy_hardforce_001_pos',
+    'zpool_destroy_hardforce_002_pos',
+    'zpool_destroy_hardforce_003_pos',
+    'zpool_destroy_hardforce_004_pos',
     'zpool_destroy_003_neg']
 pre =
 post =

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -471,6 +471,8 @@ tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_hardforce_004_pos',
     'zpool_export_hardforce_005_pos',
     'zpool_export_hardforce_006_pos',
+    'zpool_export_hardforce_receive_001_pos',
+    'zpool_export_hardforce_receive_002_pos',
     'zpool_export_hardforce_send_001_pos',
     'zpool_export_hardforce_send_002_pos',
     'zpool_export_parallel_pos', 'zpool_export_parallel_admin']

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -471,6 +471,8 @@ tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_hardforce_004_pos',
     'zpool_export_hardforce_005_pos',
     'zpool_export_hardforce_006_pos',
+    'zpool_export_hardforce_send_001_pos',
+    'zpool_export_hardforce_send_002_pos',
     'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -464,8 +464,14 @@ tags = ['functional', 'cli_root', 'zpool_events']
 
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
-    'zpool_export_003_neg', 'zpool_export_004_pos',
-    'zpool_export_005_neg', 'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
+    'zpool_export_003_neg', 'zpool_export_004_pos', 'zpool_export_005_neg',
+    'zpool_export_hardforce_001_pos',
+    'zpool_export_hardforce_002_pos',
+    'zpool_export_hardforce_003_pos',
+    'zpool_export_hardforce_004_pos',
+    'zpool_export_hardforce_005_pos',
+    'zpool_export_hardforce_006_pos',
+    'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -447,6 +447,10 @@ tags = ['functional', 'cli_root', 'zpool_create']
 
 [tests/functional/cli_root/zpool_destroy]
 tests = ['zpool_destroy_001_pos', 'zpool_destroy_002_pos',
+    'zpool_destroy_hardforce_001_pos',
+    'zpool_destroy_hardforce_002_pos',
+    'zpool_destroy_hardforce_003_pos',
+    'zpool_destroy_hardforce_004_pos',
     'zpool_destroy_003_neg']
 pre =
 post =

--- a/tests/unit/mock_dmu.c
+++ b/tests/unit/mock_dmu.c
@@ -21,6 +21,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dnode.h>
 #include <sys/dsl_dataset.h>
@@ -115,6 +116,8 @@ mock_dnode_create(size_t blksize, dmu_object_type_t type)
 	mdn->mdn_refcount = 1;
 	mdn->mdn_dn.dn_type = type;
 	mdn->mdn_dn.dn_object = 1;	/* arbitrary non-zero object number */
+	struct objset *os = kmem_zalloc(sizeof (struct objset), KM_SLEEP);
+	mdn->mdn_dn.dn_objset = os;
 	mdn->mdn_blksize = blksize;
 
 	return (mdn);
@@ -142,6 +145,7 @@ mock_dnode_destroy(mock_dnode_t *mdn)
 
 	kmem_free(mdn->mdn_blocks,
 	    mdn->mdn_nblocks * sizeof (mock_dbuf_t *));
+	kmem_free(mdn->mdn_dn.dn_objset, sizeof (struct objset));
 	kmem_free(mdn, sizeof (mock_dnode_t));
 }
 
@@ -332,6 +336,13 @@ dsl_dataset_dirty(dsl_dataset_t *ds, dmu_tx_t *tx)
 }
 
 boolean_t
+spa_exiting(spa_t *spa)
+{
+	(void) spa;
+	return (B_FALSE);
+}
+
+boolean_t
 spa_feature_is_enabled(spa_t *spa, spa_feature_t f)
 {
 	(void) spa; (void) f;
@@ -371,15 +382,15 @@ dmu_object_free(objset_t *os, uint64_t object, dmu_tx_t *tx)
 	return (EIO);
 }
 
-uint64_t
+int
 dmu_object_alloc_hold(objset_t *os, dmu_object_type_t ot,
     int blocksize, int indirect_blockshift, dmu_object_type_t bonustype,
     int bonuslen, int dnodesize, dnode_t **allocated_dnode,
-    const void *tag, dmu_tx_t *tx)
+    const void *tag, dmu_tx_t *tx, uint64_t *objectp)
 {
 	(void) os; (void) ot; (void) blocksize; (void) indirect_blockshift;
 	(void) bonustype; (void) bonuslen; (void) dnodesize;
-	(void) allocated_dnode; (void) tag; (void) tx;
+	(void) allocated_dnode; (void) tag; (void) tx; (void) objectp;
 	return (EIO);
 }
 

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -68,6 +68,7 @@ export SYSTEM_FILES_COMMON='awk
     pkill
     printf
     ps
+    pv
     python3
     readlink
     rm

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -4068,4 +4068,47 @@ function get_same_blocks # dataset1 file1 dataset2 file2 [key]
 	rm -f $zdbout1 $zdbout2 $awkout1 $awkout2
 }
 
+#
+# Suspend the given pool using zinject to fail the given list of VDEVs
+#
+function suspend_pool
+{
+	typeset pool=$1
+	shift
+
+	for vdev in $@; do
+		zinject -d $vdev -e io -T probe $pool
+		zinject -d $vdev -e io -T write $pool
+	done
+
+	log_note "waiting for pool ${pool} to suspend"
+	typeset -i tries=30
+	until [[ $(kstat_pool $pool state) == "SUSPENDED" ]] ; do
+		if ((tries-- == 0)); then
+			zinject -c all
+			zpool status -s
+			log_note "UNEXPECTED -- pool ${pool} did not suspend"
+			return 1
+		fi
+		sleep 1
+	done
+
+	zinject -c all
+
+	return 0
+}
+
+#
+# Cleanup leftovers after suspend_pool() work
+#
+function clear_suspension_artifacts
+{
+	typeset pool=$1
+
+	poolexists $pool || return 0
+
+	zinject -c all
+	zpool clear $pool
+}
+
 . ${STF_SUITE}/include/kstat.shlib

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -4138,4 +4138,47 @@ function get_same_blocks # dataset1 file1 dataset2 file2 [key]
 	rm -f $zdbout1 $zdbout2 $awkout1 $awkout2
 }
 
+#
+# Suspend the given pool using zinject to fail the given list of VDEVs
+#
+function suspend_pool
+{
+	typeset pool=$1
+	shift
+
+	for vdev in $@; do
+		zinject -d $vdev -e io -T probe $pool
+		zinject -d $vdev -e io -T write $pool
+	done
+
+	log_note "waiting for pool ${pool} to suspend"
+	typeset -i tries=30
+	until [[ $(kstat_pool $pool state) == "SUSPENDED" ]] ; do
+		if ((tries-- == 0)); then
+			zinject -c all
+			zpool status -s
+			log_note "UNEXPECTED -- pool ${pool} did not suspend"
+			return 1
+		fi
+		sleep 1
+	done
+
+	zinject -c all
+
+	return 0
+}
+
+#
+# Cleanup leftovers after suspend_pool() work
+#
+function clear_suspension_artifacts
+{
+	typeset pool=$1
+
+	poolexists $pool || return 0
+
+	zinject -c all
+	zpool clear $pool
+}
+
 . ${STF_SUITE}/include/kstat.shlib

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1195,6 +1195,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_receive_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_receive_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1189,6 +1189,12 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_003_neg.ksh \
 	functional/cli_root/zpool_export/zpool_export_004_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_002_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_003_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1195,6 +1195,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1163,6 +1163,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh \
 	functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh \
 	functional/cli_root/zpool_destroy/zpool_destroy_003_neg.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_003_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_detach/cleanup.ksh \
 	functional/cli_root/zpool_detach/setup.ksh \
 	functional/cli_root/zpool_detach/zpool_detach_001_neg.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1217,6 +1217,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1217,6 +1217,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_receive_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_receive_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1211,6 +1211,12 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_003_neg.ksh \
 	functional/cli_root/zpool_export/zpool_export_004_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_005_neg.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_001_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_002_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_003_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1182,6 +1182,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh \
 	functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh \
 	functional/cli_root/zpool_destroy/zpool_destroy_003_neg.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_003_pos.ksh \
+	functional/cli_root/zpool_destroy/zpool_destroy_hardforce_004_pos.ksh \
 	functional/cli_root/zpool_detach/cleanup.ksh \
 	functional/cli_root/zpool_detach/setup.ksh \
 	functional/cli_root/zpool_detach/zpool_detach_001_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
@@ -23,6 +23,9 @@ export DISK_ARRAY_NUM=$(echo ${DISKS} | awk '{print NF}')
 export DISKSARRAY=$DISKS
 echo $DISKS | read DISK0 DISK1
 
+read -r FEDISK0 FEDISK1 FEDISK2 <<<"$DISKS"
+export FEDISK0 FEDISK1 FEDISK2
+
 if is_linux; then
 	set_device_dir
 fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh
@@ -1,0 +1,60 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool can be destroyed using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content.
+# 3. Forcibly destroy.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool destroy -F of a healthy pool."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+TESTFILE="/$TESTPOOL/file.dd"
+log_must dd if=/dev/urandom of=$TESTFILE \
+    oflag=sync bs=1M count=10
+
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_001_pos.ksh
@@ -1,3 +1,4 @@
+#!/bin/ksh -p
 # SPDX-License-Identifier: CDDL-1.0
 #
 # CDDL HEADER START
@@ -21,21 +22,39 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
+# Copyright (c) 2025, Klara, Inc.
 #
 
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# DESCRIPTION:
+# Verify that a healthy pool can be destroyed using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content.
+# 3. Forcibly destroy.
 #
 
-export DISK_ARRAY_NUM=$(echo ${DISKS} | awk '{print NF}')
-export DISKSARRAY=$DISKS
-echo $DISKS | read DISK0 DISK1
+verify_runnable "global"
 
-read -r FEDISK0 FEDISK1 FEDISK2 <<<"$DISKS"
-export FEDISK0 FEDISK1 FEDISK2
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
 
-if is_linux; then
-	set_device_dir
-fi
+log_assert "zpool destroy -F of a healthy pool."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+TESTFILE="/$TESTPOOL/file.dd"
+log_must dd if=/dev/urandom of=$TESTFILE \
+    oflag=sync bs=1M count=10
+
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh
@@ -1,3 +1,4 @@
+#!/bin/ksh -p
 # SPDX-License-Identifier: CDDL-1.0
 #
 # CDDL HEADER START
@@ -21,21 +22,36 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
+# Copyright (c) 2025, Klara, Inc.
 #
 
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# DESCRIPTION:
+# Verify that a healthy pool without mountpoints can be destroyed using
+# hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Unmount the fs.
+# 3. Forcibly destroy.
 #
 
-export DISK_ARRAY_NUM=$(echo ${DISKS} | awk '{print NF}')
-export DISKSARRAY=$DISKS
-echo $DISKS | read DISK0 DISK1
+verify_runnable "global"
 
-read -r FEDISK0 FEDISK1 FEDISK2 <<<"$DISKS"
-export FEDISK0 FEDISK1 FEDISK2
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
 
-if is_linux; then
-	set_device_dir
-fi
+log_assert "zpool destroy -F of a healthy pool without mountpoints."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+log_must zfs unmount /$TESTPOOL
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_002_pos.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool without mountpoints can be destroyed using
+# hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Unmount the fs.
+# 3. Forcibly destroy.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool destroy -F of a healthy pool without mountpoints."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+log_must zfs unmount /$TESTPOOL
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_003_pos.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool with nested mountpoints can be destroyed using
+# hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Prepare nested filesystems, and write some content.
+# 3. Forcibly destroy.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool destroy -F of a healthy pool nested mountpoints."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a healthy pool nested mountpoints."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_hardforce_004_pos.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+
+#
+# DESCRIPTION:
+# Verify that a suspended pool can be destroyed using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content.
+# 3. Suspend.
+# 4. Forcibly destroy.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	clear_suspension_artifacts $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool destroy -F of a suspended pool"
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+
+log_must suspend_pool $TESTPOOL $FEDISK0 $FEDISK2
+
+log_must zpool destroy -F $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass "zpool destroy -F of a suspended pool"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
@@ -35,6 +35,9 @@ export DISK_ARRAY_NUM=$(echo ${DISKS} | awk '{print NF}')
 read -r DISK1 _ DISK2 _ <<<"$DISKS"
 export DISK1 DISK2
 
+read -r FEDISK0 FEDISK1 FEDISK2 <<<"$DISKS"
+export FEDISK0 FEDISK1 FEDISK2
+
 if is_linux; then
 	set_slice_prefix
 	set_device_dir

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
@@ -25,6 +25,9 @@ export DISK_ARRAY_NUM=$(echo ${DISKS} | awk '{print NF}')
 read -r DISK1 _ DISK2 _ <<<"$DISKS"
 export DISK1 DISK2
 
+read -r FEDISK0 FEDISK1 FEDISK2 <<<"$DISKS"
+export FEDISK0 FEDISK1 FEDISK2
+
 if is_linux; then
 	set_slice_prefix
 	set_device_dir

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_001_pos.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool can be exported using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content to check it later.
+# 3. Sync.
+# 4. Forcibly export.
+# 5. Import it back.
+# 6. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a healthy pool."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+TESTFILE="/$TESTPOOL/file.dd"
+log_must dd if=/dev/urandom of=$TESTFILE \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE_CKSUM="$(xxh128digest $TESTFILE)"
+
+log_must zpool export -F $TESTPOOL
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE_CKSUM" = "$(xxh128digest $TESTFILE)"
+
+log_pass "zpool export -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_002_pos.ksh
@@ -1,0 +1,70 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool without mountpoints can be exported using
+# hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content to check it later.
+# 3. Sync.
+# 4. Unmount the fs.
+# 5. Forcibly export.
+# 6. Import it back.
+# 7. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a healthy pool without mountpoints."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+TESTFILE="/$TESTPOOL/file.dd"
+log_must dd if=/dev/urandom of=$TESTFILE \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE_CKSUM="$(xxh128digest $TESTFILE)"
+
+log_must zfs unmount /$TESTPOOL
+
+log_must zpool export -F $TESTPOOL
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE_CKSUM" = "$(xxh128digest $TESTFILE)"
+
+log_pass "zpool export -F of a healthy pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_003_pos.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that a healthy pool with nested mountpoints can be exported using
+# hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Prepare nested filesystems, and write some content to check it later.
+# 3. Sync.
+# 4. Forcibly export.
+# 5. Import it back.
+# 6. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a healthy pool nested mountpoints."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE1_CKSUM="$(xxh128digest $TESTFILE1)"
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE2_CKSUM="$(xxh128digest $TESTFILE2)"
+
+log_must zpool export -F $TESTPOOL
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE1_CKSUM" = "$(xxh128digest $TESTFILE1)"
+log_must test "$TESTFILE2_CKSUM" = "$(xxh128digest $TESTFILE2)"
+
+log_pass "zpool export -F of a healthy pool nested mountpoints."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_004_pos.ksh
@@ -1,0 +1,87 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that a suspended pool can be exported using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content to check it later.
+# 3. Sync.
+# 4. Suspend.
+# 5. Forcibly export.
+# 6. Import it back.
+# 7. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	# The test may fail and leave a sleeping spa_namespace_lock holder.
+	# Let's unbreak it first.
+	zpool export -F $TESTPOOL
+
+	clear_suspension_artifacts $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a suspended pool."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE1_CKSUM="$(xxh128digest $TESTFILE1)"
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE2_CKSUM="$(xxh128digest $TESTFILE2)"
+
+log_must suspend_pool $TESTPOOL $FEDISK0 $FEDISK2
+
+log_must zpool export -F $TESTPOOL
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE1_CKSUM" = "$(xxh128digest $TESTFILE1)"
+log_must test "$TESTFILE2_CKSUM" = "$(xxh128digest $TESTFILE2)"
+
+log_pass "zpool export -F of a suspended pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_005_pos.ksh
@@ -1,0 +1,140 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that a suspended pool with non-forced export hung can be exported
+# using hardforce flag.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content to check it later.
+# 3. Sync.
+# 4. Create the situation with non-forced export sleeping as the pool
+#    suspension happens after its start.
+# 5. Forcibly export.
+# 6. Verify that non-forced zpool export is not running.
+# 7. Import it back.
+# 8. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	# The test may fail and leave a sleeping spa_namespace_lock holder.
+	# Let's unbreak it first.
+	zpool export -F $TESTPOOL
+
+	clear_suspension_artifacts $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a suspended pool with non-forced export hung."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE1_CKSUM="$(xxh128digest $TESTFILE1)"
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE2_CKSUM="$(xxh128digest $TESTFILE2)"
+
+# The idea is to use existing zinject features to make I/O slow enough
+# so that non-forced export starts zfs unmounting process and while
+# it waits for sync we trigger pool suspension. Then we can remove
+# I/O slowdown and non-forced export is expected to sleep for
+# txg_wait_synced while still working on zfs unmount.
+
+# Slow down writing
+h1=$(zinject -q -d $FEDISK0 -D 500:1 -T write $TESTPOOL)
+h2=$(zinject -q -d $FEDISK1 -D 500:1 -T write $TESTPOOL)
+h3=$(zinject -q -d $FEDISK2 -D 500:1 -T write $TESTPOOL)
+
+# Add dirty data, which is not expected to quickly hit disks
+# due to slowed I/O
+echo hello-world >> /$TESTPOOL/$FS2/hello.txt
+
+# Start non-forced export
+zpool export $TESTPOOL &
+nonforced_export_pid=$!
+
+# Let it go deeper down to some sync wait logic
+sleep 1
+
+# Now we trigger pool suspension
+zinject -d $FEDISK0 -e io -T probe $TESTPOOL
+zinject -d $FEDISK0 -e io -T write $TESTPOOL
+zinject -d $FEDISK2 -e io -T probe $TESTPOOL
+zinject -d $FEDISK2 -e io -T write $TESTPOOL
+
+# Slow I/O is not required anymore
+zinject -c $h1
+zinject -c $h2
+zinject -c $h3
+
+# Let it find itself in trouble
+sleep 2
+log_must test "$(kstat_pool $TESTPOOL state)" = "SUSPENDED"
+
+# Check our assumption of where the non-forced export is.
+if is_linux; then
+	cat /proc/$nonforced_export_pid/stack
+	log_must grep txg_wait_synced /proc/$nonforced_export_pid/stack
+fi
+if is_freebsd; then
+	/usr/bin/procstat kstack $nonforced_export_pid
+	log_must eval 'echo "$(/usr/bin/procstat kstack $nonforced_export_pid)" | grep txg_wait_synced'
+fi
+
+# No injections required now
+zinject -c all
+
+log_must zpool export -F $TESTPOOL
+
+wait $nonforced_export_pid
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE1_CKSUM" = "$(xxh128digest $TESTFILE1)"
+log_must test "$TESTFILE2_CKSUM" = "$(xxh128digest $TESTFILE2)"
+
+log_pass "zpool export -F of a suspended pool with non-forced export hung."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_006_pos.ksh
@@ -1,0 +1,141 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# Verify that forced exit initiation can break through lockless way
+# if there is a sleeping spa_namespace_lock holder due to a suspended pool.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Write some content to check it later.
+# 3. Sync.
+# 4. Create the situation with zpool reguid sleeping due to suspended pool.
+# 5. Forcibly export.
+# 6. Verify that zpool reguid is not running anymore.
+# 7. Import the pool back.
+# 8. Verify that the content written before is the same.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	# The test may fail and leave a sleeping spa_namespace_lock holder.
+	# Let's unbreak it first.
+	zpool export -F $TESTPOOL
+
+	clear_suspension_artifacts $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "zpool export -F of a suspended pool with a sleeping spa_namespace_lock holder."
+log_onexit cleanup
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+FS1=fs1
+FS2=fs1/fs2
+
+log_must zfs create $TESTPOOL/$FS1
+log_must zfs create $TESTPOOL/$FS2
+
+TESTFILE1="/$TESTPOOL/$FS1/file1.dd"
+log_must dd if=/dev/urandom of=$TESTFILE1 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE1_CKSUM="$(xxh128digest $TESTFILE1)"
+
+TESTFILE2="/$TESTPOOL/$FS2/file2.dd"
+log_must dd if=/dev/urandom of=$TESTFILE2 \
+    oflag=sync bs=1M count=10
+log_must zpool sync $TESTPOOL
+TESTFILE2_CKSUM="$(xxh128digest $TESTFILE2)"
+
+# The test mechanism is based on the fact that zpool reguid does
+# txg_wait_synced while holding the spa_namespace_lock.
+#
+# The technical idea is to use existing zinject features to make I/O
+# slow enough so that zpool reguid starts its work and while it waits
+# for a txg sync we trigger pool suspension.
+
+# Slow down writing
+zinject -q -d $FEDISK0 -D 200:1 -T write $TESTPOOL
+zinject -q -d $FEDISK1 -D 200:1 -T write $TESTPOOL
+zinject -q -d $FEDISK2 -D 200:1 -T write $TESTPOOL
+
+# Ideally, we should start zpool reguid first and suspend the pool after,
+# but both of them require spa_namespace_lock. So, let's do zinject first.
+# Prepare troubles for pool suspension:
+zinject -d $FEDISK0 -e io -T probe $TESTPOOL
+zinject -d $FEDISK0 -e io -T write $TESTPOOL
+zinject -d $FEDISK2 -e io -T probe $TESTPOOL
+zinject -d $FEDISK2 -e io -T write $TESTPOOL
+
+# Immediately start zpool reguid
+zpool reguid $TESTPOOL &
+reguid_pid=$!
+
+# Let it go deeper down to the sync wait point, also let the pool find
+# itself in trouble. We need to wait longer due to slowdown injections
+# are still active.
+sleep 20
+log_must test "$(kstat_pool $TESTPOOL state)" = "SUSPENDED"
+
+# Check our assumption of where the zpool reguid is.
+if is_linux; then
+	cat /proc/$reguid_pid/stack
+	log_must grep txg_wait_synced /proc/$reguid_pid/stack
+fi
+if is_freebsd; then
+	/usr/bin/procstat kstack $reguid_pid
+	log_must eval 'echo "$(/usr/bin/procstat kstack $reguid_pid)" | grep txg_wait_synced'
+fi
+
+# Unfortunately, we cannot clear zinject'ions first as they also need
+# spa_namespace_lock which is held by zpool reguid. Let's initiate forced
+# exit, which is expected to break through lockless way. The actual export
+# is not expected to be done due to zinject'ions references, but it should
+# make zpool reguid move forward and release the spa_namespace_lock.
+zpool export -F $TESTPOOL
+log_must test $? -ne 0
+
+# No we can remove all injections
+zinject -c all
+
+# And the final call should complete exporting
+log_must zpool export -F $TESTPOOL
+
+wait $reguid_pid
+
+log_must zpool import $TESTPOOL
+log_must test "$TESTFILE1_CKSUM" = "$(xxh128digest $TESTFILE1)"
+log_must test "$TESTFILE2_CKSUM" = "$(xxh128digest $TESTFILE2)"
+
+log_pass "zpool export -F of a suspended pool with a sleeping spa_namespace_lock holder."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_receive_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_receive_001_pos.ksh
@@ -1,0 +1,108 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# A pool should be hardforce exportable, while a receive is running.
+#
+# STRATEGY:
+# 1. Initiate a send from one pool and receive to another pool.
+# 2. Slow the send using pv, so it blocks a normal pool export.
+# 3. Check that normal export fails.
+# 4. Forcibly export pool.
+# 5. Verify pool is no longer present in the list output.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	[[ -n "$sendpid" ]] && kill -9 "$sendpid"
+	[[ -n "$recvpid" ]] && kill -9 "$recvpid"
+	[[ -n "$pvpid" ]] && kill -9 $pvpid
+	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
+	[[ -n "$file0" ]] && rm -f "$file0"
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+log_onexit cleanup
+
+log_assert "Verify a pool can be forcibly exported while receiving."
+
+mkdir -p $TESTDIR
+dstsnap=$TESTPOOL/$TESTFS@$TESTSNAP
+srcsnap=$TESTPOOL2/$TESTFS@$TESTSNAP
+sendfifo=$TESTDIR/sendfifo.$$
+recvfifo=$TESTDIR/recvfifo.$$
+file0=$TESTDIR/file0.$$
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+log_must truncate -s 1G $file0
+log_must create_pool $TESTPOOL2 $file0
+log_must zfs create $TESTPOOL2/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL2/$TESTFS/$TESTFILE1 bs=1M count=128
+log_must zfs snapshot $srcsnap
+
+log_must mkfifo $sendfifo
+log_must mkfifo $recvfifo
+zfs send $srcsnap > $sendfifo &
+sendpid=$!
+pv -L 1M < $sendfifo > $recvfifo &
+pvpid=$!
+zfs recv $dstsnap < $recvfifo &
+recvpid=$!
+
+log_note "zfs send pid is $sendpid, pv pid is $pvpid, recv pid is $recvpid"
+
+log_note "Waiting until zfs receive has a chance to start ..."
+for i in {1..5}; do
+	zfs list $TESTPOOL/$TESTFS && break
+	sleep 1
+done
+log_must zfs list $TESTPOOL/$TESTFS
+
+# Send & receive should still be running; non-forced export should yield.
+log_must kill -0 $sendpid
+log_must kill -0 $recvpid
+log_mustnot zpool export $TESTPOOL
+
+# Send should still be running; now try force export.
+log_must kill -0 $sendpid
+log_must kill -0 $recvpid
+log_must zpool export -F $TESTPOOL
+
+# Send should have exited with non-zero.
+log_mustnot wait $sendpid
+log_must wait $pvpid
+log_mustnot wait $recvpid
+
+poolexists $TESTPOOL && \
+	log_fail "$TESTPOOL unexpectedly found in 'zpool list' output."
+
+log_pass "Successfully forcibly exported a pool while receiving."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_receive_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_receive_002_pos.ksh
@@ -1,0 +1,116 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# A suspended pool should be hardforce exportable, while a receive is running.
+#
+# STRATEGY:
+# 1. Initiate a send from one pool and receive to another pool.
+# 2. Slow the send using pv, so it blocks a normal pool export.
+# 3. Suspend the pool.
+# 4. Check that normal export fails.
+# 5. Forcibly export pool.
+# 6. Verify pool is no longer present in the list output.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	# The test may fail and leave a sleeping spa_namespace_lock holder.
+	# Let's unbreak it first.
+	zpool export -F $TESTPOOL
+
+	clear_suspension_artifacts $TESTPOOL
+
+	[[ -n "$sendpid" ]] && kill -9 "$sendpid"
+	[[ -n "$recvpid" ]] && kill -9 "$recvpid"
+	[[ -n "$pvpid" ]] && kill -9 $pvpid
+	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
+	[[ -n "$file0" ]] && rm -f "$file0"
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+log_onexit cleanup
+
+log_assert "Verify a suspended pool can be forcibly exported while receiving."
+
+mkdir -p $TESTDIR
+dstsnap=$TESTPOOL/$TESTFS@$TESTSNAP
+srcsnap=$TESTPOOL2/$TESTFS@$TESTSNAP
+sendfifo=$TESTDIR/sendfifo.$$
+recvfifo=$TESTDIR/recvfifo.$$
+file0=$TESTDIR/file0.$$
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+
+log_must truncate -s 1G $file0
+log_must create_pool $TESTPOOL2 $file0
+log_must zfs create $TESTPOOL2/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL2/$TESTFS/$TESTFILE1 bs=1M count=128
+log_must zfs snapshot $srcsnap
+
+log_must mkfifo $sendfifo
+log_must mkfifo $recvfifo
+zfs send $srcsnap > $sendfifo &
+sendpid=$!
+pv -L 1M < $sendfifo > $recvfifo &
+pvpid=$!
+zfs recv $dstsnap < $recvfifo &
+recvpid=$!
+
+log_note "zfs send pid is $sendpid, pv pid is $pvpid, recv pid is $recvpid"
+
+log_note "Waiting until zfs receive has a chance to start ..."
+for i in {1..5}; do
+	zfs list $TESTPOOL/$TESTFS && break
+	sleep 1
+done
+log_must zfs list $TESTPOOL/$TESTFS
+
+# Send & receive should still be running
+log_must kill -0 $sendpid
+log_must kill -0 $recvpid
+
+log_must suspend_pool $TESTPOOL $FEDISK0 $FEDISK2
+
+# Send should still be running; now try force export.
+log_must kill -0 $sendpid
+log_must kill -0 $recvpid
+log_must zpool export -F $TESTPOOL
+
+# Send should have exited with non-zero.
+log_mustnot wait $sendpid
+log_must wait $pvpid
+log_mustnot wait $recvpid
+
+poolexists $TESTPOOL && \
+	log_fail "$TESTPOOL unexpectedly found in 'zpool list' output."
+
+log_pass "Successfully forcibly exported a suspended pool while receiving."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_send_001_pos.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# A pool should be hardforce exportable, while a send is running from it.
+#
+# STRATEGY:
+# 1. Initiate a send from pool to a file.
+# 2. Slow the send using pv, so it blocks a normal pool export.
+# 3. Check that normal export fails.
+# 4. Forcibly export pool.
+# 5. Verify pool is no longer present in the list output.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	[[ -n "$sendpid" ]] && kill -9 "$sendpid"
+	[[ -n "$pvpid" ]] && kill -9 $pvpid
+	[[ -n "$snapstream" ]] && rm -f "$snapstream"
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+log_onexit cleanup
+
+log_assert "Verify a pool can be forcibly exported while sending."
+
+mkdir -p $TESTDIR
+snap=$TESTPOOL/$TESTFS@$TESTSNAP
+snapfifo=$TESTDIR/snapfifo.$$
+snapstream=$TESTDIR/send.$$
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+log_must zfs create $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/$TESTFILE1 bs=1M count=128
+log_must zfs snapshot $snap
+
+# Create FIFOs for the send, so the processes can be controlled and
+# monitored individually.
+log_must mkfifo $snapfifo
+zfs send $snap > $snapfifo &
+sendpid=$!
+pv -L 1M < $snapfifo > $snapstream &
+pvpid=$!
+
+log_note "zfs send pid is $sendpid, pv pid is $pvpid"
+
+# Send should still be running; non-forced export should yield.
+log_must kill -0 $sendpid
+log_must kill -0 $pvpid
+log_mustnot zpool export $TESTPOOL
+
+# Send should still be running; now try force export.
+log_must kill -0 $sendpid
+log_must kill -0 $pvpid
+log_must zpool export -F $TESTPOOL
+
+# Send should have exited with non-zero.
+log_mustnot wait $sendpid
+log_must wait $pvpid
+
+poolexists $TESTPOOL && \
+	log_fail "$TESTPOOL unexpectedly found in 'zpool list' output."
+
+log_pass "Successfully forcibly exported a pool while sending."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_hardforce_send_002_pos.ksh
@@ -1,0 +1,103 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+# A suspended pool with a running send should be hardforce exportable.
+#
+# STRATEGY:
+# 1. Initiate a send from pool to a file.
+# 2. Slow the send using pv, so it blocks a normal pool export.
+# 3. Suspend the pool.
+# 4. Check that normal export fails.
+# 5. Forcibly export pool.
+# 6. Verify pool is no longer present in the list output.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	# The test may fail and leave a sleeping spa_namespace_lock holder.
+	# Let's unbreak it first.
+	zpool export -F $TESTPOOL
+
+	clear_suspension_artifacts $TESTPOOL
+
+	[[ -n "$sendpid" ]] && kill -9 "$sendpid"
+	[[ -n "$pvpid" ]] && kill -9 $pvpid
+	[[ -n "$snapstream" ]] && rm -f "$snapstream"
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+log_onexit cleanup
+
+log_assert "Verify a suspended pool can be forcibly exported while sending."
+
+mkdir -p $TESTDIR
+snap=$TESTPOOL/$TESTFS@$TESTSNAP
+snapfifo=$TESTDIR/snapfifo.$$
+snapstream=$TESTDIR/send.$$
+
+log_must create_pool $TESTPOOL raidz $FEDISK0 $FEDISK1 $FEDISK2
+log_must zfs create $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/$TESTFILE1 bs=1M count=128
+log_must zfs snapshot $snap
+
+# Create FIFOs for the send, so the processes can be controlled and
+# monitored individually.
+log_must mkfifo $snapfifo
+zfs send $snap > $snapfifo &
+sendpid=$!
+pv -L 1M < $snapfifo > $snapstream &
+pvpid=$!
+
+log_note "zfs send pid is $sendpid, pv pid is $pvpid"
+
+# Send should still be running.
+log_must kill -0 $sendpid
+log_must kill -0 $pvpid
+
+log_must suspend_pool $TESTPOOL $FEDISK0 $FEDISK2
+
+# Non-forced export should yield.
+log_mustnot zpool export $TESTPOOL
+
+# Send should still be running; now try force export.
+log_must kill -0 $sendpid
+log_must kill -0 $pvpid
+log_must zpool export -F $TESTPOOL
+
+# Send should have exited with non-zero.
+log_mustnot wait $sendpid
+log_must wait $pvpid
+
+poolexists $TESTPOOL && \
+	log_fail "$TESTPOOL unexpectedly found in 'zpool list' output."
+
+log_pass "Successfully forcibly exported a suspended pool while sending."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
@@ -82,7 +82,7 @@ log_onexit cleanup
 #
 for i in {0..$(($MAX_NUM - 1))}; do
 	log_must truncate -s $MINVDEVSIZE ${DEVICE_DIR}/disk$i
-	log_must zpool create $POOLNAME-$i $DEVICE_DIR/disk$i
+	log_must zpool create -f $POOLNAME-$i $DEVICE_DIR/disk$i
 	log_must zinject -P export -s 8 $POOLNAME-$i
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
@@ -72,7 +72,7 @@ log_onexit cleanup
 #
 for i in {0..$(($MAX_NUM - 1))}; do
 	log_must truncate -s $MINVDEVSIZE ${DEVICE_DIR}/disk$i
-	log_must zpool create $POOLNAME-$i $DEVICE_DIR/disk$i
+	log_must zpool create -f $POOLNAME-$i $DEVICE_DIR/disk$i
 	log_must zinject -P export -s 8 $POOLNAME-$i
 done
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This change enables users to forcibly export a pool in a manner which safely discards all pending dirty data, transaction groups, associated zios, metaslab changes, etc.  It allows a regular `zpool export` to fail out so that it releases the namespace lock to enable a forced export.  It is able to do this regardless of whether the current pool activity involves send, receive, or POSIX I/O.

This allows users to continue using their system without rebooting, in the event the disk cannot be recovered in an online manner, or the user prefers to resume use of their pool at a later time.  Since ZFS can simply resume from the most recent consistent transaction group, the latter is easily achieved.

Closes #3461

### Description
This is primarily of use when a pool has lost its disk, while the user
doesn't care about any pending (or otherwise) transactions.

Implement various control methods to make this feasible:
- txg_wait can now take a NOSUSPEND flag, in which case the caller will be
  alerted if their txg can't be committed.  This is primarily of interest
  for callers that would normally pass TXG_WAIT, but don't want to wait if
  the pool becomes suspended, which allows unwinding in some cases,
  specifically when one is attempting a non-forced export.  Without this,
  the non-forced export would preclude a forced export by virtue of holding
  the namespace lock indefinitely.
- txg_wait also returns failure for TXG_WAIT users if a pool is actually
  being force exported.  Adjust most callers to tolerate this.
- spa_config_enter_flags now takes a NOSUSPEND flag to the same effect.
- DMU objset "killer" flag which may be set on an objset being forcibly
  exported / unmounted.
- SPA "killer" flag which may be set on a pool being forcibly exported.
- DMU send/recv now use an interruption mechanism which relies on the SPA
  killer being able to enumerate datasets and closing any send/recv streams,
  causing their EINTR paths to be invoked.
- ZIO now has a cancel entry point, which tells all suspended zios to fail,
  and which suppresses the failures for non-CANFAIL users.
- metaslab, etc. cleanup, which consists of simply throwing away any changes
  that were not able to be synced out.
- Linux specific: introduce a new tunable, zfs_forced_export_unmount_enabled,
  which allows the filesystem to remain in a modified 'unmounted' state upon
  exiting zpl_umount_begin, to achieve parity with FreeBSD and illumos,
  which have VFS-level support for yanking filesystems out from under users.
  However, this only helps when the user is actively performing I/O, while
  not sitting on the filesystem.  In particular, this allows test #3 below
  to pass on Linux.
- Add basic logic to zpool to indicate a force-exporting pool, instead of
  crashing due to lack of config, etc.

Add tests which cover the basic use cases:
- Force export while a send is in progress
- Force export while a recv is in progress
- Force export while POSIX I/O is in progress

### How Has This Been Tested?
* New ZFS Test Suite tests covering the three main pool activity scenarios.
* Testing in a production environment that focuses around use of send/recv to a network-based disk, which can fail and not return "for a while".  User doesn't mind losing the last few transaction groups, and is able to pick up later.
* Existing ZFS Test Suite tests, to check for any unexpected breakage of non-forced-export scenarios.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Pending items on this checklist are pending review.  I am seeking feedback on whether to break out any of the commits, rather than squash all of them into the primary one.