### PR TITLE
FreeBSD: Intialize zlog in zvol_first_open, this prevents a NULL reference later.

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -891,7 +891,8 @@ zvol_cdev_open(struct cdev *dev, int flags, int fmt, struct thread *td)
 	if (flags & (FSYNC | FDSYNC)) {
 		zsd = &zv->zv_zso->zso_dev;
 		zsd->zsd_sync_cnt++;
-		if (zsd->zsd_sync_cnt == 1)
+		if (zsd->zsd_sync_cnt == 1 &&
+		    (zv->zv_flags & ZVOL_WRITTEN_TO) != 0)
 			zil_async_to_sync(zv->zv_zilog, ZVOL_OBJ);
 	}
 


### PR DESCRIPTION
### Motivation and Context
In the past the zilog was initialized in the zvol_first_open (https://svnweb.freebsd.org/base/stable/12/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zvol.c?revision=365689&view=markup#l842).
While the openzfs upgrade this was dropped.
This cause an page fault in the zvol_cdev_open function while accessing the ZVOL.

https://drive.google.com/file/d/1-dvj8eoUNqRWL5mcVtH5Px4NbrhLfzML/view?usp=sharing

### Description
Initialize zlog in the zvol_first_open like in old version of ZFS.

### How Has This Been Tested?
Tested on FreeBSD box.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
