### PR TITLE
copy-builtin cleanup for zfs-0.8.6-staging

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -36,6 +36,7 @@ rm -rf "$KERNEL_DIR/include/zfs" "$KERNEL_DIR/fs/zfs"
 cp --recursive include "$KERNEL_DIR/include/zfs"
 cp --recursive module "$KERNEL_DIR/fs/zfs"
 cp zfs_config.h "$KERNEL_DIR/include/zfs/"
+rm "$KERNEL_DIR/include/zfs/.gitignore"
 
 for MODULE in "${MODULES[@]}"
 do

--- a/copy-builtin
+++ b/copy-builtin
@@ -42,6 +42,7 @@ for MODULE in "${MODULES[@]}"
 do
 	sed -i '/obj =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
 	sed -i '/src =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
+	sed -i "s|-I$PWD/module/|-I\$(srctree)/fs/zfs/|" "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
 done
 
 cat > "$KERNEL_DIR/fs/zfs/Kconfig" <<"EOF"

--- a/copy-builtin
+++ b/copy-builtin
@@ -40,8 +40,8 @@ rm "$KERNEL_DIR/include/zfs/.gitignore"
 
 for MODULE in "${MODULES[@]}"
 do
-	sed -i.bak '/obj =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
-	sed -i.bak '/src =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
+	sed -i '/obj =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
+	sed -i '/src =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
 done
 
 cat > "$KERNEL_DIR/fs/zfs/Kconfig" <<"EOF"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There are a couple issues I've run into maintaining a Linux kernel tree in git w/ ZFS module sources copied in via the `copy_builtin` script.  Most/All of them have been fixed on `master` and on `zfs-2.0-release`, but via a couple rather large commits that aren't likely to get backported.  This is a much simpler set of patches that just fix the problems I've experience, w/out messing with the underlying build system.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Modified `copy_builtin`:
- don't hide `zfs_gitrev.h` from git in kernel source tree
- don't litter kernel source tree with `.bak` files
- don't look in `/path/to/zfs/module/icp/include` for headers that are copied into the kernel source tree

### How Has This Been Tested?
I've exported the ZFS module sources into my Linux kernel tree (based on `linux-5.9.y`) and can compile the Linux kernel after removing my ZFS source tree.  This used to fail, because icp's Makefile was referencing my old zfs clone for include files which are now gone.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
