### PR TITLE
ZTS: Corrupt all block copies with corrupt_file_at_level, test L1 corruption

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -99,7 +99,8 @@ tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
 tags = ['functional', 'channel_program', 'synctask_core']
 
 [tests/functional/checksum]
-tests = ['run_sha2_test', 'run_skein_test', 'filetest_001_pos']
+tests = ['run_sha2_test', 'run_skein_test', 'filetest_001_pos',
+    'filetest_002_pos']
 tags = ['functional', 'checksum']
 
 [tests/functional/clean_mirror]

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -586,20 +586,37 @@ function list_file_blocks # input_file
 	# two are converted to decimal in the while loop. 4M is added to
 	# the offset to compensate for the first two labels and boot
 	# block. Lastly, the offset and length are printed in units of
-	# 512b blocks for ease of use with dd.
+	# 512B blocks for ease of use with dd.
 	#
+	typeset level vdev path offset length
+	if awk -n '' 2>/dev/null; then
+		# gawk needs -n to decode hex
+		AWK='awk -n'
+	else
+		AWK='awk'
+	fi
 	log_must zpool sync -f
-	typeset level path offset length
-	zdb -ddddd $ds $objnum | awk -F: '
+	zdb -dddddd $ds $objnum | $AWK -v pad=$((4<<20)) -v bs=512 '
+	    /^$/ { looking = 0 }
+	    looking {
+	        level = $2
+	        field = 3
+	        while (split($field, dva, ":") == 3) {
+	            # top level vdev id
+	            vdev = int(dva[1])
+	            # offset + 4M label/boot pad in 512B blocks
+	            offset = (int("0x"dva[2]) + pad) / bs
+		    # length in 512B blocks
+		    len = int("0x"dva[3]) / bs
+
+	            print level, vdev, offset, len
+
+	            ++field
+	        }
+	    }
 	    /^Indirect blocks:/ { looking = 1 }
-	    /^\t\tsegment / { looking = 0 }
-	    /L[0-8]/ && looking { print }
-	' | sed -n 's/^.*\(L[0-9]\) *\([0-9]*\):\([0-9a-f]*\):\([0-9a-f]*\) .*$/\1 \2 \3 \4/p' | \
+	' | \
 	while read level vdev offset length; do
