### PR TITLE
Library ABI management

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,6 +136,13 @@ shellcheck:
 		echo "skipping shellcheck because shellcheck is not installed"; \
 	fi
 
+PHONY += checkabi storeabi
+checkabi: lib
+	$(MAKE) -C lib checkabi
+
+storeabi: lib
+	$(MAKE) -C lib storeabi
+
 PHONY += checkbashisms
 checkbashisms:
 	@if type checkbashisms > /dev/null 2>&1; then \

--- a/config/Abigail.am
+++ b/config/Abigail.am
@@ -1,7 +1,25 @@
+#
+# When performing an ABI check the following options are applied:
+#
+# --no-unreferenced-symbols: Exclude symbols which are not referenced by
+# any debug information.  Without this _init() and _fini() are incorrectly
+# reported on CentOS7 for libuutil.so.
+#
+# --headers-dir1: Limit ABI checks to public OpenZFS headers, otherwise
+# changes in public system headers are also reported.
+#
+# --suppressions: Honor a suppressions file for each library to provide
+# a mechanism for suppressing harmless warnings.
+#
+
 PHONY += checkabi storeabi
+
 checkabi:
 	for lib in $(lib_LTLIBRARIES) ; do \
-		abidiff $${lib%.la}.abi .libs/$${lib%.la}.so ; \
+		abidiff --no-unreferenced-symbols \
+		    --headers-dir1 ../../include \
+		    --suppressions $${lib%.la}.suppr \
+		    $${lib%.la}.abi .libs/$${lib%.la}.so ; \
 	done
 
 storeabi:

--- a/config/Abigail.am
+++ b/config/Abigail.am
@@ -1,0 +1,11 @@
+PHONY += checkabi storeabi
+checkabi:
+	for lib in $(lib_LTLIBRARIES) ; do \
+		abidiff $${lib%.la}.abi .libs/$${lib%.la}.so ; \
+	done
+
+storeabi:
+	cd .libs ; \
+	for lib in $(lib_LTLIBRARIES) ; do \
+		abidw $${lib%.la}.so > ../$${lib%.la}.abi ; \
+	done

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -15,4 +15,17 @@ SUBDIRS += libzutil libunicode
 
 # These five libraries, which are installed as the final build product,
 # incorporate the eight convenience libraries given above.
-SUBDIRS += libuutil libzfs_core libzfs libzpool libzfsbootenv
+DISTLIBS = libuutil libzfs_core libzfs libzpool libzfsbootenv
+SUBDIRS += $(DISTLIBS)
+DISTLIBS += libnvpair
+
+PHONY = checkabi storeabi
+checkabi: $(DISTLIBS)
+	set -e ; for dir in $(DISTLIBS) ; do \
+		$(MAKE) -C $$dir checkabi ; \
+	done
+
+storeabi: $(DISTLIBS)
+	set -e ; for dir in $(DISTLIBS) ; do \
+		$(MAKE) -C $$dir storeabi ; \
+	done

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,13 +19,17 @@ DISTLIBS = libuutil libzfs_core libzfs libzpool libzfsbootenv
 SUBDIRS += $(DISTLIBS)
 DISTLIBS += libnvpair
 
+# An ABI is stored for each of these libraries.  Note that libzpool.so
+# is only linked against by ztest and zdb and no stable ABI is provided.
+ABILIBS = libnvpair libuutil libzfs_core libzfs libzfsbootenv
+
 PHONY = checkabi storeabi
-checkabi: $(DISTLIBS)
-	set -e ; for dir in $(DISTLIBS) ; do \
+checkabi: $(ABILIBS)
+	set -e ; for dir in $(ABILIBS) ; do \
 		$(MAKE) -C $$dir checkabi ; \
 	done
 
-storeabi: $(DISTLIBS)
-	set -e ; for dir in $(DISTLIBS) ; do \
+storeabi: $(ABILIBS)
+	set -e ; for dir in $(ABILIBS) ; do \
 		$(MAKE) -C $$dir storeabi ; \
 	done

--- a/lib/libnvpair/Makefile.am
+++ b/lib/libnvpair/Makefile.am
@@ -1,4 +1,5 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 VPATH = \
 	$(top_srcdir)/module/nvpair \
@@ -9,6 +10,8 @@ VPATH = \
 AM_CFLAGS += $(FRAME_LARGER_THAN) $(LIBTIRPC_CFLAGS)
 
 lib_LTLIBRARIES = libnvpair.la
+
+include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	libnvpair.c \

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -1,0 +1,2805 @@
+<abi-corpus path='libnvpair.so' architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
+  <elf-needed>
+    <dependency name='libtirpc.so.3'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='dump_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_nvlist_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_string_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_add_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_dup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_lookup_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_merge' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_num_pairs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_pack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_pack_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_remove_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvlist_unpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fnvpair_value_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assertf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_reset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_double' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_hrtime' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_nvlist_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_string_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_add_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_dup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_empty' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_exists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_double' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_hrtime' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_nv_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_nvlist_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_nvpair_embedded_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_pairs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_string_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_lookup_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_merge' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_next_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_nvflag' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_pack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prev_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_print_json' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_dofmt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_doindent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_getdest' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_setdest' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_setfmt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctl_setindent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_double' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_hrtime' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_nvlist_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_string_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_prtctlop_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_remove_all' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_remove_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_unpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_xalloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_xdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_xpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_xunpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_type_is_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_boolean_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_byte' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_byte_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_double' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_hrtime' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_int8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_match' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_match_regex' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_nvlist_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_string_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint16_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint32_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint64_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_value_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_nosleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_nosleep_def' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_sleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_alloc_sleep_def' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_fixed_ops' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nv_fixed_ops_def' size='40' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_hashtable_init_size' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvpair_max_recursion' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr version='1.0' address-size='64' path='libnvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+
+
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-2'>
+      <subrange length='1' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-5'>
+      <subrange length='20' type-id='type-id-3' id='type-id-6'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-7'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-8'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-9'/>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-10'/>
+    <type-decl name='double' size-in-bits='64' id='type-id-11'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-12'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-13'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-14'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-15'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-16'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-17'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-18'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-19'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-20'/>
+    <type-decl name='void' id='type-id-21'/>
+    <typedef-decl name='nvpair_t' type-id='type-id-22' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-23'/>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvp_size' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvp_name_sz' type-id='type-id-25' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='type-id-25' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvp_value_elem' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='type-id-26' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int32_t' type-id='type-id-27' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-24'/>
+    <typedef-decl name='__int32_t' type-id='type-id-12' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-27'/>
+    <typedef-decl name='int16_t' type-id='type-id-28' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-25'/>
+    <typedef-decl name='__int16_t' type-id='type-id-15' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-28'/>
+    <typedef-decl name='data_type_t' type-id='type-id-29' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-26'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-29'>
+      <underlying-type type-id='type-id-17'/>
+      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
+      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
+      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
+      <enumerator name='DATA_TYPE_BYTE' value='2'/>
+      <enumerator name='DATA_TYPE_INT16' value='3'/>
+      <enumerator name='DATA_TYPE_UINT16' value='4'/>
+      <enumerator name='DATA_TYPE_INT32' value='5'/>
+      <enumerator name='DATA_TYPE_UINT32' value='6'/>
+      <enumerator name='DATA_TYPE_INT64' value='7'/>
+      <enumerator name='DATA_TYPE_UINT64' value='8'/>
+      <enumerator name='DATA_TYPE_STRING' value='9'/>
+      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
+      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
+      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
+      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
+      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
+      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
+      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
+      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
+      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
+      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
+      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
+      <enumerator name='DATA_TYPE_INT8' value='22'/>
+      <enumerator name='DATA_TYPE_UINT8' value='23'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
+      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
+      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
+      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
+    </enum-decl>
+    <typedef-decl name='nvlist_t' type-id='type-id-30' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-31'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='type-id-32' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='type-id-33' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='type-id-32' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uint32_t' type-id='type-id-34' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-32'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-19' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-34'/>
+    <typedef-decl name='uint64_t' type-id='type-id-35' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-33'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='45' column='1' id='type-id-35'/>
+    <typedef-decl name='nvlist_prtctl_t' type-id='type-id-36' filepath='../../include/libnvpair.h' line='84' column='1' id='type-id-37'/>
+    <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='91' column='1' id='type-id-38'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvprt_fp' type-id='type-id-39' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvprt_indent_mode' type-id='type-id-40' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvprt_indent' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvprt_indentinc' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='nvprt_nmfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nvprt_eomfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='nvprt_btwnarrfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='nvprt_btwnarrfmt_nl' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='nvprt_dfltops' type-id='type-id-42' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='nvprt_custops' type-id='type-id-42' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='101' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='FILE' type-id='type-id-43' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-44'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-47' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-48' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-50' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-51' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-52' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-47' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-53' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-54' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__off_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-48'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-21' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-55'/>
+    <typedef-decl name='__off64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-50'/>
+    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-54'/>
+    <enum-decl name='nvlist_indent_mode' filepath='../../include/libnvpair.h' line='86' column='1' id='type-id-40'>
+      <underlying-type type-id='type-id-17'/>
+      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
+      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
+    </enum-decl>
+    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='61' column='1' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='print_boolean' type-id='type-id-57' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='print_boolean_value' type-id='type-id-58' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='print_byte' type-id='type-id-59' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='print_int8' type-id='type-id-60' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='print_uint8' type-id='type-id-61' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='print_int16' type-id='type-id-62' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='print_uint16' type-id='type-id-63' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='print_int32' type-id='type-id-64' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='print_uint32' type-id='type-id-65' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='print_int64' type-id='type-id-66' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='print_uint64' type-id='type-id-67' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='print_double' type-id='type-id-68' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='print_string' type-id='type-id-69' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='print_hrtime' type-id='type-id-70' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='print_nvlist' type-id='type-id-71' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='print_boolean_array' type-id='type-id-72' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='print_byte_array' type-id='type-id-73' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='print_int8_array' type-id='type-id-74' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='print_uint8_array' type-id='type-id-75' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='print_int16_array' type-id='type-id-76' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='print_uint16_array' type-id='type-id-77' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='print_int32_array' type-id='type-id-78' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='print_uint32_array' type-id='type-id-79' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2944'>
+        <var-decl name='print_int64_array' type-id='type-id-80' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='print_uint64_array' type-id='type-id-81' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3200'>
+        <var-decl name='print_string_array' type-id='type-id-82' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='print_nvlist_array' type-id='type-id-83' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-84' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-85' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='boolean_t' type-id='type-id-86' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-87'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-86'>
+      <underlying-type type-id='type-id-17'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-88' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uchar_t' type-id='type-id-18' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-89'/>
+    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-90' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int8_t' type-id='type-id-91' filepath='/usr/include/bits/stdint-intn.h' line='24' column='1' id='type-id-92'/>
+    <typedef-decl name='__int8_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-91'/>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-93' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uint8_t' type-id='type-id-94' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-95'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-18' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-94'/>
+    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-96' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1' id='type-id-63'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-97' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uint16_t' type-id='type-id-98' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-99'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-20' filepath='/usr/include/bits/types.h' line='40' column='1' id='type-id-98'/>
+    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-100' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-101' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-102' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int64_t' type-id='type-id-103' filepath='/usr/include/bits/stdint-intn.h' line='27' column='1' id='type-id-104'/>
+    <typedef-decl name='__int64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-103'/>
+    <class-decl name='__anonymous_struct__10' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-105' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__11' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1' id='type-id-68'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-106' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-107' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-108' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='hrtime_t' type-id='type-id-14' filepath='../../lib/libspl/include/sys/time.h' line='78' column='1' id='type-id-109'/>
+    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-110' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__15' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-111' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uint_t' type-id='type-id-19' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-112'/>
+    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-113' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-114' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-115' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-116' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-117' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__21' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-118' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__22' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-119' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1' id='type-id-80'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-120' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-121' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-122' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__26' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-123' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='nvlist_prtctl_fmt' filepath='../../include/libnvpair.h' line='104' column='1' id='type-id-124'>
+      <underlying-type type-id='type-id-17'/>
+      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
+      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
+      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
+    </enum-decl>
+    <typedef-decl name='regex_t' type-id='type-id-125' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-126'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-125'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='buffer' type-id='type-id-127' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='allocated' type-id='type-id-128' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='used' type-id='type-id-128' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='syntax' type-id='type-id-129' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fastmap' type-id='type-id-45' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='translate' type-id='type-id-130' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='re_nsub' type-id='type-id-54' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='can_be_null' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='29'>
+        <var-decl name='regs_allocated' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='28'>
+        <var-decl name='fastmap_accurate' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='27'>
+        <var-decl name='no_sub' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='26'>
+        <var-decl name='not_bol' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='25'>
+        <var-decl name='not_eol' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24'>
+        <var-decl name='newline_anchor' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__re_long_size_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-128'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-55' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-132'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-41'/>
+    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-170'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-174'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-178'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-180'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-182'/>
+    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-184'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
+    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-188'/>
+    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-190'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-192'/>
+    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-194'/>
+    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-196'/>
+    <pointer-type-def type-id='type-id-197' size-in-bits='64' id='type-id-198'/>
+    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-200'/>
+    <pointer-type-def type-id='type-id-201' size-in-bits='64' id='type-id-202'/>
+    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-204'/>
+    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-206'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-210'/>
+    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-212'/>
+    <pointer-type-def type-id='type-id-213' size-in-bits='64' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-215'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-216'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-218'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-42'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-219'/>
+    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-220'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-221'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-222'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-223'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-224'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-225'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-226'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-227'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-53'/>
+    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
+      <parameter type-id='type-id-221' name='nvp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-12' name='ai' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-45' name='value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-132' name='ep' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
+      <parameter type-id='type-id-219' name='list' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
+      <parameter type-id='type-id-12' name='indent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
+      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
+      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
+      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='546' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <parameter type-id='type-id-182' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <parameter type-id='type-id-166' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <parameter type-id='type-id-212' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <parameter type-id='type-id-176' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-210' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <parameter type-id='type-id-174' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <parameter type-id='type-id-208' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <parameter type-id='type-id-172' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <parameter type-id='type-id-214' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <parameter type-id='type-id-178' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <parameter type-id='type-id-206' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <parameter type-id='type-id-162' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <parameter type-id='type-id-180' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <parameter type-id='type-id-186' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <parameter type-id='type-id-164' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <parameter type-id='type-id-168' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <parameter type-id='type-id-202' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-192' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <parameter type-id='type-id-200' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <parameter type-id='type-id-190' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <parameter type-id='type-id-198' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <parameter type-id='type-id-188' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <parameter type-id='type-id-204' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <parameter type-id='type-id-194' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <parameter type-id='type-id-196' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_boolean_value' mangled-name='nvlist_prtctlop_boolean_value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_value'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-184' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <parameter type-id='type-id-170' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
+      <parameter type-id='type-id-124' name='which' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
+      <parameter type-id='type-id-124' name='which' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
+      <parameter type-id='type-id-41' name='fmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='351' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
+      <parameter type-id='type-id-12' name='onemore' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
+      <parameter type-id='type-id-40' name='mode' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
+      <parameter type-id='type-id-12' name='start' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
+      <parameter type-id='type-id-12' name='inc' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='318' column='1'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
+      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
+      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
+      <parameter type-id='type-id-221' name='nvp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
+      <parameter type-id='type-id-12' name='ai' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
+      <parameter type-id='type-id-45' name='value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <parameter type-id='type-id-222' name='value_regex' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <parameter type-id='type-id-132' name='ep' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='__builtin_fputs' mangled-name='fputs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='__builtin_strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-134'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-131'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-135'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-45'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-136'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-137'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-138'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-215'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-140'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-216'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-141'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-143'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-220'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-146'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-109'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-25'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-148'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-149'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-150'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-92'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-151'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-152'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-99'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-153'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-32'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-154'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-155'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-95'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-156'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-223'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-157'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-224'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-158'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-225'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-159'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-160'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-161'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-131'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-163'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-45'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-165'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-167'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-215'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-216'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-179'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-181'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-220'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-183'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-185'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-109'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-187'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-25'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-189'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-191'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-193'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-92'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-195'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-197'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-99'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-199'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-32'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-201'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-203'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-95'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-205'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-223'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-207'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-224'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-209'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-225'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-211'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-213'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
+      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
+      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-228'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-53' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='125' column='1' id='type-id-229'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nva_ops' type-id='type-id-230' visibility='default' filepath='../../include/sys/nvpair.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nva_arg' type-id='type-id-53' visibility='default' filepath='../../include/sys/nvpair.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nv_alloc_ops_t' type-id='type-id-231' filepath='../../include/sys/nvpair.h' line='123' column='1' id='type-id-232'/>
+    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='130' column='1' id='type-id-231'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nv_ao_init' type-id='type-id-233' visibility='default' filepath='../../include/sys/nvpair.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nv_ao_fini' type-id='type-id-234' visibility='default' filepath='../../include/sys/nvpair.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nv_ao_alloc' type-id='type-id-235' visibility='default' filepath='../../include/sys/nvpair.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='nv_ao_free' type-id='type-id-236' visibility='default' filepath='../../include/sys/nvpair.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nv_ao_reset' type-id='type-id-234' visibility='default' filepath='../../include/sys/nvpair.h' line='135' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nv_alloc_t' type-id='type-id-229' filepath='../../include/sys/nvpair.h' line='128' column='1' id='type-id-237'/>
+    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-238'/>
+    <qualified-type-def type-id='type-id-232' const='yes' id='type-id-239'/>
+    <pointer-type-def type-id='type-id-239' size-in-bits='64' id='type-id-230'/>
+    <pointer-type-def type-id='type-id-240' size-in-bits='64' id='type-id-233'/>
+    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-241'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-234'/>
+    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-236'/>
+    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-235'/>
+    <var-decl name='nv_alloc_sleep_def' type-id='type-id-237' mangled-name='nv_alloc_sleep_def' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1' elf-symbol-id='nv_alloc_sleep_def'/>
+    <var-decl name='nv_alloc_nosleep_def' type-id='type-id-237' mangled-name='nv_alloc_nosleep_def' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='59' column='1' elf-symbol-id='nv_alloc_nosleep_def'/>
+    <var-decl name='nv_alloc_sleep' type-id='type-id-241' mangled-name='nv_alloc_sleep' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='64' column='1' elf-symbol-id='nv_alloc_sleep'/>
+    <var-decl name='nv_alloc_nosleep' type-id='type-id-241' mangled-name='nv_alloc_nosleep' visibility='default' filepath='../../include/sys/nvpair.h' line='139' column='1' elf-symbol-id='nv_alloc_nosleep'/>
+    <function-type size-in-bits='64' id='type-id-240'>
+      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-238'/>
+      <return type-id='type-id-12'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-242'>
+      <parameter type-id='type-id-241'/>
+      <return type-id='type-id-21'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-243'>
+      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-54'/>
+      <return type-id='type-id-21'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-244'>
+      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-54'/>
+      <return type-id='type-id-53'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+    <var-decl name='nv_fixed_ops_def' type-id='type-id-239' mangled-name='nv_fixed_ops_def' visibility='default' filepath='../../module/nvpair/nvpair_alloc_fixed.c' line='103' column='1' elf-symbol-id='nv_fixed_ops_def'/>
+    <var-decl name='nv_fixed_ops' type-id='type-id-230' mangled-name='nv_fixed_ops' visibility='default' filepath='../../include/sys/nvpair.h' line='138' column='1' elf-symbol-id='nv_fixed_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-245'/>
+    <qualified-type-def type-id='type-id-45' const='yes' id='type-id-246'/>
+    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-248'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-250'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-252'/>
+    <pointer-type-def type-id='type-id-216' size-in-bits='64' id='type-id-253'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-254'/>
+    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-255'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-256'/>
+    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-257'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-258'/>
+    <pointer-type-def type-id='type-id-223' size-in-bits='64' id='type-id-259'/>
+    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-260'/>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-261'/>
+    <pointer-type-def type-id='type-id-226' size-in-bits='64' id='type-id-262'/>
+    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-263'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-264'/>
+    <var-decl name='nvpair_max_recursion' type-id='type-id-12' mangled-name='nvpair_max_recursion' visibility='default' filepath='../../module/nvpair/nvpair.c' line='151' column='1' elf-symbol-id='nvpair_max_recursion'/>
+    <var-decl name='nvlist_hashtable_init_size' type-id='type-id-33' mangled-name='nvlist_hashtable_init_size' visibility='default' filepath='../../module/nvpair/nvpair.c' line='154' column='1' elf-symbol-id='nvlist_hashtable_init_size'/>
+    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' filepath='../../module/nvpair/nvpair.c' line='2721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
+      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' filepath='../../module/nvpair/nvpair.c' line='2715' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
+      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' filepath='../../module/nvpair/nvpair.c' line='2657' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-132' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-258' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2658' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_size' mangled-name='nvlist_size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <parameter type-id='type-id-258' name='size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' filepath='../../module/nvpair/nvpair.c' line='2279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
+      <parameter type-id='type-id-219' name='dst' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <parameter type-id='type-id-12' name='flag' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' filepath='../../module/nvpair/nvpair.c' line='2262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' filepath='../../module/nvpair/nvpair.c' line='2253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
+      <parameter type-id='type-id-250' name='val' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='2247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <parameter type-id='type-id-256' name='val' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' filepath='../../module/nvpair/nvpair.c' line='2241' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <parameter type-id='type-id-248' name='val' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' filepath='../../module/nvpair/nvpair.c' line='2235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <parameter type-id='type-id-262' name='val' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' filepath='../../module/nvpair/nvpair.c' line='2229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <parameter type-id='type-id-254' name='val' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' filepath='../../module/nvpair/nvpair.c' line='2223' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <parameter type-id='type-id-261' name='val' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' filepath='../../module/nvpair/nvpair.c' line='2217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <parameter type-id='type-id-253' name='val' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' filepath='../../module/nvpair/nvpair.c' line='2211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <parameter type-id='type-id-260' name='val' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' filepath='../../module/nvpair/nvpair.c' line='2205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <parameter type-id='type-id-252' name='val' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' filepath='../../module/nvpair/nvpair.c' line='2199' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <parameter type-id='type-id-263' name='val' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' filepath='../../module/nvpair/nvpair.c' line='2193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <parameter type-id='type-id-255' name='val' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' filepath='../../module/nvpair/nvpair.c' line='2187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <parameter type-id='type-id-259' name='val' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' filepath='../../module/nvpair/nvpair.c' line='2181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <parameter type-id='type-id-245' name='val' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../module/nvpair/nvpair.c' line='2175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
+      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' filepath='../../module/nvpair/nvpair.c' line='2169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
+      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' filepath='../../module/nvpair/nvpair.c' line='2162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
+      <parameter type-id='type-id-249' name='val' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' filepath='../../module/nvpair/nvpair.c' line='2155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
+      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' filepath='../../module/nvpair/nvpair.c' line='2149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
+      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' filepath='../../module/nvpair/nvpair.c' line='2143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
+      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../module/nvpair/nvpair.c' line='2137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
+      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' filepath='../../module/nvpair/nvpair.c' line='2131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
+      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' filepath='../../module/nvpair/nvpair.c' line='2125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
+      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' filepath='../../module/nvpair/nvpair.c' line='2119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
+      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' filepath='../../module/nvpair/nvpair.c' line='2113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
+      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' filepath='../../module/nvpair/nvpair.c' line='2107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
+      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' filepath='../../module/nvpair/nvpair.c' line='2101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
+      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' filepath='../../module/nvpair/nvpair.c' line='2080' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' filepath='../../module/nvpair/nvpair.c' line='2073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2073' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-257' name='ret' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-251' name='ip' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-132' name='ep' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' filepath='../../module/nvpair/nvpair.c' line='2063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <parameter type-id='type-id-257' name='ret' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' filepath='../../module/nvpair/nvpair.c' line='1813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
+      <parameter type-id='type-id-12' name='flag' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' filepath='../../module/nvpair/nvpair.c' line='1807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <parameter type-id='type-id-250' name='val' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
+      <parameter type-id='type-id-256' name='a' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' filepath='../../module/nvpair/nvpair.c' line='1793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
+      <parameter type-id='type-id-248' name='a' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
+      <parameter type-id='type-id-262' name='a' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' filepath='../../module/nvpair/nvpair.c' line='1779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
+      <parameter type-id='type-id-254' name='a' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
+      <parameter type-id='type-id-261' name='a' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' filepath='../../module/nvpair/nvpair.c' line='1765' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
+      <parameter type-id='type-id-253' name='a' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
+      <parameter type-id='type-id-260' name='a' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' filepath='../../module/nvpair/nvpair.c' line='1751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
+      <parameter type-id='type-id-252' name='a' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
+      <parameter type-id='type-id-263' name='a' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' filepath='../../module/nvpair/nvpair.c' line='1738' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-255' name='a' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' filepath='../../module/nvpair/nvpair.c' line='1731' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
+      <parameter type-id='type-id-259' name='a' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1723' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
+      <parameter type-id='type-id-245' name='a' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' filepath='../../module/nvpair/nvpair.c' line='1717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' filepath='../../module/nvpair/nvpair.c' line='1711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' filepath='../../module/nvpair/nvpair.c' line='1704' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <parameter type-id='type-id-249' name='val' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' filepath='../../module/nvpair/nvpair.c' line='1697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' filepath='../../module/nvpair/nvpair.c' line='1691' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' filepath='../../module/nvpair/nvpair.c' line='1685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' filepath='../../module/nvpair/nvpair.c' line='1679' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' filepath='../../module/nvpair/nvpair.c' line='1673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' filepath='../../module/nvpair/nvpair.c' line='1667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' filepath='../../module/nvpair/nvpair.c' line='1661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' filepath='../../module/nvpair/nvpair.c' line='1655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' filepath='../../module/nvpair/nvpair.c' line='1649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' filepath='../../module/nvpair/nvpair.c' line='1636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1636' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1636' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' filepath='../../module/nvpair/nvpair.c' line='1520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1520' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../module/nvpair/nvpair.c' line='1514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1514' column='1'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../module/nvpair/nvpair.c' line='1508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1508' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' filepath='../../module/nvpair/nvpair.c' line='1496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1496' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' filepath='../../module/nvpair/nvpair.c' line='1472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1472' column='1'/>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1472' column='1'/>
+      <return type-id='type-id-221'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' filepath='../../module/nvpair/nvpair.c' line='1443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <return type-id='type-id-221'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-220' name='a' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' filepath='../../module/nvpair/nvpair.c' line='1430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <parameter type-id='type-id-219' name='val' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' filepath='../../module/nvpair/nvpair.c' line='1424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <parameter type-id='type-id-109' name='val' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' filepath='../../module/nvpair/nvpair.c' line='1417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
+      <parameter type-id='type-id-247' name='a' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-226' name='a' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' filepath='../../module/nvpair/nvpair.c' line='1405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-217' name='a' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-225' name='a' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' filepath='../../module/nvpair/nvpair.c' line='1393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-216' name='a' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-224' name='a' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' filepath='../../module/nvpair/nvpair.c' line='1381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-215' name='a' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-227' name='a' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' filepath='../../module/nvpair/nvpair.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-218' name='a' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' filepath='../../module/nvpair/nvpair.c' line='1363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-223' name='a' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1356' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
+      <parameter type-id='type-id-131' name='a' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' filepath='../../module/nvpair/nvpair.c' line='1350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <parameter type-id='type-id-41' name='val' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' filepath='../../module/nvpair/nvpair.c' line='1343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <parameter type-id='type-id-11' name='val' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' filepath='../../module/nvpair/nvpair.c' line='1336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <parameter type-id='type-id-33' name='val' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' filepath='../../module/nvpair/nvpair.c' line='1330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <parameter type-id='type-id-104' name='val' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' filepath='../../module/nvpair/nvpair.c' line='1324' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <parameter type-id='type-id-32' name='val' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' filepath='../../module/nvpair/nvpair.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <parameter type-id='type-id-24' name='val' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' filepath='../../module/nvpair/nvpair.c' line='1312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <parameter type-id='type-id-99' name='val' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' filepath='../../module/nvpair/nvpair.c' line='1306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <parameter type-id='type-id-25' name='val' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' filepath='../../module/nvpair/nvpair.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <parameter type-id='type-id-95' name='val' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' filepath='../../module/nvpair/nvpair.c' line='1294' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <parameter type-id='type-id-92' name='val' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' filepath='../../module/nvpair/nvpair.c' line='1288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1282' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <parameter type-id='type-id-87' name='val' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' filepath='../../module/nvpair/nvpair.c' line='1276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../module/nvpair/nvpair.c' line='916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../module/nvpair/nvpair.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='866' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../module/nvpair/nvpair.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <parameter type-id='type-id-112' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' filepath='../../module/nvpair/nvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='559' column='1'/>
+      <return type-id='type-id-112'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' filepath='../../module/nvpair/nvpair.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='188' column='1'/>
+      <return type-id='type-id-241'/>
+    </function-decl>
+    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' filepath='../../module/nvpair/nvpair.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='181' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' filepath='../../module/nvpair/nvpair.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='174' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' filepath='../../module/nvpair/nvpair.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
+      <parameter type-id='type-id-230' name='nvo' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' filepath='../../module/nvpair/nvpair.c' line='591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <parameter type-id='type-id-112' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' filepath='../../module/nvpair/nvpair.c' line='978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' filepath='../../module/nvpair/nvpair.c' line='945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../module/nvpair/nvpair.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <parameter type-id='type-id-26' name='type' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' filepath='../../module/nvpair/nvpair.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' filepath='../../module/nvpair/nvpair.c' line='2665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-132' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-258' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='2666' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../module/nvpair/fnvpair.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='583' column='1'/>
+      <return type-id='type-id-219'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' filepath='../../module/nvpair/fnvpair.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='575' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' filepath='../../module/nvpair/fnvpair.c' line='567' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='567' column='1'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' filepath='../../module/nvpair/fnvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='559' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' filepath='../../module/nvpair/fnvpair.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='551' column='1'/>
+      <return type-id='type-id-99'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' filepath='../../module/nvpair/fnvpair.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='543' column='1'/>
+      <return type-id='type-id-95'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' filepath='../../module/nvpair/fnvpair.c' line='535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='535' column='1'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' filepath='../../module/nvpair/fnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='527' column='1'/>
+      <return type-id='type-id-24'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' filepath='../../module/nvpair/fnvpair.c' line='519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='519' column='1'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' filepath='../../module/nvpair/fnvpair.c' line='511' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='511' column='1'/>
+      <return type-id='type-id-92'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' filepath='../../module/nvpair/fnvpair.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='503' column='1'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
+      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='495' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='487' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <return type-id='type-id-226'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' filepath='../../module/nvpair/fnvpair.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <return type-id='type-id-217'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' filepath='../../module/nvpair/fnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <return type-id='type-id-216'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <return type-id='type-id-224'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' filepath='../../module/nvpair/fnvpair.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <return type-id='type-id-215'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <return type-id='type-id-227'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' filepath='../../module/nvpair/fnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <return type-id='type-id-218'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' filepath='../../module/nvpair/fnvpair.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <return type-id='type-id-223'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <return type-id='type-id-131'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' filepath='../../module/nvpair/fnvpair.c' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
+      <return type-id='type-id-219'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' filepath='../../module/nvpair/fnvpair.c' line='400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' filepath='../../module/nvpair/fnvpair.c' line='392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' filepath='../../module/nvpair/fnvpair.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' filepath='../../module/nvpair/fnvpair.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
+      <return type-id='type-id-99'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' filepath='../../module/nvpair/fnvpair.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
+      <return type-id='type-id-95'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' filepath='../../module/nvpair/fnvpair.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' filepath='../../module/nvpair/fnvpair.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
+      <return type-id='type-id-24'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' filepath='../../module/nvpair/fnvpair.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' filepath='../../module/nvpair/fnvpair.c' line='336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
+      <return type-id='type-id-92'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' filepath='../../module/nvpair/fnvpair.c' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' filepath='../../module/nvpair/fnvpair.c' line='314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' filepath='../../module/nvpair/fnvpair.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
+      <return type-id='type-id-221'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' filepath='../../module/nvpair/fnvpair.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='299' column='1'/>
+      <parameter type-id='type-id-221' name='pair' filepath='../../module/nvpair/fnvpair.c' line='299' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' filepath='../../module/nvpair/fnvpair.c' line='293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='293' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='293' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' filepath='../../module/nvpair/fnvpair.c' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
+      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' filepath='../../module/nvpair/fnvpair.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
+      <parameter type-id='type-id-247' name='val' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
+      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' filepath='../../module/nvpair/fnvpair.c' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
+      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' filepath='../../module/nvpair/fnvpair.c' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
+      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' filepath='../../module/nvpair/fnvpair.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' filepath='../../module/nvpair/fnvpair.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' filepath='../../module/nvpair/fnvpair.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
+      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
+      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <parameter type-id='type-id-221' name='pair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' filepath='../../module/nvpair/fnvpair.c' line='203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <parameter type-id='type-id-219' name='val' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' filepath='../../module/nvpair/fnvpair.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <parameter type-id='type-id-41' name='val' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../module/nvpair/fnvpair.c' line='191' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <parameter type-id='type-id-33' name='val' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' filepath='../../module/nvpair/fnvpair.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <parameter type-id='type-id-104' name='val' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' filepath='../../module/nvpair/fnvpair.c' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <parameter type-id='type-id-32' name='val' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' filepath='../../module/nvpair/fnvpair.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <parameter type-id='type-id-24' name='val' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' filepath='../../module/nvpair/fnvpair.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <parameter type-id='type-id-99' name='val' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' filepath='../../module/nvpair/fnvpair.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <parameter type-id='type-id-25' name='val' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' filepath='../../module/nvpair/fnvpair.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <parameter type-id='type-id-95' name='val' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' filepath='../../module/nvpair/fnvpair.c' line='149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <parameter type-id='type-id-92' name='val' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' filepath='../../module/nvpair/fnvpair.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <parameter type-id='type-id-87' name='val' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' filepath='../../module/nvpair/fnvpair.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' filepath='../../module/nvpair/fnvpair.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='119' column='1'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../module/nvpair/fnvpair.c' line='113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
+      <parameter type-id='type-id-219' name='dst' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
+      <parameter type-id='type-id-219' name='src' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' filepath='../../module/nvpair/fnvpair.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='105' column='1'/>
+      <return type-id='type-id-219'/>
+    </function-decl>
+    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' filepath='../../module/nvpair/fnvpair.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
+      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
+      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
+      <return type-id='type-id-219'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' filepath='../../module/nvpair/fnvpair.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
+      <parameter type-id='type-id-45' name='pack' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
+      <parameter type-id='type-id-54' name='size' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' filepath='../../module/nvpair/fnvpair.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
+      <parameter type-id='type-id-258' name='sizep' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' filepath='../../module/nvpair/fnvpair.c' line='65' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='65' column='1'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' filepath='../../module/nvpair/fnvpair.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
+      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='59' column='1'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../module/nvpair/fnvpair.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
+      <return type-id='type-id-219'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='aok' type-id='type-id-12' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-41' name='file' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-41' name='func' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-12' name='line' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-41' name='format' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='33' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-21'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/lib/libnvpair/libnvpair.suppr
+++ b/lib/libnvpair/libnvpair.suppr
@@ -1,0 +1,2 @@
+[suppress_type]
+	name = FILE*

