### PR TITLE
Scalable teardown lock for FreeBSD

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
@@ -113,52 +113,52 @@ struct zfsvfs {
 };
 
 #ifdef TEARDOWN_INACTIVE_RMS
-#define	ZFS_INIT_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_INIT(zfsvfs)		\
 	rms_init(&(zfsvfs)->z_teardown_inactive_lock, "zfs teardown inactive")
 
-#define	ZFS_DESTROY_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_DESTROY(zfsvfs)		\
 	rms_destroy(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_TRYRLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_TRY_ENTER_READ(zfsvfs)	\
 	rms_try_rlock(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_RLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_ENTER_READ(zfsvfs)	\
 	rms_rlock(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_RUNLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_EXIT_READ(zfsvfs)		\
 	rms_runlock(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_WLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_ENTER_WRITE(zfsvfs)	\
 	rms_wlock(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs)	\
 	rms_wunlock(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_TEARDOWN_INACTIVE_WLOCKED(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs)	\
 	rms_wowned(&(zfsvfs)->z_teardown_inactive_lock)
 #else
-#define	ZFS_INIT_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_INIT(zfsvfs)		\
 	rw_init(&(zfsvfs)->z_teardown_inactive_lock, NULL, RW_DEFAULT, NULL)
 
-#define	ZFS_DESTROY_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_DESTROY(zfsvfs)		\
 	rw_destroy(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_TRYRLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_TRY_ENTER_READ(zfsvfs)	\
 	rw_tryenter(&(zfsvfs)->z_teardown_inactive_lock, RW_READER)
 
-#define	ZFS_RLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_ENTER_READ(zfsvfs)	\
 	rw_enter(&(zfsvfs)->z_teardown_inactive_lock, RW_READER)
 
-#define	ZFS_RUNLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_EXIT_READ(zfsvfs)		\
 	rw_exit(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_WLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_ENTER_WRITE(zfsvfs)	\
 	rw_enter(&(zfsvfs)->z_teardown_inactive_lock, RW_WRITER)
 
-#define	ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs)	\
 	rw_exit(&(zfsvfs)->z_teardown_inactive_lock)
 
-#define	ZFS_TEARDOWN_INACTIVE_WLOCKED(zfsvfs)	\
+#define	ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs)	\
 	RW_WRITE_HELD(&(zfsvfs)->z_teardown_inactive_lock)
 #endif
 

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -124,15 +124,15 @@ extern minor_t zfsdev_minor_alloc(void);
 /* Called on entry to each ZFS vnode and vfs operation  */
 #define	ZFS_ENTER(zfsvfs) \
 	{ \
-		rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG); \
+		ZFS_TEARDOWN_ENTER_READ((zfsvfs), FTAG); \
 		if (__predict_false((zfsvfs)->z_unmounted)) { \
-			ZFS_EXIT(zfsvfs); \
+			ZFS_TEARDOWN_EXIT_READ(zfsvfs, FTAG); \
 			return (EIO); \
 		} \
 	}
 
 /* Must be called before exiting the vop */
-#define	ZFS_EXIT(zfsvfs) rrm_exit(&(zfsvfs)->z_teardown_lock, FTAG)
+#define	ZFS_EXIT(zfsvfs) ZFS_TEARDOWN_EXIT_READ(zfsvfs, FTAG)
 
 /* Verifies the znode is valid */
 #define	ZFS_VERIFY_ZP(zp) \

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -125,7 +125,7 @@ extern minor_t zfsdev_minor_alloc(void);
 #define	ZFS_ENTER(zfsvfs) \
 	{ \
 		rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG); \
-		if ((zfsvfs)->z_unmounted) { \
+		if (__predict_false((zfsvfs)->z_unmounted)) { \
 			ZFS_EXIT(zfsvfs); \
 			return (EIO); \
 		} \
@@ -136,7 +136,7 @@ extern minor_t zfsdev_minor_alloc(void);
 
 /* Verifies the znode is valid */
 #define	ZFS_VERIFY_ZP(zp) \
-	if ((zp)->z_sa_hdl == NULL) { \
+	if (__predict_false((zp)->z_sa_hdl == NULL)) { \
 		ZFS_EXIT((zp)->z_zfsvfs); \
 		return (EIO); \
 	} \

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -138,6 +138,39 @@ struct zfsvfs {
 	taskqid_t	z_drain_task;	/* task id for the unlink drain task */
 };
 
+#define	ZFS_TEARDOWN_INIT(zfsvfs)		\
+	rrm_init(&(zfsvfs)->z_teardown_lock, B_FALSE)
+
+#define	ZFS_TEARDOWN_DESTROY(zfsvfs)		\
+	rrm_destroy(&(zfsvfs)->z_teardown_lock)
+
+#define	ZFS_TEARDOWN_TRY_ENTER_READ(zfsvfs)	\
+	rw_tryenter(&(zfsvfs)->z_teardown_lock, RW_READER)
+
+#define	ZFS_TEARDOWN_ENTER_READ(zfsvfs, tag)	\
+	rrm_enter_read(&(zfsvfs)->z_teardown_lock, tag);
+
+#define	ZFS_TEARDOWN_EXIT_READ(zfsvfs, tag)	\
+	rrm_exit(&(zfsvfs)->z_teardown_lock, tag)
+
+#define	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, tag)	\
+	rrm_enter(&(zfsvfs)->z_teardown_lock, RW_WRITER, tag)
+
+#define	ZFS_TEARDOWN_EXIT_WRITE(zfsvfs)		\
+	rrm_exit(&(zfsvfs)->z_teardown_lock, tag)
+
+#define	ZFS_TEARDOWN_EXIT(zfsvfs, tag)		\
+	rrm_exit(&(zfsvfs)->z_teardown_lock, tag)
+
+#define	ZFS_TEARDOWN_READ_HELD(zfsvfs)		\
+	RRM_READ_HELD(&(zfsvfs)->z_teardown_lock)
+
+#define	ZFS_TEARDOWN_WRITE_HELD(zfsvfs)		\
+	RRM_WRITE_HELD(&(zfsvfs)->z_teardown_lock)
+
+#define	ZFS_TEARDOWN_HELD(zfsvfs)		\
+	RRM_LOCK_HELD(&(zfsvfs)->z_teardown_lock)
+
 #define	ZSB_XATTR	0x0001		/* Enable user xattrs */
 
 /*

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -79,9 +79,9 @@ extern "C" {
 /* Called on entry to each ZFS inode and vfs operation. */
 #define	ZFS_ENTER_ERROR(zfsvfs, error)				\
 do {								\
-	rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG);	\
+	ZFS_TEARDOWN_ENTER_READ(zfsvfs, FTAG);			\
 	if (unlikely((zfsvfs)->z_unmounted)) {			\
-		ZFS_EXIT(zfsvfs);				\
+		ZFS_TEARDOWN_EXIT_READ(zfsvfs, FTAG);		\
 		return (error);					\
 	}							\
 } while (0)
@@ -92,7 +92,7 @@ do {								\
 #define	ZFS_EXIT(zfsvfs)					\
 do {								\
 	zfs_exit_fs(zfsvfs);					\
-	rrm_exit(&(zfsvfs)->z_teardown_lock, FTAG);		\
+	ZFS_TEARDOWN_EXIT_READ(zfsvfs, FTAG);			\
 } while (0)
 
 #define	ZPL_EXIT(zfsvfs)					\

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -80,7 +80,7 @@ extern "C" {
 #define	ZFS_ENTER_ERROR(zfsvfs, error)				\
 do {								\
 	rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG);	\
-	if ((zfsvfs)->z_unmounted) {				\
+	if (unlikely((zfsvfs)->z_unmounted)) {			\
 		ZFS_EXIT(zfsvfs);				\
 		return (error);					\
 	}							\
@@ -103,7 +103,7 @@ do {								\
 /* Verifies the znode is valid. */
 #define	ZFS_VERIFY_ZP_ERROR(zp, error)				\
 do {								\
-	if ((zp)->z_sa_hdl == NULL) {				\
+	if (unlikely((zp)->z_sa_hdl == NULL)) {			\
 		ZFS_EXIT(ZTOZSB(zp));				\
 		return (error);					\
 	}							\

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -206,10 +206,10 @@ zfs_dd_lookup(znode_t *dzp, znode_t **zpp)
 	uint64_t parent;
 	int error;
 
+#ifdef ZFS_DEBUG
 	if (zfsvfs->z_replay == B_FALSE)
 		ASSERT_VOP_LOCKED(ZTOV(dzp), __func__);
-	ASSERT(RRM_READ_HELD(&zfsvfs->z_teardown_lock));
-
+#endif
 	if (dzp->z_unlinked)
 		return (ENOENT);
 
@@ -233,7 +233,6 @@ zfs_dirlook(znode_t *dzp, const char *name, znode_t **zpp)
 #ifdef ZFS_DEBUG
 	if (zfsvfs->z_replay == B_FALSE)
 		ASSERT_VOP_LOCKED(ZTOV(dzp), __func__);
-	ASSERT(RRM_READ_HELD(&zfsvfs->z_teardown_lock));
 #endif
 	if (dzp->z_unlinked)
 		return (SET_ERROR(ENOENT));

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -986,11 +986,7 @@ zfsvfs_create_impl(zfsvfs_t **zfvp, zfsvfs_t *zfsvfs, objset_t *os)
 	    offsetof(znode_t, z_link_node));
 	TASK_INIT(&zfsvfs->z_unlinked_drain_task, 0,
 	    zfsvfs_task_unlinked_drain, zfsvfs);
-#ifdef DIAGNOSTIC
-	rrm_init(&zfsvfs->z_teardown_lock, B_TRUE);
-#else
-	rrm_init(&zfsvfs->z_teardown_lock, B_FALSE);
-#endif
+	ZFS_TEARDOWN_INIT(zfsvfs);
 	ZFS_TEARDOWN_INACTIVE_INIT(zfsvfs);
 	rw_init(&zfsvfs->z_fuid_lock, NULL, RW_DEFAULT, NULL);
 	for (int i = 0; i != ZFS_OBJ_MTX_SZ; i++)
@@ -1130,7 +1126,7 @@ zfsvfs_free(zfsvfs_t *zfsvfs)
 	mutex_destroy(&zfsvfs->z_lock);
 	ASSERT(zfsvfs->z_nr_znodes == 0);
 	list_destroy(&zfsvfs->z_all_znodes);
-	rrm_destroy(&zfsvfs->z_teardown_lock);
+	ZFS_TEARDOWN_DESTROY(zfsvfs);
 	ZFS_TEARDOWN_INACTIVE_DESTROY(zfsvfs);
 	rw_destroy(&zfsvfs->z_fuid_lock);
 	for (i = 0; i != ZFS_OBJ_MTX_SZ; i++)
@@ -1382,10 +1378,10 @@ zfs_mount(vfs_t *vfsp)
 		 * manipulations between entry to zfs_suspend_fs() and return
 		 * from zfs_resume_fs().
 		 */
-		rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+		ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
 		zfs_unregister_callbacks(zfsvfs);
 		error = zfs_register_callbacks(vfsp);
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 		goto out;
 	}
 
@@ -1531,7 +1527,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 				break;
 		}
 	}
-	rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
 
 	if (!unmounting) {
 		/*
@@ -1567,7 +1563,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	 */
 	if (!unmounting && (zfsvfs->z_unmounted || zfsvfs->z_os == NULL)) {
 		ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 		return (SET_ERROR(EIO));
 	}
 
@@ -1595,7 +1591,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	if (unmounting) {
 		zfsvfs->z_unmounted = B_TRUE;
 		ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 	}
 
 	/*
@@ -1655,9 +1651,9 @@ zfs_umount(vfs_t *vfsp, int fflag)
 		 * vflush(FORCECLOSE). This way we ensure no future vnops
 		 * will be called and risk operating on DOOMED vnodes.
 		 */
-		rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+		ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
 		zfsvfs->z_unmounted = B_TRUE;
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 	}
 
 	/*
@@ -1913,7 +1909,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	int err;
 	znode_t *zp;
 
-	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
+	ASSERT(ZFS_TEARDOWN_WRITE_HELD(zfsvfs));
 	ASSERT(ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs));
 
 	/*
@@ -1953,7 +1949,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 bail:
 	/* release the VOPs */
 	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
-	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+	ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 
 	if (err) {
 		/*
@@ -2068,7 +2064,7 @@ zfs_busy(void)
 int
 zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 {
-	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
+	ASSERT(ZFS_TEARDOWN_WRITE_HELD(zfsvfs));
 	ASSERT(ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs));
 
 	/*
@@ -2086,7 +2082,7 @@ zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 
 	/* release the VOPs */
 	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
-	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+	ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 
 	/*
 	 * Try to force unmount this file system.

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -991,7 +991,7 @@ zfsvfs_create_impl(zfsvfs_t **zfvp, zfsvfs_t *zfsvfs, objset_t *os)
 #else
 	rrm_init(&zfsvfs->z_teardown_lock, B_FALSE);
 #endif
-	ZFS_INIT_TEARDOWN_INACTIVE(zfsvfs);
+	ZFS_TEARDOWN_INACTIVE_INIT(zfsvfs);
 	rw_init(&zfsvfs->z_fuid_lock, NULL, RW_DEFAULT, NULL);
 	for (int i = 0; i != ZFS_OBJ_MTX_SZ; i++)
 		mutex_init(&zfsvfs->z_hold_mtx[i], NULL, MUTEX_DEFAULT, NULL);
@@ -1131,7 +1131,7 @@ zfsvfs_free(zfsvfs_t *zfsvfs)
 	ASSERT(zfsvfs->z_nr_znodes == 0);
 	list_destroy(&zfsvfs->z_all_znodes);
 	rrm_destroy(&zfsvfs->z_teardown_lock);
-	ZFS_DESTROY_TEARDOWN_INACTIVE(zfsvfs);
+	ZFS_TEARDOWN_INACTIVE_DESTROY(zfsvfs);
 	rw_destroy(&zfsvfs->z_fuid_lock);
 	for (i = 0; i != ZFS_OBJ_MTX_SZ; i++)
 		mutex_destroy(&zfsvfs->z_hold_mtx[i]);
@@ -1558,7 +1558,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 		zfsvfs->z_log = NULL;
 	}
 
-	ZFS_WLOCK_TEARDOWN_INACTIVE(zfsvfs);
+	ZFS_TEARDOWN_INACTIVE_ENTER_WRITE(zfsvfs);
 
 	/*
 	 * If we are not unmounting (ie: online recv) and someone already
@@ -1566,7 +1566,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	 * or a reopen of z_os failed then just bail out now.
 	 */
 	if (!unmounting && (zfsvfs->z_unmounted || zfsvfs->z_os == NULL)) {
-		ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs);
+		ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
 		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
 		return (SET_ERROR(EIO));
 	}
@@ -1594,7 +1594,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	 */
 	if (unmounting) {
 		zfsvfs->z_unmounted = B_TRUE;
-		ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs);
+		ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
 		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
 	}
 
@@ -1914,7 +1914,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	znode_t *zp;
 
 	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
-	ASSERT(ZFS_TEARDOWN_INACTIVE_WLOCKED(zfsvfs));
+	ASSERT(ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs));
 
 	/*
 	 * We already own this, so just update the objset_t, as the one we
@@ -1952,7 +1952,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 
 bail:
 	/* release the VOPs */
-	ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs);
+	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
 	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
 
 	if (err) {
@@ -2069,7 +2069,7 @@ int
 zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 {
 	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
-	ASSERT(ZFS_TEARDOWN_INACTIVE_WLOCKED(zfsvfs));
+	ASSERT(ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zfsvfs));
 
 	/*
 	 * We already own this, so just hold and rele it to update the
@@ -2085,7 +2085,7 @@ zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	zfsvfs->z_os = os;
 
 	/* release the VOPs */
-	ZFS_WUNLOCK_TEARDOWN_INACTIVE(zfsvfs);
+	ZFS_TEARDOWN_INACTIVE_EXIT_WRITE(zfsvfs);
 	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
 
 	/*

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -372,7 +372,7 @@ zfs_znode_dmu_fini(znode_t *zp)
 {
 	ASSERT(MUTEX_HELD(ZFS_OBJ_MUTEX(zp->z_zfsvfs, zp->z_id)) ||
 	    zp->z_unlinked ||
-	    ZFS_TEARDOWN_INACTIVE_WLOCKED(zp->z_zfsvfs));
+	    ZFS_TEARDOWN_INACTIVE_WRITE_HELD(zp->z_zfsvfs));
 
 	sa_handle_destroy(zp->z_sa_hdl);
 	zp->z_sa_hdl = NULL;

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -815,7 +815,7 @@ zfsvfs_create_impl(zfsvfs_t **zfvp, zfsvfs_t *zfsvfs, objset_t *os)
 	mutex_init(&zfsvfs->z_lock, NULL, MUTEX_DEFAULT, NULL);
 	list_create(&zfsvfs->z_all_znodes, sizeof (znode_t),
 	    offsetof(znode_t, z_link_node));
-	rrm_init(&zfsvfs->z_teardown_lock, B_FALSE);
+	ZFS_TEARDOWN_INIT(zfsvfs);
 	rw_init(&zfsvfs->z_teardown_inactive_lock, NULL, RW_DEFAULT, NULL);
 	rw_init(&zfsvfs->z_fuid_lock, NULL, RW_DEFAULT, NULL);
 
@@ -951,7 +951,7 @@ zfsvfs_free(zfsvfs_t *zfsvfs)
 	mutex_destroy(&zfsvfs->z_znodes_lock);
 	mutex_destroy(&zfsvfs->z_lock);
 	list_destroy(&zfsvfs->z_all_znodes);
-	rrm_destroy(&zfsvfs->z_teardown_lock);
+	ZFS_TEARDOWN_DESTROY(zfsvfs);
 	rw_destroy(&zfsvfs->z_teardown_inactive_lock);
 	rw_destroy(&zfsvfs->z_fuid_lock);
 	for (i = 0; i != size; i++) {
@@ -1336,7 +1336,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 		}
 	}
 
-	rrm_enter(&zfsvfs->z_teardown_lock, RW_WRITER, FTAG);
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
 
 	if (!unmounting) {
 		/*
@@ -1367,7 +1367,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	 */
 	if (!unmounting && (zfsvfs->z_unmounted || zfsvfs->z_os == NULL)) {
 		rw_exit(&zfsvfs->z_teardown_inactive_lock);
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 		return (SET_ERROR(EIO));
 	}
 
@@ -1404,7 +1404,7 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	if (unmounting) {
 		zfsvfs->z_unmounted = B_TRUE;
 		rw_exit(&zfsvfs->z_teardown_inactive_lock);
-		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 	}
 
 	/*
@@ -1810,7 +1810,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	int err, err2;
 	znode_t *zp;
 
-	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
+	ASSERT(ZFS_TEARDOWN_WRITE_HELD(zfsvfs));
 	ASSERT(RW_WRITE_HELD(&zfsvfs->z_teardown_inactive_lock));
 
 	/*
@@ -1886,7 +1886,7 @@ bail:
 
 	/* release the VFS ops */
 	rw_exit(&zfsvfs->z_teardown_inactive_lock);
-	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+	ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 
 	if (err != 0) {
 		/*
@@ -1905,7 +1905,7 @@ bail:
 int
 zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 {
-	ASSERT(RRM_WRITE_HELD(&zfsvfs->z_teardown_lock));
+	ASSERT(ZFS_TEARDOWN_WRITE_HELD(zfsvfs));
 	ASSERT(RW_WRITE_HELD(&zfsvfs->z_teardown_inactive_lock));
 
 	/*
@@ -1923,7 +1923,7 @@ zfs_end_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 
 	/* release the VOPs */
 	rw_exit(&zfsvfs->z_teardown_inactive_lock);
-	rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+	ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 
 	/*
 	 * Try to force unmount this file system.


### PR DESCRIPTION
### Motivation and Context

"reader-mostly lock" (module/zfs/rrwlock.c) suffers significant scalability problems and is used all the time with ZFS_ENTER/ZFS_EXIT. The lock array of 17 elements hashed into based on current thread address very early runs into conflicts, inhibiting performance way below the 17 limit. thread address hashing has additional problem of bouncing locks across different NUMA nodes if they happen to match. All of this is fixable with enough effort, but I have no immediate interest in reimplementing it.

Effect can be seen here: https://people.freebsd.org/~mjg/fstat1-zfs.svg

This patchset switches the teardown lock to use a scalable routine present in the FreeBSD kernel.

Non-FreeBSD changes are almost a no-op and mostly concern abstracting teardown_lock use with macros. Note with the patchset in place it will also be possible to fix the problem on Linux with whatever Linux-specific manner available.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
