### PR TITLE
zpoolprops.8: clarify vdev expansion rules

### DIFF
--- a/man/man8/zpoolprops.8
+++ b/man/man8/zpoolprops.8
@@ -54,12 +54,15 @@ This property can also be referred to by its shortened column name,
 .It Sy expandsize
 Amount of uninitialized space within the pool or device that can be used to
 increase the total capacity of the pool.
-Uninitialized space consists of any space on an EFI labeled vdev which has not
-been brought online
-.Po e.g, using
-.Nm zpool Cm online Fl e
-.Pc .
-This space occurs when a LUN is dynamically expanded.
+On whole-disk vdevs, this is the space beyond the end of the GPT –
+typically occurring when a LUN is dynamically expanded
+or a disk replaced with a larger one.
+On partition vdevs, this is the space appended to the partition after it was
+added to the pool – most likely by resizing it in-place.
+The space can be claimed for the pool by bringing it online with
+.Sy autoexpand=on
+or using
+.Nm zpool Cm online Fl e .
 .It Sy fragmentation
 The amount of fragmentation in the pool. As the amount of space
 .Sy allocated


### PR DESCRIPTION
The below is just the chopped-up commit message 

### Motivation and Context
The previous phrasing was confusing and seemed to indicate that `zpool online -e` will be able to claim
```
GPT[whatever, ZFS, free space, whatever]
```
into
```
GPT[whatever, ZFS, whatever]
```
but that's not the case, as it'll only be able to do so after manually resizing the ZFS partition to include the free space beforehand, i.e.:
```
GPT[whatever, ZFS, free space, whatever]
GPT[whatever, [ZFS + free space], potentially left-overs, whatever]
# zpool online -e
GPT[whatever, ZFS, whatever]
```

### Description
Remove reference to EFI(?), concretify that the new space is beyond the GPT for whole-disk vdevs, and add sexion noting how it behaves with partition vdevs in terms of how the user is most likely to encounter it.

### How Has This Been Tested?
I ran
```
man ./man8/zpoolprops.8
```
on it

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – N/A
- [ ] I have run the ZFS Test Suite with this change applied. – I don't know how and I don't think it matters
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
