### PR TITLE
initramfs: zfsunlock hook breaks /usr/bin

### DIFF
--- a/contrib/initramfs/hooks/zfsunlock.in
+++ b/contrib/initramfs/hooks/zfsunlock.in
@@ -15,4 +15,4 @@ esac
 
 . /usr/share/initramfs-tools/hook-functions
 
-copy_exec /usr/share/initramfs-tools/zfsunlock /usr/bin
+copy_exec /usr/share/initramfs-tools/zfsunlock /usr/bin/zfsunlock


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

When running `update-initramfs -u`, we get the following output:
```
$ sudo update-initramfs -u
update-initramfs: Generating /boot/initrd.img-5.4.0-1025-aws
mkdir: cannot create directory ‘/var/tmp/mkinitramfs_x4d2p6//usr/bin’: File exists
cp: failed to access '/var/tmp/mkinitramfs_x4d2p6//usr/bin/dirname': Not a directory
mkdir: cannot create directory ‘/var/tmp/mkinitramfs_x4d2p6//usr/bin’: File exists
cp: failed to access '/var/tmp/mkinitramfs_x4d2p6//usr/bin/env': Not a directory
mkdir: cannot create directory ‘/var/tmp/mkinitramfs_x4d2p6/usr/bin’: File exists
touch: cannot touch '/var/tmp/mkinitramfs_x4d2p6/usr/bin/net': Not a directory
chmod: cannot access '/var/tmp/mkinitramfs_x4d2p6/usr/bin/net': Not a directory
```

When the initramfs archive is created or updated, it runs a bunch of hooks in `/usr/share/initramfs-tools/hooks`. A new hook introduced by #10027, `zfsunlock`, copies a new file in the `/usr/bin` directory of the initramfs archive. The problem is that when that hook is executed the `/usr/bin` directory doesn't exist, so instead of copying the script into the `/usr/bin` directory, it creates a new `/usr/bin` file with the contents of that script.


### Description
The `copy_exec()` function expects that the full path of the target file is passed rather than just the directory, and will take care of creating the underlying directories if they don't exist.

### How Has This Been Tested?
The issue was detected on Ubuntu 18.04 running with zfs on root, using `initramfs-tools` version `0.130ubuntu3.11`. I've modified the hook installed under `/usr/share/initramfs-tools/hooks/zfsunlock`, re-ran `update-initramfs -u` and made sure the system can still boot.

### Additional thoughts
We may want to consider running all zfs hooks with `-e`, so that they fail if any sub-command fails. In this case, the errors come from the "zfs" hook, which seems to run after the "zfsunlock" hook.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).