--- a/lib/libuutil/Makefile.am
+++ b/lib/libuutil/Makefile.am
@@ -1,6 +1,9 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 lib_LTLIBRARIES = libuutil.la
+
+include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	uu_alloc.c \

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -1,0 +1,1608 @@
+<abi-corpus path='libuutil.so' architecture='elf-amd-x86_64' soname='libuutil.so.3'>
+  <elf-needed>
+    <dependency name='libpthread.so.0'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-x86-64.so.2'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_short' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_int_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_char_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_8' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_32' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64,atomic_add_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64_nv,atomic_add_long_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_uchar_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_8' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_64' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ptr,atomic_cas_64' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_16' is-defined='yes'/>
+    <elf-symbol name='atomic_clear_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_64' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_64' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_16' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_set_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_int_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_ptr,atomic_sub_long' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_char' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_32' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_long_nv,atomic_sub_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ulong,atomic_swap_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_destroy_nodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_find' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_first' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_insert_here' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_is_empty' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_last' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_nearest' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_numnodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_swap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update_gt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update_lt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_system_hostid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getexecname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getextmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getmntany' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getzoneid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assertf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_after' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_before' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_is_empty' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_active' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_replace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_move_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_consumer' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_enter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_exit' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_producer' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='mkdirp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='print_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='spl_pagesize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='strlcat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='strlcpy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_alt_exit' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_find' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_first' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_last' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_lockup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_nearest_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_nearest_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_node_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_node_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_numnodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_pool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_pool_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_release' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_teardown' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_walk_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_walk_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_avl_walk_start' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_check_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_die' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_dprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_dprintf_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_dprintf_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_dprintf_getname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_dump' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_fatal' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_ok' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_usage' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_getpname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_find' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_first' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_insert_after' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_insert_before' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_last' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_lockup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_nearest_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_nearest_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_node_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_node_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_numnodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_pool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_pool_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_release' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_teardown' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_walk_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_walk_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_list_walk_start' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_memdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_msprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_open_tmp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_panic' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_set_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_setpname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_strbw' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_strcaseeq' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_strdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_streq' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_strndup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_vdie' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_vwarn' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_vxdie' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_warn' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_xdie' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_zalloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='buf' size='4110' type='tls-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='pagesize' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_fatal_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_ok_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uu_exit_usage_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-2'/>
+    <type-decl name='void' id='type-id-3'/>
+    <typedef-decl name='size_t' type-id='type-id-2' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-4'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-5'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-8'/>
+    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='108' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_memdup' mangled-name='uu_memdup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
+      <parameter type-id='type-id-8' name='buf' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
+      <parameter type-id='type-id-4' name='sz' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_strndup' mangled-name='uu_strndup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
+      <parameter type-id='type-id-7' name='s' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
+      <parameter type-id='type-id-4' name='n' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_strdup' mangled-name='uu_strdup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
+      <parameter type-id='type-id-7' name='str' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='54' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_free' mangled-name='uu_free' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
+      <parameter type-id='type-id-8' name='p' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='48' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
+      <parameter type-id='type-id-4' name='n' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='33' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='__builtin_calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_avl.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+
+
+
+
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='128' id='type-id-10'>
+      <subrange length='2' type-id='type-id-2' id='type-id-11'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-12'>
+      <subrange length='40' type-id='type-id-2' id='type-id-13'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='512' id='type-id-14'>
+      <subrange length='64' type-id='type-id-2' id='type-id-15'/>
+
+    </array-type-def>
+    <type-decl name='int' size-in-bits='32' id='type-id-16'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-17'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-18'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-19'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='192' id='type-id-21'>
+      <subrange length='3' type-id='type-id-2' id='type-id-22'/>
+
+    </array-type-def>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-23'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-24'/>
+    <class-decl name='uu_avl' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='137' column='1' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ua_next_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='138' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ua_prev_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='139' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ua_pool' type-id='type-id-26' visibility='default' filepath='../../include/libuutil_impl.h' line='141' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ua_parent_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ua_debug' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='ua_index' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ua_tree' type-id='type-id-28' visibility='default' filepath='../../include/libuutil_impl.h' line='146' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ua_null_walk' type-id='type-id-29' visibility='default' filepath='../../include/libuutil_impl.h' line='147' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uintptr_t' type-id='type-id-2' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-20'/>
+    <class-decl name='uu_avl_pool' size-in-bits='2176' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='154' column='1' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uap_next' type-id='type-id-26' visibility='default' filepath='../../include/libuutil_impl.h' line='155' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uap_prev' type-id='type-id-26' visibility='default' filepath='../../include/libuutil_impl.h' line='156' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uap_name' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='158' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='uap_nodeoffset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='uap_objsize' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='uap_cmp' type-id='type-id-31' visibility='default' filepath='../../include/libuutil_impl.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='uap_debug' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='840'>
+        <var-decl name='uap_last_index' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='uap_lock' type-id='type-id-32' visibility='default' filepath='../../include/libuutil_impl.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='uap_null_avl' type-id='type-id-33' visibility='default' filepath='../../include/libuutil_impl.h' line='165' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_avl_pool_t' type-id='type-id-30' filepath='../../include/libuutil.h' line='287' column='1' id='type-id-34'/>
+    <typedef-decl name='uu_compare_fn_t' type-id='type-id-35' filepath='../../include/libuutil.h' line='159' column='1' id='type-id-36'/>
+    <typedef-decl name='uint8_t' type-id='type-id-37' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-27'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-23' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-37'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-38' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-32'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' id='type-id-38'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-39' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-17' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='24' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-18' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-18' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-40' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-41' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1' id='type-id-40'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='49' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-42' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-42' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='52' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_avl_t' type-id='type-id-25' filepath='../../include/libuutil.h' line='288' column='1' id='type-id-33'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='type-id-9' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='type-id-43' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='type-id-4' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='type-id-44' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_size' type-id='type-id-4' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-10' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-20' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ulong_t' type-id='type-id-2' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-44'/>
+    <class-decl name='uu_avl_walk' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='127' column='1' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uaw_next' type-id='type-id-47' visibility='default' filepath='../../include/libuutil_impl.h' line='128' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uaw_prev' type-id='type-id-47' visibility='default' filepath='../../include/libuutil_impl.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uaw_avl' type-id='type-id-48' visibility='default' filepath='../../include/libuutil_impl.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='uaw_next_result' type-id='type-id-8' visibility='default' filepath='../../include/libuutil_impl.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='uaw_dir' type-id='type-id-49' visibility='default' filepath='../../include/libuutil_impl.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='uaw_robust' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='134' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_avl_walk_t' type-id='type-id-46' filepath='../../include/libuutil.h' line='298' column='1' id='type-id-29'/>
+    <typedef-decl name='int8_t' type-id='type-id-50' filepath='/usr/include/bits/stdint-intn.h' line='24' column='1' id='type-id-49'/>
+    <typedef-decl name='__int8_t' type-id='type-id-19' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-50'/>
+    <typedef-decl name='uu_avl_index_t' type-id='type-id-20' filepath='../../include/libuutil.h' line='300' column='1' id='type-id-51'/>
+    <typedef-decl name='uu_walk_fn_t' type-id='type-id-52' filepath='../../include/libuutil.h' line='183' column='1' id='type-id-53'/>
+    <typedef-decl name='uint32_t' type-id='type-id-54' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-55'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-24' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-54'/>
+    <typedef-decl name='uu_avl_node_t' type-id='type-id-56' filepath='../../include/libuutil.h' line='296' column='1' id='type-id-57'/>
+    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libuutil.h' line='290' column='1' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uan_opaque' type-id='type-id-21' visibility='default' filepath='../../include/libuutil.h' line='292' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-42'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-9'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='561' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='550' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='537' column='1'/>
+      <parameter type-id='type-id-51' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='537' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='527' column='1'/>
+      <parameter type-id='type-id-51' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='527' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='493' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='493' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='493' column='1'/>
+      <parameter type-id='type-id-51' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='493' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='472' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='472' column='1'/>
+      <parameter type-id='type-id-8' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='472' column='1'/>
+      <parameter type-id='type-id-58' name='out' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='472' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='457' column='1'/>
+      <parameter type-id='type-id-61' name='cookie' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='457' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='421' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='421' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='396' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='396' column='1'/>
+      <parameter type-id='type-id-60' name='func' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='396' column='1'/>
+      <parameter type-id='type-id-8' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='396' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='396' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
+      <parameter type-id='type-id-47' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='389' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
+      <parameter type-id='type-id-47' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='383' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='363' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='363' column='1'/>
+      <return type-id='type-id-47'/>
+    </function-decl>
+    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='302' column='1'/>
+      <parameter type-id='type-id-8' name='node' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='302' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='296' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='296' column='1'/>
+      <parameter type-id='type-id-8' name='node' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='296' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='290' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='284' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='278' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
+      <parameter type-id='type-id-48' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='249' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='210' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
+      <parameter type-id='type-id-26' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='210' column='1'/>
+      <parameter type-id='type-id-8' name='parent' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='210' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='210' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
+      <parameter type-id='type-id-8' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='162' column='1'/>
+      <parameter type-id='type-id-59' name='np' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='162' column='1'/>
+      <parameter type-id='type-id-26' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='162' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_init'>
+      <parameter type-id='type-id-8' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='137' column='1'/>
+      <parameter type-id='type-id-59' name='np' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='137' column='1'/>
+      <parameter type-id='type-id-26' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='137' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
+      <parameter type-id='type-id-26' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='114' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
+      <parameter type-id='type-id-7' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-4' name='objsize' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-4' name='nodeoffset' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-31' name='compare_func' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-52'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-35'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_dprintf.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-62'/>
+    <typedef-decl name='uu_dprintf_t' type-id='type-id-63' filepath='../../include/libuutil.h' line='104' column='1' id='type-id-64'/>
+    <class-decl name='uu_dprintf' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='49' column='1' id='type-id-63'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uud_name' type-id='type-id-5' visibility='default' filepath='../../include/libuutil_impl.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uud_severity' type-id='type-id-65' visibility='default' filepath='../../include/libuutil_impl.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='uud_flags' type-id='type-id-66' visibility='default' filepath='../../include/libuutil_impl.h' line='52' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_dprintf_severity_t' type-id='type-id-67' filepath='../../include/libuutil.h' line='113' column='1' id='type-id-65'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libuutil.h' line='106' column='1' id='type-id-67'>
+      <underlying-type type-id='type-id-62'/>
+      <enumerator name='UU_DPRINTF_SILENT' value='0'/>
+      <enumerator name='UU_DPRINTF_FATAL' value='1'/>
+      <enumerator name='UU_DPRINTF_WARNING' value='2'/>
+      <enumerator name='UU_DPRINTF_NOTICE' value='3'/>
+      <enumerator name='UU_DPRINTF_INFO' value='4'/>
+      <enumerator name='UU_DPRINTF_DEBUG' value='5'/>
+    </enum-decl>
+    <typedef-decl name='uint_t' type-id='type-id-24' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-68'/>
+    <function-decl name='uu_dprintf_getname' mangled-name='uu_dprintf_getname' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='127' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_dprintf_getname'>
+      <parameter type-id='type-id-68' name='D' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='127' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='uu_dprintf_destroy' mangled-name='uu_dprintf_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_dprintf_destroy'>
+      <parameter type-id='type-id-68' name='D' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='118' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_dprintf' mangled-name='uu_dprintf' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_dprintf'>
+      <parameter type-id='type-id-68' name='D' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='99' column='1'/>
+      <parameter type-id='type-id-65' name='severity' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='99' column='1'/>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='100' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_dprintf_create' mangled-name='uu_dprintf_create' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_dprintf_create'>
+      <parameter type-id='type-id-7' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='67' column='1'/>
+      <parameter type-id='type-id-65' name='severity' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='67' column='1'/>
+      <parameter type-id='type-id-66' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_dprintf.c' line='68' column='1'/>
+      <return type-id='type-id-68'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_ident.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_check_name' mangled-name='uu_check_name' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
+      <parameter type-id='type-id-7' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
+      <parameter type-id='type-id-66' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_list.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='128' id='type-id-69'>
+      <subrange length='2' type-id='type-id-2' id='type-id-11'/>
+
+    </array-type-def>
+    <class-decl name='uu_list' size-in-bits='896' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='88' column='1' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ul_next_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ul_prev_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='90' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ul_pool' type-id='type-id-71' visibility='default' filepath='../../include/libuutil_impl.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ul_parent_enc' type-id='type-id-20' visibility='default' filepath='../../include/libuutil_impl.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ul_offset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ul_numnodes' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='ul_debug' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='392'>
+        <var-decl name='ul_sorted' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='ul_index' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='ul_null_node' type-id='type-id-72' visibility='default' filepath='../../include/libuutil_impl.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='ul_null_walk' type-id='type-id-73' visibility='default' filepath='../../include/libuutil_impl.h' line='101' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='uu_list_pool' size-in-bits='2112' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='108' column='1' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ulp_next' type-id='type-id-71' visibility='default' filepath='../../include/libuutil_impl.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ulp_prev' type-id='type-id-71' visibility='default' filepath='../../include/libuutil_impl.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ulp_name' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ulp_nodeoffset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='113' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='ulp_objsize' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='ulp_cmp' type-id='type-id-31' visibility='default' filepath='../../include/libuutil_impl.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='ulp_debug' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='840'>
+        <var-decl name='ulp_last_index' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='ulp_lock' type-id='type-id-32' visibility='default' filepath='../../include/libuutil_impl.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='ulp_null_list' type-id='type-id-75' visibility='default' filepath='../../include/libuutil_impl.h' line='119' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_pool_t' type-id='type-id-74' filepath='../../include/libuutil.h' line='188' column='1' id='type-id-76'/>
+    <typedef-decl name='uu_list_t' type-id='type-id-70' filepath='../../include/libuutil.h' line='189' column='1' id='type-id-75'/>
+    <typedef-decl name='uu_list_node_impl_t' type-id='type-id-77' filepath='../../include/libuutil_impl.h' line='76' column='1' id='type-id-72'/>
+    <class-decl name='uu_list_node_impl' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='73' column='1' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_next' type-id='type-id-78' visibility='default' filepath='../../include/libuutil_impl.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uln_prev' type-id='type-id-78' visibility='default' filepath='../../include/libuutil_impl.h' line='75' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='uu_list_walk' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='78' column='1' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ulw_next' type-id='type-id-80' visibility='default' filepath='../../include/libuutil_impl.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ulw_prev' type-id='type-id-80' visibility='default' filepath='../../include/libuutil_impl.h' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ulw_list' type-id='type-id-81' visibility='default' filepath='../../include/libuutil_impl.h' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ulw_dir' type-id='type-id-49' visibility='default' filepath='../../include/libuutil_impl.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='ulw_robust' type-id='type-id-27' visibility='default' filepath='../../include/libuutil_impl.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ulw_next_result' type-id='type-id-82' visibility='default' filepath='../../include/libuutil_impl.h' line='85' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_walk_t' type-id='type-id-79' filepath='../../include/libuutil.h' line='195' column='1' id='type-id-73'/>
+    <typedef-decl name='uu_list_index_t' type-id='type-id-20' filepath='../../include/libuutil.h' line='197' column='1' id='type-id-83'/>
+    <typedef-decl name='uu_list_node_t' type-id='type-id-84' filepath='../../include/libuutil.h' line='193' column='1' id='type-id-85'/>
+    <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil.h' line='191' column='1' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_opaque' type-id='type-id-69' visibility='default' filepath='../../include/libuutil.h' line='192' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-80'/>
+    <function-decl name='uu_list_release' mangled-name='uu_list_release' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='710' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='685' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='685' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_next' mangled-name='uu_list_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_last' mangled-name='uu_list_last' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='665' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_first' mangled-name='uu_list_first' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='656' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='650' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='650' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='624' column='1'/>
+      <parameter type-id='type-id-8' name='target' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='624' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='624' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-8' name='target' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
+      <parameter type-id='type-id-61' name='cookie' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-60' name='func' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-8' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
+      <parameter type-id='type-id-80' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='488' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
+      <parameter type-id='type-id-80' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='476' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
+      <return type-id='type-id-80'/>
+    </function-decl>
+    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='373' column='1'/>
+      <parameter type-id='type-id-83' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='373' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+      <parameter type-id='type-id-83' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_find' mangled-name='uu_list_find' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-8' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-86' name='out' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+      <parameter type-id='type-id-8' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+      <parameter type-id='type-id-83' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
+      <parameter type-id='type-id-81' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='231' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_create' mangled-name='uu_list_create' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
+      <parameter type-id='type-id-71' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+      <parameter type-id='type-id-8' name='parent' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
+      <parameter type-id='type-id-8' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+      <parameter type-id='type-id-87' name='np_arg' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+      <parameter type-id='type-id-71' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_node_init' mangled-name='uu_list_node_init' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_init'>
+      <parameter type-id='type-id-8' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+      <parameter type-id='type-id-87' name='np_arg' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+      <parameter type-id='type-id-71' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
+      <parameter type-id='type-id-71' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='110' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
+      <parameter type-id='type-id-7' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
+      <parameter type-id='type-id-4' name='objsize' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
+      <parameter type-id='type-id-4' name='nodeoffset' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+      <parameter type-id='type-id-31' name='compare_func' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+      <parameter type-id='type-id-55' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_misc.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-88'>
+      <subrange length='1' type-id='type-id-2' id='type-id-89'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-90'>
+      <subrange length='20' type-id='type-id-2' id='type-id-91'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-92'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-93'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-94'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-95'/>
+    <typedef-decl name='FILE' type-id='type-id-96' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-97'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-96'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-98' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-99' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-100' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-95' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-19' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-88' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-101' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-102' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-103' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-104' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-99' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-8' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-4' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-90' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__off_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-100'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-3' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-105'/>
+    <typedef-decl name='__off64_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-104'/>
+    <function-decl name='uu_dump' mangled-name='uu_dump' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='260' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_dump'>
+      <parameter type-id='type-id-106' name='out' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='260' column='1'/>
+      <parameter type-id='type-id-7' name='prefix' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='260' column='1'/>
+      <parameter type-id='type-id-8' name='buf' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='260' column='1'/>
+      <parameter type-id='type-id-4' name='len' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='260' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_panic' mangled-name='uu_panic' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_panic'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='186' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_strerror' mangled-name='uu_strerror' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
+      <parameter type-id='type-id-55' name='code' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='118' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='uu_error' mangled-name='uu_error' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
+      <return type-id='type-id-55'/>
+    </function-decl>
+    <function-decl name='uu_set_error' mangled-name='uu_set_error' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
+      <parameter type-id='type-id-66' name='code' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='73' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='__builtin_fputs' mangled-name='fputs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_open.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_open_tmp' mangled-name='uu_open_tmp' filepath='/home/fedora/zfs/lib/libuutil/uu_open.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_open_tmp'>
+      <parameter type-id='type-id-7' name='dir' filepath='/home/fedora/zfs/lib/libuutil/uu_open.c' line='47' column='1'/>
+      <parameter type-id='type-id-66' name='uflags' filepath='/home/fedora/zfs/lib/libuutil/uu_open.c' line='47' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_pname.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-109'/>
+    <var-decl name='uu_exit_ok_value' type-id='type-id-16' mangled-name='uu_exit_ok_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='49' column='1' elf-symbol-id='uu_exit_ok_value'/>
+    <var-decl name='uu_exit_fatal_value' type-id='type-id-16' mangled-name='uu_exit_fatal_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='50' column='1' elf-symbol-id='uu_exit_fatal_value'/>
+    <var-decl name='uu_exit_usage_value' type-id='type-id-16' mangled-name='uu_exit_usage_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='51' column='1' elf-symbol-id='uu_exit_usage_value'/>
+    <function-decl name='uu_getpname' mangled-name='uu_getpname' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='uu_setpname' mangled-name='uu_setpname' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
+      <parameter type-id='type-id-5' name='arg0' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='167' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='uu_xdie' mangled-name='uu_xdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
+      <parameter type-id='type-id-16' name='status' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_vxdie' mangled-name='uu_vxdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vxdie'>
+      <parameter type-id='type-id-16' name='status' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+      <parameter type-id='type-id-108' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_die' mangled-name='uu_die' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='142' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_vdie' mangled-name='uu_vdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
+      <parameter type-id='type-id-108' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_warn' mangled-name='uu_warn' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='108' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
+      <parameter type-id='type-id-108' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
+      <parameter type-id='type-id-16' name='profile' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='72' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
+      <return type-id='type-id-109'/>
+    </function-decl>
+    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
+      <return type-id='type-id-109'/>
+    </function-decl>
+    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
+      <return type-id='type-id-109'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_string.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+    <typedef-decl name='boolean_t' type-id='type-id-110' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-111'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-110'>
+      <underlying-type type-id='type-id-62'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <function-decl name='uu_strbw' mangled-name='uu_strbw' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
+      <parameter type-id='type-id-7' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='51' column='1'/>
+      <parameter type-id='type-id-7' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='51' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='uu_strcaseeq' mangled-name='uu_strcaseeq' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strcaseeq'>
+      <parameter type-id='type-id-7' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='44' column='1'/>
+      <parameter type-id='type-id-7' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='44' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='uu_streq' mangled-name='uu_streq' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
+      <parameter type-id='type-id-7' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+      <parameter type-id='type-id-7' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/fedora/zfs/lib/libavl' language='LANG_C99'>
+    <typedef-decl name='avl_tree_t' type-id='type-id-28' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-112'/>
+    <typedef-decl name='avl_index_t' type-id='type-id-20' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-115'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='965' column='1'/>
+      <parameter type-id='type-id-61' name='cookie' filepath='../../module/avl/avl.c' line='965' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='937' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='937' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='930' column='1'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='918' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='918' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='895' column='1'/>
+      <parameter type-id='type-id-43' name='compar' filepath='../../module/avl/avl.c' line='895' column='1'/>
+      <parameter type-id='type-id-4' name='size' filepath='../../module/avl/avl.c' line='896' column='1'/>
+      <parameter type-id='type-id-4' name='offset' filepath='../../module/avl/avl.c' line='896' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-115' name='tree1' filepath='../../module/avl/avl.c' line='874' column='1'/>
+      <parameter type-id='type-id-115' name='tree2' filepath='../../module/avl/avl.c' line='874' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-115' name='t' filepath='../../module/avl/avl.c' line='854' column='1'/>
+      <parameter type-id='type-id-8' name='obj' filepath='../../module/avl/avl.c' line='854' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-115' name='t' filepath='../../module/avl/avl.c' line='837' column='1'/>
+      <parameter type-id='type-id-8' name='obj' filepath='../../module/avl/avl.c' line='837' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='820' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-115' name='t' filepath='../../module/avl/avl.c' line='820' column='1'/>
+      <parameter type-id='type-id-8' name='obj' filepath='../../module/avl/avl.c' line='820' column='1'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='670' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='670' column='1'/>
+      <parameter type-id='type-id-8' name='data' filepath='../../module/avl/avl.c' line='670' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='637' column='1'/>
+      <parameter type-id='type-id-8' name='new_node' filepath='../../module/avl/avl.c' line='637' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='577' column='1'/>
+      <parameter type-id='type-id-8' name='new_data' filepath='../../module/avl/avl.c' line='578' column='1'/>
+      <parameter type-id='type-id-8' name='here' filepath='../../module/avl/avl.c' line='579' column='1'/>
+      <parameter type-id='type-id-16' name='direction' filepath='../../module/avl/avl.c' line='580' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-8' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-113' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-8' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-114' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-113' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-16' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='206' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-115' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-8' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-16' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='list_t' type-id='type-id-116' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-117'/>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-116'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='list_size' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='list_offset' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='list_head' type-id='type-id-118' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-118'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-119' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-119' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='list_node_t' type-id='type-id-118' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-122'/>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-121' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='type-id-121' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-121' name='lold' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <parameter type-id='type-id-121' name='lnew' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-122' name='dst' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <parameter type-id='type-id-122' name='src' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_prev' mangled-name='list_prev' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='list_remove' mangled-name='list_remove' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <parameter type-id='type-id-8' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-8' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-8' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='list_create' mangled-name='list_create' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-122' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-4' name='size' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-4' name='offset' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='mode_t' type-id='type-id-123' filepath='/usr/include/sys/types.h' line='69' column='1' id='type-id-124'/>
+    <typedef-decl name='__mode_t' type-id='type-id-24' filepath='/usr/include/bits/types.h' line='150' column='1' id='type-id-123'/>
+    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
+      <parameter type-id='type-id-7' name='d' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <parameter type-id='type-id-124' name='mode' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='__builtin_strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='pagesize' type-id='type-id-4' mangled-name='pagesize' visibility='default' filepath='/home/fedora/zfs/lib/libspl/page.c' line='25' column='1' elf-symbol-id='pagesize'/>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/home/fedora/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcat' mangled-name='strlcat' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
+      <parameter type-id='type-id-5' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-7' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-4' name='dstsize' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
+      <parameter type-id='type-id-5' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-7' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-4' name='len' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
+      <parameter type-id='type-id-66' name='timestamp_fmt' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='getexecname' mangled-name='getexecname' filepath='os/linux/getexecname.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
+      <return type-id='type-id-2'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-125' size-in-bits='192' id='type-id-126'>
+      <subrange length='3' type-id='type-id-2' id='type-id-22'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='32880' id='type-id-127'>
+      <subrange length='4110' type-id='type-id-2' id='type-id-128'/>
+
+    </array-type-def>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_major' type-id='type-id-66' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_minor' type-id='type-id-66' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/bits/stat.h' line='119' column='1' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='type-id-131' visibility='default' filepath='/usr/include/bits/stat.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='type-id-132' visibility='default' filepath='/usr/include/bits/stat.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='type-id-133' visibility='default' filepath='/usr/include/bits/stat.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-123' visibility='default' filepath='/usr/include/bits/stat.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='type-id-134' visibility='default' filepath='/usr/include/bits/stat.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='type-id-135' visibility='default' filepath='/usr/include/bits/stat.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/stat.h' line='135' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='type-id-131' visibility='default' filepath='/usr/include/bits/stat.h' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='type-id-100' visibility='default' filepath='/usr/include/bits/stat.h' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='type-id-136' visibility='default' filepath='/usr/include/bits/stat.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='type-id-137' visibility='default' filepath='/usr/include/bits/stat.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='type-id-138' visibility='default' filepath='/usr/include/bits/stat.h' line='152' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-138' visibility='default' filepath='/usr/include/bits/stat.h' line='153' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-138' visibility='default' filepath='/usr/include/bits/stat.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/stat.h' line='164' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='type-id-2' filepath='/usr/include/bits/types.h' line='145' column='1' id='type-id-131'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-2' filepath='/usr/include/bits/types.h' line='149' column='1' id='type-id-132'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-2' filepath='/usr/include/bits/types.h' line='151' column='1' id='type-id-133'/>
+    <typedef-decl name='__uid_t' type-id='type-id-24' filepath='/usr/include/bits/types.h' line='146' column='1' id='type-id-134'/>
+    <typedef-decl name='__gid_t' type-id='type-id-24' filepath='/usr/include/bits/types.h' line='147' column='1' id='type-id-135'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='175' column='1' id='type-id-136'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-137'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='10' column='1' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-139' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='12' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-125' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='16' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='160' column='1' id='type-id-139'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-17' filepath='/usr/include/bits/types.h' line='197' column='1' id='type-id-125'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-5' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-143'/>
+    <var-decl name='buf' type-id='type-id-127' mangled-name='buf' visibility='default' filepath='os/linux/getmntany.c' line='44' column='1' elf-symbol-id='buf'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='type-id-7' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-141' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-143' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
+      <parameter type-id='type-id-106' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-142' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-142' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
+      <parameter type-id='type-id-106' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <parameter type-id='type-id-142' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-16' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-144'/>
+    <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
+      <return type-id='type-id-144'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='aok' type-id='type-id-16' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-7' name='file' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-7' name='func' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-16' name='line' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-7' name='format' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='33' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/lib/libuutil/libuutil.suppr
+++ b/lib/libuutil/libuutil.suppr
@@ -1,0 +1,2 @@
+[suppress_type]
+	name = FILE*

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -1,4 +1,5 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 VPATH = \
 	$(top_srcdir)/module/icp \