-		offset=$((16#$offset))  # Conversion from hex
-		length=$((16#$length))
-		offset="$(((offset + 4 * 1024 * 1024) / 512))"
-		length="$((length / 512))"
 		for path in ${VDEV_MAP[$vdev][@]}; do
 			echo "$level $path $offset $length"
 		done

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -548,22 +548,37 @@ function list_file_blocks # input_file
 
 	#
 	# Establish a mapping between vdev ids as shown in a DVA and the
-	# pathnames they correspond to in ${VDEV_MAP[]}.
+	# pathnames they correspond to in ${VDEV_MAP[][]}.
+	#
+	# The vdev bits in a DVA refer to the top level vdev id.
+	# ${VDEV_MAP[$id]} is an array of the vdev paths within that vdev.
 	#
 	eval $(zdb -C $pool | awk '
-		BEGIN {
-			printf("typeset VDEV_MAP\n");
-			looking = 0;
-		}
-		/^            children/ {
-			id = $1;
-			looking = 1;
-		}
-		/path: / && looking == 1 {
-			print id" "$2;
-			looking = 0;
-		}
-	' | sed -n 's/^children\[\([0-9]\)\]: \(.*\)$/VDEV_MAP[\1]=\2/p')
+	    BEGIN { printf "typeset -a VDEV_MAP;" }
+	    function subscript(s) {
+	        # "[#]" is more convenient than the bare "#"
+	        match(s, /\[[0-9]*\]/)
+		return substr(s, RSTART, RLENGTH)
+	    }
+	    id && !/^                / {
+	        # left a top level vdev
+	        id = 0
+	    }
+	    id && $1 ~ /^path:$/ {
+	        # found a vdev path; save it in the map
+	        printf "VDEV_MAP%s%s=%s;", id, child, $2
+	    }
+	    /^            children/ {
+	        # entering a top level vdev
+	        id = subscript($0)
+		child = "[0]" # default in case there is no nested vdev
+		printf "typeset -a VDEV_MAP%s;", id
+	    }
+	    /^                children/ {
+	        # entering a nested vdev (e.g. child of a top level mirror)
+	        child = subscript($0)
+	    }
+	')
 
 	#
 	# The awk below parses the output of zdb, printing out the level
@@ -576,17 +591,18 @@ function list_file_blocks # input_file
 	log_must zpool sync -f
 	typeset level path offset length
 	zdb -ddddd $ds $objnum | awk -F: '
-		BEGIN { looking = 0 }
-		/^Indirect blocks:/ { looking = 1}
-		/^\t\tsegment / { looking = 0}
-		/L[0-8]/ && looking == 1 { print $0}
-	' | sed -n 's/^.*\(L[0-9]\) \([0-9]*\):\([0-9a-f]*\):\([0-9a-f]*\) .*$/\1 \2 \3 \4/p' | \
-	while read level path offset length; do
+	    /^Indirect blocks:/ { looking = 1 }
+	    /^\t\tsegment / { looking = 0 }
+	    /L[0-8]/ && looking { print }
+	' | sed -n 's/^.*\(L[0-9]\) *\([0-9]*\):\([0-9a-f]*\):\([0-9a-f]*\) .*$/\1 \2 \3 \4/p' | \
+	while read level vdev offset length; do
 		offset=$((16#$offset))  # Conversion from hex
 		length=$((16#$length))
 		offset="$(((offset + 4 * 1024 * 1024) / 512))"
 		length="$((length / 512))"
-		echo "$level ${VDEV_MAP[$path]} $offset $length"
+		for path in ${VDEV_MAP[$vdev][@]}; do
+			echo "$level $path $offset $length"
+		done
 	done 2>/dev/null
 }
 

--- a/tests/zfs-tests/tests/functional/checksum/Makefile.am
+++ b/tests/zfs-tests/tests/functional/checksum/Makefile.am
@@ -12,7 +12,8 @@ dist_pkgdata_SCRIPTS = \
 	run_edonr_test.ksh \
 	run_sha2_test.ksh \
 	run_skein_test.ksh \
-	filetest_001_pos.ksh
+	filetest_001_pos.ksh \
+	filetest_002_pos.ksh
 
 dist_pkgdata_DATA = \
 	default.cfg


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In ZTS, `list_file_blocks` is supposed to output the level, vdev path, offset, and length of blocks in a given file.
It fails in the following ways:
* Only the path of the first child of a mirrored vdev is output
    This prevents `corrupt_blocks_at_level` from corrupting *all* copies of the blocks, which is desired for reproducing a particular issue we encountered in the async DMU project.
* Only L0 blocks and only the first DVA per block are output
    This prevents `corrupt_blocks_at_level` from working at any level other than 0.

### Description
<!--- Describe your changes in detail -->
#### Only the path of the first child of a mirrored vdev is output
The first part of `list_file_blocks` transforms the pool configuration output by `zdb -C $pool` into shell code to set up a shell variable, `VDEV_MAP`, that maps from vdev id to the underlying vdev path. This variable is a simple indexed array. However, the vdev id in a DVA is only the id of the top level vdev.

When the pool is mirrored, the top level vdev is a mirror and its children are the mirrored devices. So, what we need is to map from the top level vdev id to *a list* of the underlying vdev paths. `list_file_blocks` does not need to work for raidz vdevs, so we can disregard that case.

#### Only L0 blocks and only the first DVA per block are output
The second part of `list_file_blocks` transforms the object description output by `zdb -ddddd $ds $objnum` into a stream of lines of the form "level path offset length" for the indirect blocks in the given file. The current code only works for the first copy of L0 blocks.

Add one more `-d` to the zdb command so we get all block copies and rewrite the transformation to match more than L0 and output all DVAs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
