### PR TITLE
zvol_os: Code cleanup

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -248,7 +248,7 @@ retry:
 	}
 	mutex_enter(&zv->zv_state_lock);
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_GEOM);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_GEOM);
 
 	/*
 	 * make sure zvol is not suspended during first open
@@ -342,17 +342,17 @@ zvol_geom_close(struct g_provider *pp, int flag, int count)
 
 	mutex_enter(&zv->zv_state_lock);
 	if (zv->zv_flags & ZVOL_EXCL) {
-		ASSERT(zv->zv_open_count == 1);
+		ASSERT3U(zv->zv_open_count, ==, 1);
 		zv->zv_flags &= ~ZVOL_EXCL;
 	}
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_GEOM);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_GEOM);
 
 	/*
 	 * If the open count is zero, this is a spurious close.
 	 * That indicates a bug in the kernel / DDI framework.
 	 */
-	ASSERT(zv->zv_open_count > 0);
+	ASSERT3U(zv->zv_open_count, >, 0);
 
 	/*
 	 * make sure zvol is not suspended during last close
@@ -400,7 +400,7 @@ zvol_geom_run(zvol_state_t *zv)
 	struct zvol_state_geom *zsg = &zv->zv_zso->zso_geom;
 	struct g_provider *pp = zsg->zsg_provider;
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_GEOM);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_GEOM);
 
 	g_error_provider(pp, 0);
 
@@ -414,7 +414,7 @@ zvol_geom_destroy(zvol_state_t *zv)
 	struct zvol_state_geom *zsg = &zv->zv_zso->zso_geom;
 	struct g_provider *pp = zsg->zsg_provider;
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_GEOM);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_GEOM);
 
 	g_topology_assert();
 
@@ -483,7 +483,7 @@ zvol_geom_worker(void *arg)
 	struct zvol_state_geom *zsg = &zv->zv_zso->zso_geom;
 	struct bio *bp;
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_GEOM);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_GEOM);
 
 	thread_lock(curthread);
 	sched_prio(curthread, PRIBIO);
@@ -540,7 +540,7 @@ zvol_geom_bio_getattr(struct bio *bp)
 	zvol_state_t *zv;
 
 	zv = bp->bio_to->private;
-	ASSERT(zv != NULL);
+	ASSERT3P(zv, !=, NULL);
 
 	spa_t *spa = dmu_objset_spa(zv->zv_objset);
 	uint64_t refd, avail, usedobjs, availobjs;
@@ -621,7 +621,7 @@ zvol_geom_bio_strategy(struct bio *bp)
 	volsize = zv->zv_volsize;
 
 	os = zv->zv_objset;
-	ASSERT(os != NULL);
+	ASSERT3P(os, !=, NULL);
 
 	addr = bp->bio_data;
 	resid = bp->bio_length;
@@ -836,7 +836,7 @@ zvol_cdev_open(struct cdev *dev, int flags, int fmt, struct thread *td)
 
 	mutex_enter(&zv->zv_state_lock);
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_DEV);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_DEV);
 
 	/*
 	 * make sure zvol is not suspended during first open
@@ -925,17 +925,17 @@ zvol_cdev_close(struct cdev *dev, int flags, int fmt, struct thread *td)
 
 	mutex_enter(&zv->zv_state_lock);
 	if (zv->zv_flags & ZVOL_EXCL) {
-		ASSERT(zv->zv_open_count == 1);
+		ASSERT3U(zv->zv_open_count, ==, 1);
 		zv->zv_flags &= ~ZVOL_EXCL;
 	}
 
-	ASSERT(zv->zv_zso->zso_volmode == ZFS_VOLMODE_DEV);
+	ASSERT3S(zv->zv_zso->zso_volmode, ==, ZFS_VOLMODE_DEV);
 
 	/*
 	 * If the open count is zero, this is a spurious close.
 	 * That indicates a bug in the kernel / DDI framework.
 	 */
-	ASSERT(zv->zv_open_count > 0);
+	ASSERT3U(zv->zv_open_count, >, 0);
 	/*
 	 * make sure zvol is not suspended during last close
 	 * (hold zv_suspend_lock) and respect proper lock acquisition
@@ -1150,7 +1150,7 @@ zvol_rename_minor(zvol_state_t *zv, const char *newname)
 
 		g_topology_lock();
 		gp = pp->geom;
-		ASSERT(gp != NULL);
+		ASSERT3P(gp, !=, NULL);
 
 		zsg->zsg_provider = NULL;
 		g_wither_provider(pp, ENXIO);
@@ -1205,7 +1205,7 @@ zvol_free(zvol_state_t *zv)
 {
 	ASSERT(!RW_LOCK_HELD(&zv->zv_suspend_lock));
 	ASSERT(!MUTEX_HELD(&zv->zv_state_lock));
-	ASSERT(zv->zv_open_count == 0);
+	ASSERT0(zv->zv_open_count);
 
 	ZFS_LOG(1, "ZVOL %s destroyed.", zv->zv_name);
 

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1328,7 +1328,7 @@ zvol_create_minor_impl(const char *name)
 			mutex_destroy(&zv->zv_state_lock);
 			kmem_free(zv, sizeof (*zv));
 			dmu_objset_disown(os, B_TRUE, FTAG);
-			goto out_giant;
+			goto out_doi;
 		}
 		dev->si_iosize_max = MAXPHYS;
 		zsd->zsd_cdev = dev;
@@ -1372,7 +1372,6 @@ out_doi:
 		rw_exit(&zvol_state_lock);
 		ZFS_LOG(1, "ZVOL %s created.", name);
 	}
-out_giant:
 	PICKUP_GIANT();
 	return (error);
 }

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -106,8 +106,9 @@ zvol_write(void *arg)
 	uio_from_bio(&uio, bio);
 
 	zvol_state_t *zv = zvr->zv;
-	ASSERT(zv && zv->zv_open_count > 0);
-	ASSERT(zv->zv_zilog != NULL);
+	ASSERT3P(zv, !=, NULL);
+	ASSERT3U(zv->zv_open_count, >, 0);
+	ASSERT3P(zv->zv_zilog, !=, NULL);
 
 	/* bio marked as FLUSH need to flush before write */
 	if (bio_is_flush(bio))