@@ -12,6 +13,8 @@ AM_CFLAGS += $(LIBCRYPTO_CFLAGS) $(ZLIB_CFLAGS)
 pkgconfig_DATA = libzfs.pc
 
 lib_LTLIBRARIES = libzfs.la
+
+include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	libzfs_changelist.c \

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -1,0 +1,4879 @@
+<abi-corpus path='libzfs.so' architecture='elf-amd-x86_64' soname='libzfs.so.4'>
+  <elf-needed>
+    <dependency name='libzfs_core.so.3'/>
+    <dependency name='libuuid.so.1'/>
+    <dependency name='libblkid.so.1'/>
+    <dependency name='libudev.so.1'/>
+    <dependency name='libnvpair.so.3'/>
+    <dependency name='libtirpc.so.3'/>
+    <dependency name='libuutil.so.3'/>
+    <dependency name='libm.so.6'/>
+    <dependency name='libcrypto.so.1.1'/>
+    <dependency name='libz.so.1'/>
+    <dependency name='libpthread.so.0'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='SHA256Init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='SHA2Final' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='SHA2Init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='SHA2Update' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='SHA384Init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='SHA512Init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='bookmark_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_gather' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_haszonedchild' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_postfix' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_prefix' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='changelist_unshare' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='cityhash4' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='color_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='color_start' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='create_parents' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='dataset_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='dataset_nestcheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='do_mount' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='do_unmount' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='entity_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='find_shares_object' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_2_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_2_incremental_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_2_incremental_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_2_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_impl_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_incremental_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_incremental_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_native_varsize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_dataset_depth' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getprop_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='is_mounted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='is_shared' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='isa_child_of' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libshare_nfs_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libshare_smb_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_add_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_envvar_is_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_errno' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_error_action' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_error_description' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_error_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_free_str_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_load_module' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_find' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_mnttab_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_print_on_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_run_process' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_run_process_get_stdout' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_run_process_get_stdout_nopath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_set_pipe_max' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='make_bookmark_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='make_dataset_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='make_dataset_handle_zc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='make_dataset_simple_handle_zc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='mountpoint_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='namespace_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='no_memory' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='permset_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='pool_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='printf_color' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='register_fstype' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='remove_mountpoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_commit_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_disable_share' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_enable_share' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_errorstr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_is_shared' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_validate_shareopts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='snapshot_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unshare_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_alloc_dst_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_expand_dst_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_free_nvlists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_read_dst_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_write_conf_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_write_src_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_depends_on' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_is_supported' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_is_valid_guid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_lookup_guid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_lookup_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_adjust_mount_options' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_allocatable_devs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_asprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_bookmark_exists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_clone' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_close' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_commit_all_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_commit_nfs_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_commit_proto' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_commit_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_commit_smb_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_component_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_create_ancestors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_attempt_load_keys' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_clone_check' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_get_encryption_root' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_load_key' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_rewrap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_crypto_unload_key' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dataset_exists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dataset_name_hidden' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_canonicalize_perm' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_verify_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_whokey' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_destroy_snaps' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_destroy_snaps_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_error_aux' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_error_fmt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_expand_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_foreach_mountpoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_all_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_clones_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_fsacl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_holds' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_pool_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_pool_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_recvd_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_user_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_handle_dup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_hold' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_hold_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_ioctl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_mountable' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_mounted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_shared' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_shared_nfs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_shared_proto' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_is_shared_smb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_bookmarks' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_children' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_dependents' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_filesystems' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_mounted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_root' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_snapshots' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_snapshots_sorted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_iter_snapspec' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_mod_supported' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_mount' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_mount_at' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_mount_delegation_check' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_name_to_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_name_valid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_nicestrtonum' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_open' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_parent_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_parse_mount_options' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_parse_options' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_path_to_zhandle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_promote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_align_right' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_column_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_default_numeric' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_default_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_delegatable' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_encryption_key_param' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_numeric' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_recvd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_userquota' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_userquota_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_written' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_get_written_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_index_to_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_inherit' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_inheritable' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_is_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_random_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_readonly' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_set_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_setonce' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_string_to_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_user' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_userquota' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_valid_for_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_valid_keylocation' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_values' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_visible' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_written' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prune_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_realloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_receive' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_refresh_properties' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_release' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_rollback' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_save_arguments' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send_progress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send_resume_token_to_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_send_saved' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_set_fsacl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_setprop_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_share' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_share_nfs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_share_proto' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_share_smb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_shareall' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_show_diffs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_smb_acl_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_smb_acl_purge' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_smb_acl_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_smb_acl_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_snapshot' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_snapshot_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_spa_version' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_spa_version_map' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_special_devs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_standard_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_standard_error_fmt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_strdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_type_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unmount' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unmountall' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshare' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshare_nfs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshare_proto' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshare_smb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshareall' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshareall_bypath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshareall_bytype' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshareall_nfs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_unshareall_smb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_userspace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valid_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_validate_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_version_kernel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_version_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_version_userland' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_wait_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_zpl_version_map' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_checkpoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_clear_label' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_close' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_disable_datasets' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_discard_checkpoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_enable_datasets' type='func-type' binding='global-binding' visibility='default-visibility' alias='zpool_mount_datasets' is-defined='yes'/>
+    <elf-symbol name='zpool_events_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_events_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_events_seek' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_expand_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_explain_recover' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_export' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_export_force' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_feature_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_find_vdev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_find_vdev_by_physpath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_free_handles' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_bootenv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_config' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_errlog' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_features' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_history' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_load_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_physpath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_prop_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_state_str' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_import' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_import_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_import_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_in_use' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_initialize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_initialize_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_is_draid_spare' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_iter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_label_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_log_history' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_mount_datasets' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_name_to_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_name_valid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_obj_to_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_obj_to_path_ds' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_open' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_open_canfail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_open_silent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_pool_state_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_print_unsup_feat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_align_right' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_column_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_default_numeric' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_default_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_feature' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_get_feature' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_get_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_get_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_index_to_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_random_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_readonly' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_setonce' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_string_to_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_unsupported' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_prop_values' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_props_refresh' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_refresh_stats' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_reguid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_relabel_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_reopen_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_scan' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_set_bootenv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_set_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_skip_pool' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_standard_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_standard_error_fmt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_state_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_sync_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_trim' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_unmount_datasets' type='func-type' binding='weak-binding' visibility='default-visibility' alias='zpool_disable_datasets' is-defined='yes'/>
+    <elf-symbol name='zpool_upgrade' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_attach' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_degrade' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_detach' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_fault' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_indirect_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_offline' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_online' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_path_to_guid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_remove_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_vdev_split' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_wait_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_expand_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_free_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_get_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_index_to_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_iter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_iter_common' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_name_to_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_parse_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_print_one_property' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_random_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_register_hidden' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_register_impl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_register_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_register_number' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_register_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_string_to_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_valid_for_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_values' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_width' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zvol_volsize_to_reservation' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='fletcher_4_abd_ops' size='24' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_avx2_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_avx512bw_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_avx512f_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_sse2_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_ssse3_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_superscalar4_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_superscalar_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_config_ops' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nfs_only' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='proto_table' size='48' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='share_all_proto' size='12' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='smb_only' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='smb_shares' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='spa_feature_table' size='1904' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfeature_checks_disable' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_perm_tab' size='512' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_history_event_names' size='328' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+
+
+
+
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='128' id='type-id-2'>
+      <subrange length='2' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <type-decl name='char' size-in-bits='8' id='type-id-5'/>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='8192' id='type-id-6'>
+      <subrange length='1024' type-id='type-id-3' id='type-id-7'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='8' id='type-id-8'>
+      <subrange length='1' type-id='type-id-3' id='type-id-9'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='160' id='type-id-10'>
+      <subrange length='20' type-id='type-id-3' id='type-id-11'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='2048' id='type-id-12'>
+      <subrange length='256' type-id='type-id-3' id='type-id-13'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='320' id='type-id-14'>
+      <subrange length='40' type-id='type-id-3' id='type-id-15'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-16'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-17'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-18'/>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-19'/>
+    <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-20'/>
+    <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-21'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-23'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-24'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-25'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-26'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-27'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-28'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-29'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-30'/>
+    <type-decl name='void' id='type-id-31'/>
+    <typedef-decl name='prop_changelist_t' type-id='type-id-32' filepath='../../include/libzfs_impl.h' line='174' column='1' id='type-id-33'/>
+    <class-decl name='prop_changelist' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='75' column='1' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cl_prop' type-id='type-id-34' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='cl_realprop' type-id='type-id-34' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='cl_shareprop' type-id='type-id-34' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cl_pool' type-id='type-id-35' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='cl_tree' type-id='type-id-36' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='cl_waslegacy' type-id='type-id-37' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='cl_allchildren' type-id='type-id-37' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='cl_alldependents' type-id='type-id-37' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='cl_mflags' type-id='type-id-22' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='cl_gflags' type-id='type-id-22' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cl_haszonedchild' type-id='type-id-37' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='86' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_prop_t' type-id='type-id-38' filepath='../../include/sys/fs/zfs.h' line='190' column='1' id='type-id-34'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='91' column='1' id='type-id-38'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPROP_CONT' value='-2'/>
+      <enumerator name='ZPROP_INVAL' value='-1'/>
+      <enumerator name='ZFS_PROP_TYPE' value='0'/>
+      <enumerator name='ZFS_PROP_CREATION' value='1'/>
+      <enumerator name='ZFS_PROP_USED' value='2'/>
+      <enumerator name='ZFS_PROP_AVAILABLE' value='3'/>
+      <enumerator name='ZFS_PROP_REFERENCED' value='4'/>
+      <enumerator name='ZFS_PROP_COMPRESSRATIO' value='5'/>
+      <enumerator name='ZFS_PROP_MOUNTED' value='6'/>
+      <enumerator name='ZFS_PROP_ORIGIN' value='7'/>
+      <enumerator name='ZFS_PROP_QUOTA' value='8'/>
+      <enumerator name='ZFS_PROP_RESERVATION' value='9'/>
+      <enumerator name='ZFS_PROP_VOLSIZE' value='10'/>
+      <enumerator name='ZFS_PROP_VOLBLOCKSIZE' value='11'/>
+      <enumerator name='ZFS_PROP_RECORDSIZE' value='12'/>
+      <enumerator name='ZFS_PROP_MOUNTPOINT' value='13'/>
+      <enumerator name='ZFS_PROP_SHARENFS' value='14'/>
+      <enumerator name='ZFS_PROP_CHECKSUM' value='15'/>
+      <enumerator name='ZFS_PROP_COMPRESSION' value='16'/>
+      <enumerator name='ZFS_PROP_ATIME' value='17'/>
+      <enumerator name='ZFS_PROP_DEVICES' value='18'/>
+      <enumerator name='ZFS_PROP_EXEC' value='19'/>
+      <enumerator name='ZFS_PROP_SETUID' value='20'/>
+      <enumerator name='ZFS_PROP_READONLY' value='21'/>
+      <enumerator name='ZFS_PROP_ZONED' value='22'/>
+      <enumerator name='ZFS_PROP_SNAPDIR' value='23'/>
+      <enumerator name='ZFS_PROP_ACLMODE' value='24'/>
+      <enumerator name='ZFS_PROP_ACLINHERIT' value='25'/>
+      <enumerator name='ZFS_PROP_CREATETXG' value='26'/>
+      <enumerator name='ZFS_PROP_NAME' value='27'/>
+      <enumerator name='ZFS_PROP_CANMOUNT' value='28'/>
+      <enumerator name='ZFS_PROP_ISCSIOPTIONS' value='29'/>
+      <enumerator name='ZFS_PROP_XATTR' value='30'/>
+      <enumerator name='ZFS_PROP_NUMCLONES' value='31'/>
+      <enumerator name='ZFS_PROP_COPIES' value='32'/>
+      <enumerator name='ZFS_PROP_VERSION' value='33'/>
+      <enumerator name='ZFS_PROP_UTF8ONLY' value='34'/>
+      <enumerator name='ZFS_PROP_NORMALIZE' value='35'/>
+      <enumerator name='ZFS_PROP_CASE' value='36'/>
+      <enumerator name='ZFS_PROP_VSCAN' value='37'/>
+      <enumerator name='ZFS_PROP_NBMAND' value='38'/>
+      <enumerator name='ZFS_PROP_SHARESMB' value='39'/>
+      <enumerator name='ZFS_PROP_REFQUOTA' value='40'/>
+      <enumerator name='ZFS_PROP_REFRESERVATION' value='41'/>
+      <enumerator name='ZFS_PROP_GUID' value='42'/>
+      <enumerator name='ZFS_PROP_PRIMARYCACHE' value='43'/>
+      <enumerator name='ZFS_PROP_SECONDARYCACHE' value='44'/>
+      <enumerator name='ZFS_PROP_USEDSNAP' value='45'/>
+      <enumerator name='ZFS_PROP_USEDDS' value='46'/>
+      <enumerator name='ZFS_PROP_USEDCHILD' value='47'/>
+      <enumerator name='ZFS_PROP_USEDREFRESERV' value='48'/>
+      <enumerator name='ZFS_PROP_USERACCOUNTING' value='49'/>
+      <enumerator name='ZFS_PROP_STMF_SHAREINFO' value='50'/>
+      <enumerator name='ZFS_PROP_DEFER_DESTROY' value='51'/>
+      <enumerator name='ZFS_PROP_USERREFS' value='52'/>
+      <enumerator name='ZFS_PROP_LOGBIAS' value='53'/>
+      <enumerator name='ZFS_PROP_UNIQUE' value='54'/>
+      <enumerator name='ZFS_PROP_OBJSETID' value='55'/>
+      <enumerator name='ZFS_PROP_DEDUP' value='56'/>
+      <enumerator name='ZFS_PROP_MLSLABEL' value='57'/>
+      <enumerator name='ZFS_PROP_SYNC' value='58'/>
+      <enumerator name='ZFS_PROP_DNODESIZE' value='59'/>
+      <enumerator name='ZFS_PROP_REFRATIO' value='60'/>
+      <enumerator name='ZFS_PROP_WRITTEN' value='61'/>
+      <enumerator name='ZFS_PROP_CLONES' value='62'/>
+      <enumerator name='ZFS_PROP_LOGICALUSED' value='63'/>
+      <enumerator name='ZFS_PROP_LOGICALREFERENCED' value='64'/>
+      <enumerator name='ZFS_PROP_INCONSISTENT' value='65'/>
+      <enumerator name='ZFS_PROP_VOLMODE' value='66'/>
+      <enumerator name='ZFS_PROP_FILESYSTEM_LIMIT' value='67'/>
+      <enumerator name='ZFS_PROP_SNAPSHOT_LIMIT' value='68'/>
+      <enumerator name='ZFS_PROP_FILESYSTEM_COUNT' value='69'/>
+      <enumerator name='ZFS_PROP_SNAPSHOT_COUNT' value='70'/>
+      <enumerator name='ZFS_PROP_SNAPDEV' value='71'/>
+      <enumerator name='ZFS_PROP_ACLTYPE' value='72'/>
+      <enumerator name='ZFS_PROP_SELINUX_CONTEXT' value='73'/>
+      <enumerator name='ZFS_PROP_SELINUX_FSCONTEXT' value='74'/>
+      <enumerator name='ZFS_PROP_SELINUX_DEFCONTEXT' value='75'/>
+      <enumerator name='ZFS_PROP_SELINUX_ROOTCONTEXT' value='76'/>
+      <enumerator name='ZFS_PROP_RELATIME' value='77'/>
+      <enumerator name='ZFS_PROP_REDUNDANT_METADATA' value='78'/>
+      <enumerator name='ZFS_PROP_OVERLAY' value='79'/>
+      <enumerator name='ZFS_PROP_PREV_SNAP' value='80'/>
+      <enumerator name='ZFS_PROP_RECEIVE_RESUME_TOKEN' value='81'/>
+      <enumerator name='ZFS_PROP_ENCRYPTION' value='82'/>
+      <enumerator name='ZFS_PROP_KEYLOCATION' value='83'/>
+      <enumerator name='ZFS_PROP_KEYFORMAT' value='84'/>
+      <enumerator name='ZFS_PROP_PBKDF2_SALT' value='85'/>
+      <enumerator name='ZFS_PROP_PBKDF2_ITERS' value='86'/>
+      <enumerator name='ZFS_PROP_ENCRYPTION_ROOT' value='87'/>
+      <enumerator name='ZFS_PROP_KEY_GUID' value='88'/>
+      <enumerator name='ZFS_PROP_KEYSTATUS' value='89'/>
+      <enumerator name='ZFS_PROP_REMAPTXG' value='90'/>
+      <enumerator name='ZFS_PROP_SPECIAL_SMALL_BLOCKS' value='91'/>
+      <enumerator name='ZFS_PROP_IVSET_GUID' value='92'/>
+      <enumerator name='ZFS_PROP_REDACTED' value='93'/>
+      <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
+      <enumerator name='ZFS_NUM_PROPS' value='95'/>
+    </enum-decl>
+    <typedef-decl name='uu_avl_pool_t' type-id='type-id-21' filepath='../../include/libuutil.h' line='287' column='1' id='type-id-39'/>
+    <typedef-decl name='uu_avl_t' type-id='type-id-20' filepath='../../include/libuutil.h' line='288' column='1' id='type-id-40'/>
+    <typedef-decl name='boolean_t' type-id='type-id-41' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-37'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-41'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_handle_t' type-id='type-id-42' filepath='../../include/libzfs.h' line='194' column='1' id='type-id-43'/>
+    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='77' column='1' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zfs_hdl' type-id='type-id-44' visibility='default' filepath='../../include/libzfs_impl.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zpool_hdl' type-id='type-id-45' visibility='default' filepath='../../include/libzfs_impl.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zfs_name' type-id='type-id-12' visibility='default' filepath='../../include/libzfs_impl.h' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='zfs_type' type-id='type-id-46' visibility='default' filepath='../../include/libzfs_impl.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2208'>
+        <var-decl name='zfs_head_type' type-id='type-id-46' visibility='default' filepath='../../include/libzfs_impl.h' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='zfs_dmustats' type-id='type-id-47' visibility='default' filepath='../../include/libzfs_impl.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4544'>
+        <var-decl name='zfs_props' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4608'>
+        <var-decl name='zfs_user_props' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4672'>
+        <var-decl name='zfs_recvd_props' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='zfs_mntcheck' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='zfs_mntopts' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4864'>
+        <var-decl name='zfs_props_table' type-id='type-id-50' visibility='default' filepath='../../include/libzfs_impl.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='libzfs_handle' size-in-bits='20224' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='48' column='1' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='libzfs_error' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='49' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='libzfs_fd' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='libzfs_mnttab' type-id='type-id-52' visibility='default' filepath='../../include/libzfs_impl.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='libzfs_pool_handles' type-id='type-id-45' visibility='default' filepath='../../include/libzfs_impl.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='libzfs_ns_avlpool' type-id='type-id-35' visibility='default' filepath='../../include/libzfs_impl.h' line='53' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='libzfs_ns_avl' type-id='type-id-36' visibility='default' filepath='../../include/libzfs_impl.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='libzfs_ns_gen' type-id='type-id-53' visibility='default' filepath='../../include/libzfs_impl.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='libzfs_desc_active' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='libzfs_action' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8608'>
+        <var-decl name='libzfs_desc' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16800'>
+        <var-decl name='libzfs_printerr' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16832'>
+        <var-decl name='libzfs_storeerr' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16864'>
+        <var-decl name='libzfs_mnttab_enable' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16896'>
+        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-54' visibility='default' filepath='../../include/libzfs_impl.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='17216'>
+        <var-decl name='libzfs_mnttab_cache' type-id='type-id-55' visibility='default' filepath='../../include/libzfs_impl.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='17536'>
+        <var-decl name='libzfs_pool_iter' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='17568'>
+        <var-decl name='libzfs_chassis_id' type-id='type-id-12' visibility='default' filepath='../../include/libzfs_impl.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='19616'>
+        <var-decl name='libzfs_prop_debug' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='19648'>
+        <var-decl name='libzfs_urire' type-id='type-id-56' visibility='default' filepath='../../include/libzfs_impl.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20160'>
+        <var-decl name='libzfs_max_nvlist' type-id='type-id-53' visibility='default' filepath='../../include/libzfs_impl.h' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='FILE' type-id='type-id-57' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-58'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-59' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-60' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-61' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-30' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-8' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-62' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-63' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-64' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-65' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-60' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-66' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-67' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-10' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__off_t' type-id='type-id-23' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-61'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-31' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-68'/>
+    <typedef-decl name='__off64_t' type-id='type-id-23' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-63'/>
+    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-67'/>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zpool_hdl' type-id='type-id-44' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zpool_next' type-id='type-id-45' visibility='default' filepath='../../include/libzfs_impl.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zpool_name' type-id='type-id-12' visibility='default' filepath='../../include/libzfs_impl.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='zpool_state' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='zpool_config_size' type-id='type-id-67' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='zpool_config' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='zpool_old_config' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='zpool_props' type-id='type-id-48' visibility='default' filepath='../../include/libzfs_impl.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2496'>
+        <var-decl name='zpool_start_block' type-id='type-id-70' visibility='default' filepath='../../include/libzfs_impl.h' line='107' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='libzfs_handle_t' type-id='type-id-51' filepath='../../include/libzfs.h' line='196' column='1' id='type-id-71'/>
+    <typedef-decl name='zpool_handle_t' type-id='type-id-69' filepath='../../include/libzfs.h' line='195' column='1' id='type-id-72'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-73' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-74'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='type-id-75' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='type-id-76' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='type-id-53' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='type-id-76' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-75' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int32_t' type-id='type-id-77' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-75'/>
+    <typedef-decl name='__int32_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-77'/>
+    <typedef-decl name='uint32_t' type-id='type-id-78' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-76'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-29' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-78'/>
+    <typedef-decl name='uint64_t' type-id='type-id-79' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-53'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='45' column='1' id='type-id-79'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-80' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-70'/>
+    <typedef-decl name='longlong_t' type-id='type-id-24' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-80'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-81' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-54'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' id='type-id-81'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-82' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-14' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-23' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='24' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-83' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-84' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1' id='type-id-83'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='49' column='1' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-85' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-85' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='52' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='avl_tree_t' type-id='type-id-86' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-55'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='type-id-1' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='type-id-87' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='type-id-67' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='type-id-88' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_size' type-id='type-id-67' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-2' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-90' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uintptr_t' type-id='type-id-3' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-90'/>
+    <typedef-decl name='ulong_t' type-id='type-id-3' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-88'/>
+    <typedef-decl name='regex_t' type-id='type-id-91' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-56'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-91'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='buffer' type-id='type-id-92' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='allocated' type-id='type-id-93' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='used' type-id='type-id-93' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='syntax' type-id='type-id-94' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fastmap' type-id='type-id-49' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='translate' type-id='type-id-95' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='re_nsub' type-id='type-id-67' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='can_be_null' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='29'>
+        <var-decl name='regs_allocated' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='28'>
+        <var-decl name='fastmap_accurate' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='27'>
+        <var-decl name='no_sub' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='26'>
+        <var-decl name='not_bol' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='25'>
+        <var-decl name='not_eol' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24'>
+        <var-decl name='newline_anchor' type-id='type-id-29' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__re_long_size_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-93'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-94'/>
+    <typedef-decl name='zfs_type_t' type-id='type-id-96' filepath='../../include/sys/fs/zfs.h' line='58' column='1' id='type-id-46'/>
+    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='52' column='1' id='type-id-96'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
+      <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
+      <enumerator name='ZFS_TYPE_VOLUME' value='4'/>
+      <enumerator name='ZFS_TYPE_POOL' value='8'/>
+      <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
+    </enum-decl>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-97' filepath='../../include/sys/dmu.h' line='943' column='1' id='type-id-47'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1' id='type-id-97'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='type-id-53' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='type-id-53' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='type-id-53' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='type-id-99' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='type-id-99' visibility='default' filepath='../../include/sys/dmu.h' line='940' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='type-id-99' visibility='default' filepath='../../include/sys/dmu.h' line='941' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='type-id-12' visibility='default' filepath='../../include/sys/dmu.h' line='942' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-100' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-98'/>
+    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-100'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <typedef-decl name='uint8_t' type-id='type-id-101' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-99'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-101'/>
+    <typedef-decl name='zfs_share_proto_t' type-id='type-id-102' filepath='../../include/libzfs_impl.h' line='114' column='1' id='type-id-103'/>
+    <enum-decl name='__anonymous_enum__3' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='110' column='1' id='type-id-102'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='PROTO_NFS' value='0'/>
+      <enumerator name='PROTO_SMB' value='1'/>
+      <enumerator name='PROTO_END' value='2'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-1'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-49'/>
+    <qualified-type-def type-id='type-id-5' const='yes' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-45'/>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_gather'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-22' name='gather_flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-22' name='mnt_flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='625' column='1'/>
+      <return type-id='type-id-107'/>
+    </function-decl>
+    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_free'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_remove'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_haszonedchild'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+      <parameter type-id='type-id-109' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_rename'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-105' name='src' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-105' name='dst' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
+      <parameter type-id='type-id-105' name='dataset' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+      <parameter type-id='type-id-105' name='parent' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_postfix'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_prefix'>
+      <parameter type-id='type-id-107' name='clp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='zfs_iter_f' type-id='type-id-110' filepath='../../include/libzfs.h' line='609' column='1' id='type-id-111'/>
+    <typedef-decl name='zpool_iter_f' type-id='type-id-112' filepath='../../include/libzfs.h' line='245' column='1' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-117'/>
+    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-113' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
+      <parameter type-id='type-id-105' name='poolname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='340' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='232' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+      <parameter type-id='type-id-117' name='oldconfig' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='namespace_clear'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_config.c' line='79' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-115'>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-116'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='uint_t' type-id='type-id-29' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-120'/>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1389' column='1'/>
+      <parameter type-id='type-id-48' name='raw_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1389' column='1'/>
+      <parameter type-id='type-id-37' name='inheritkey' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1389' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1253' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1085' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1085' column='1'/>
+      <parameter type-id='type-id-37' name='noop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1085' column='1'/>
+      <parameter type-id='type-id-49' name='alt_keylocation' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1085' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1050' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1050' column='1'/>
+      <parameter type-id='type-id-49' name='fsname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='1050' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='984' column='1'/>
+      <parameter type-id='type-id-108' name='origin_zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='984' column='1'/>
+      <parameter type-id='type-id-49' name='parent_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='985' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='985' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
+      <parameter type-id='type-id-49' name='parent_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
+      <parameter type-id='type-id-48' name='pool_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='813' column='1'/>
+      <parameter type-id='type-id-37' name='stdin_available' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='813' column='1'/>
+      <parameter type-id='type-id-119' name='wkeydata_out' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='813' column='1'/>
+      <parameter type-id='type-id-120' name='wkeylen_out' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='814' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='781' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='781' column='1'/>
+      <parameter type-id='type-id-114' name='is_encroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='781' column='1'/>
+      <parameter type-id='type-id-49' name='buf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_crypto.c' line='782' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+
+
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='32768' id='type-id-121'>
+      <subrange length='4096' type-id='type-id-3' id='type-id-122'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='65536' id='type-id-123'>
+      <subrange length='8192' type-id='type-id-3' id='type-id-124'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='128' id='type-id-125'>
+      <subrange length='2' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-99' size-in-bits='24' id='type-id-126'>
+      <subrange length='3' type-id='type-id-3' id='type-id-127'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-128' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-129'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1424' column='1' id='type-id-128'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-130' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-131'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-130'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFS_PROP_USERUSED' value='0'/>
+      <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
+      <enumerator name='ZFS_PROP_GROUPUSED' value='2'/>
+      <enumerator name='ZFS_PROP_GROUPQUOTA' value='3'/>
+      <enumerator name='ZFS_PROP_USEROBJUSED' value='4'/>
+      <enumerator name='ZFS_PROP_USEROBJQUOTA' value='5'/>
+      <enumerator name='ZFS_PROP_GROUPOBJUSED' value='6'/>
+      <enumerator name='ZFS_PROP_GROUPOBJQUOTA' value='7'/>
+      <enumerator name='ZFS_PROP_PROJECTUSED' value='8'/>
+      <enumerator name='ZFS_PROP_PROJECTQUOTA' value='9'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJUSED' value='10'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
+      <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
+    </enum-decl>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-132' filepath='../../include/libzfs.h' line='732' column='1' id='type-id-133'/>
+    <typedef-decl name='uid_t' type-id='type-id-134' filepath='/usr/include/sys/types.h' line='79' column='1' id='type-id-135'/>
+    <typedef-decl name='__uid_t' type-id='type-id-29' filepath='/usr/include/bits/types.h' line='146' column='1' id='type-id-134'/>
+    <typedef-decl name='zprop_list_t' type-id='type-id-136' filepath='../../include/libzfs.h' line='541' column='1' id='type-id-137'/>
+    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='533' column='1' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pl_prop' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='534' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pl_user_prop' type-id='type-id-49' visibility='default' filepath='../../include/libzfs.h' line='535' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pl_next' type-id='type-id-138' visibility='default' filepath='../../include/libzfs.h' line='536' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pl_all' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='537' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pl_width' type-id='type-id-67' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pl_recvd_width' type-id='type-id-67' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pl_fixed' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='renameflags_t' type-id='type-id-139' filepath='../../include/libzfs.h' line='656' column='1' id='type-id-140'/>
+    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='647' column='1' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='recursive' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='649' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='30'>
+        <var-decl name='nounmount' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='652' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='29'>
+        <var-decl name='forceunmount' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='655' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zprop_source_t' type-id='type-id-141' filepath='../../include/sys/fs/zfs.h' line='265' column='1' id='type-id-142'/>
+    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='258' column='1' id='type-id-141'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPROP_SRC_NONE' value='1'/>
+      <enumerator name='ZPROP_SRC_DEFAULT' value='2'/>
+      <enumerator name='ZPROP_SRC_TEMPORARY' value='4'/>
+      <enumerator name='ZPROP_SRC_LOCAL' value='8'/>
+      <enumerator name='ZPROP_SRC_INHERITED' value='16'/>
+      <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
+    </enum-decl>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-49' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-49' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-49' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-49' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-144' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-145'/>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_name' type-id='type-id-121' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32768'>
+        <var-decl name='zc_nvlist_src' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32960'>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33024'>
+        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-37' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='483' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33056'>
+        <var-decl name='zc_pad2' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='484' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33088'>
+        <var-decl name='zc_history' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33152'>
+        <var-decl name='zc_value' type-id='type-id-123' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='98688'>
+        <var-decl name='zc_string' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100736'>
+        <var-decl name='zc_guid' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100800'>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100864'>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100928'>
+        <var-decl name='zc_cookie' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100992'>
+        <var-decl name='zc_objset_type' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101056'>
+        <var-decl name='zc_perm_action' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101120'>
+        <var-decl name='zc_history_len' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101184'>
+        <var-decl name='zc_history_offset' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101248'>
+        <var-decl name='zc_obj' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101312'>
+        <var-decl name='zc_iflags' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101376'>
+        <var-decl name='zc_share' type-id='type-id-146' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101632'>
+        <var-decl name='zc_objset_stats' type-id='type-id-47' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='103936'>
+        <var-decl name='zc_begin_record' type-id='type-id-147' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106368'>
+        <var-decl name='zc_inject_record' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109184'>
+        <var-decl name='zc_defer_destroy' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109216'>
+        <var-decl name='zc_flags' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109248'>
+        <var-decl name='zc_action_handle' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109312'>
+        <var-decl name='zc_cleanup_fd' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109344'>
+        <var-decl name='zc_simple' type-id='type-id-99' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109352'>
+        <var-decl name='zc_pad' type-id='type-id-126' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109376'>
+        <var-decl name='zc_sendobj' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109440'>
+        <var-decl name='zc_fromobj' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109504'>
+        <var-decl name='zc_createtxg' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109568'>
+        <var-decl name='zc_stat' type-id='type-id-149' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109888'>
+        <var-decl name='zc_zoneid' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='type-id-150' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-146'/>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_exportdata' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_sharedata' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='type-id-151' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-148'/>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='type-id-75' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-152' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-149'/>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-152'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zs_gen' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zs_mode' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zs_links' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zs_ctime' type-id='type-id-125' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-153'/>
+    <qualified-type-def type-id='type-id-43' const='yes' id='type-id-154'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-158'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-159'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-163'/>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+      <parameter type-id='type-id-129' name='activity' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5548' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5548' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='type-id-45' name='zph' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
+      <parameter type-id='type-id-53' name='volsize' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5492' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1'/>
+      <parameter type-id='type-id-117' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
+      <parameter type-id='type-id-37' name='un' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
+      <parameter type-id='type-id-48' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1'/>
+      <parameter type-id='type-id-117' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
+      <parameter type-id='type-id-105' name='snapname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
+      <parameter type-id='type-id-105' name='tag' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
+      <parameter type-id='type-id-37' name='recursive' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='5032' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
+      <parameter type-id='type-id-22' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
+      <parameter type-id='type-id-48' name='holds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+      <parameter type-id='type-id-105' name='snapname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+      <parameter type-id='type-id-105' name='tag' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+      <parameter type-id='type-id-37' name='recursive' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4901' column='1'/>
+      <parameter type-id='type-id-22' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4901' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+      <parameter type-id='type-id-131' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+      <parameter type-id='type-id-133' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4821' column='1'/>
+      <parameter type-id='type-id-66' name='arg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4821' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+      <parameter type-id='type-id-49' name='dataset' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+      <parameter type-id='type-id-49' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+      <parameter type-id='type-id-49' name='oldname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4813' column='1'/>
+      <parameter type-id='type-id-49' name='newname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4813' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
+      <parameter type-id='type-id-49' name='dataset' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
+      <parameter type-id='type-id-49' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-49' name='dataset' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-49' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4798' column='1'/>
+      <parameter type-id='type-id-49' name='resource' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4798' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
+      <parameter type-id='type-id-49' name='dataset' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
+      <parameter type-id='type-id-49' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
+      <parameter type-id='type-id-49' name='resource' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1'/>
+      <parameter type-id='type-id-50' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
+      <parameter type-id='type-id-162' name='plp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
+      <parameter type-id='type-id-37' name='received' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4611' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4591' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4582' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4576' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
+      <parameter type-id='type-id-105' name='target' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
+      <parameter type-id='type-id-140' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
+      <parameter type-id='type-id-108' name='snap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
+      <parameter type-id='type-id-37' name='force' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
+      <parameter type-id='type-id-37' name='recursive' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4174' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
+      <parameter type-id='type-id-48' name='snaps' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4009' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='4009' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
+      <parameter type-id='type-id-105' name='target' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
+      <parameter type-id='type-id-48' name='snaps' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
+      <parameter type-id='type-id-37' name='defer' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
+      <parameter type-id='type-id-49' name='snapname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
+      <parameter type-id='type-id-37' name='defer' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1'/>
+      <parameter type-id='type-id-37' name='defer' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3610' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
+      <parameter type-id='type-id-49' name='target' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
+      <parameter type-id='type-id-22' name='prefixlen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
+      <parameter type-id='type-id-49' name='buf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
+      <parameter type-id='type-id-67' name='buflen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
+      <parameter type-id='type-id-155' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3331' column='1'/>
+      <return type-id='type-id-46'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
+      <parameter type-id='type-id-155' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3322' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
+      <parameter type-id='type-id-155' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3313' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-49' name='propbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3289' column='1'/>
+      <parameter type-id='type-id-22' name='proplen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3289' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3289' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
+      <parameter type-id='type-id-159' name='propvalue' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3254' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-49' name='propbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3218' column='1'/>
+      <parameter type-id='type-id-22' name='proplen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3218' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3218' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
+      <parameter type-id='type-id-159' name='propvalue' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3208' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-159' name='value' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-163' name='src' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3004' column='1'/>
+      <parameter type-id='type-id-49' name='statbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3004' column='1'/>
+      <parameter type-id='type-id-67' name='statlen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3004' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2980' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2980' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-49' name='propbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-67' name='proplen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-163' name='src' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2606' column='1'/>
+      <parameter type-id='type-id-49' name='statbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2606' column='1'/>
+      <parameter type-id='type-id-67' name='statlen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2606' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2606' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2436' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+      <parameter type-id='type-id-49' name='propbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+      <parameter type-id='type-id-67' name='proplen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2350' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2350' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2038' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2038' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2038' column='1'/>
+      <parameter type-id='type-id-153' name='source' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='2038' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1927' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1927' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1927' column='1'/>
+      <parameter type-id='type-id-37' name='received' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1927' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1745' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1745' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1714' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1714' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1714' column='1'/>
+      <parameter type-id='type-id-105' name='propval' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1714' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-48' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-53' name='zoned' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+      <parameter type-id='type-id-45' name='zpool_hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+      <parameter type-id='type-id-37' name='key_params_ok' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1007' column='1'/>
+      <parameter type-id='type-id-105' name='errbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='1007' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='968' column='1'/>
+      <parameter type-id='type-id-157' name='spa_version' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='968' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='948' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='948' column='1'/>
+      <parameter type-id='type-id-105' name='fsname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='948' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <parameter type-id='type-id-105' name='special' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <parameter type-id='type-id-105' name='mountp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='919' column='1'/>
+      <parameter type-id='type-id-105' name='mntopts' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='919' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+      <parameter type-id='type-id-105' name='fsname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+      <parameter type-id='type-id-158' name='entry' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='873' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <parameter type-id='type-id-37' name='enable' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='848' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='848' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='801' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='773' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='684' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='684' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='684' column='1'/>
+      <parameter type-id='type-id-22' name='types' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='684' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_bookmark_handle'>
+      <parameter type-id='type-id-108' name='parent' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
+      <parameter type-id='type-id-48' name='bmark_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='620' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='588' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
+      <parameter type-id='type-id-108' name='zhp_orig' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='541' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='524' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_simple_handle_zc'>
+      <parameter type-id='type-id-108' name='pzhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='524' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='524' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle_zc'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='507' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='507' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='478' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='478' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='434' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='313' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='222' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='222' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_validate_name'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
+      <parameter type-id='type-id-22' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
+      <parameter type-id='type-id-37' name='modifying' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='107' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='80' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
+      <parameter type-id='type-id-46' name='types' filepath='/home/fedora/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-156'>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-53'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-22' name='outfd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-105' name='fromsnap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-105' name='tosnap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-164' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-165'/>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-166'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pco_refresh_config' type-id='type-id-167' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pco_pool_active' type-id='type-id-168' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-169' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-170'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-171' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-172'/>
+    <typedef-decl name='pool_state_t' type-id='type-id-173' filepath='../../include/sys/fs/zfs.h' line='908' column='1' id='type-id-174'/>
+    <enum-decl name='pool_state' filepath='../../include/sys/fs/zfs.h' line='899' column='1' id='type-id-173'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='POOL_STATE_ACTIVE' value='0'/>
+      <enumerator name='POOL_STATE_EXPORTED' value='1'/>
+      <enumerator name='POOL_STATE_DESTROYED' value='2'/>
+      <enumerator name='POOL_STATE_SPARE' value='3'/>
+      <enumerator name='POOL_STATE_L2CACHE' value='4'/>
+      <enumerator name='POOL_STATE_UNINITIALIZED' value='5'/>
+      <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
+      <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
+    </enum-decl>
+    <qualified-type-def type-id='type-id-166' const='yes' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-167'/>
+    <var-decl name='libzfs_config_ops' type-id='type-id-165' mangled-name='libzfs_config_ops' visibility='default' filepath='../../include/libzutil.h' line='59' column='1' elf-symbol-id='libzfs_config_ops'/>
+    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-22' name='fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-175' name='state' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-153' name='namestr' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-114' name='inuse' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='301' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
+      <parameter type-id='type-id-22' name='fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_import.c' line='144' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-48'/>
+      <return type-id='type-id-48'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-37' name='allowrecursion' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
+      <parameter type-id='type-id-108' name='fs_zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-105' name='spec_orig' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+      <parameter type-id='type-id-66' name='arg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-111' name='callback' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-53' name='min_txg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+      <parameter type-id='type-id-53' name='max_txg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-37' name='simple' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-53' name='min_txg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-53' name='max_txg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-176' size-in-bits='384' id='type-id-177'>
+      <subrange length='2' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-103' size-in-bits='64' alignment-in-bits='32' id='type-id-178'>
+      <subrange length='2' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-103' size-in-bits='96' alignment-in-bits='32' id='type-id-179'>
+      <subrange length='3' type-id='type-id-3' id='type-id-127'/>
+
+    </array-type-def>
+    <typedef-decl name='proto_table_t' type-id='type-id-180' filepath='../../include/libzfs_impl.h' line='219' column='1' id='type-id-176'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-176' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_prop' type-id='type-id-34' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_name' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_share_err' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='217' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_unshare_err' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='218' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='get_all_cb_t' type-id='type-id-181' filepath='../../include/libzfs.h' line='626' column='1' id='type-id-182'/>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='622' column='1' id='type-id-181'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_handles' type-id='type-id-183' visibility='default' filepath='../../include/libzfs.h' line='623' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='cb_alloc' type-id='type-id-67' visibility='default' filepath='../../include/libzfs.h' line='624' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cb_used' type-id='type-id-67' visibility='default' filepath='../../include/libzfs.h' line='625' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_type_t' type-id='type-id-184' filepath='../../include/libzfs_impl.h' line='124' column='1' id='type-id-185'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='120' column='1' id='type-id-184'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='SHARED_NOT_SHARED' value='0'/>
+      <enumerator name='SHARED_NFS' value='2'/>
+      <enumerator name='SHARED_SMB' value='4'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-186'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-183'/>
+    <var-decl name='proto_table' type-id='type-id-177' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='242' column='1' elf-symbol-id='proto_table'/>
+    <var-decl name='nfs_only' type-id='type-id-178' mangled-name='nfs_only' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='110' column='1' elf-symbol-id='nfs_only'/>
+    <var-decl name='smb_only' type-id='type-id-178' mangled-name='smb_only' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='115' column='1' elf-symbol-id='smb_only'/>
+    <var-decl name='share_all_proto' type-id='type-id-179' mangled-name='share_all_proto' visibility='default' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='119' column='1' elf-symbol-id='share_all_proto'/>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1484' column='1'/>
+      <parameter type-id='type-id-37' name='force' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1484' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1414' column='1'/>
+      <parameter type-id='type-id-105' name='mntopts' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1414' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1414' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1353' column='1'/>
+      <parameter type-id='type-id-183' name='handles' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1353' column='1'/>
+      <parameter type-id='type-id-67' name='num_handles' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1354' column='1'/>
+      <parameter type-id='type-id-111' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1354' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1354' column='1'/>
+      <parameter type-id='type-id-37' name='parallel' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1354' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1031' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='type-id-186' name='cbp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1031' column='1'/>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1031' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1005' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='1005' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='980' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='980' column='1'/>
+      <parameter type-id='type-id-105' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='981' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='974' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='974' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='968' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='962' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='956' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='956' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='925' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='925' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='925' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1'/>
+      <parameter type-id='type-id-109' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='888' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='872' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='866' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='855' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='type-id-105' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='855' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_all_shares'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_smb_shares'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_nfs_shares'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='828' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
+      <parameter type-id='type-id-109' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='828' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
+      <parameter type-id='type-id-49' name='options' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1'/>
+      <parameter type-id='type-id-103' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='809' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='809' column='1'/>
+      <parameter type-id='type-id-153' name='where' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='809' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='802' column='1'/>
+      <parameter type-id='type-id-153' name='where' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='802' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='780' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='780' column='1'/>
+      <parameter type-id='type-id-153' name='where' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='780' column='1'/>
+      <parameter type-id='type-id-103' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='780' column='1'/>
+      <return type-id='type-id-185'/>
+    </function-decl>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='770' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='770' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <parameter type-id='type-id-109' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='678' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='678' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='678' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='678' column='1'/>
+      <parameter type-id='type-id-103' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='679' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='659' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='659' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='642' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='642' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='568' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='568' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='568' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='568' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-105' name='options' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-105' name='options' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+      <parameter type-id='type-id-153' name='where' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
+      <parameter type-id='type-id-44' name='zfs_hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-105' name='special' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-153' name='where' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_is_mountable' mangled-name='zfs_is_mountable' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mountable'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-49' name='buf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-67' name='buflen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-163' name='source' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='697' column='1'/>
+      <parameter type-id='type-id-103' name='proto' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='697' column='1'/>
+      <return type-id='type-id-185'/>
+    </function-decl>
+    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_mount.c' line='763' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-187' filepath='../../include/sys/fs/zfs.h' line='1422' column='1' id='type-id-188'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1412' column='1' id='type-id-187'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='splitflags_t' type-id='type-id-189' filepath='../../include/libzfs.h' line='264' column='1' id='type-id-190'/>
+    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='257' column='1' id='type-id-189'>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='dryrun' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='30'>
+        <var-decl name='import' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='262' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='name_flags' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='263' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='vdev_aux_t' type-id='type-id-191' filepath='../../include/sys/fs/zfs.h' line='891' column='1' id='type-id-192'/>
+    <enum-decl name='vdev_aux' filepath='../../include/sys/fs/zfs.h' line='869' column='1' id='type-id-191'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='VDEV_AUX_NONE' value='0'/>
+      <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
+      <enumerator name='VDEV_AUX_CORRUPT_DATA' value='2'/>
+      <enumerator name='VDEV_AUX_NO_REPLICAS' value='3'/>
+      <enumerator name='VDEV_AUX_BAD_GUID_SUM' value='4'/>
+      <enumerator name='VDEV_AUX_TOO_SMALL' value='5'/>
+      <enumerator name='VDEV_AUX_BAD_LABEL' value='6'/>
+      <enumerator name='VDEV_AUX_VERSION_NEWER' value='7'/>
+      <enumerator name='VDEV_AUX_VERSION_OLDER' value='8'/>
+      <enumerator name='VDEV_AUX_UNSUP_FEAT' value='9'/>
+      <enumerator name='VDEV_AUX_SPARED' value='10'/>
+      <enumerator name='VDEV_AUX_ERR_EXCEEDED' value='11'/>
+      <enumerator name='VDEV_AUX_IO_FAILURE' value='12'/>
+      <enumerator name='VDEV_AUX_BAD_LOG' value='13'/>
+      <enumerator name='VDEV_AUX_EXTERNAL' value='14'/>
+      <enumerator name='VDEV_AUX_SPLIT_POOL' value='15'/>
+      <enumerator name='VDEV_AUX_BAD_ASHIFT' value='16'/>
+      <enumerator name='VDEV_AUX_EXTERNAL_PERSIST' value='17'/>
+      <enumerator name='VDEV_AUX_ACTIVE' value='18'/>
+      <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
+      <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
+    </enum-decl>
+    <typedef-decl name='vdev_state_t' type-id='type-id-193' filepath='../../include/sys/fs/zfs.h' line='861' column='1' id='type-id-194'/>
+    <enum-decl name='vdev_state' filepath='../../include/sys/fs/zfs.h' line='852' column='1' id='type-id-193'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
+      <enumerator name='VDEV_STATE_CLOSED' value='1'/>
+      <enumerator name='VDEV_STATE_OFFLINE' value='2'/>
+      <enumerator name='VDEV_STATE_REMOVED' value='3'/>
+      <enumerator name='VDEV_STATE_CANT_OPEN' value='4'/>
+      <enumerator name='VDEV_STATE_FAULTED' value='5'/>
+      <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
+      <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
+    </enum-decl>
+    <typedef-decl name='pool_scan_func_t' type-id='type-id-195' filepath='../../include/sys/fs/zfs.h' line='928' column='1' id='type-id-196'/>
+    <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='923' column='1' id='type-id-195'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='POOL_SCAN_NONE' value='0'/>
+      <enumerator name='POOL_SCAN_SCRUB' value='1'/>
+      <enumerator name='POOL_SCAN_RESILVER' value='2'/>
+      <enumerator name='POOL_SCAN_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-197' filepath='../../include/sys/fs/zfs.h' line='937' column='1' id='type-id-198'/>
+    <enum-decl name='pool_scrub_cmd' filepath='../../include/sys/fs/zfs.h' line='933' column='1' id='type-id-197'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
+      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
+      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-199' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-200'/>
+    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1162' column='1' id='type-id-199'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='trimflags_t' type-id='type-id-201' filepath='../../include/libzfs.h' line='278' column='1' id='type-id-202'/>
+    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='266' column='1' id='type-id-201'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fullpool' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='268' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='secure' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='271' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='wait' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='274' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rate' type-id='type-id-53' visibility='default' filepath='../../include/libzfs.h' line='277' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-203' filepath='../../include/sys/fs/zfs.h' line='1157' column='1' id='type-id-204'/>
+    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1152' column='1' id='type-id-203'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='zpool_prop_t' type-id='type-id-205' filepath='../../include/sys/fs/zfs.h' line='250' column='1' id='type-id-206'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='215' column='1' id='type-id-205'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
+      <enumerator name='ZPOOL_PROP_NAME' value='0'/>
+      <enumerator name='ZPOOL_PROP_SIZE' value='1'/>
+      <enumerator name='ZPOOL_PROP_CAPACITY' value='2'/>
+      <enumerator name='ZPOOL_PROP_ALTROOT' value='3'/>
+      <enumerator name='ZPOOL_PROP_HEALTH' value='4'/>
+      <enumerator name='ZPOOL_PROP_GUID' value='5'/>
+      <enumerator name='ZPOOL_PROP_VERSION' value='6'/>
+      <enumerator name='ZPOOL_PROP_BOOTFS' value='7'/>
+      <enumerator name='ZPOOL_PROP_DELEGATION' value='8'/>
+      <enumerator name='ZPOOL_PROP_AUTOREPLACE' value='9'/>
+      <enumerator name='ZPOOL_PROP_CACHEFILE' value='10'/>
+      <enumerator name='ZPOOL_PROP_FAILUREMODE' value='11'/>
+      <enumerator name='ZPOOL_PROP_LISTSNAPS' value='12'/>
+      <enumerator name='ZPOOL_PROP_AUTOEXPAND' value='13'/>
+      <enumerator name='ZPOOL_PROP_DEDUPDITTO' value='14'/>
+      <enumerator name='ZPOOL_PROP_DEDUPRATIO' value='15'/>
+      <enumerator name='ZPOOL_PROP_FREE' value='16'/>
+      <enumerator name='ZPOOL_PROP_ALLOCATED' value='17'/>
+      <enumerator name='ZPOOL_PROP_READONLY' value='18'/>
+      <enumerator name='ZPOOL_PROP_ASHIFT' value='19'/>
+      <enumerator name='ZPOOL_PROP_COMMENT' value='20'/>
+      <enumerator name='ZPOOL_PROP_EXPANDSZ' value='21'/>
+      <enumerator name='ZPOOL_PROP_FREEING' value='22'/>
+      <enumerator name='ZPOOL_PROP_FRAGMENTATION' value='23'/>
+      <enumerator name='ZPOOL_PROP_LEAKED' value='24'/>
+      <enumerator name='ZPOOL_PROP_MAXBLOCKSIZE' value='25'/>
+      <enumerator name='ZPOOL_PROP_TNAME' value='26'/>
+      <enumerator name='ZPOOL_PROP_MAXDNODESIZE' value='27'/>
+      <enumerator name='ZPOOL_PROP_MULTIHOST' value='28'/>
+      <enumerator name='ZPOOL_PROP_CHECKPOINT' value='29'/>
+      <enumerator name='ZPOOL_PROP_LOAD_GUID' value='30'/>
+      <enumerator name='ZPOOL_PROP_AUTOTRIM' value='31'/>
+      <enumerator name='ZPOOL_NUM_PROPS' value='32'/>
+    </enum-decl>
+    <qualified-type-def type-id='type-id-74' const='yes' id='type-id-207'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-209'/>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-210'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-211'/>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4582' column='1'/>
+      <parameter type-id='type-id-117' name='nvlp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4582' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4569' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4569' column='1'/>
+      <parameter type-id='type-id-208' name='envmap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4569' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4551' column='1'/>
+      <parameter type-id='type-id-188' name='activity' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4551' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4552' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4552' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4524' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4524' column='1'/>
+      <parameter type-id='type-id-188' name='activity' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4524' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4515' column='1'/>
+      <parameter type-id='type-id-53' name='dsobj' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4515' column='1'/>
+      <parameter type-id='type-id-53' name='obj' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4515' column='1'/>
+      <parameter type-id='type-id-49' name='pathname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4516' column='1'/>
+      <parameter type-id='type-id-67' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4516' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4508' column='1'/>
+      <parameter type-id='type-id-53' name='dsobj' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4508' column='1'/>
+      <parameter type-id='type-id-53' name='obj' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4508' column='1'/>
+      <parameter type-id='type-id-49' name='pathname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4509' column='1'/>
+      <parameter type-id='type-id-67' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4509' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4426' column='1'/>
+      <parameter type-id='type-id-53' name='eid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4426' column='1'/>
+      <parameter type-id='type-id-22' name='zevent_fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4426' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4403' column='1'/>
+      <parameter type-id='type-id-157' name='count' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4403' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4343' column='1'/>
+      <parameter type-id='type-id-117' name='nvp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4343' column='1'/>
+      <parameter type-id='type-id-157' name='dropped' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4344' column='1'/>
+      <parameter type-id='type-id-29' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4344' column='1'/>
+      <parameter type-id='type-id-22' name='zevent_fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4344' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4273' column='1'/>
+      <parameter type-id='type-id-117' name='nvhisp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4273' column='1'/>
+      <parameter type-id='type-id-159' name='off' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4273' column='1'/>
+      <parameter type-id='type-id-114' name='eof' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4274' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4204' column='1'/>
+      <parameter type-id='type-id-105' name='message' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4204' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='type-id-22' name='argc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4192' column='1'/>
+      <parameter type-id='type-id-153' name='argv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4192' column='1'/>
+      <parameter type-id='type-id-49' name='string' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4192' column='1'/>
+      <parameter type-id='type-id-22' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4192' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4176' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4176' column='1'/>
+      <parameter type-id='type-id-53' name='new_version' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4176' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4077' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4077' column='1'/>
+      <parameter type-id='type-id-117' name='nverrlistp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='4077' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3952' column='1'/>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3952' column='1'/>
+      <parameter type-id='type-id-48' name='nv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3952' column='1'/>
+      <parameter type-id='type-id-22' name='name_flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3953' column='1'/>
+      <return type-id='type-id-49'/>
+    </function-decl>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3915' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3915' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3897' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3897' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3897' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3877' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3877' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3853' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3853' column='1'/>
+      <parameter type-id='type-id-53' name='guid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3853' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3777' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3777' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3777' column='1'/>
+      <parameter type-id='type-id-48' name='rewindnvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3777' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3744' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3744' column='1'/>
+      <parameter type-id='type-id-159' name='sizep' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3745' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3724' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3724' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3652' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3652' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3652' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3430' column='1'/>
+      <parameter type-id='type-id-49' name='newname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3430' column='1'/>
+      <parameter type-id='type-id-117' name='newroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3430' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3431' column='1'/>
+      <parameter type-id='type-id-190' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3431' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3333' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3333' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3333' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3160' column='1'/>
+      <parameter type-id='type-id-105' name='old_disk' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3160' column='1'/>
+      <parameter type-id='type-id-105' name='new_disk' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3161' column='1'/>
+      <parameter type-id='type-id-48' name='nvroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3161' column='1'/>
+      <parameter type-id='type-id-22' name='replacing' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3161' column='1'/>
+      <parameter type-id='type-id-37' name='rebuild' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3161' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3106' column='1'/>
+      <parameter type-id='type-id-53' name='guid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3106' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3106' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3071' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3071' column='1'/>
+      <parameter type-id='type-id-53' name='guid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3071' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3071' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3021' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3021' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3021' column='1'/>
+      <parameter type-id='type-id-37' name='istmp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='3021' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2934' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2934' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2934' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2934' column='1'/>
+      <parameter type-id='type-id-210' name='newstate' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2935' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2924' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2924' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2924' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2886' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2886' column='1'/>
+      <parameter type-id='type-id-49' name='physpath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2886' column='1'/>
+      <parameter type-id='type-id-67' name='phypath_size' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2886' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2713' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2713' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2713' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2714' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2714' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2662' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2662' column='1'/>
+      <parameter type-id='type-id-105' name='ppath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2662' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2663' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2663' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2663' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2417' column='1'/>
+      <parameter type-id='type-id-196' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2417' column='1'/>
+      <parameter type-id='type-id-198' name='cmd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2417' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2361' column='1'/>
+      <parameter type-id='type-id-200' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2361' column='1'/>
+      <parameter type-id='type-id-48' name='vds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2361' column='1'/>
+      <parameter type-id='type-id-209' name='trim_flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2362' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2252' column='1'/>
+      <parameter type-id='type-id-204' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2252' column='1'/>
+      <parameter type-id='type-id-48' name='vds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2253' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2245' column='1'/>
+      <parameter type-id='type-id-204' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2245' column='1'/>
+      <parameter type-id='type-id-48' name='vds' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='2246' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1856' column='1'/>
+      <parameter type-id='type-id-48' name='config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1856' column='1'/>
+      <parameter type-id='type-id-105' name='newname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1856' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1857' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1857' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1825' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='type-id-48' name='config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1825' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1767' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1767' column='1'/>
+      <parameter type-id='type-id-48' name='config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1767' column='1'/>
+      <parameter type-id='type-id-105' name='newname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1767' column='1'/>
+      <parameter type-id='type-id-49' name='altroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1768' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
+      <parameter type-id='type-id-22' name='reason' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
+      <parameter type-id='type-id-48' name='config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1622' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1622' column='1'/>
+      <parameter type-id='type-id-105' name='log_str' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1622' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1616' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1616' column='1'/>
+      <parameter type-id='type-id-37' name='force' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1616' column='1'/>
+      <parameter type-id='type-id-105' name='log_str' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1616' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1482' column='1'/>
+      <parameter type-id='type-id-48' name='nvroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1482' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1460' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1439' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1396' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1396' column='1'/>
+      <parameter type-id='type-id-105' name='log_str' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1396' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1228' column='1'/>
+      <parameter type-id='type-id-105' name='pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1228' column='1'/>
+      <parameter type-id='type-id-48' name='nvroot' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1228' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1229' column='1'/>
+      <parameter type-id='type-id-48' name='fsprops' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1229' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1209' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1162' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1152' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1140' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1119' column='1'/>
+      <parameter type-id='type-id-105' name='pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1119' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1088' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1088' column='1'/>
+      <parameter type-id='type-id-105' name='pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1088' column='1'/>
+      <parameter type-id='type-id-211' name='ret' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1088' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1046' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1046' column='1'/>
+      <parameter type-id='type-id-105' name='pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='1046' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='947' column='1'/>
+      <parameter type-id='type-id-37' name='isopen' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='947' column='1'/>
+      <parameter type-id='type-id-105' name='pool' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='947' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='885' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='885' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='885' column='1'/>
+      <parameter type-id='type-id-49' name='buf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='885' column='1'/>
+      <parameter type-id='type-id-67' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='886' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='787' column='1'/>
+      <parameter type-id='type-id-162' name='plp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='787' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='788' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='731' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='731' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='731' column='1'/>
+      <parameter type-id='type-id-105' name='propval' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='731' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='280' column='1'/>
+      <parameter type-id='type-id-206' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='280' column='1'/>
+      <parameter type-id='type-id-49' name='buf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='280' column='1'/>
+      <parameter type-id='type-id-67' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='281' column='1'/>
+      <parameter type-id='type-id-163' name='srctype' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='281' column='1'/>
+      <parameter type-id='type-id-37' name='literal' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='281' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='248' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
+      <parameter type-id='type-id-174' name='state' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='217' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
+      <parameter type-id='type-id-194' name='state' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='184' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='184' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='142' column='1'/>
+      <parameter type-id='type-id-206' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='142' column='1'/>
+      <parameter type-id='type-id-163' name='src' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='142' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_pool.c' line='102' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='recvflags_t' type-id='type-id-212' filepath='../../include/libzfs.h' line='786' column='1' id='type-id-213'/>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='741' column='1' id='type-id-212'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='verbose' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='743' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='isprefix' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='746' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='istail' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='752' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dryrun' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='755' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='force' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='758' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='canmountoff' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='761' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resumable' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='767' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='byteswap' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='770' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nomount' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='773' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='holds' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='776' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='skipholds' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='779' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='domount' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='782' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='forceunmount' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='785' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='sendflags_t' type-id='type-id-214' filepath='../../include/libzfs.h' line='708' column='1' id='type-id-215'/>
+    <class-decl name='sendflags' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='660' column='1' id='type-id-214'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='verbosity' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='662' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='replicate' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='665' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='doall' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='668' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='fromorigin' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='671' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pad' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='674' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='props' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='677' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dryrun' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='680' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='parsable' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='683' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='progress' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='686' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='largeblock' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='689' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='embed_data' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='692' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='compress' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='695' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='raw' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='698' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='backup' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='701' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='holds' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='704' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='saved' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='707' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='snapfilter_cb_t' type-id='type-id-216' filepath='../../include/libzfs.h' line='710' column='1' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-55' size-in-bits='64' id='type-id-218'/>
+    <pointer-type-def type-id='type-id-213' size-in-bits='64' id='type-id-219'/>
+    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-220'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-221'/>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5118' column='1'/>
+      <parameter type-id='type-id-105' name='tosnap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5118' column='1'/>
+      <parameter type-id='type-id-48' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5118' column='1'/>
+      <parameter type-id='type-id-219' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5119' column='1'/>
+      <parameter type-id='type-id-22' name='infd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5119' column='1'/>
+      <parameter type-id='type-id-218' name='stream_avl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='5119' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2385' column='1'/>
+      <parameter type-id='type-id-105' name='from' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2385' column='1'/>
+      <parameter type-id='type-id-22' name='fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2385' column='1'/>
+      <parameter type-id='type-id-220' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2385' column='1'/>
+      <parameter type-id='type-id-105' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2386' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2111' column='1'/>
+      <parameter type-id='type-id-105' name='fromsnap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2111' column='1'/>
+      <parameter type-id='type-id-105' name='tosnap' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2111' column='1'/>
+      <parameter type-id='type-id-220' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2112' column='1'/>
+      <parameter type-id='type-id-22' name='outfd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2112' column='1'/>
+      <parameter type-id='type-id-221' name='filter_func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2112' column='1'/>
+      <parameter type-id='type-id-66' name='cb_arg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2113' column='1'/>
+      <parameter type-id='type-id-117' name='debugnvp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='2113' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1859' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1859' column='1'/>
+      <parameter type-id='type-id-220' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1859' column='1'/>
+      <parameter type-id='type-id-22' name='outfd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1859' column='1'/>
+      <parameter type-id='type-id-105' name='resume_token' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1860' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1833' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1833' column='1'/>
+      <parameter type-id='type-id-220' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1833' column='1'/>
+      <parameter type-id='type-id-22' name='outfd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1833' column='1'/>
+      <parameter type-id='type-id-105' name='resume_token' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1834' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1360' column='1'/>
+      <parameter type-id='type-id-105' name='token' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='1360' column='1'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='872' column='1'/>
+      <parameter type-id='type-id-22' name='fd' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='872' column='1'/>
+      <parameter type-id='type-id-159' name='bytes_written' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='872' column='1'/>
+      <parameter type-id='type-id-159' name='blocks_visited' filepath='/home/fedora/zfs/lib/libzfs/libzfs_sendrecv.c' line='873' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='__builtin_strcpy' mangled-name='strcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-216'>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='zpool_status_t' type-id='type-id-222' filepath='../../include/libzfs.h' line='399' column='1' id='type-id-223'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='338' column='1' id='type-id-222'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPOOL_STATUS_CORRUPT_CACHE' value='0'/>
+      <enumerator name='ZPOOL_STATUS_MISSING_DEV_R' value='1'/>
+      <enumerator name='ZPOOL_STATUS_MISSING_DEV_NR' value='2'/>
+      <enumerator name='ZPOOL_STATUS_CORRUPT_LABEL_R' value='3'/>
+      <enumerator name='ZPOOL_STATUS_CORRUPT_LABEL_NR' value='4'/>
+      <enumerator name='ZPOOL_STATUS_BAD_GUID_SUM' value='5'/>
+      <enumerator name='ZPOOL_STATUS_CORRUPT_POOL' value='6'/>
+      <enumerator name='ZPOOL_STATUS_CORRUPT_DATA' value='7'/>
+      <enumerator name='ZPOOL_STATUS_FAILING_DEV' value='8'/>
+      <enumerator name='ZPOOL_STATUS_VERSION_NEWER' value='9'/>
+      <enumerator name='ZPOOL_STATUS_HOSTID_MISMATCH' value='10'/>
+      <enumerator name='ZPOOL_STATUS_HOSTID_ACTIVE' value='11'/>
+      <enumerator name='ZPOOL_STATUS_HOSTID_REQUIRED' value='12'/>
+      <enumerator name='ZPOOL_STATUS_IO_FAILURE_WAIT' value='13'/>
+      <enumerator name='ZPOOL_STATUS_IO_FAILURE_CONTINUE' value='14'/>
+      <enumerator name='ZPOOL_STATUS_IO_FAILURE_MMP' value='15'/>
+      <enumerator name='ZPOOL_STATUS_BAD_LOG' value='16'/>
+      <enumerator name='ZPOOL_STATUS_ERRATA' value='17'/>
+      <enumerator name='ZPOOL_STATUS_UNSUP_FEAT_READ' value='18'/>
+      <enumerator name='ZPOOL_STATUS_UNSUP_FEAT_WRITE' value='19'/>
+      <enumerator name='ZPOOL_STATUS_FAULTED_DEV_R' value='20'/>
+      <enumerator name='ZPOOL_STATUS_FAULTED_DEV_NR' value='21'/>
+      <enumerator name='ZPOOL_STATUS_VERSION_OLDER' value='22'/>
+      <enumerator name='ZPOOL_STATUS_FEAT_DISABLED' value='23'/>
+      <enumerator name='ZPOOL_STATUS_RESILVERING' value='24'/>
+      <enumerator name='ZPOOL_STATUS_OFFLINE_DEV' value='25'/>
+      <enumerator name='ZPOOL_STATUS_REMOVED_DEV' value='26'/>
+      <enumerator name='ZPOOL_STATUS_REBUILDING' value='27'/>
+      <enumerator name='ZPOOL_STATUS_REBUILD_SCRUB' value='28'/>
+      <enumerator name='ZPOOL_STATUS_NON_NATIVE_ASHIFT' value='29'/>
+      <enumerator name='ZPOOL_STATUS_OK' value='30'/>
+    </enum-decl>
+    <typedef-decl name='zpool_errata_t' type-id='type-id-224' filepath='../../include/sys/fs/zfs.h' line='1041' column='1' id='type-id-225'/>
+    <enum-decl name='zpool_errata' filepath='../../include/sys/fs/zfs.h' line='1035' column='1' id='type-id-224'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZPOOL_ERRATA_NONE' value='0'/>
+      <enumerator name='ZPOOL_ERRATA_ZOL_2094_SCRUB' value='1'/>
+      <enumerator name='ZPOOL_ERRATA_ZOL_2094_ASYNC_DESTROY' value='2'/>
+      <enumerator name='ZPOOL_ERRATA_ZOL_6845_ENCRYPTION' value='3'/>
+      <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-226'/>
+    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='498' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
+      <parameter type-id='type-id-48' name='config' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='498' column='1'/>
+      <parameter type-id='type-id-153' name='msgid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='498' column='1'/>
+      <parameter type-id='type-id-226' name='errata' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='498' column='1'/>
+      <return type-id='type-id-223'/>
+    </function-decl>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='485' column='1'/>
+      <parameter type-id='type-id-153' name='msgid' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='485' column='1'/>
+      <parameter type-id='type-id-226' name='errata' filepath='/home/fedora/zfs/lib/libzfs/libzfs_status.c' line='485' column='1'/>
+      <return type-id='type-id-223'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='192' id='type-id-227'>
+      <subrange length='6' type-id='type-id-3' id='type-id-228'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-229' size-in-bits='160' alignment-in-bits='32' id='type-id-230'>
+      <subrange length='5' type-id='type-id-3' id='type-id-231'/>
+
+    </array-type-def>
+    <typedef-decl name='zprop_func' type-id='type-id-232' filepath='../../include/sys/fs/zfs.h' line='286' column='1' id='type-id-233'/>
+    <typedef-decl name='nvpair_t' type-id='type-id-234' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-235'/>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-234'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvp_size' type-id='type-id-75' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvp_name_sz' type-id='type-id-236' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='type-id-236' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvp_value_elem' type-id='type-id-75' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='type-id-237' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int16_t' type-id='type-id-238' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-236'/>
+    <typedef-decl name='__int16_t' type-id='type-id-25' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-238'/>
+    <typedef-decl name='data_type_t' type-id='type-id-239' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-237'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-239'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
+      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
+      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
+      <enumerator name='DATA_TYPE_BYTE' value='2'/>
+      <enumerator name='DATA_TYPE_INT16' value='3'/>
+      <enumerator name='DATA_TYPE_UINT16' value='4'/>
+      <enumerator name='DATA_TYPE_INT32' value='5'/>
+      <enumerator name='DATA_TYPE_UINT32' value='6'/>
+      <enumerator name='DATA_TYPE_INT64' value='7'/>
+      <enumerator name='DATA_TYPE_UINT64' value='8'/>
+      <enumerator name='DATA_TYPE_STRING' value='9'/>
+      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
+      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
+      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
+      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
+      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
+      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
+      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
+      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
+      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
+      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
+      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
+      <enumerator name='DATA_TYPE_INT8' value='22'/>
+      <enumerator name='DATA_TYPE_UINT8' value='23'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
+      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
+      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
+      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
+    </enum-decl>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-240' filepath='../../include/libzfs.h' line='600' column='1' id='type-id-241'/>
+    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='591' column='1' id='type-id-240'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_sources' type-id='type-id-22' visibility='default' filepath='../../include/libzfs.h' line='592' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='cb_columns' type-id='type-id-230' visibility='default' filepath='../../include/libzfs.h' line='593' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='cb_colwidths' type-id='type-id-227' visibility='default' filepath='../../include/libzfs.h' line='594' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='cb_scripted' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='595' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cb_literal' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='cb_first' type-id='type-id-37' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='cb_proplist' type-id='type-id-161' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='cb_type' type-id='type-id-46' visibility='default' filepath='../../include/libzfs.h' line='599' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_get_column_t' type-id='type-id-242' filepath='../../include/libzfs.h' line='586' column='1' id='type-id-229'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../include/libzfs.h' line='579' column='1' id='type-id-242'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='GET_COL_NONE' value='0'/>
+      <enumerator name='GET_COL_NAME' value='1'/>
+      <enumerator name='GET_COL_PROPERTY' value='2'/>
+      <enumerator name='GET_COL_VALUE' value='3'/>
+      <enumerator name='GET_COL_RECVD' value='4'/>
+      <enumerator name='GET_COL_SOURCE' value='5'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-243'/>
+    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-232'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-245'/>
+    <pointer-type-def type-id='type-id-241' size-in-bits='64' id='type-id-246'/>
+    <function-decl name='printf_color' mangled-name='printf_color' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2088' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
+      <parameter type-id='type-id-49' name='color' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2088' column='1'/>
+      <parameter type-id='type-id-49' name='format' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2088' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='color_end' mangled-name='color_end' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2080' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='color_start' mangled-name='color_start' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
+      <parameter type-id='type-id-49' name='color' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='2073' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
+      <parameter type-id='type-id-49' name='version' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1984' column='1'/>
+      <parameter type-id='type-id-22' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1984' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_iter' mangled-name='zprop_iter' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
+      <parameter type-id='type-id-233' name='func' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1974' column='1'/>
+      <parameter type-id='type-id-66' name='cb' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1974' column='1'/>
+      <parameter type-id='type-id-37' name='show_all' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1974' column='1'/>
+      <parameter type-id='type-id-37' name='ordered' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1974' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1975' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_expand_list'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1933' column='1'/>
+      <parameter type-id='type-id-162' name='plp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1933' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1933' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
+      <parameter type-id='type-id-161' name='pl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1895' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1814' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1814' column='1'/>
+      <parameter type-id='type-id-49' name='props' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1814' column='1'/>
+      <parameter type-id='type-id-162' name='listp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1814' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1815' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_parse_value'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1606' column='1'/>
+      <parameter type-id='type-id-245' name='elem' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1606' column='1'/>
+      <parameter type-id='type-id-22' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1606' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1607' column='1'/>
+      <parameter type-id='type-id-48' name='ret' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1607' column='1'/>
+      <parameter type-id='type-id-153' name='svalp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1607' column='1'/>
+      <parameter type-id='type-id-159' name='ivalp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1607' column='1'/>
+      <parameter type-id='type-id-105' name='errbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1608' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1521' column='1'/>
+      <parameter type-id='type-id-105' name='value' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1521' column='1'/>
+      <parameter type-id='type-id-159' name='num' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1521' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1389' column='1'/>
+      <parameter type-id='type-id-246' name='cbp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1389' column='1'/>
+      <parameter type-id='type-id-105' name='propname' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1390' column='1'/>
+      <parameter type-id='type-id-105' name='value' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1390' column='1'/>
+      <parameter type-id='type-id-142' name='sourcetype' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1390' column='1'/>
+      <parameter type-id='type-id-105' name='source' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1391' column='1'/>
+      <parameter type-id='type-id-105' name='recvd_value' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1391' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_read_dst_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1249' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1249' column='1'/>
+      <parameter type-id='type-id-117' name='nvlp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1249' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_src_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1239' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1239' column='1'/>
+      <parameter type-id='type-id-48' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1239' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_conf_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1232' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1232' column='1'/>
+      <parameter type-id='type-id-48' name='nvl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1232' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_free_nvlists'>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1201' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_expand_dst_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1186' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1186' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_alloc_dst_nvlist'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1167' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1167' column='1'/>
+      <parameter type-id='type-id-67' name='len' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1167' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1134' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1134' column='1'/>
+      <parameter type-id='type-id-46' name='argtype' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1134' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
+      <parameter type-id='type-id-155' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1122' column='1'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
+      <parameter type-id='type-id-108' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1116' column='1'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
+      <parameter type-id='type-id-45' name='zhp' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1110' column='1'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1091' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1091' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='1007' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
+      <parameter type-id='type-id-49' name='envvar' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='995' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
+      <parameter type-id='type-id-153' name='strs' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='980' column='1'/>
+      <parameter type-id='type-id-22' name='count' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='980' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='968' column='1'/>
+      <parameter type-id='type-id-153' name='argv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='968' column='1'/>
+      <parameter type-id='type-id-153' name='env' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='969' column='1'/>
+      <parameter type-id='type-id-243' name='lines' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='969' column='1'/>
+      <parameter type-id='type-id-157' name='lines_cnt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='969' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='957' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='957' column='1'/>
+      <parameter type-id='type-id-153' name='argv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='957' column='1'/>
+      <parameter type-id='type-id-153' name='env' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='957' column='1'/>
+      <parameter type-id='type-id-243' name='lines' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='958' column='1'/>
+      <parameter type-id='type-id-157' name='lines_cnt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='958' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
+      <parameter type-id='type-id-105' name='path' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='945' column='1'/>
+      <parameter type-id='type-id-153' name='argv' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='945' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='945' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='823' column='1'/>
+      <parameter type-id='type-id-37' name='printerr' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='823' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strdup'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+      <parameter type-id='type-id-105' name='str' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+      <return type-id='type-id-49'/>
+    </function-decl>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_realloc'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-66' name='ptr' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-67' name='oldsize' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-67' name='newsize' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_asprintf'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+      <parameter type-id='type-id-105' name='fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-49'/>
+    </function-decl>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_alloc'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <parameter type-id='type-id-67' name='size' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='no_memory' mangled-name='no_memory' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='no_memory'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='749' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error_fmt'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-105' name='fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-105' name='msg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_setprop_error'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-34' name='prop' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-22' name='err' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-49' name='errbuf' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='497' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error_fmt'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-105' name='fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='398' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='398' column='1'/>
+      <parameter type-id='type-id-105' name='msg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='398' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_fmt'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-105' name='fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='347' column='1'/>
+      <parameter type-id='type-id-22' name='error' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='347' column='1'/>
+      <parameter type-id='type-id-105' name='msg' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='347' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_aux'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+      <parameter type-id='type-id-105' name='fmt' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='76' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='70' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
+      <parameter type-id='type-id-44' name='hdl' filepath='/home/fedora/zfs/lib/libzfs/libzfs_util.c' line='82' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-244'>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-247'/>
+    <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' filepath='os/linux/libzfs_mount_os.c' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='do_unmount' mangled-name='do_unmount' filepath='os/linux/libzfs_mount_os.c' line='377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_unmount'>
+      <parameter type-id='type-id-105' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='do_mount' mangled-name='do_mount' filepath='os/linux/libzfs_mount_os.c' line='323' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_mount'>
+      <parameter type-id='type-id-108' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-105' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-49' name='opts' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-22' name='flags' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' filepath='os/linux/libzfs_mount_os.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
+      <parameter type-id='type-id-108' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-105' name='mntpoint' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-49' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
+      <parameter type-id='type-id-49' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' filepath='os/linux/libzfs_mount_os.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
+      <parameter type-id='type-id-49' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
+      <parameter type-id='type-id-247' name='mntflags' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
+      <parameter type-id='type-id-247' name='zfsflags' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <parameter type-id='type-id-22' name='sloppy' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <parameter type-id='type-id-49' name='badopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <parameter type-id='type-id-49' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' filepath='os/linux/libzfs_pool_os.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
+      <parameter type-id='type-id-44' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
+      <parameter type-id='type-id-45' name='zhp' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='os/linux/libzfs_pool_os.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_relabel_disk'>
+      <parameter type-id='type-id-44' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-105' name='path' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-105' name='msg' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_set_pipe_max'>
+      <parameter type-id='type-id-22' name='infd' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='differ_info_t' type-id='type-id-248' filepath='../../include/libzfs_impl.h' line='240' column='1' id='type-id-249'/>
+    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1' id='type-id-248'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zhp' type-id='type-id-108' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fromsnap' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='frommnt' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='224' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='tosnap' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='225' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='tomnt' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='226' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ds' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='227' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dsmnt' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='228' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='tmpsnap' type-id='type-id-49' visibility='default' filepath='../../include/libzfs_impl.h' line='229' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='errbuf' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='230' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8704'>
+        <var-decl name='isclone' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='231' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8736'>
+        <var-decl name='scripted' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='232' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8768'>
+        <var-decl name='classify' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='233' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8800'>
+        <var-decl name='timestamped' type-id='type-id-37' visibility='default' filepath='../../include/libzfs_impl.h' line='234' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8832'>
+        <var-decl name='shares' type-id='type-id-53' visibility='default' filepath='../../include/libzfs_impl.h' line='235' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8896'>
+        <var-decl name='zerr' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='236' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8928'>
+        <var-decl name='cleanupfd' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='237' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8960'>
+        <var-decl name='outputfd' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='238' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8992'>
+        <var-decl name='datafd' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='239' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='os/linux/libzfs_util_os.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
+      <parameter type-id='type-id-49' name='version' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
+      <parameter type-id='type-id-22' name='len' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='os/linux/libzfs_util_os.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='find_shares_object'>
+      <parameter type-id='type-id-250' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='os/linux/libzfs_util_os.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_load_module'>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' filepath='os/linux/libzfs_util_os.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
+      <parameter type-id='type-id-22' name='error' filepath='os/linux/libzfs_util_os.c' line='55' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='os/linux/libzfs_util_os.c' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
+      <parameter type-id='type-id-44' name='hdl' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
+      <parameter type-id='type-id-22' name='request' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
+      <parameter type-id='type-id-160' name='zc' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+
+
+
+    <array-type-def dimensions='1' type-id='type-id-76' size-in-bits='64' id='type-id-251'>
+      <subrange length='2' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-76' size-in-bits='1024' id='type-id-252'>
+      <subrange length='32' type-id='type-id-3' id='type-id-253'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-76' size-in-bits='256' id='type-id-254'>
+      <subrange length='8' type-id='type-id-3' id='type-id-255'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='1024' id='type-id-256'>
+      <subrange length='16' type-id='type-id-3' id='type-id-257'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='512' id='type-id-258'>
+      <subrange length='8' type-id='type-id-3' id='type-id-255'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-99' size-in-bits='1024' id='type-id-259'>
+      <subrange length='128' type-id='type-id-3' id='type-id-260'/>
+
+    </array-type-def>
+    <typedef-decl name='SHA2_CTX' type-id='type-id-261' filepath='../../lib/libspl/include/sys/sha2.h' line='87' column='1' id='type-id-262'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='1728' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-262' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='69' column='1' id='type-id-261'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='algotype' type-id='type-id-76' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='state' type-id='type-id-263' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='count' type-id='type-id-264' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='buf_un' type-id='type-id-265' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='86' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='512' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='73' column='1' id='type-id-263'>
+      <data-member access='private'>
+        <var-decl name='s32' type-id='type-id-254' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='s64' type-id='type-id-258' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='78' column='1' id='type-id-264'>
+      <data-member access='private'>
+        <var-decl name='c32' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='c64' type-id='type-id-125' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='80' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__2' size-in-bits='1024' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='82' column='1' id='type-id-265'>
+      <data-member access='private'>
+        <var-decl name='buf8' type-id='type-id-259' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf32' type-id='type-id-252' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf64' type-id='type-id-256' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='85' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='SHA512_CTX' type-id='type-id-262' filepath='../../lib/libspl/include/sys/sha2.h' line='91' column='1' id='type-id-266'/>
+    <typedef-decl name='SHA384_CTX' type-id='type-id-262' filepath='../../lib/libspl/include/sys/sha2.h' line='90' column='1' id='type-id-267'/>
+    <typedef-decl name='SHA256_CTX' type-id='type-id-262' filepath='../../lib/libspl/include/sys/sha2.h' line='89' column='1' id='type-id-268'/>
+    <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-269'/>
+    <pointer-type-def type-id='type-id-262' size-in-bits='64' id='type-id-270'/>
+    <pointer-type-def type-id='type-id-267' size-in-bits='64' id='type-id-271'/>
+    <pointer-type-def type-id='type-id-266' size-in-bits='64' id='type-id-272'/>
+    <function-decl name='SHA2Final' mangled-name='SHA2Final' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Final'>
+      <parameter type-id='type-id-66' name='digest' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <parameter type-id='type-id-270' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='SHA2Update' mangled-name='SHA2Update' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Update'>
+      <parameter type-id='type-id-270' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-66' name='inptr' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-67' name='input_len' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='SHA512Init' mangled-name='SHA512Init' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA512Init'>
+      <parameter type-id='type-id-272' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='SHA384Init' mangled-name='SHA384Init' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA384Init'>
+      <parameter type-id='type-id-271' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='SHA256Init' mangled-name='SHA256Init' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA256Init'>
+      <parameter type-id='type-id-269' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='SHA2Init' mangled-name='SHA2Init' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Init'>
+      <parameter type-id='type-id-53' name='mech' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
+      <parameter type-id='type-id-270' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='cityhash4' mangled-name='cityhash4' filepath='../../module/zcommon/cityhash.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
+      <parameter type-id='type-id-53' name='w1' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-53' name='w2' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-53' name='w3' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-53' name='w4' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-273' size-in-bits='15232' id='type-id-274'>
+      <subrange length='34' type-id='type-id-3' id='type-id-275'/>
+
+    </array-type-def>
+    <typedef-decl name='zfeature_info_t' type-id='type-id-276' filepath='../../include/zfeature_common.h' line='115' column='1' id='type-id-273'/>
+    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/zfeature_common.h' line='105' column='1' id='type-id-276'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fi_feature' type-id='type-id-277' visibility='default' filepath='../../include/zfeature_common.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fi_uname' type-id='type-id-105' visibility='default' filepath='../../include/zfeature_common.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fi_guid' type-id='type-id-105' visibility='default' filepath='../../include/zfeature_common.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fi_desc' type-id='type-id-105' visibility='default' filepath='../../include/zfeature_common.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fi_flags' type-id='type-id-278' visibility='default' filepath='../../include/zfeature_common.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='fi_zfs_mod_supported' type-id='type-id-37' visibility='default' filepath='../../include/zfeature_common.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='fi_type' type-id='type-id-279' visibility='default' filepath='../../include/zfeature_common.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='fi_depends' type-id='type-id-280' visibility='default' filepath='../../include/zfeature_common.h' line='114' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='spa_feature_t' type-id='type-id-281' filepath='../../include/zfeature_common.h' line='81' column='1' id='type-id-277'/>
+    <enum-decl name='spa_feature' filepath='../../include/zfeature_common.h' line='42' column='1' id='type-id-281'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='SPA_FEATURE_NONE' value='-1'/>
+      <enumerator name='SPA_FEATURE_ASYNC_DESTROY' value='0'/>
+      <enumerator name='SPA_FEATURE_EMPTY_BPOBJ' value='1'/>
+      <enumerator name='SPA_FEATURE_LZ4_COMPRESS' value='2'/>
+      <enumerator name='SPA_FEATURE_MULTI_VDEV_CRASH_DUMP' value='3'/>
+      <enumerator name='SPA_FEATURE_SPACEMAP_HISTOGRAM' value='4'/>
+      <enumerator name='SPA_FEATURE_ENABLED_TXG' value='5'/>
+      <enumerator name='SPA_FEATURE_HOLE_BIRTH' value='6'/>
+      <enumerator name='SPA_FEATURE_EXTENSIBLE_DATASET' value='7'/>
+      <enumerator name='SPA_FEATURE_EMBEDDED_DATA' value='8'/>
+      <enumerator name='SPA_FEATURE_BOOKMARKS' value='9'/>
+      <enumerator name='SPA_FEATURE_FS_SS_LIMIT' value='10'/>
+      <enumerator name='SPA_FEATURE_LARGE_BLOCKS' value='11'/>
+      <enumerator name='SPA_FEATURE_LARGE_DNODE' value='12'/>
+      <enumerator name='SPA_FEATURE_SHA512' value='13'/>
+      <enumerator name='SPA_FEATURE_SKEIN' value='14'/>
+      <enumerator name='SPA_FEATURE_EDONR' value='15'/>
+      <enumerator name='SPA_FEATURE_USEROBJ_ACCOUNTING' value='16'/>
+      <enumerator name='SPA_FEATURE_ENCRYPTION' value='17'/>
+      <enumerator name='SPA_FEATURE_PROJECT_QUOTA' value='18'/>
+      <enumerator name='SPA_FEATURE_DEVICE_REMOVAL' value='19'/>
+      <enumerator name='SPA_FEATURE_OBSOLETE_COUNTS' value='20'/>
+      <enumerator name='SPA_FEATURE_POOL_CHECKPOINT' value='21'/>
+      <enumerator name='SPA_FEATURE_SPACEMAP_V2' value='22'/>
+      <enumerator name='SPA_FEATURE_ALLOCATION_CLASSES' value='23'/>
+      <enumerator name='SPA_FEATURE_RESILVER_DEFER' value='24'/>
+      <enumerator name='SPA_FEATURE_BOOKMARK_V2' value='25'/>
+      <enumerator name='SPA_FEATURE_REDACTION_BOOKMARKS' value='26'/>
+      <enumerator name='SPA_FEATURE_REDACTED_DATASETS' value='27'/>
+      <enumerator name='SPA_FEATURE_BOOKMARK_WRITTEN' value='28'/>
+      <enumerator name='SPA_FEATURE_LOG_SPACEMAP' value='29'/>
+      <enumerator name='SPA_FEATURE_LIVELIST' value='30'/>
+      <enumerator name='SPA_FEATURE_DEVICE_REBUILD' value='31'/>
+      <enumerator name='SPA_FEATURE_ZSTD_COMPRESS' value='32'/>
+      <enumerator name='SPA_FEATURE_DRAID' value='33'/>
+      <enumerator name='SPA_FEATURES' value='34'/>
+    </enum-decl>
+    <typedef-decl name='zfeature_flags_t' type-id='type-id-282' filepath='../../include/zfeature_common.h' line='97' column='1' id='type-id-278'/>
+    <enum-decl name='zfeature_flags' filepath='../../include/zfeature_common.h' line='85' column='1' id='type-id-282'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFEATURE_FLAG_READONLY_COMPAT' value='1'/>
+      <enumerator name='ZFEATURE_FLAG_MOS' value='2'/>
+      <enumerator name='ZFEATURE_FLAG_ACTIVATE_ON_ENABLE' value='4'/>
+      <enumerator name='ZFEATURE_FLAG_PER_DATASET' value='8'/>
+    </enum-decl>
+    <typedef-decl name='zfeature_type_t' type-id='type-id-283' filepath='../../include/zfeature_common.h' line='103' column='1' id='type-id-279'/>
+    <enum-decl name='zfeature_type' filepath='../../include/zfeature_common.h' line='99' column='1' id='type-id-283'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFEATURE_TYPE_BOOLEAN' value='0'/>
+      <enumerator name='ZFEATURE_TYPE_UINT64_ARRAY' value='1'/>
+      <enumerator name='ZFEATURE_NUM_TYPES' value='2'/>
+    </enum-decl>
+    <qualified-type-def type-id='type-id-277' const='yes' id='type-id-284'/>
+    <pointer-type-def type-id='type-id-284' size-in-bits='64' id='type-id-280'/>
+    <pointer-type-def type-id='type-id-277' size-in-bits='64' id='type-id-285'/>
+    <var-decl name='zfeature_checks_disable' type-id='type-id-37' mangled-name='zfeature_checks_disable' visibility='default' filepath='../../module/zcommon/zfeature_common.c' line='49' column='1' elf-symbol-id='zfeature_checks_disable'/>
+    <var-decl name='spa_feature_table' type-id='type-id-274' mangled-name='spa_feature_table' visibility='default' filepath='../../include/zfeature_common.h' line='121' column='1' elf-symbol-id='spa_feature_table'/>
+    <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' filepath='../../module/zcommon/zfeature_common.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_feature_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' filepath='../../module/zcommon/zfeature_common.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
+      <parameter type-id='type-id-277' name='fid' filepath='../../module/zcommon/zfeature_common.c' line='144' column='1'/>
+      <parameter type-id='type-id-277' name='check' filepath='../../module/zcommon/zfeature_common.c' line='144' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' filepath='../../module/zcommon/zfeature_common.c' line='127' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfeature_common.c' line='127' column='1'/>
+      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='127' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' filepath='../../module/zcommon/zfeature_common.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
+      <parameter type-id='type-id-105' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='110' column='1'/>
+      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='110' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
+      <parameter type-id='type-id-105' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' filepath='../../module/zcommon/zfeature_common.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mod_supported'>
+      <parameter type-id='type-id-105' name='scope' filepath='../../module/zcommon/zfeature_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfeature_common.c' line='185' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-105' size-in-bits='2624' id='type-id-286'>
+      <subrange length='41' type-id='type-id-3' id='type-id-287'/>
+
+    </array-type-def>
+    <typedef-decl name='zpool_load_policy_t' type-id='type-id-288' filepath='../../include/sys/fs/zfs.h' line='595' column='1' id='type-id-289'/>
+    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='590' column='1' id='type-id-288'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zlp_rewind' type-id='type-id-76' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zlp_maxmeta' type-id='type-id-53' visibility='default' filepath='../../include/sys/fs/zfs.h' line='592' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zlp_maxdata' type-id='type-id-53' visibility='default' filepath='../../include/sys/fs/zfs.h' line='593' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zlp_txg' type-id='type-id-53' visibility='default' filepath='../../include/sys/fs/zfs.h' line='594' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-289' size-in-bits='64' id='type-id-290'/>
+    <var-decl name='zfs_history_event_names' type-id='type-id-286' mangled-name='zfs_history_event_names' visibility='default' filepath='../../include/zfs_comutil.h' line='46' column='1' elf-symbol-id='zfs_history_event_names'/>
+    <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
+      <parameter type-id='type-id-22' name='zpl_version' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_zpl_version_map' mangled-name='zfs_zpl_version_map' filepath='../../module/zcommon/zfs_comutil.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_zpl_version_map'>
+      <parameter type-id='type-id-22' name='spa_version' filepath='../../module/zcommon/zfs_comutil.c' line='159' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
+      <parameter type-id='type-id-48' name='nvl' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
+      <parameter type-id='type-id-290' name='zlpp' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
+      <parameter type-id='type-id-48' name='nv' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1'/>
+      <parameter type-id='type-id-49' name='type' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_allocatable_devs' mangled-name='zfs_allocatable_devs' filepath='../../module/zcommon/zfs_comutil.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_allocatable_devs'>
+      <parameter type-id='type-id-48' name='nv' filepath='../../module/zcommon/zfs_comutil.c' line='46' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-291' size-in-bits='4096' id='type-id-292'>
+      <subrange length='32' type-id='type-id-3' id='type-id-253'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-291' size-in-bits='infinite' id='type-id-293'>
+      <subrange length='infinite' id='type-id-294'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-295' filepath='../../include/zfs_deleg.h' line='86' column='1' id='type-id-291'/>
+    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_deleg.h' line='83' column='1' id='type-id-295'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_perm' type-id='type-id-49' visibility='default' filepath='../../include/zfs_deleg.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_note' type-id='type-id-296' visibility='default' filepath='../../include/zfs_deleg.h' line='85' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-297' filepath='../../include/zfs_deleg.h' line='81' column='1' id='type-id-296'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_deleg.h' line='48' column='1' id='type-id-297'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFS_DELEG_NOTE_CREATE' value='0'/>
+      <enumerator name='ZFS_DELEG_NOTE_DESTROY' value='1'/>
+      <enumerator name='ZFS_DELEG_NOTE_SNAPSHOT' value='2'/>
+      <enumerator name='ZFS_DELEG_NOTE_ROLLBACK' value='3'/>
+      <enumerator name='ZFS_DELEG_NOTE_CLONE' value='4'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROMOTE' value='5'/>
+      <enumerator name='ZFS_DELEG_NOTE_RENAME' value='6'/>
+      <enumerator name='ZFS_DELEG_NOTE_SEND' value='7'/>
+      <enumerator name='ZFS_DELEG_NOTE_RECEIVE' value='8'/>
+      <enumerator name='ZFS_DELEG_NOTE_ALLOW' value='9'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERPROP' value='10'/>
+      <enumerator name='ZFS_DELEG_NOTE_MOUNT' value='11'/>
+      <enumerator name='ZFS_DELEG_NOTE_SHARE' value='12'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERQUOTA' value='13'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPQUOTA' value='14'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERUSED' value='15'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPUSED' value='16'/>
+      <enumerator name='ZFS_DELEG_NOTE_USEROBJQUOTA' value='17'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJQUOTA' value='18'/>
+      <enumerator name='ZFS_DELEG_NOTE_USEROBJUSED' value='19'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJUSED' value='20'/>
+      <enumerator name='ZFS_DELEG_NOTE_HOLD' value='21'/>
+      <enumerator name='ZFS_DELEG_NOTE_RELEASE' value='22'/>
+      <enumerator name='ZFS_DELEG_NOTE_DIFF' value='23'/>
+      <enumerator name='ZFS_DELEG_NOTE_BOOKMARK' value='24'/>
+      <enumerator name='ZFS_DELEG_NOTE_LOAD_KEY' value='25'/>
+      <enumerator name='ZFS_DELEG_NOTE_CHANGE_KEY' value='26'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTUSED' value='27'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTQUOTA' value='28'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJUSED' value='29'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
+      <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
+    </enum-decl>
+    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-298' filepath='../../include/sys/fs/zfs.h' line='351' column='1' id='type-id-299'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='339' column='1' id='type-id-298'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
+      <enumerator name='ZFS_DELEG_USER' value='117'/>
+      <enumerator name='ZFS_DELEG_USER_SETS' value='85'/>
+      <enumerator name='ZFS_DELEG_GROUP' value='103'/>
+      <enumerator name='ZFS_DELEG_GROUP_SETS' value='71'/>
+      <enumerator name='ZFS_DELEG_EVERYONE' value='101'/>
+      <enumerator name='ZFS_DELEG_EVERYONE_SETS' value='69'/>
+      <enumerator name='ZFS_DELEG_CREATE' value='99'/>
+      <enumerator name='ZFS_DELEG_CREATE_SETS' value='67'/>
+      <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
+      <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
+    </enum-decl>
+    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-293' mangled-name='zfs_deleg_perm_tab' visibility='default' filepath='../../include/zfs_deleg.h' line='88' column='1' elf-symbol-id='zfs_deleg_perm_tab'/>
+    <function-decl name='zfs_deleg_whokey' mangled-name='zfs_deleg_whokey' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_whokey'>
+      <parameter type-id='type-id-49' name='attr' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
+      <parameter type-id='type-id-299' name='type' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
+      <parameter type-id='type-id-5' name='inheritchr' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
+      <parameter type-id='type-id-48' name='nvp' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
+      <parameter type-id='type-id-105' name='perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='256' id='type-id-300'>
+      <subrange length='4' type-id='type-id-3' id='type-id-301'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-302' size-in-bits='2048' id='type-id-303'>
+      <subrange length='4' type-id='type-id-3' id='type-id-301'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-304' size-in-bits='1024' id='type-id-305'>
+      <subrange length='4' type-id='type-id-3' id='type-id-301'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-306' size-in-bits='512' id='type-id-307'>
+      <subrange length='4' type-id='type-id-3' id='type-id-301'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-308' size-in-bits='1024' id='type-id-309'>
+      <subrange length='4' type-id='type-id-3' id='type-id-301'/>
+
+    </array-type-def>
+    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-310' filepath='../../include/sys/zio_checksum.h' line='81' column='1' id='type-id-311'/>
+    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='77' column='1' id='type-id-312'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acf_init' type-id='type-id-313' visibility='default' filepath='../../include/sys/zio_checksum.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='acf_fini' type-id='type-id-314' visibility='default' filepath='../../include/sys/zio_checksum.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='acf_iter' type-id='type-id-315' visibility='default' filepath='../../include/sys/zio_checksum.h' line='80' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-316' filepath='../../include/sys/zio_checksum.h' line='73' column='1' id='type-id-317'/>
+    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-318' filepath='../../include/sys/zio_checksum.h' line='71' column='1' id='type-id-319'/>
+    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='66' column='1' id='type-id-318'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acd_byteorder' type-id='type-id-320' visibility='default' filepath='../../include/sys/zio_checksum.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='acd_ctx' type-id='type-id-321' visibility='default' filepath='../../include/sys/zio_checksum.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='acd_zcp' type-id='type-id-322' visibility='default' filepath='../../include/sys/zio_checksum.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='acd_private' type-id='type-id-66' visibility='default' filepath='../../include/sys/zio_checksum.h' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zio_byteorder_t' type-id='type-id-323' filepath='../../include/sys/zio_checksum.h' line='64' column='1' id='type-id-320'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zio_checksum.h' line='61' column='1' id='type-id-323'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
+      <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
+    </enum-decl>
+    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-324' filepath='../../include/zfs_fletcher.h' line='106' column='1' id='type-id-325'/>
+    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' filepath='../../include/zfs_fletcher.h' line='90' column='1' id='type-id-324'>
+      <data-member access='private'>
+        <var-decl name='scalar' type-id='type-id-326' visibility='default' filepath='../../include/zfs_fletcher.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='superscalar' type-id='type-id-309' visibility='default' filepath='../../include/zfs_fletcher.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sse' type-id='type-id-307' visibility='default' filepath='../../include/zfs_fletcher.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='avx' type-id='type-id-305' visibility='default' filepath='../../include/zfs_fletcher.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='avx512' type-id='type-id-303' visibility='default' filepath='../../include/zfs_fletcher.h' line='101' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-327' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-326'/>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-327'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_word' type-id='type-id-300' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-328' filepath='../../include/zfs_fletcher.h' line='71' column='1' id='type-id-308'/>
+    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='69' column='1' id='type-id-328'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-300' visibility='default' filepath='../../include/zfs_fletcher.h' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-329' filepath='../../include/zfs_fletcher.h' line='75' column='1' id='type-id-306'/>
+    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='73' column='1' id='type-id-329'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-125' visibility='default' filepath='../../include/zfs_fletcher.h' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-330' filepath='../../include/zfs_fletcher.h' line='79' column='1' id='type-id-304'/>
+    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='77' column='1' id='type-id-330'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-300' visibility='default' filepath='../../include/zfs_fletcher.h' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-331' filepath='../../include/zfs_fletcher.h' line='83' column='1' id='type-id-302'/>
+    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='81' column='1' id='type-id-331'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-258' visibility='default' filepath='../../include/zfs_fletcher.h' line='82' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-316' filepath='../../include/sys/zio_checksum.h' line='74' column='1' id='type-id-332'/>
+    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-333' filepath='../../include/sys/zio_checksum.h' line='75' column='1' id='type-id-334'/>
+    <qualified-type-def type-id='type-id-312' const='yes' id='type-id-310'/>
+    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-321'/>
+    <pointer-type-def type-id='type-id-319' size-in-bits='64' id='type-id-335'/>
+    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-314'/>
+    <pointer-type-def type-id='type-id-317' size-in-bits='64' id='type-id-313'/>
+    <pointer-type-def type-id='type-id-334' size-in-bits='64' id='type-id-315'/>
+    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-322'/>
+    <var-decl name='fletcher_4_abd_ops' type-id='type-id-311' mangled-name='fletcher_4_abd_ops' visibility='default' filepath='../../include/sys/zio_checksum.h' line='125' column='1' elf-symbol-id='fletcher_4_abd_ops'/>
+    <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' filepath='../../module/zcommon/zfs_fletcher.c' line='798' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' filepath='../../module/zcommon/zfs_fletcher.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-67' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_native'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-67' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <parameter type-id='type-id-53' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
+      <parameter type-id='type-id-105' name='val' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-53' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-66' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-67' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='fletcher_2_native' mangled-name='fletcher_2_native' filepath='../../module/zcommon/zfs_fletcher.c' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_native'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='263' column='1'/>
+      <parameter type-id='type-id-53' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='263' column='1'/>
+      <parameter type-id='type-id-66' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='264' column='1'/>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='264' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1'/>
+      <parameter type-id='type-id-67' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1'/>
+      <parameter type-id='type-id-66' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='fletcher_init' mangled-name='fletcher_init' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_4_native' mangled-name='fletcher_4_native' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
+      <parameter type-id='type-id-53' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
+      <parameter type-id='type-id-66' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='fletcher_4_byteswap' mangled-name='fletcher_4_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_byteswap'>
+      <parameter type-id='type-id-66' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
+      <parameter type-id='type-id-53' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
+      <parameter type-id='type-id-66' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <parameter type-id='type-id-322' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-333'>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-316'>
+      <parameter type-id='type-id-335'/>
+      <return type-id='type-id-31'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-336' filepath='../../include/zfs_fletcher.h' line='125' column='1' id='type-id-337'/>
+    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='116' column='1' id='type-id-336'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='init_native' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fini_native' type-id='type-id-339' visibility='default' filepath='../../include/zfs_fletcher.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='compute_native' type-id='type-id-340' visibility='default' filepath='../../include/zfs_fletcher.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='init_byteswap' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fini_byteswap' type-id='type-id-339' visibility='default' filepath='../../include/zfs_fletcher.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='compute_byteswap' type-id='type-id-340' visibility='default' filepath='../../include/zfs_fletcher.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='valid' type-id='type-id-341' visibility='default' filepath='../../include/zfs_fletcher.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='name' type-id='type-id-105' visibility='default' filepath='../../include/zfs_fletcher.h' line='124' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='fletcher_4_init_f' type-id='type-id-342' filepath='../../include/zfs_fletcher.h' line='111' column='1' id='type-id-338'/>
+    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-343' filepath='../../include/zfs_fletcher.h' line='112' column='1' id='type-id-339'/>
+    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-344' filepath='../../include/zfs_fletcher.h' line='113' column='1' id='type-id-340'/>
+    <qualified-type-def type-id='type-id-337' const='yes' id='type-id-345'/>
+    <pointer-type-def type-id='type-id-346' size-in-bits='64' id='type-id-341'/>
+    <pointer-type-def type-id='type-id-347' size-in-bits='64' id='type-id-342'/>
+    <pointer-type-def type-id='type-id-348' size-in-bits='64' id='type-id-344'/>
+    <pointer-type-def type-id='type-id-349' size-in-bits='64' id='type-id-343'/>
+    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-345' mangled-name='fletcher_4_avx512f_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='143' column='1' elf-symbol-id='fletcher_4_avx512f_ops'/>
+    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-345' mangled-name='fletcher_4_avx512bw_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='147' column='1' elf-symbol-id='fletcher_4_avx512bw_ops'/>
+    <function-type size-in-bits='64' id='type-id-346'>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-347'>
+      <parameter type-id='type-id-321'/>
+      <return type-id='type-id-31'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-348'>
+      <parameter type-id='type-id-321'/>
+      <parameter type-id='type-id-66'/>
+      <parameter type-id='type-id-53'/>
+      <return type-id='type-id-31'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-349'>
+      <parameter type-id='type-id-321'/>
+      <parameter type-id='type-id-322'/>
+      <return type-id='type-id-31'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-345' mangled-name='fletcher_4_avx2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='139' column='1' elf-symbol-id='fletcher_4_avx2_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-345' mangled-name='fletcher_4_sse2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='131' column='1' elf-symbol-id='fletcher_4_sse2_ops'/>
+    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-345' mangled-name='fletcher_4_ssse3_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='135' column='1' elf-symbol-id='fletcher_4_ssse3_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-345' mangled-name='fletcher_4_superscalar_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='127' column='1' elf-symbol-id='fletcher_4_superscalar_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-345' mangled-name='fletcher_4_superscalar4_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='128' column='1' elf-symbol-id='fletcher_4_superscalar4_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <typedef-decl name='namecheck_err_t' type-id='type-id-350' filepath='../../include/zfs_namecheck.h' line='50' column='1' id='type-id-351'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_namecheck.h' line='36' column='1' id='type-id-350'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
+      <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
+      <enumerator name='NAME_ERR_TRAILING_SLASH' value='2'/>
+      <enumerator name='NAME_ERR_INVALCHAR' value='3'/>
+      <enumerator name='NAME_ERR_MULTIPLE_DELIMITERS' value='4'/>
+      <enumerator name='NAME_ERR_NOLETTER' value='5'/>
+      <enumerator name='NAME_ERR_RESERVED' value='6'/>
+      <enumerator name='NAME_ERR_DISKLIKE' value='7'/>
+      <enumerator name='NAME_ERR_TOOLONG' value='8'/>
+      <enumerator name='NAME_ERR_SELF_REF' value='9'/>
+      <enumerator name='NAME_ERR_PARENT_REF' value='10'/>
+      <enumerator name='NAME_ERR_NO_AT' value='11'/>
+      <enumerator name='NAME_ERR_NO_POUND' value='12'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-351' size-in-bits='64' id='type-id-352'/>
+    <var-decl name='zfs_max_dataset_nesting' type-id='type-id-22' mangled-name='zfs_max_dataset_nesting' visibility='default' filepath='../../include/zfs_namecheck.h' line='54' column='1' elf-symbol-id='zfs_max_dataset_nesting'/>
+    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
+      <parameter type-id='type-id-105' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='dataset_namecheck' mangled-name='dataset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
+      <parameter type-id='type-id-105' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-352' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-49' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-105' size-in-bits='768' id='type-id-353'>
+      <subrange length='12' type-id='type-id-3' id='type-id-354'/>
+
+    </array-type-def>
+    <typedef-decl name='zprop_type_t' type-id='type-id-355' filepath='../../include/zfs_prop.h' line='44' column='1' id='type-id-356'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='40' column='1' id='type-id-355'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='PROP_TYPE_NUMBER' value='0'/>
+      <enumerator name='PROP_TYPE_STRING' value='1'/>
+      <enumerator name='PROP_TYPE_INDEX' value='2'/>
+    </enum-decl>
+    <typedef-decl name='zprop_desc_t' type-id='type-id-357' filepath='../../include/zfs_prop.h' line='85' column='1' id='type-id-358'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-358' visibility='default' filepath='../../include/zfs_prop.h' line='67' column='1' id='type-id-357'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pd_name' type-id='type-id-105' visibility='default' filepath='../../include/zfs_prop.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pd_propnum' type-id='type-id-22' visibility='default' filepath='../../include/zfs_prop.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pd_proptype' type-id='type-id-356' visibility='default' filepath='../../include/zfs_prop.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pd_strdefault' type-id='type-id-105' visibility='default' filepath='../../include/zfs_prop.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pd_numdefault' type-id='type-id-53' visibility='default' filepath='../../include/zfs_prop.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pd_attr' type-id='type-id-359' visibility='default' filepath='../../include/zfs_prop.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pd_types' type-id='type-id-22' visibility='default' filepath='../../include/zfs_prop.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pd_values' type-id='type-id-105' visibility='default' filepath='../../include/zfs_prop.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pd_colname' type-id='type-id-105' visibility='default' filepath='../../include/zfs_prop.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='pd_rightalign' type-id='type-id-37' visibility='default' filepath='../../include/zfs_prop.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='pd_visible' type-id='type-id-37' visibility='default' filepath='../../include/zfs_prop.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pd_zfs_mod_supported' type-id='type-id-37' visibility='default' filepath='../../include/zfs_prop.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='pd_table' type-id='type-id-360' visibility='default' filepath='../../include/zfs_prop.h' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pd_table_size' type-id='type-id-67' visibility='default' filepath='../../include/zfs_prop.h' line='84' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zprop_attr_t' type-id='type-id-361' filepath='../../include/zfs_prop.h' line='60' column='1' id='type-id-359'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='46' column='1' id='type-id-361'>
+      <underlying-type type-id='type-id-27'/>
+      <enumerator name='PROP_DEFAULT' value='0'/>
+      <enumerator name='PROP_READONLY' value='1'/>
+      <enumerator name='PROP_INHERIT' value='2'/>
+      <enumerator name='PROP_ONETIME' value='3'/>
+      <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
+    </enum-decl>
+    <typedef-decl name='zprop_index_t' type-id='type-id-362' filepath='../../include/zfs_prop.h' line='65' column='1' id='type-id-363'/>
+    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_prop.h' line='62' column='1' id='type-id-362'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pi_name' type-id='type-id-105' visibility='default' filepath='../../include/zfs_prop.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pi_value' type-id='type-id-53' visibility='default' filepath='../../include/zfs_prop.h' line='64' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-364'/>
+    <qualified-type-def type-id='type-id-363' const='yes' id='type-id-365'/>
+    <pointer-type-def type-id='type-id-365' size-in-bits='64' id='type-id-360'/>
+    <pointer-type-def type-id='type-id-358' size-in-bits='64' id='type-id-366'/>
+    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-353' mangled-name='zfs_userquota_prop_prefixes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='208' column='1' elf-symbol-id='zfs_userquota_prop_prefixes'/>
+    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' filepath='../../module/zcommon/zfs_prop.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='952' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
+      <parameter type-id='type-id-105' name='str' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
+      <parameter type-id='type-id-37' name='encrypted' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' filepath='../../module/zcommon/zfs_prop.c' line='915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_encryption_key_param'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='915' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' filepath='../../module/zcommon/zfs_prop.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inheritable'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='904' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../module/zcommon/zfs_prop.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='895' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' filepath='../../module/zcommon/zfs_prop.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='872' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_visible' mangled-name='zfs_prop_visible' filepath='../../module/zcommon/zfs_prop.c' line='862' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_visible'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='862' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' filepath='../../module/zcommon/zfs_prop.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_readonly'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='851' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1'/>
+      <return type-id='type-id-356'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1'/>
+      <parameter type-id='type-id-46' name='types' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1'/>
+      <parameter type-id='type-id-37' name='headcheck' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
+      <parameter type-id='type-id-53' name='seed' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <parameter type-id='type-id-53' name='index' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <parameter type-id='type-id-364' name='string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-105' name='string' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-159' name='index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
+      <parameter type-id='type-id-105' name='propname' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
+      <parameter type-id='type-id-34' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' filepath='../../module/zcommon/zfs_prop.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../module/zcommon/zfs_prop.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
+      <return type-id='type-id-366'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' filepath='../../module/zcommon/zpool_prop.c' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='253' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' filepath='../../module/zcommon/zpool_prop.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='247' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' filepath='../../module/zcommon/zpool_prop.c' line='241' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='241' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' filepath='../../module/zcommon/zpool_prop.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='232' column='1'/>
+      <parameter type-id='type-id-53' name='seed' filepath='../../module/zcommon/zpool_prop.c' line='232' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' filepath='../../module/zcommon/zpool_prop.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='225' column='1'/>
+      <parameter type-id='type-id-53' name='index' filepath='../../module/zcommon/zpool_prop.c' line='225' column='1'/>
+      <parameter type-id='type-id-364' name='string' filepath='../../module/zcommon/zpool_prop.c' line='226' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' filepath='../../module/zcommon/zpool_prop.c' line='218' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='218' column='1'/>
+      <parameter type-id='type-id-105' name='string' filepath='../../module/zcommon/zpool_prop.c' line='218' column='1'/>
+      <parameter type-id='type-id-159' name='index' filepath='../../module/zcommon/zpool_prop.c' line='219' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' filepath='../../module/zcommon/zpool_prop.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zpool_prop.c' line='211' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' filepath='../../module/zcommon/zpool_prop.c' line='201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zpool_prop.c' line='201' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../module/zcommon/zpool_prop.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='192' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../module/zcommon/zpool_prop.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='186' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' filepath='../../module/zcommon/zpool_prop.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='180' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' filepath='../../module/zcommon/zpool_prop.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='174' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' filepath='../../module/zcommon/zpool_prop.c' line='168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='168' column='1'/>
+      <return type-id='type-id-356'/>
+    </function-decl>
+    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' filepath='../../module/zcommon/zpool_prop.c' line='162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
+      <parameter type-id='type-id-206' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='162' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' filepath='../../module/zcommon/zpool_prop.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
+      <parameter type-id='type-id-105' name='propname' filepath='../../module/zcommon/zpool_prop.c' line='152' column='1'/>
+      <return type-id='type-id-206'/>
+    </function-decl>
+    <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' filepath='../../module/zcommon/zpool_prop.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' filepath='../../module/zcommon/zpool_prop.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
+      <return type-id='type-id-366'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/fedora/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zprop_width' mangled-name='zprop_width' filepath='../../module/zcommon/zprop_common.c' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
+      <parameter type-id='type-id-114' name='fixed' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
+      <return type-id='type-id-67'/>
+    </function-decl>
+    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' filepath='../../module/zcommon/zprop_common.c' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='380' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='380' column='1'/>
+      <parameter type-id='type-id-37' name='headcheck' filepath='../../module/zcommon/zprop_common.c' line='380' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zprop_values' mangled-name='zprop_values' filepath='../../module/zcommon/zprop_common.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
+      <return type-id='type-id-105'/>
+    </function-decl>
+    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' filepath='../../module/zcommon/zprop_common.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
+      <parameter type-id='type-id-53' name='seed' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-53' name='index' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-364' name='string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='316' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-105' name='string' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-159' name='index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='290' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' filepath='../../module/zcommon/zprop_common.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
+      <parameter type-id='type-id-105' name='propname' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' filepath='../../module/zcommon/zprop_common.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
+      <parameter type-id='type-id-233' name='func' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-66' name='cb' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-37' name='show_all' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-37' name='ordered' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
+      <parameter type-id='type-id-46' name='type' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' filepath='../../module/zcommon/zprop_common.c' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-356' name='type' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <parameter type-id='type-id-22' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <parameter type-id='type-id-105' name='colname' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' filepath='../../module/zcommon/zprop_common.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-53' name='def' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-22' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-105' name='values' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-105' name='colname' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' filepath='../../module/zcommon/zprop_common.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-53' name='def' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-22' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-105' name='values' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-105' name='colname' filepath='../../module/zcommon/zprop_common.c' line='134' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' filepath='../../module/zcommon/zprop_common.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-105' name='def' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-22' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-105' name='values' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-105' name='colname' filepath='../../module/zcommon/zprop_common.c' line='124' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' filepath='../../module/zcommon/zprop_common.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
+      <parameter type-id='type-id-22' name='prop' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-105' name='name' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-356' name='type' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-53' name='numdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-105' name='strdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-22' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-105' name='values' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-105' name='colname' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-37' name='rightalign' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
+      <parameter type-id='type-id-37' name='visible' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
+      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/fedora/zfs/lib/libshare' language='LANG_C99'>
+    <typedef-decl name='sa_fstype_t' type-id='type-id-367' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='59' column='1' id='type-id-368'/>
+    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='53' column='1' id='type-id-367'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-369' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='name' type-id='type-id-105' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ops' type-id='type-id-370' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fsinfo_index' type-id='type-id-22' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='58' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='sa_share_ops_t' type-id='type-id-371' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='51' column='1' id='type-id-372'/>
+    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='42' column='1' id='type-id-371'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='enable_share' type-id='type-id-373' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='disable_share' type-id='type-id-373' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='is_shared' type-id='type-id-374' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='validate_shareopts' type-id='type-id-375' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='update_shareopts' type-id='type-id-376' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='47' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='clear_shareopts' type-id='type-id-377' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='49' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='commit_shares' type-id='type-id-378' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='50' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='sa_share_impl_t' type-id='type-id-379' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='37' column='1' id='type-id-380'/>
+    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='32' column='1' id='type-id-381'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='sa_mountpoint' type-id='type-id-49' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='33' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='sa_zfsname' type-id='type-id-49' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='sa_fsinfo' type-id='type-id-382' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-383' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='30' column='1' id='type-id-384'/>
+    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='28' column='1' id='type-id-383'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='shareopts' type-id='type-id-49' visibility='default' filepath='/home/fedora/zfs/lib/libshare/libshare_impl.h' line='29' column='1'/>
+      </data-member>
+    </class-decl>
+    <qualified-type-def type-id='type-id-372' const='yes' id='type-id-385'/>
+    <pointer-type-def type-id='type-id-385' size-in-bits='64' id='type-id-370'/>
+    <pointer-type-def type-id='type-id-386' size-in-bits='64' id='type-id-378'/>
+    <pointer-type-def type-id='type-id-387' size-in-bits='64' id='type-id-375'/>
+    <pointer-type-def type-id='type-id-388' size-in-bits='64' id='type-id-373'/>
+    <pointer-type-def type-id='type-id-389' size-in-bits='64' id='type-id-376'/>
+    <pointer-type-def type-id='type-id-367' size-in-bits='64' id='type-id-369'/>
+    <pointer-type-def type-id='type-id-368' size-in-bits='64' id='type-id-390'/>
+    <pointer-type-def type-id='type-id-384' size-in-bits='64' id='type-id-382'/>
+    <pointer-type-def type-id='type-id-381' size-in-bits='64' id='type-id-379'/>
+    <pointer-type-def type-id='type-id-391' size-in-bits='64' id='type-id-374'/>
+    <pointer-type-def type-id='type-id-392' size-in-bits='64' id='type-id-377'/>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
+      <parameter type-id='type-id-49' name='options' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+      <parameter type-id='type-id-49' name='proto' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
+      <parameter type-id='type-id-22' name='err' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='182' column='1'/>
+      <return type-id='type-id-49'/>
+    </function-decl>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
+      <parameter type-id='type-id-105' name='protocol' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='166' column='1'/>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+      <parameter type-id='type-id-49' name='protocol' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+      <parameter type-id='type-id-49' name='protocol' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
+      <parameter type-id='type-id-105' name='zfsname' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-105' name='mountpoint' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-105' name='shareopts' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+      <parameter type-id='type-id-49' name='protocol' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='register_fstype' mangled-name='register_fstype' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='register_fstype'>
+      <parameter type-id='type-id-105' name='name' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <parameter type-id='type-id-370' name='ops' filepath='/home/fedora/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <return type-id='type-id-390'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-386'>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-387'>
+      <parameter type-id='type-id-105'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-388'>
+      <parameter type-id='type-id-380'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-389'>
+      <parameter type-id='type-id-380'/>
+      <parameter type-id='type-id-105'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-391'>
+      <parameter type-id='type-id-380'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-392'>
+      <parameter type-id='type-id-380'/>
+      <return type-id='type-id-31'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/fedora/zfs/lib/libshare' language='LANG_C99'>
+    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' filepath='os/linux/nfs.c' line='721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libshare_nfs_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+    <function-decl name='__builtin_stpcpy' mangled-name='stpcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/fedora/zfs/lib/libshare' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='2040' id='type-id-393'>
+      <subrange length='255' type-id='type-id-3' id='type-id-394'/>
+
+    </array-type-def>
+    <typedef-decl name='smb_share_t' type-id='type-id-395' filepath='./smb.h' line='45' column='1' id='type-id-396'/>
+    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' filepath='./smb.h' line='38' column='1' id='type-id-395'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name' type-id='type-id-393' visibility='default' filepath='./smb.h' line='39' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2040'>
+        <var-decl name='path' type-id='type-id-121' visibility='default' filepath='./smb.h' line='40' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='34808'>
+        <var-decl name='comment' type-id='type-id-393' visibility='default' filepath='./smb.h' line='41' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='36864'>
+        <var-decl name='guest_ok' type-id='type-id-37' visibility='default' filepath='./smb.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='36928'>
+        <var-decl name='next' type-id='type-id-397' visibility='default' filepath='./smb.h' line='44' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-395' size-in-bits='64' id='type-id-397'/>
+    <pointer-type-def type-id='type-id-396' size-in-bits='64' id='type-id-398'/>
+    <var-decl name='smb_shares' type-id='type-id-398' mangled-name='smb_shares' visibility='default' filepath='./smb.h' line='47' column='1' elf-symbol-id='smb_shares'/>
+    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' filepath='os/linux/smb.c' line='450' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libshare_smb_init'>
+      <return type-id='type-id-31'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/lib/libzfs/libzfs.suppr
+++ b/lib/libzfs/libzfs.suppr
@@ -1,0 +1,13 @@
+[suppress_type]
+	name = FILE*
+
+[suppress_type]
+	type_kind = typedef
+	name = SHA256_CTX
+
+[suppress_type]
+	type_kind = typedef
+	name = SHA2_CTX
+
+[suppress_variable]
+	name = zfs_deleg_perm_tab

