### PR TITLE
ZTS: zdb_block_size_histogram increase variance

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_block_size_histogram.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_block_size_histogram.ksh
@@ -209,11 +209,11 @@ function histo_check_test_pool
 	# 4096 blocksize count for asize.   For verification we stick
 	# to just lsize counts.
 	#
-	# The max_variance is hard-coded here at 10%.  testing so far
-	# has shown this to be in the range of 2%-8% so we leave a
-	# generous allowance... This might need changes in the future
+	# The max_variance is hard-coded here at 12% to leave us some
+	# margin.  Testing has shown this normally to be in the range
+	# of 2%-8%, but it may be as large as 11%.
 	###################
-	let max_variance=10
+	let max_variance=12
 	let fail_value=0
 	let error_count=0
 	log_note "Comparisons for ${pool}"


### PR DESCRIPTION
### Motivation and Context

Resolve occasional CI failures:

http://build.zfsonlinux.org/builders/Ubuntu%2018.04%20x86_64%20Coverage%20%28TEST%29/builds/3563
http://build.zfsonlinux.org/builders/Ubuntu%2018.04%20x86_64%20Coverage%20%28TEST%29/builds/3550

### Description

The expected variance for this test case was originally set at 10%
based on local testing.  Additional testing via the CI has show it
can be as large as 11%.  Increase the expected maximum to 12% to
prevent this test from incorrectly failing.

### How Has This Been Tested?

Manually inspected all CI failure to verify the worst variance ever reported was 11%.
Then verified the updated test works by locally running 100 iterations in a loop.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
