### PR TITLE
Introduce CPU_SEQID_UNSTABLE

### DIFF
--- a/include/os/freebsd/spl/sys/sysmacros.h
+++ b/include/os/freebsd/spl/sys/sysmacros.h
@@ -80,6 +80,7 @@ extern "C" {
 #define	kpreempt_disable() critical_enter()
 #define	kpreempt_enable() critical_exit()
 #define	CPU_SEQID curcpu
+#define	CPU_SEQID_UNSTABLE curcpu
 #define	is_system_labeled()		0
 /*
  * Convert a single byte to/from binary-coded decimal (BCD).

--- a/include/os/linux/spl/sys/sysmacros.h
+++ b/include/os/linux/spl/sys/sysmacros.h
@@ -76,6 +76,7 @@
 #define	max_ncpus			num_possible_cpus()
 #define	boot_ncpus			num_online_cpus()
 #define	CPU_SEQID			smp_processor_id()
+#define	CPU_SEQID_UNSTABLE		raw_smp_processor_id()
 #define	is_system_labeled()		0
 
 #ifndef RLIM64_INFINITY

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -626,6 +626,7 @@ extern void delay(clock_t ticks);
 #define	defclsyspri	0
 
 #define	CPU_SEQID	((uintptr_t)pthread_self() & (max_ncpus - 1))
+#define	CPU_SEQID_UNSTABLE	CPU_SEQID
 
 #define	kcred		NULL
 #define	CRED()		NULL

--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -1308,9 +1308,7 @@ kcf_reqid_insert(kcf_areq_node_t *areq)
 	kcf_areq_node_t *headp;
 	kcf_reqid_table_t *rt;
 
-	kpreempt_disable();
-	rt = kcf_reqid_table[CPU_SEQID & REQID_TABLE_MASK];
-	kpreempt_enable();
+	rt = kcf_reqid_table[CPU_SEQID_UNSTABLE & REQID_TABLE_MASK];
 
 	mutex_enter(&rt->rt_lock);
 

--- a/module/zfs/aggsum.c
+++ b/module/zfs/aggsum.c
@@ -167,9 +167,7 @@ aggsum_add(aggsum_t *as, int64_t delta)
 	struct aggsum_bucket *asb;
 	int64_t borrow;
 
-	kpreempt_disable();
-	asb = &as->as_buckets[CPU_SEQID % as->as_numbuckets];
-	kpreempt_enable();
+	asb = &as->as_buckets[CPU_SEQID_UNSTABLE % as->as_numbuckets];
 
 	/* Try fast path if we already borrowed enough before. */
 	mutex_enter(&asb->asc_lock);

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -58,10 +58,8 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 	int dnodes_per_chunk = 1 << dmu_object_alloc_chunk_shift;
 	int error;
 
-	kpreempt_disable();
-	cpuobj = &os->os_obj_next_percpu[CPU_SEQID %
+	cpuobj = &os->os_obj_next_percpu[CPU_SEQID_UNSTABLE %
 	    os->os_obj_next_percpu_len];
-	kpreempt_enable();
 
 	if (dn_slots == 0) {
 		dn_slots = DNODE_MIN_SLOTS;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -305,9 +305,7 @@ txg_hold_open(dsl_pool_t *dp, txg_handle_t *th)
 	 * significance to the chosen tx_cpu. Because.. Why not use
 	 * the current cpu to index into the array?
 	 */
-	kpreempt_disable();
-	tc = &tx->tx_cpu[CPU_SEQID];
-	kpreempt_enable();
+	tc = &tx->tx_cpu[CPU_SEQID_UNSTABLE];
 
 	mutex_enter(&tc->tc_open_lock);
 	txg = tx->tx_open_txg;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2246,9 +2246,7 @@ zio_nowait(zio_t *zio)
 		 * will ensure they complete prior to unloading the pool.
 		 */
 		spa_t *spa = zio->io_spa;
-		kpreempt_disable();
-		pio = spa->spa_async_zio_root[CPU_SEQID];
-		kpreempt_enable();
+		pio = spa->spa_async_zio_root[CPU_SEQID_UNSTABLE];
 
 		zio_add_child(pio, zio);
 	}


### PR DESCRIPTION
Current CPU_SEQID users don't care about possibly changing CPU ID, but
enclose it within kpreempt disable/enable in order to fend off warnings
from Linux's CONFIG_DEBUG_PREEMPT.

There is no need to do it. The expected way to get CPU ID while allowing
for migration is to use raw_smp_processor_id.

In order to make this future-proof this patch keeps CPU_SEQID as is and
introduces CPU_SEQID_UNSTABLE instead, to make it clear that consumers
explicitly want this behavior.

Signed-off-by: Mateusz Guzik <mjguzik@gmail.com>

As a side note, it looks like all these users have a de facto per-cpu allocation performed in a naive manner -- cpu count * sizeof struct or so. Both FreeBSD and Linux have APIs for doing the same much better. I'll see about creating a provisional API and employing it here. The change at hand stads on its own though. 

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The spurious kpreempt disable/enable users add completely unnecessary branching to check for preemption. Also the code looks weird.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Got a kernel with CONFIG_DEBUG_PREEMPT=y. Modified the load routine to printk CPU_SEQID and it immediately resulted in warnings. Switching to CPU_SEQID_UNSTABLE cleared the picture. Finally converted all other consumers, created a pool, touched some files etc. No warnings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