--- a/lib/libzfs_core/Makefile.am
+++ b/lib/libzfs_core/Makefile.am
@@ -1,8 +1,11 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 pkgconfig_DATA = libzfs_core.pc
 
 lib_LTLIBRARIES = libzfs_core.la
+
+include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	libzfs_core.c

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1,0 +1,2820 @@
+<abi-corpus path='libzfs_core.so' architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
+  <elf-needed>
+    <dependency name='libuuid.so.1'/>
+    <dependency name='libz.so.1'/>
+    <dependency name='libm.so.6'/>
+    <dependency name='libblkid.so.1'/>
+    <dependency name='libudev.so.1'/>
+    <dependency name='libnvpair.so.3'/>
+    <dependency name='libtirpc.so.3'/>
+    <dependency name='libpthread.so.0'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-x86-64.so.2'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_int' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_ptr,atomic_add_long' is-defined='yes'/>
+    <elf-symbol name='atomic_add_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_char_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_8' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64_nv,atomic_add_ptr_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_16' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ushort_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_32' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ptr,atomic_cas_64' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_clear_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uchar_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_64' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_or_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_or_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_set_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_int_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_char' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_32' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_64,atomic_sub_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_64_nv,atomic_sub_ptr_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_32' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_64,atomic_swap_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_destroy_nodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_find' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_first' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_insert_here' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_is_empty' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_last' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_nearest' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_numnodes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_swap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update_gt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_update_lt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='avl_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_alloc_and_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_alloc_and_read' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_auto_sense' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_err_check' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_rescan' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_use_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_write' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_system_hostid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getexecname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getextmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getmntany' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='getzoneid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='is_mpath_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='label_paths' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assertf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_core_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_core_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_after' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_before' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_insert_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_is_empty' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_active' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_link_replace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_move_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_next' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_prev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_remove_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='list_tail' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_bookmark' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_change_key' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_channel_program' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_channel_program_nosync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_clone' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_destroy_bookmarks' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_destroy_snaps' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_exists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_get_bookmark_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_get_bookmarks' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_get_bootenv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_get_holds' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_hold' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_initialize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_load_key' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_pool_checkpoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_pool_checkpoint_discard' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_promote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_receive' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_receive_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_receive_resumable' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_receive_with_cmdprops' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_receive_with_header' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_redact' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_release' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_reopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_rollback' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_rollback_to' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send_redacted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send_resume_redacted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_send_space_resume_redacted' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_set_bootenv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_snaprange_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_snapshot' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_sync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_trim' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_unload_key' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_wait_fs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_wait_tag' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_consumer' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_enter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_exit' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='membar_producer' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='mkdirp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='print_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='slice_cache_compare' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='spl_pagesize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='strlcat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='strlcpy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_abandon' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_dispatch' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_member' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_suspend' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_suspended' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='tpool_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='update_vdev_config_dev_strs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_append_partition' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dev_flush' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dev_is_dm' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dev_is_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_device_get_devid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_device_get_physical' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_enclosure_sysfs_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_underlying_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_ioctl_fd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_isnumber' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_nicebytes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_nicenum' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_nicenum_format' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_niceraw' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_nicetime' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_resolve_shortname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_strcmp_pathname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_strip_partition' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_strip_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_default_search_paths' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_dump_ddt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_find_config' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_find_import_blkid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_history_unpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_label_disk_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_open_func' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_read_label' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_search_import' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zutil_alloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zutil_strdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='buf' size='4110' type='tls-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='default_vtoc_map' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_debug' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='pagesize' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' comp-dir-path='/home/fedora/zfs/lib/libzfs_core' language='LANG_C99'>
+
+
+
+
+
+
+
+
+
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='2048' id='type-id-2'>
+      <subrange length='256' type-id='type-id-3' id='type-id-4'/>
+
+    </array-type-def>
+    <type-decl name='int' size-in-bits='32' id='type-id-5'/>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='2176' id='type-id-7'>
+      <subrange length='34' type-id='type-id-3' id='type-id-8'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='256' id='type-id-9'>
+      <subrange length='4' type-id='type-id-3' id='type-id-10'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='96' id='type-id-12'>
+      <subrange length='12' type-id='type-id-3' id='type-id-13'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='128' id='type-id-14'>
+      <subrange length='16' type-id='type-id-3' id='type-id-15'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='24' id='type-id-16'>
+      <subrange length='3' type-id='type-id-3' id='type-id-17'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='40' id='type-id-18'>
+      <subrange length='5' type-id='type-id-3' id='type-id-19'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='48' id='type-id-20'>
+      <subrange length='6' type-id='type-id-3' id='type-id-21'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='64' id='type-id-22'>
+      <subrange length='8' type-id='type-id-3' id='type-id-23'/>
+
+    </array-type-def>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-24'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-25'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-26'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='void' id='type-id-27'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-28' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-29'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='type-id-30' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='type-id-31' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='type-id-6' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='type-id-31' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-30' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='int32_t' type-id='type-id-32' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-30'/>
+    <typedef-decl name='__int32_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-32'/>
+    <typedef-decl name='uint32_t' type-id='type-id-33' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-31'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-33'/>
+    <typedef-decl name='uint64_t' type-id='type-id-34' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-6'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='45' column='1' id='type-id-34'/>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-35' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-36'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1424' column='1' id='type-id-35'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='type-id-37' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-38'/>
+    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-37'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-39' filepath='../../include/sys/fs/zfs.h' line='1422' column='1' id='type-id-40'/>
+    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1412' column='1' id='type-id-39'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-41' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-42'/>
+    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1162' column='1' id='type-id-41'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-43' filepath='../../include/sys/fs/zfs.h' line='1157' column='1' id='type-id-44'/>
+    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1152' column='1' id='type-id-43'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='uint8_t' type-id='type-id-45' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-11'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-25' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-45'/>
+    <typedef-decl name='uint_t' type-id='type-id-26' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-46'/>
+    <typedef-decl name='dmu_replay_record_t' type-id='type-id-47' filepath='../../include/sys/zfs_ioctl.h' line='385' column='1' id='type-id-48'/>
+    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='242' column='1' id='type-id-47'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_type' type-id='type-id-49' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='drr_payloadlen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='249' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_u' type-id='type-id-50' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='384' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__3' is-anonymous='yes' filepath='../../include/sys/zfs_ioctl.h' line='243' column='1' id='type-id-49'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='DRR_BEGIN' value='0'/>
+      <enumerator name='DRR_OBJECT' value='1'/>
+      <enumerator name='DRR_FREEOBJECTS' value='2'/>
+      <enumerator name='DRR_WRITE' value='3'/>
+      <enumerator name='DRR_FREE' value='4'/>
+      <enumerator name='DRR_END' value='5'/>
+      <enumerator name='DRR_WRITE_BYREF' value='6'/>
+      <enumerator name='DRR_SPILL' value='7'/>
+      <enumerator name='DRR_WRITE_EMBEDDED' value='8'/>
+      <enumerator name='DRR_OBJECT_RANGE' value='9'/>
+      <enumerator name='DRR_REDACT' value='10'/>
+      <enumerator name='DRR_NUMTYPES' value='11'/>
+    </enum-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='250' column='1' id='type-id-50'>
+      <data-member access='private'>
+        <var-decl name='drr_begin' type-id='type-id-51' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='251' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_end' type-id='type-id-52' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_object' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='275' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_freeobjects' type-id='type-id-54' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='280' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_write' type-id='type-id-55' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='301' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_free' type-id='type-id-56' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='307' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_write_byref' type-id='type-id-57' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='323' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_spill' type-id='type-id-58' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='338' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_write_embedded' type-id='type-id-59' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='351' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_object_range' type-id='type-id-60' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='361' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_redact' type-id='type-id-61' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='367' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='drr_checksum' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='383' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='type-id-63' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-64' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-63'/>
+    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-64'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='252' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_checksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='253' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='254' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-66' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-65'/>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_word' type-id='type-id-9' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='256' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='257' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='258' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='drr_bonustype' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_blksz' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='260' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='drr_bonuslen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='261' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='262' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='drr_compress' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='263' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='drr_dn_slots' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='264' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='216'>
+        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='265' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_raw_bonuslen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='266' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='267' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_indblkshift' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='269' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drr_nlevels' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='270' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='drr_nblkptr' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='271' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='drr_pad' type-id='type-id-18' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='272' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_maxblkid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='273' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_object_type_t' type-id='type-id-68' filepath='../../include/sys/dmu.h' line='272' column='1' id='type-id-67'/>
+    <enum-decl name='dmu_object_type' filepath='../../include/sys/dmu.h' line='168' column='1' id='type-id-68'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='DMU_OT_NONE' value='0'/>
+      <enumerator name='DMU_OT_OBJECT_DIRECTORY' value='1'/>
+      <enumerator name='DMU_OT_OBJECT_ARRAY' value='2'/>
+      <enumerator name='DMU_OT_PACKED_NVLIST' value='3'/>
+      <enumerator name='DMU_OT_PACKED_NVLIST_SIZE' value='4'/>
+      <enumerator name='DMU_OT_BPOBJ' value='5'/>
+      <enumerator name='DMU_OT_BPOBJ_HDR' value='6'/>
+      <enumerator name='DMU_OT_SPACE_MAP_HEADER' value='7'/>
+      <enumerator name='DMU_OT_SPACE_MAP' value='8'/>
+      <enumerator name='DMU_OT_INTENT_LOG' value='9'/>
+      <enumerator name='DMU_OT_DNODE' value='10'/>
+      <enumerator name='DMU_OT_OBJSET' value='11'/>
+      <enumerator name='DMU_OT_DSL_DIR' value='12'/>
+      <enumerator name='DMU_OT_DSL_DIR_CHILD_MAP' value='13'/>
+      <enumerator name='DMU_OT_DSL_DS_SNAP_MAP' value='14'/>
+      <enumerator name='DMU_OT_DSL_PROPS' value='15'/>
+      <enumerator name='DMU_OT_DSL_DATASET' value='16'/>
+      <enumerator name='DMU_OT_ZNODE' value='17'/>
+      <enumerator name='DMU_OT_OLDACL' value='18'/>
+      <enumerator name='DMU_OT_PLAIN_FILE_CONTENTS' value='19'/>
+      <enumerator name='DMU_OT_DIRECTORY_CONTENTS' value='20'/>
+      <enumerator name='DMU_OT_MASTER_NODE' value='21'/>
+      <enumerator name='DMU_OT_UNLINKED_SET' value='22'/>
+      <enumerator name='DMU_OT_ZVOL' value='23'/>
+      <enumerator name='DMU_OT_ZVOL_PROP' value='24'/>
+      <enumerator name='DMU_OT_PLAIN_OTHER' value='25'/>
+      <enumerator name='DMU_OT_UINT64_OTHER' value='26'/>
+      <enumerator name='DMU_OT_ZAP_OTHER' value='27'/>
+      <enumerator name='DMU_OT_ERROR_LOG' value='28'/>
+      <enumerator name='DMU_OT_SPA_HISTORY' value='29'/>
+      <enumerator name='DMU_OT_SPA_HISTORY_OFFSETS' value='30'/>
+      <enumerator name='DMU_OT_POOL_PROPS' value='31'/>
+      <enumerator name='DMU_OT_DSL_PERMS' value='32'/>
+      <enumerator name='DMU_OT_ACL' value='33'/>
+      <enumerator name='DMU_OT_SYSACL' value='34'/>
+      <enumerator name='DMU_OT_FUID' value='35'/>
+      <enumerator name='DMU_OT_FUID_SIZE' value='36'/>
+      <enumerator name='DMU_OT_NEXT_CLONES' value='37'/>
+      <enumerator name='DMU_OT_SCAN_QUEUE' value='38'/>
+      <enumerator name='DMU_OT_USERGROUP_USED' value='39'/>
+      <enumerator name='DMU_OT_USERGROUP_QUOTA' value='40'/>
+      <enumerator name='DMU_OT_USERREFS' value='41'/>
+      <enumerator name='DMU_OT_DDT_ZAP' value='42'/>
+      <enumerator name='DMU_OT_DDT_STATS' value='43'/>
+      <enumerator name='DMU_OT_SA' value='44'/>
+      <enumerator name='DMU_OT_SA_MASTER_NODE' value='45'/>
+      <enumerator name='DMU_OT_SA_ATTR_REGISTRATION' value='46'/>
+      <enumerator name='DMU_OT_SA_ATTR_LAYOUTS' value='47'/>
+      <enumerator name='DMU_OT_SCAN_XLATE' value='48'/>
+      <enumerator name='DMU_OT_DEDUP' value='49'/>
+      <enumerator name='DMU_OT_DEADLIST' value='50'/>
+      <enumerator name='DMU_OT_DEADLIST_HDR' value='51'/>
+      <enumerator name='DMU_OT_DSL_CLONES' value='52'/>
+      <enumerator name='DMU_OT_BPOBJ_SUBOBJ' value='53'/>
+      <enumerator name='DMU_OT_NUMTYPES' value='54'/>
+      <enumerator name='DMU_OTN_UINT8_DATA' value='128'/>
+      <enumerator name='DMU_OTN_UINT8_METADATA' value='192'/>
+      <enumerator name='DMU_OTN_UINT16_DATA' value='129'/>
+      <enumerator name='DMU_OTN_UINT16_METADATA' value='193'/>
+      <enumerator name='DMU_OTN_UINT32_DATA' value='130'/>
+      <enumerator name='DMU_OTN_UINT32_METADATA' value='194'/>
+      <enumerator name='DMU_OTN_UINT64_DATA' value='131'/>
+      <enumerator name='DMU_OTN_UINT64_METADATA' value='195'/>
+      <enumerator name='DMU_OTN_ZAP_DATA' value='132'/>
+      <enumerator name='DMU_OTN_ZAP_METADATA' value='196'/>
+      <enumerator name='DMU_OTN_UINT8_ENC_DATA' value='160'/>
+      <enumerator name='DMU_OTN_UINT8_ENC_METADATA' value='224'/>
+      <enumerator name='DMU_OTN_UINT16_ENC_DATA' value='161'/>
+      <enumerator name='DMU_OTN_UINT16_ENC_METADATA' value='225'/>
+      <enumerator name='DMU_OTN_UINT32_ENC_DATA' value='162'/>
+      <enumerator name='DMU_OTN_UINT32_ENC_METADATA' value='226'/>
+      <enumerator name='DMU_OTN_UINT64_ENC_DATA' value='163'/>
+      <enumerator name='DMU_OTN_UINT64_ENC_METADATA' value='227'/>
+      <enumerator name='DMU_OTN_ZAP_ENC_DATA' value='164'/>
+      <enumerator name='DMU_OTN_ZAP_ENC_METADATA' value='228'/>
+    </enum-decl>
+    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='276' column='1' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_firstobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='277' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_numobjs' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='278' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='279' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='281' column='1' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='282' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='283' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='drr_pad' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='284' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='285' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_logical_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='286' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='287' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='288' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='289' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='drr_compressiontype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='290' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='drr_pad2' type-id='type-id-18' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='291' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_key' type-id='type-id-69' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='293' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='drr_compressed_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='295' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='297' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='298' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='299' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ddt_key_t' type-id='type-id-70' filepath='../../include/sys/ddt.h' line='77' column='1' id='type-id-69'/>
+    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/ddt.h' line='67' column='1' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ddk_cksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/ddt.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ddk_prop' type-id='type-id-6' visibility='default' filepath='../../include/sys/ddt.h' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='302' column='1' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='303' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='304' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='305' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='306' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='308' column='1' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='310' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='311' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='312' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='313' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_refguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='315' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_refobject' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='316' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_refoffset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='317' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='319' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='456'>
+        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='320' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='464'>
+        <var-decl name='drr_pad2' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='321' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='drr_key' type-id='type-id-69' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='322' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='324' column='1' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='325' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='326' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='327' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='328' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='drr_compressiontype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='329' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='drr_pad' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='330' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_compressed_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='332' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='333' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='334' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='335' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='336' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='339' column='1' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='340' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='341' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='343' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='344' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_compression' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='345' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='drr_etype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='346' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='272'>
+        <var-decl name='drr_pad' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='347' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_lsize' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='348' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='drr_psize' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='349' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='352' column='1' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_firstobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='353' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_numslots' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='354' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='355' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='356' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='357' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='358' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='359' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='488'>
+        <var-decl name='drr_pad' type-id='type-id-16' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='360' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='362' column='1' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='363' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='364' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='365' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='366' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='376' column='1' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_pad' type-id='type-id-7' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='377' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='drr_checksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='382' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='lzc_send_flags' filepath='../../include/libzfs_core.h' line='77' column='1' id='type-id-71'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
+      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
+      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
+      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
+      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
+    </enum-decl>
+    <enum-decl name='lzc_dataset_type' filepath='../../include/libzfs_core.h' line='47' column='1' id='type-id-72'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
+      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
+    <qualified-type-def type-id='type-id-48' const='yes' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
+    <qualified-type-def type-id='type-id-29' const='yes' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1'/>
+      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
+      <parameter type-id='type-id-80' name='env' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
+      <parameter type-id='type-id-76' name='fs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <parameter type-id='type-id-36' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-40' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-6' name='tag' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1599' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_wait' mangled-name='lzc_wait' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <parameter type-id='type-id-40' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_redact' mangled-name='lzc_redact' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
+      <parameter type-id='type-id-76' name='snapshot' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <parameter type-id='type-id-76' name='bookname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <parameter type-id='type-id-81' name='snapnv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_trim' mangled-name='lzc_trim' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
+      <parameter type-id='type-id-76' name='poolname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-42' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-6' name='rate' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-38' name='secure' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <parameter type-id='type-id-81' name='vdevs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
+      <parameter type-id='type-id-76' name='poolname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
+      <parameter type-id='type-id-44' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
+      <parameter type-id='type-id-81' name='vdevs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
+      <parameter type-id='type-id-76' name='pool_name' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
+      <parameter type-id='type-id-38' name='scrub_restart' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-6' name='crypt_cmd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
+      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-38' name='noop' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1404' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1'/>
+      <parameter type-id='type-id-76' name='program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1'/>
+      <parameter type-id='type-id-6' name='timeout' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
+      <parameter type-id='type-id-6' name='memlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
+      <parameter type-id='type-id-81' name='argnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
+      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1360' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
+      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-76' name='program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-6' name='instrlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-6' name='memlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-81' name='argnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
+      <parameter type-id='type-id-81' name='bmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
+      <parameter type-id='type-id-76' name='bookmark' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
+      <parameter type-id='type-id-82' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
+      <parameter type-id='type-id-82' name='bmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
+      <parameter type-id='type-id-81' name='bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <parameter type-id='type-id-74' name='snapnamebuf' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <parameter type-id='type-id-5' name='snapnamelen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
+      <parameter type-id='type-id-81' name='cmdprops' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-5' name='input_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
+      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
+      <parameter type-id='type-id-83' name='read_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-83' name='errflags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-83' name='action_handle' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-82' name='errors' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1052' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-5' name='input_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-83' name='read_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-83' name='errflags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-83' name='action_handle' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-82' name='errors' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1032' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
+      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
+      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
+      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_receive' mangled-name='lzc_receive' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
+      <parameter type-id='type-id-83' name='spacep' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-6' name='resume_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-83' name='spacep' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='663' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
+      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_send' mangled-name='lzc_send' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='626' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
+      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <parameter type-id='type-id-82' name='holdsp' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_release' mangled-name='lzc_release' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
+      <parameter type-id='type-id-81' name='holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_hold' mangled-name='lzc_hold' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
+      <parameter type-id='type-id-81' name='holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_sync' mangled-name='lzc_sync' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
+      <parameter type-id='type-id-76' name='pool_name' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-81' name='innvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_exists' mangled-name='lzc_exists' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
+      <parameter type-id='type-id-76' name='dataset' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
+      <parameter type-id='type-id-76' name='firstsnap' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
+      <parameter type-id='type-id-76' name='lastsnap' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
+      <parameter type-id='type-id-83' name='usedp' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='431' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
+      <parameter type-id='type-id-81' name='snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <parameter type-id='type-id-38' name='defer' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
+      <parameter type-id='type-id-81' name='snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_rename' mangled-name='lzc_rename' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
+      <parameter type-id='type-id-76' name='source' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
+      <parameter type-id='type-id-76' name='target' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_promote' mangled-name='lzc_promote' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <parameter type-id='type-id-74' name='snapnamebuf' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <parameter type-id='type-id-5' name='snapnamelen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_clone' mangled-name='lzc_clone' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lzc_create' mangled-name='lzc_create' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
+      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-72' name='type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
+      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-85'/>
+    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
+      <parameter type-id='type-id-76' name='name' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <parameter type-id='type-id-76' name='cmp' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <parameter type-id='type-id-5' name='wholedisk' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
+      <parameter type-id='type-id-76' name='name' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <parameter type-id='type-id-74' name='path' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <parameter type-id='type-id-85' name='len' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8192' id='type-id-86'>
+      <subrange length='1024' type-id='type-id-3' id='type-id-87'/>
+
+    </array-type-def>
+    <typedef-decl name='importargs_t' type-id='type-id-88' filepath='../../include/libzutil.h' line='71' column='1' id='type-id-89'/>
+    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='62' column='1' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='path' type-id='type-id-90' visibility='default' filepath='../../include/libzutil.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='paths' type-id='type-id-5' visibility='default' filepath='../../include/libzutil.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='poolname' type-id='type-id-76' visibility='default' filepath='../../include/libzutil.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='guid' type-id='type-id-6' visibility='default' filepath='../../include/libzutil.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='cachefile' type-id='type-id-76' visibility='default' filepath='../../include/libzutil.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='can_be_active' type-id='type-id-38' visibility='default' filepath='../../include/libzutil.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='scan' type-id='type-id-38' visibility='default' filepath='../../include/libzutil.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='policy' type-id='type-id-81' visibility='default' filepath='../../include/libzutil.h' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-91' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-92'/>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pco_refresh_config' type-id='type-id-94' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pco_pool_active' type-id='type-id-95' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-96' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-97'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-98' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-99'/>
+    <typedef-decl name='libpc_handle_t' type-id='type-id-100' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='48' column='1' id='type-id-101'/>
+    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='41' column='1' id='type-id-100'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lpc_printerr' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='lpc_open_access_error' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lpc_desc_active' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='lpc_desc' type-id='type-id-86' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8320'>
+        <var-decl name='lpc_ops' type-id='type-id-102' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8384'>
+        <var-decl name='lpc_lib_handle' type-id='type-id-103' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='47' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-90'/>
+    <qualified-type-def type-id='type-id-93' const='yes' id='type-id-91'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-103'/>
+    <function-decl name='zpool_find_config' mangled-name='zpool_find_config' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
+      <parameter type-id='type-id-103' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
+      <parameter type-id='type-id-76' name='target' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
+      <parameter type-id='type-id-82' name='configp' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
+      <parameter type-id='type-id-104' name='args' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1537' column='1'/>
+      <parameter type-id='type-id-102' name='pco' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1537' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zpool_search_import' mangled-name='zpool_search_import' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
+      <parameter type-id='type-id-103' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1'/>
+      <parameter type-id='type-id-104' name='import' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1'/>
+      <parameter type-id='type-id-102' name='pco' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1493' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='label_paths' mangled-name='label_paths' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='label_paths'>
+      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
+      <parameter type-id='type-id-81' name='label' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
+      <parameter type-id='type-id-90' name='path' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
+      <parameter type-id='type-id-90' name='devid' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='slice_cache_compare' mangled-name='slice_cache_compare' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='slice_cache_compare'>
+      <parameter type-id='type-id-103' name='arg1' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1'/>
+      <parameter type-id='type-id-103' name='arg2' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
+      <parameter type-id='type-id-82' name='config' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
+      <parameter type-id='type-id-105' name='num_labels' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zutil_strdup' mangled-name='zutil_strdup' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_strdup'>
+      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1'/>
+      <parameter type-id='type-id-76' name='str' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <function-decl name='zutil_alloc' mangled-name='zutil_alloc' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_alloc'>
+      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1'/>
+      <parameter type-id='type-id-85' name='size' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-81'/>
+      <return type-id='type-id-81'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+    <enum-decl name='zfs_nicenum_format' filepath='../../include/libzutil.h' line='123' column='1' id='type-id-107'>
+      <underlying-type type-id='type-id-24'/>
+      <enumerator name='ZFS_NICENUM_1024' value='0'/>
+      <enumerator name='ZFS_NICENUM_BYTES' value='1'/>
+      <enumerator name='ZFS_NICENUM_TIME' value='2'/>
+      <enumerator name='ZFS_NICENUM_RAW' value='3'/>
+      <enumerator name='ZFS_NICENUM_RAWTIME' value='4'/>
+    </enum-decl>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
+      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
+      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
+      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
+      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
+      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
+      <parameter type-id='type-id-107' name='format' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='50' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
+      <parameter type-id='type-id-76' name='str' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-108' size-in-bits='32768' id='type-id-109'>
+      <subrange length='64' type-id='type-id-3' id='type-id-110'/>
+
+    </array-type-def>
+    <typedef-decl name='ddt_stat_t' type-id='type-id-111' filepath='../../include/sys/fs/zfs.h' line='1188' column='1' id='type-id-108'/>
+    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1179' column='1' id='type-id-111'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_blocks' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_lsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_psize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_dsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dds_ref_blocks' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dds_ref_lsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1185' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dds_ref_psize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dds_ref_dsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1187' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ddt_histogram_t' type-id='type-id-112' filepath='../../include/sys/fs/zfs.h' line='1192' column='1' id='type-id-113'/>
+    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1190' column='1' id='type-id-112'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ddh_stat' type-id='type-id-109' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1191' column='1'/>
+      </data-member>
+    </class-decl>
+    <qualified-type-def type-id='type-id-113' const='yes' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-115'/>
+    <qualified-type-def type-id='type-id-108' const='yes' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-119'/>
+    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
+      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-6' name='bytes_read' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-83' name='leftover' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-118' name='records' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
+      <parameter type-id='type-id-119' name='numrecords' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
+      <parameter type-id='type-id-117' name='dds_total' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
+      <parameter type-id='type-id-115' name='ddh' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='470' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
+      <parameter type-id='type-id-76' name='path' filepath='os/linux/zutil_device_path_os.c' line='470' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' filepath='os/linux/zutil_device_path_os.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
+      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='348' column='1'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' filepath='os/linux/zutil_device_path_os.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
+      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='312' column='1'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
+      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='252' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' filepath='os/linux/zutil_device_path_os.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
+      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='231' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' filepath='os/linux/zutil_device_path_os.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
+      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='152' column='1'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' filepath='os/linux/zutil_device_path_os.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
+      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='84' column='1'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' filepath='os/linux/zutil_device_path_os.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
+      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
+      <parameter type-id='type-id-85' name='max_len' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='128' id='type-id-121'>
+      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-123'>
+      <subrange length='40' type-id='type-id-3' id='type-id-124'/>
+
+    </array-type-def>
+    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-125'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-126'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-127'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-128' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-129'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' id='type-id-128'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-130' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-123' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='24' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-127' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-127' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-131' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-132' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1' id='type-id-131'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='49' column='1' id='type-id-132'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-133' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-133' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='52' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='avl_tree_t' type-id='type-id-134' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-135'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='type-id-120' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='type-id-136' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='type-id-137' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_size' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-121' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-139' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uintptr_t' type-id='type-id-3' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-139'/>
+    <typedef-decl name='ulong_t' type-id='type-id-3' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
+    <qualified-type-def type-id='type-id-76' const='yes' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-147'/>
+    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' filepath='os/linux/zutil_import_os.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
+      <parameter type-id='type-id-81' name='nv' filepath='os/linux/zutil_import_os.c' line='801' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' filepath='os/linux/zutil_import_os.c' line='607' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
+      <parameter type-id='type-id-76' name='path' filepath='os/linux/zutil_import_os.c' line='607' column='1'/>
+      <parameter type-id='type-id-5' name='timeout_ms' filepath='os/linux/zutil_import_os.c' line='607' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' filepath='os/linux/zutil_import_os.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
+      <parameter type-id='type-id-147' name='dev' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
+      <parameter type-id='type-id-74' name='bufptr' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' filepath='os/linux/zutil_import_os.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
+      <parameter type-id='type-id-147' name='dev' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
+      <parameter type-id='type-id-74' name='bufptr' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
+      <parameter type-id='type-id-85' name='buflen' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zpool_find_import_blkid' mangled-name='zpool_find_import_blkid' filepath='os/linux/zutil_import_os.c' line='322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_import_blkid'>
+      <parameter type-id='type-id-106' name='hdl' filepath='os/linux/zutil_import_os.c' line='322' column='1'/>
+      <parameter type-id='type-id-145' name='lock' filepath='os/linux/zutil_import_os.c' line='322' column='1'/>
+      <parameter type-id='type-id-141' name='slice_cache' filepath='os/linux/zutil_import_os.c' line='323' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' filepath='os/linux/zutil_import_os.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
+      <parameter type-id='type-id-146' name='count' filepath='os/linux/zutil_import_os.c' line='273' column='1'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='zpool_open_func' mangled-name='zpool_open_func' filepath='os/linux/zutil_import_os.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_func'>
+      <parameter type-id='type-id-103' name='arg' filepath='os/linux/zutil_import_os.c' line='102' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' filepath='os/linux/zutil_import_os.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
+      <parameter type-id='type-id-5' name='fd' filepath='os/linux/zutil_import_os.c' line='96' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-103'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='32768' id='type-id-148'>
+      <subrange length='4096' type-id='type-id-3' id='type-id-149'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='65536' id='type-id-150'>
+      <subrange length='8192' type-id='type-id-3' id='type-id-151'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='128' id='type-id-152'>
+      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-153' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-154'/>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_name' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32768'>
+        <var-decl name='zc_nvlist_src' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32960'>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33024'>
+        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-38' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='483' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33056'>
+        <var-decl name='zc_pad2' type-id='type-id-5' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='484' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33088'>
+        <var-decl name='zc_history' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33152'>
+        <var-decl name='zc_value' type-id='type-id-150' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='98688'>
+        <var-decl name='zc_string' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100736'>
+        <var-decl name='zc_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100800'>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100864'>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100928'>
+        <var-decl name='zc_cookie' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100992'>
+        <var-decl name='zc_objset_type' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101056'>
+        <var-decl name='zc_perm_action' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101120'>
+        <var-decl name='zc_history_len' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101184'>
+        <var-decl name='zc_history_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101248'>
+        <var-decl name='zc_obj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101312'>
+        <var-decl name='zc_iflags' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101376'>
+        <var-decl name='zc_share' type-id='type-id-155' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101632'>
+        <var-decl name='zc_objset_stats' type-id='type-id-156' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='103936'>
+        <var-decl name='zc_begin_record' type-id='type-id-51' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106368'>
+        <var-decl name='zc_inject_record' type-id='type-id-157' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109184'>
+        <var-decl name='zc_defer_destroy' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109216'>
+        <var-decl name='zc_flags' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109248'>
+        <var-decl name='zc_action_handle' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109312'>
+        <var-decl name='zc_cleanup_fd' type-id='type-id-5' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109344'>
+        <var-decl name='zc_simple' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109352'>
+        <var-decl name='zc_pad' type-id='type-id-16' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109376'>
+        <var-decl name='zc_sendobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109440'>
+        <var-decl name='zc_fromobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109504'>
+        <var-decl name='zc_createtxg' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109568'>
+        <var-decl name='zc_stat' type-id='type-id-158' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109888'>
+        <var-decl name='zc_zoneid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='type-id-159' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-155'/>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-159'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_exportdata' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_sharedata' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-160' filepath='../../include/sys/dmu.h' line='943' column='1' id='type-id-156'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='type-id-63' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='940' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='941' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='type-id-2' visibility='default' filepath='../../include/sys/dmu.h' line='942' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='type-id-161' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-157'/>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-161'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='type-id-30' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-162' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-158'/>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-162'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zs_gen' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zs_mode' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zs_links' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zs_ctime' type-id='type-id-152' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-163'/>
+    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' filepath='os/linux/zutil_compat.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
+      <parameter type-id='type-id-5' name='fd' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <parameter type-id='type-id-3' name='request' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <parameter type-id='type-id-163' name='zc' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/fedora/zfs/lib/libavl' language='LANG_C99'>
+    <typedef-decl name='avl_index_t' type-id='type-id-139' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='965' column='1'/>
+      <parameter type-id='type-id-166' name='cookie' filepath='../../module/avl/avl.c' line='965' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='937' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='937' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='930' column='1'/>
+      <return type-id='type-id-137'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='918' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='918' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='895' column='1'/>
+      <parameter type-id='type-id-136' name='compar' filepath='../../module/avl/avl.c' line='895' column='1'/>
+      <parameter type-id='type-id-85' name='size' filepath='../../module/avl/avl.c' line='896' column='1'/>
+      <parameter type-id='type-id-85' name='offset' filepath='../../module/avl/avl.c' line='896' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-140' name='tree1' filepath='../../module/avl/avl.c' line='874' column='1'/>
+      <parameter type-id='type-id-140' name='tree2' filepath='../../module/avl/avl.c' line='874' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='854' column='1'/>
+      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='854' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='837' column='1'/>
+      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='837' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='820' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='820' column='1'/>
+      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='820' column='1'/>
+      <return type-id='type-id-38'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='670' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='670' column='1'/>
+      <parameter type-id='type-id-103' name='data' filepath='../../module/avl/avl.c' line='670' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='637' column='1'/>
+      <parameter type-id='type-id-103' name='new_node' filepath='../../module/avl/avl.c' line='637' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='577' column='1'/>
+      <parameter type-id='type-id-103' name='new_data' filepath='../../module/avl/avl.c' line='578' column='1'/>
+      <parameter type-id='type-id-103' name='here' filepath='../../module/avl/avl.c' line='579' column='1'/>
+      <parameter type-id='type-id-5' name='direction' filepath='../../module/avl/avl.c' line='580' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-103' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-164' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-103' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-165' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-164' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-5' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='206' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-103' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-5' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/home/fedora/zfs/lib/libtpool' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-167'>
+      <subrange length='48' type-id='type-id-3' id='type-id-168'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='448' id='type-id-169'>
+      <subrange length='56' type-id='type-id-3' id='type-id-170'/>
+
+    </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-171'/>
+    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-172'/>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='64' id='type-id-173'>
+      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
+
+    </array-type-def>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='63' column='1' id='type-id-174'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tp_forw' type-id='type-id-175' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tp_back' type-id='type-id-175' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tp_mutex' type-id='type-id-129' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='tp_busycv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='tp_workcv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='tp_waitcv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='tp_active' type-id='type-id-177' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='tp_head' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1728'>
+        <var-decl name='tp_tail' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='tp_attr' type-id='type-id-179' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='tp_flags' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2272'>
+        <var-decl name='tp_linger' type-id='type-id-46' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='tp_njobs' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2336'>
+        <var-decl name='tp_minimum' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='tp_maximum' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2400'>
+        <var-decl name='tp_current' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='tp_idle' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='80' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_t' type-id='type-id-174' filepath='../../include/thread_pool.h' line='38' column='1' id='type-id-180'/>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-181' filepath='/usr/include/bits/pthreadtypes.h' line='80' column='1' id='type-id-176'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='75' column='1' id='type-id-181'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-182' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-167' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-171' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='79' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='92' column='1' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__g_refs' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__g_size' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='113' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='__g1_orig_size' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__wrefs' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='__g_signals' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='116' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='94' column='1' id='type-id-183'>
+      <data-member access='private'>
+        <var-decl name='__wseq' type-id='type-id-172' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__wseq32' type-id='type-id-184' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='101' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='97' column='1' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__low' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__high' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='100' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='55' column='1' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpa_next' type-id='type-id-177' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpa_tid' type-id='type-id-186' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='57' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_active_t' type-id='type-id-185' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='54' column='1' id='type-id-187'/>
+    <typedef-decl name='pthread_t' type-id='type-id-3' filepath='/usr/include/bits/pthreadtypes.h' line='27' column='1' id='type-id-186'/>
+    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='45' column='1' id='type-id-188'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpj_next' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpj_func' type-id='type-id-189' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='47' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tpj_arg' type-id='type-id-103' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='48' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_job_t' type-id='type-id-188' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='44' column='1' id='type-id-190'/>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-191' filepath='/usr/include/bits/pthreadtypes.h' line='62' column='1' id='type-id-179'/>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='56' column='1' id='type-id-191'>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-169' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='59' column='1'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-192'/>
+    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-177'/>
+    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-178'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='tpool_member' mangled-name='tpool_member' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='583' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='tpool_resume' mangled-name='tpool_resume' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='560' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='546' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='536' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='520' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='497' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='459' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
+      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <parameter type-id='type-id-189' name='func' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <parameter type-id='type-id-103' name='arg' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='tpool_create' mangled-name='tpool_create' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
+      <parameter type-id='type-id-46' name='min_threads' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-46' name='max_threads' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-46' name='linger' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-192' name='attr' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='323' column='1'/>
+      <return type-id='type-id-175'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-193'>
+      <parameter type-id='type-id-103'/>
+      <return type-id='type-id-27'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='aok' type-id='type-id-5' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-76' name='file' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-76' name='func' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-5' name='line' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
+      <parameter type-id='type-id-76' name='format' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='33' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='getexecname' mangled-name='getexecname' filepath='os/linux/getexecname.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
+      <return type-id='type-id-76'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+
+
+
+    <array-type-def dimensions='1' type-id='type-id-194' size-in-bits='192' id='type-id-195'>
+      <subrange length='3' type-id='type-id-3' id='type-id-17'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-196'>
+      <subrange length='1' type-id='type-id-3' id='type-id-197'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-198'>
+      <subrange length='20' type-id='type-id-3' id='type-id-199'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='32880' id='type-id-200'>
+      <subrange length='4110' type-id='type-id-3' id='type-id-201'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-202'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-203'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-204'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-205'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-206'/>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-207'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_major' type-id='type-id-46' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_minor' type-id='type-id-46' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/bits/stat.h' line='119' column='1' id='type-id-208'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='type-id-209' visibility='default' filepath='/usr/include/bits/stat.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='type-id-210' visibility='default' filepath='/usr/include/bits/stat.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='type-id-211' visibility='default' filepath='/usr/include/bits/stat.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-212' visibility='default' filepath='/usr/include/bits/stat.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='type-id-213' visibility='default' filepath='/usr/include/bits/stat.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='type-id-214' visibility='default' filepath='/usr/include/bits/stat.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/stat.h' line='135' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='type-id-209' visibility='default' filepath='/usr/include/bits/stat.h' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='type-id-215' visibility='default' filepath='/usr/include/bits/stat.h' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='type-id-216' visibility='default' filepath='/usr/include/bits/stat.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='type-id-217' visibility='default' filepath='/usr/include/bits/stat.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='152' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='153' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-195' visibility='default' filepath='/usr/include/bits/stat.h' line='164' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='145' column='1' id='type-id-209'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='149' column='1' id='type-id-210'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='151' column='1' id='type-id-211'/>
+    <typedef-decl name='__mode_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='150' column='1' id='type-id-212'/>
+    <typedef-decl name='__uid_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='146' column='1' id='type-id-213'/>
+    <typedef-decl name='__gid_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='147' column='1' id='type-id-214'/>
+    <typedef-decl name='__off_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-215'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='175' column='1' id='type-id-216'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-217'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='10' column='1' id='type-id-218'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-219' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='12' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-194' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='16' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='160' column='1' id='type-id-219'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='197' column='1' id='type-id-194'/>
+    <typedef-decl name='FILE' type-id='type-id-220' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-221'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-220'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-222' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-223' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-215' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-206' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-205' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-196' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-224' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-225' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-226' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-227' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-223' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-103' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-85' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-198' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-27' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-228'/>
+    <typedef-decl name='__off64_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-225'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-229'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-230'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-223'/>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-226'/>
+    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-224'/>
+    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-222'/>
+    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-227'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-231'/>
+    <pointer-type-def type-id='type-id-229' size-in-bits='64' id='type-id-232'/>
+    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-233'/>
+    <var-decl name='buf' type-id='type-id-200' mangled-name='buf' visibility='default' filepath='os/linux/getmntany.c' line='44' column='1' elf-symbol-id='buf'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='type-id-76' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-231' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-233' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
+      <parameter type-id='type-id-230' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-232' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-232' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
+      <parameter type-id='type-id-230' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <parameter type-id='type-id-232' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='list_t' type-id='type-id-234' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-235'/>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-234'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='list_size' type-id='type-id-85' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='list_offset' type-id='type-id-85' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='list_head' type-id='type-id-236' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-236'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-237' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-237' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='list_node_t' type-id='type-id-236' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-238'/>
+    <pointer-type-def type-id='type-id-236' size-in-bits='64' id='type-id-237'/>
+    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-239'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-240'/>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-239' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='type-id-239' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-239' name='lold' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <parameter type-id='type-id-239' name='lnew' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-240' name='dst' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <parameter type-id='type-id-240' name='src' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_prev' mangled-name='list_prev' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='list_remove' mangled-name='list_remove' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <parameter type-id='type-id-103' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-103' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='list_create' mangled-name='list_create' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-85' name='size' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-85' name='offset' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='mode_t' type-id='type-id-212' filepath='/usr/include/sys/types.h' line='69' column='1' id='type-id-241'/>
+    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
+      <parameter type-id='type-id-76' name='d' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <parameter type-id='type-id-241' name='mode' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='pagesize' type-id='type-id-85' mangled-name='pagesize' visibility='default' filepath='/home/fedora/zfs/lib/libspl/page.c' line='25' column='1' elf-symbol-id='pagesize'/>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/home/fedora/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
+      <return type-id='type-id-85'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcat' mangled-name='strlcat' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
+      <parameter type-id='type-id-74' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-76' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-85' name='dstsize' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
+      <parameter type-id='type-id-74' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-76' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-85' name='len' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
+      <parameter type-id='type-id-46' name='timestamp_fmt' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-5' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-242'/>
+    <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
+      <return type-id='type-id-242'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' comp-dir-path='/home/fedora/zfs/lib/libefi' language='LANG_C99'>
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='288' id='type-id-243'>
+      <subrange length='36' type-id='type-id-3' id='type-id-244'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-245' size-in-bits='512' id='type-id-246'>
+      <subrange length='16' type-id='type-id-3' id='type-id-15'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-247' size-in-bits='960' id='type-id-248'>
+      <subrange length='1' type-id='type-id-3' id='type-id-197'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='384' id='type-id-249'>
+      <subrange length='12' type-id='type-id-3' id='type-id-13'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='256' id='type-id-250'>
+      <subrange length='8' type-id='type-id-3' id='type-id-23'/>
+
+    </array-type-def>
+    <class-decl name='dk_map2' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='103' column='1' id='type-id-245'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_tag' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='p_flag' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uint16_t' type-id='type-id-252' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-251'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-206' filepath='/usr/include/bits/types.h' line='40' column='1' id='type-id-252'/>
+    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='316' column='1' id='type-id-253'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='efi_version' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='317' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='efi_nparts' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='318' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='efi_part_size' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='319' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='efi_lbasize' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='321' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='efi_last_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='322' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='efi_first_u_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='323' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='efi_last_u_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='324' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='efi_disk_uguid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='325' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='efi_flags' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='326' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='efi_reserved1' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='327' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='efi_altern_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='328' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='efi_reserved' type-id='type-id-249' visibility='default' filepath='../../include/sys/efi_partition.h' line='329' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='efi_parts' type-id='type-id-248' visibility='default' filepath='../../include/sys/efi_partition.h' line='330' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='diskaddr_t' type-id='type-id-256' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-254'/>
+    <typedef-decl name='longlong_t' type-id='type-id-171' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-256'/>
+    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/uuid.h' line='68' column='1' id='type-id-255'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='time_low' type-id='type-id-31' visibility='default' filepath='../../include/sys/uuid.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='time_mid' type-id='type-id-251' visibility='default' filepath='../../include/sys/uuid.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='time_hi_and_version' type-id='type-id-251' visibility='default' filepath='../../include/sys/uuid.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-11' visibility='default' filepath='../../include/sys/uuid.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='72'>
+        <var-decl name='clock_seq_low' type-id='type-id-11' visibility='default' filepath='../../include/sys/uuid.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='node_addr' type-id='type-id-20' visibility='default' filepath='../../include/sys/uuid.h' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='301' column='1' id='type-id-247'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_start' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='302' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_size' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='303' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_guid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='304' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_tag' type-id='type-id-257' visibility='default' filepath='../../include/sys/efi_partition.h' line='305' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='272'>
+        <var-decl name='p_flag' type-id='type-id-257' visibility='default' filepath='../../include/sys/efi_partition.h' line='306' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='p_name' type-id='type-id-243' visibility='default' filepath='../../include/sys/efi_partition.h' line='307' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='p_uguid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='308' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='p_resv' type-id='type-id-250' visibility='default' filepath='../../include/sys/efi_partition.h' line='309' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ushort_t' type-id='type-id-206' filepath='../../lib/libspl/include/sys/stdtypes.h' line='32' column='1' id='type-id-257'/>
+    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-258'/>
+    <pointer-type-def type-id='type-id-258' size-in-bits='64' id='type-id-259'/>
+    <var-decl name='default_vtoc_map' type-id='type-id-246' mangled-name='default_vtoc_map' visibility='default' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='146' column='1' elf-symbol-id='default_vtoc_map'/>
+    <var-decl name='efi_debug' type-id='type-id-5' mangled-name='efi_debug' visibility='default' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='177' column='1' elf-symbol-id='efi_debug'/>
+    <function-decl name='efi_auto_sense' mangled-name='efi_auto_sense' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_auto_sense'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1'/>
+      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_err_check' mangled-name='efi_err_check' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1612' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
+      <parameter type-id='type-id-258' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1612' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='efi_type' mangled-name='efi_type' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1590' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_free' mangled-name='efi_free' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1579' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
+      <parameter type-id='type-id-258' name='ptr' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1579' column='1'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='efi_write' mangled-name='efi_write' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1'/>
+      <parameter type-id='type-id-258' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1160' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_rescan' mangled-name='efi_rescan' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='607' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='607' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
+      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
+      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <parameter type-id='type-id-31' name='nparts' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/lib/libzfs_core/libzfs_core.suppr
+++ b/lib/libzfs_core/libzfs_core.suppr
@@ -1,0 +1,5 @@
+[suppress_type]
+	name = FILE*
+
+[suppress_type]
+	name = pthread_cond_t