@@ -188,8 +189,9 @@ zvol_discard(void *arg)
 	dmu_tx_t *tx;
 	unsigned long start_jif;
 
-	ASSERT(zv && zv->zv_open_count > 0);
-	ASSERT(zv->zv_zilog != NULL);
+	ASSERT3P(zv, !=, NULL);
+	ASSERT3U(zv->zv_open_count, >, 0);
+	ASSERT3P(zv->zv_zilog, !=, NULL);
 
 	start_jif = jiffies;
 	blk_generic_start_io_acct(zv->zv_zso->zvo_queue, WRITE,
@@ -255,7 +257,8 @@ zvol_read(void *arg)
 	uio_from_bio(&uio, bio);
 
 	zvol_state_t *zv = zvr->zv;
-	ASSERT(zv && zv->zv_open_count > 0);
+	ASSERT3P(zv, !=, NULL);
+	ASSERT3U(zv->zv_open_count, >, 0);
 
 	ssize_t start_resid = uio.uio_resid;
 	unsigned long start_jif = jiffies;
@@ -481,9 +484,9 @@ zvol_open(struct block_device *bdev, fmode_t flag)
 	rw_exit(&zvol_state_lock);
 
 	ASSERT(MUTEX_HELD(&zv->zv_state_lock));
-	ASSERT(zv->zv_open_count != 0 || RW_READ_HELD(&zv->zv_suspend_lock));
 
 	if (zv->zv_open_count == 0) {
+		ASSERT(RW_READ_HELD(&zv->zv_suspend_lock));
 		error = -zvol_first_open(zv, !(flag & FMODE_WRITE));
 		if (error)
 			goto out_mutex;
@@ -529,7 +532,7 @@ zvol_release(struct gendisk *disk, fmode_t mode)
 	zv = disk->private_data;
 
 	mutex_enter(&zv->zv_state_lock);
-	ASSERT(zv->zv_open_count > 0);
+	ASSERT3U(zv->zv_open_count, >, 0);
 	/*
 	 * make sure zvol is not suspended during last close
 	 * (hold zv_suspend_lock) and respect proper lock acquisition
@@ -552,11 +555,12 @@ zvol_release(struct gendisk *disk, fmode_t mode)
 	rw_exit(&zvol_state_lock);
 
 	ASSERT(MUTEX_HELD(&zv->zv_state_lock));
-	ASSERT(zv->zv_open_count != 1 || RW_READ_HELD(&zv->zv_suspend_lock));
 
 	zv->zv_open_count--;
-	if (zv->zv_open_count == 0)
+	if (zv->zv_open_count == 0) {
+		ASSERT(RW_READ_HELD(&zv->zv_suspend_lock));
 		zvol_last_close(zv);
+	}
 
 	mutex_exit(&zv->zv_state_lock);
 
@@ -858,8 +862,8 @@ zvol_free(zvol_state_t *zv)
 
 	ASSERT(!RW_LOCK_HELD(&zv->zv_suspend_lock));
 	ASSERT(!MUTEX_HELD(&zv->zv_state_lock));
-	ASSERT(zv->zv_open_count == 0);
-	ASSERT(zv->zv_zso->zvo_disk->private_data == NULL);
+	ASSERT0(zv->zv_open_count);
+	ASSERT3P(zv->zv_zso->zvo_disk->private_data, ==, NULL);
 
 	rw_destroy(&zv->zv_suspend_lock);
 	zfs_rangelock_fini(&zv->zv_rangelock);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Various issues were found while investigating -o volmode=xxx being ignored on FreeBSD when creating a zvol.
These commits do not fix the volmode issue, but a separate FreeBSD issue is fixed where changing volmode after creation would not take effect until the next time the pool is imported or the zvol is renamed.

### Description
<!--- Describe your changes in detail -->
* Tidy up asserts (FreeBSD & Linux):
  - Using more specific assert variants gives better messages on failure.

* Keep better track of open count in close (FreeBSD):
  - zvol_geom_close gets a count of the number of close operations to do. Make sure we're always using this count to check if this will be the last close operation performed on the zvol.

* Code cleanup in zvol_create_minor_impl (FreeBSD):
  - Nonfunctional changes for readability and consistency.

* Properly ignore error in volmode lookup (FreeBSD):
  - We fall back to a default volmode and continue when looking up a zvol's volmode property fails.  After this we should set the error to 0 to ensure we take the success paths in the out section.
  - While here, make sure we only log that the zvol was created on success.

* Don't leak doi in cdev error path (FreeBSD):
  - Make sure to free doi in zvol_create_minor impl when make_dev_s fails.

* Fix handling of zvol private data (FreeBSD):
  - zvol private data is supposed to be nulled by zvol_clear_private before zvol_free is called as an indicator that the zvol is going away.
  - Implement zvol_clear_private for volmode=dev.
  - Assert that zvol_clear_private has been called before zvol_free.
  - Check that zvol_clear_private has not been called when updating volsize.  If it has, fail with ENXIO.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD; manual messing with the volmode property
 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
