### PR TITLE
Yield periodically when rebuilding L2ARC.

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9893,6 +9893,7 @@ l2arc_rebuild(l2arc_dev_t *dev)
 		    !dev->l2ad_first)
 			goto out;
 
+		cond_resched();
 		for (;;) {
 			mutex_enter(&l2arc_rebuild_thr_lock);
 			if (dev->l2ad_rebuild_cancel) {


### PR DESCRIPTION
### Motivation and Context
L2ARC devices of several terabytes filled with 4KB blocks may take 15 minutes to rebuild.  Due to the way L2ARC log reading is implemented it is quite likely that for all that time rebuild thread will never sleep.  At least on FreeBSD kernel threads have absolute priority and can not be preempted by threads with lower priorities.  If some thread is also bound to that specific CPU it may not get any CPU time for all the 15 minutes.

### Description
This patch solves the issue by adding cond_resched() call after processing of every log block.

### How Has This Been Tested?
The patch has been tested on FreeBSD by filling large L2ARC with 4KB blocks, re-importing the pool to start the rebuild and attempt to read dev.cpu sysctl tree.  Without the patch some of the sysctls there got stuck trying to bind to respective CPU cores.  With the patch the sysctl delays are barely noticeable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