--- a/lib/libzfsbootenv/Makefile.am
+++ b/lib/libzfsbootenv/Makefile.am
@@ -1,8 +1,11 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 pkgconfig_DATA = libzfsbootenv.pc
 
 lib_LTLIBRARIES = libzfsbootenv.la
+
+include $(top_srcdir)/config/Abigail.am
 
 if BUILD_FREEBSD
 DEFAULT_INCLUDES += -I$(top_srcdir)/include/os/freebsd/zfs

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -1,0 +1,212 @@
+<abi-corpus path='libzfsbootenv.so' architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
+  <elf-needed>
+    <dependency name='libzfs.so.4'/>
+    <dependency name='libzfs_core.so.3'/>
+    <dependency name='libuuid.so.1'/>
+    <dependency name='libblkid.so.1'/>
+    <dependency name='libudev.so.1'/>
+    <dependency name='libuutil.so.3'/>
+    <dependency name='libm.so.6'/>
+    <dependency name='libcrypto.so.1.1'/>
+    <dependency name='libz.so.1'/>
+    <dependency name='libnvpair.so.3'/>
+    <dependency name='libtirpc.so.3'/>
+    <dependency name='libpthread.so.0'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='lzbe_add_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_bootenv_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_get_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_nvlist_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_nvlist_get' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_nvlist_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_remove_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzbe_set_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr version='1.0' address-size='64' path='lzbe_device.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-2'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-3'/>
+    <typedef-decl name='lzbe_flags_t' type-id='type-id-4' filepath='../../include/libzfsbootenv.h' line='26' column='1' id='type-id-5'/>
+    <enum-decl name='lzbe_flags' filepath='../../include/libzfsbootenv.h' line='23' column='1' id='type-id-4'>
+      <underlying-type type-id='type-id-3'/>
+      <enumerator name='lzbe_add' value='0'/>
+      <enumerator name='lzbe_replace' value='1'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-8'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-9'/>
+    <function-decl name='lzbe_get_boot_device' mangled-name='lzbe_get_boot_device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_get_boot_device'>
+      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1'/>
+      <parameter type-id='type-id-7' name='device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='lzbe_set_boot_device' mangled-name='lzbe_set_boot_device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_set_boot_device'>
+      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
+      <parameter type-id='type-id-5' name='flag' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
+      <parameter type-id='type-id-9' name='device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='lzbe_pair.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-10'/>
+    <type-decl name='void' id='type-id-11'/>
+    <typedef-decl name='size_t' type-id='type-id-10' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-12'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-13'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='lzbe_remove_pair' mangled-name='lzbe_remove_pair' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_remove_pair'>
+      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1'/>
+      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='lzbe_add_pair' mangled-name='lzbe_add_pair' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_add_pair'>
+      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
+      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
+      <parameter type-id='type-id-9' name='type' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
+      <parameter type-id='type-id-13' name='value' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
+      <parameter type-id='type-id-12' name='size' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='183' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_free' mangled-name='lzbe_nvlist_free' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_free'>
+      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='131' column='1'/>
+      <return type-id='type-id-11'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_set' mangled-name='lzbe_nvlist_set' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_set'>
+      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
+      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
+      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_get'>
+      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
+      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
+      <parameter type-id='type-id-14' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='lzbe_util.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
+
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-15'>
+      <subrange length='1' type-id='type-id-10' id='type-id-16'/>
+
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-17'>
+      <subrange length='20' type-id='type-id-10' id='type-id-18'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-19'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-20'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-21'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-22'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-23'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-24'/>
+    <typedef-decl name='FILE' type-id='type-id-25' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-26'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-27' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-23' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='_lock' type-id='type-id-30' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-31' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-32' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-33' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-13' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-17' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__off_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-29'/>
+    <typedef-decl name='_IO_lock_t' type-id='type-id-11' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-34'/>
+    <typedef-decl name='__off64_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-33'/>
+    <function-decl name='lzbe_bootenv_print' mangled-name='lzbe_bootenv_print' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_bootenv_print'>
+      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
+      <parameter type-id='type-id-9' name='nvlist' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
+      <parameter type-id='type-id-35' name='of' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/lib/libzfsbootenv/libzfsbootenv.suppr
+++ b/lib/libzfsbootenv/libzfsbootenv.suppr
@@ -1,0 +1,2 @@
+[suppress_type]
+	name = FILE*

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -1,4 +1,5 @@
 include $(top_srcdir)/config/Rules.am
