### PR TITLE
lz4: add optional kmem_alloc support

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -44,7 +44,8 @@ static int LZ4_compressCtx(void *ctx, const char *source, char *dest,
 static int LZ4_compress64kCtx(void *ctx, const char *source, char *dest,
     int isize, int osize);
 
-static kmem_cache_t *lz4_cache;
+static void *lz4_alloc(int flags);
+static void lz4_free(void *ctx);
 
 /*ARGSUSED*/
 size_t
@@ -838,8 +839,7 @@ real_LZ4_compress(const char *source, char *dest, int isize, int osize)
 	void *ctx;
 	int result;
 
-	ASSERT(lz4_cache != NULL);
-	ctx = kmem_cache_alloc(lz4_cache, KM_SLEEP);
+	ctx = lz4_alloc(KM_SLEEP);
 
 	/*
 	 * out of kernel memory, gently fall through - this will disable
@@ -855,7 +855,7 @@ real_LZ4_compress(const char *source, char *dest, int isize, int osize)
 	else
 		result = LZ4_compressCtx(ctx, source, dest, isize, osize);
 
-	kmem_cache_free(lz4_cache, ctx);
+	lz4_free(ctx);
 	return (result);
 }
 
@@ -1014,6 +1014,23 @@ LZ4_uncompress_unknownOutputSize(const char *source, char *dest, int isize,
 	return (-1);
 }
 
+#ifdef __FreeBSD__
+/*
+ * FreeBSD has 4, 8 and 16 KB malloc zones which can be used here.
+ * Should struct refTables get resized this may need to be revisited, hence
+ * compile-time asserts.
+ */
+_Static_assert(sizeof (struct refTables) <= 16384,
+	"refTables too big for malloc");
+_Static_assert((sizeof (struct refTables) % 4096) == 0,
+	"refTables not a multiple of page size");
+#else
+#define	ZFS_LZ4_USE_CACHE
+#endif
+
+#ifdef ZFS_LZ4_USE_CACHE
+static kmem_cache_t *lz4_cache;
+
 void
 lz4_init(void)
 {
@@ -1029,3 +1046,39 @@ lz4_fini(void)
 		lz4_cache = NULL;
 	}
 }
+
+static void *
+lz4_alloc(int flags)
+{
+	ASSERT(lz4_cache != NULL);
+	return (kmem_cache_alloc(lz4_cache, flags));
+}
+
+static void
+lz4_free(void *ctx)
+{
+	kmem_cache_free(lz4_cache, ctx);
+}
+#else
+void
+lz4_init(void)
+{
+}
+
+void
+lz4_fini(void)
+{
+}
+
+static void *
+lz4_alloc(int flags)
+{
+	return (kmem_alloc(sizeof (struct refTables), flags));
+}
+
+static void
+lz4_free(void *ctx)
+{
+	kmem_free(ctx, sizeof (struct refTables));
+}
+#endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

lz4 port from illumos to Linux added a 16KB per-CPU cache to accommodate for the missing 16KB malloc. FreeBSD supports this size, making the extra cache harmful as it can't share buckets.

I'm not particularly fond of the current form of the patch and I'm open to suggestions where to move the FreeBSD stuff. I don't think it is overly ugly as it is though.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
