### PR TITLE
ZTS: Wait on all events in events_001_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/events/events_common.kshlib
+++ b/tests/zfs-tests/tests/functional/events/events_common.kshlib
@@ -119,8 +119,16 @@ function run_and_verify
 
 	# If the only event is history then we don't observe zed debug log
 	if [[ "${events[0]}" != "sysevent.fs.zfs.history_event" ]]; then
-		# wait for the last event to show up in the debug log
-		log_must file_wait_event $ZED_DEBUG_LOG ${events[-1]}
+		# wait for all the non-history events to show up in the
+		# debug log, all-debug.sh filters history events.
+		for event in ${events[*]}; do
+			if [[ "$event" == \
+			    "sysevent.fs.zfs.history_event" ]]; then
+				continue
+			fi
+
+			log_must file_wait_event $ZED_DEBUG_LOG "$event"
+		done
 
 		log_must cp $ZED_DEBUG_LOG $TMP_EVENTS_ZED
 		log_must test -s $TMP_EVENTS_ZED


### PR DESCRIPTION
### Motivation and Context

Occasional test failures reported by the CI:

http://build.zfsonlinux.org/builders/Ubuntu%2018.04%20x86_64%20%28TEST%29/builds/11357
http://build.zfsonlinux.org/builders/Ubuntu%2020.04%20x86_64%20%28TEST%29/builds/1712
http://build.zfsonlinux.org/builders/CentOS%207%20x86_64%20%28TEST%29/builds/13758

### Description

The events_001_pos.ksh test case can fail because it's possible,
and correct, for the config_sync event to be posted after the last
"expected" event.  To accomidate this the run_and_verify() function
has been updated to wait for all non-history events, not just the
last event.  This does not increase the run time of the test as
long as all the events do get generated.

### How Has This Been Tested?

Locally by running the events_001_pos test case in a loop.  Without
the change the test would occasionally fail in the test environment,
with it applied I haven't been able to reproduce the failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
