### PR TITLE
ICP: gcm: Allocate hash subkey table separately

### DIFF
--- a/module/icp/algs/modes/modes.c
+++ b/module/icp/algs/modes/modes.c
@@ -152,6 +152,14 @@ crypto_free_mode_ctx(void *ctx)
 			vmem_free(((gcm_ctx_t *)ctx)->gcm_pt_buf,
 			    ((gcm_ctx_t *)ctx)->gcm_pt_buf_len);
 
+#ifdef CAN_USE_GCM_ASM
+		if (((gcm_ctx_t *)ctx)->gcm_Htable != NULL) {
+			gcm_ctx_t *gcm_ctx = (gcm_ctx_t *)ctx;
+			bzero(gcm_ctx->gcm_Htable, gcm_ctx->gcm_htab_len);
+			kmem_free(gcm_ctx->gcm_Htable, gcm_ctx->gcm_htab_len);
+		}
+#endif
+
 		kmem_free(ctx, sizeof (gcm_ctx_t));
 	}
 }

--- a/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
@@ -714,6 +714,8 @@ aesni_gcm_decrypt:
 .cfi_offset	%r14,-48
 	pushq	%r15
 .cfi_offset	%r15,-56
+	pushq	%r9
+.cfi_offset	%r9,-64
 	vzeroupper
 
 	vmovdqu	(%r8),%xmm1
@@ -726,7 +728,8 @@ aesni_gcm_decrypt:
 	andq	$-128,%rsp
 	vmovdqu	(%r11),%xmm0
 	leaq	128(%rcx),%rcx
-	leaq	32+32(%r9),%r9
+	movq	32(%r9),%r9
+	leaq	32(%r9),%r9
 	movl	504-128(%rcx),%ebp	// ICP has a larger offset for rounds.
 	vpshufb	%xmm0,%xmm8,%xmm8
 
@@ -782,7 +785,9 @@ aesni_gcm_decrypt:
 	vmovups	%xmm14,-16(%rsi)
 
 	vpshufb	(%r11),%xmm8,%xmm8
-	vmovdqu	%xmm8,-64(%r9)
+	movq	-56(%rax),%r9
+.cfi_restore	%r9
+	vmovdqu	%xmm8,(%r9)
 
 	vzeroupper
 	movq	-48(%rax),%r15
@@ -918,6 +923,8 @@ aesni_gcm_encrypt:
 .cfi_offset	%r14,-48
 	pushq	%r15
 .cfi_offset	%r15,-56
+	pushq	%r9
+.cfi_offset	%r9,-64
 	vzeroupper
 
 	vmovdqu	(%r8),%xmm1
@@ -960,7 +967,8 @@ aesni_gcm_encrypt:
 	call	_aesni_ctr32_6x
 
 	vmovdqu	(%r9),%xmm8
-	leaq	32+32(%r9),%r9
+	movq	32(%r9),%r9
+	leaq	32(%r9),%r9
 	subq	$12,%rdx
 	movq	$192,%r10
 	vpshufb	%xmm0,%xmm8,%xmm8
@@ -1151,7 +1159,9 @@ aesni_gcm_encrypt:
 	vpxor	%xmm7,%xmm2,%xmm2
 	vpxor	%xmm2,%xmm8,%xmm8
 	vpshufb	(%r11),%xmm8,%xmm8
-	vmovdqu	%xmm8,-64(%r9)
+	movq	-56(%rax),%r9
+.cfi_restore	%r9
+	vmovdqu	%xmm8,(%r9)
 
 	vzeroupper
 	movq	-48(%rax),%r15

--- a/module/icp/include/modes/modes.h
+++ b/module/icp/include/modes/modes.h
@@ -219,14 +219,14 @@ typedef struct gcm_ctx {
 	size_t gcm_pt_buf_len;
 	uint32_t gcm_tmp[4];
 	/*
-	 * The relative positions of gcm_ghash, gcm_H and pre-computed
-	 * gcm_Htable are hard coded in aesni-gcm-x86_64.S and ghash-x86_64.S,
-	 * so please don't change (or adjust accordingly).
+	 * The offset of gcm_Htable relative to gcm_ghash, (32), is hard coded
+	 * in aesni-gcm-x86_64.S, so please don't change (or adjust there).
 	 */
 	uint64_t gcm_ghash[2];
 	uint64_t gcm_H[2];
 #ifdef CAN_USE_GCM_ASM
-	uint64_t gcm_Htable[12][2];
+	uint64_t *gcm_Htable;
+	size_t gcm_htab_len;
 #endif
 	uint64_t gcm_J0[2];
 	uint64_t gcm_len_a_len_c[2];

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -1051,6 +1051,16 @@ out:
 		bzero(aes_ctx.ac_keysched, aes_ctx.ac_keysched_len);
 		kmem_free(aes_ctx.ac_keysched, aes_ctx.ac_keysched_len);
 	}
+#ifdef CAN_USE_GCM_ASM
+	if (aes_ctx.ac_flags & (GCM_MODE|GMAC_MODE) &&
+	    ((gcm_ctx_t *)&aes_ctx)->gcm_Htable != NULL) {
+
+		gcm_ctx_t *ctx = (gcm_ctx_t *)&aes_ctx;
+
+		bzero(ctx->gcm_Htable, ctx->gcm_htab_len);
+		kmem_free(ctx->gcm_Htable, ctx->gcm_htab_len);
+	}
+#endif
 
 	return (ret);
 }
@@ -1209,6 +1219,14 @@ out:
 			vmem_free(((gcm_ctx_t *)&aes_ctx)->gcm_pt_buf,
 			    ((gcm_ctx_t *)&aes_ctx)->gcm_pt_buf_len);
 		}
+#ifdef CAN_USE_GCM_ASM
+		if (((gcm_ctx_t *)&aes_ctx)->gcm_Htable != NULL) {
+			gcm_ctx_t *ctx = (gcm_ctx_t *)&aes_ctx;
+
+			bzero(ctx->gcm_Htable, ctx->gcm_htab_len);
+			kmem_free(ctx->gcm_Htable, ctx->gcm_htab_len);
+		}
+#endif
 	}
 
 	return (ret);


### PR DESCRIPTION
### Motivation and Context

While evaluating other assembler implementations it turns out that the precomputed hash subkey tables vary in size, from 8\*16 bytes (avx2/avx512) up to 48\*16 bytes (avx512-vaes), depending on the implementation.

### Description

To be able to handle the size differences later, allocate `gcm_Htable` dynamically rather then having a fixed size array, and adapt consumers.

### How Has This Been Tested?

8h zloop run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