+PHONY =
 
 VPATH = \
 	$(top_srcdir)/module/zfs \
@@ -28,6 +29,8 @@ AM_CFLAGS += $(ZLIB_CFLAGS)
 AM_CFLAGS += -DLIB_ZPOOL_BUILD
 
 lib_LTLIBRARIES = libzpool.la
+
+include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	kernel.c \

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -1,5 +1,4 @@
 include $(top_srcdir)/config/Rules.am
-PHONY =
 
 VPATH = \
 	$(top_srcdir)/module/zfs \
@@ -29,8 +28,6 @@ AM_CFLAGS += $(ZLIB_CFLAGS)
 AM_CFLAGS += -DLIB_ZPOOL_BUILD
 
 lib_LTLIBRARIES = libzpool.la
-
-include $(top_srcdir)/config/Abigail.am
 
 USER_C = \
 	kernel.c \


### PR DESCRIPTION
### Motivation and Context
See #11138.  The library ABIs have evolved since ZoL 0.8.5, and should be bumped.  Simultaneously, maintaining different ABI levels for FreeBSD and Linux is unnecessary and adds (small) additional overhead.  

Additionally, we'd like to be able to track the ABI changes.  Ideally, we'd know when an ABI change occurs.

### Description

Bump the Linux SOVERSIONs, solving the first two of these problems.  Additionally, introduce a mechanism to perform automated ABI change testing via a `make checkabi` target.

### How Has This Been Tested?

I've tested this locally by running `make checkabi`, and it passing.  Also, using the ABI from zfs-2.0-staging versus master gives a failure.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
- [x] **Testing Infrastructure**

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

# Additional Work
If this mechanism is accepted, changes to the [zfs-buildbot infrastructure](https://github.com/openzfs/zfs-buildbot) should be made so that `make checkabi` is called after every build (as well as pulling [libabigail](https://sourceware.org/libabigail/), which is used to compare the ABI).  I have preliminary patches for this, but I don't have a mechanism to test the locally.
