### PR TITLE
FreeBSD: Avoid spurious EINTR in zvol_cdev_open

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -209,7 +209,7 @@ zvol_geom_open(struct g_provider *pp, int flag, int count)
 {
 	zvol_state_t *zv;
 	int err = 0;
-	boolean_t drop_suspend = B_TRUE;
+	boolean_t drop_suspend = B_FALSE;
 	boolean_t drop_namespace = B_FALSE;
 
 	if (!zpool_on_zvol && tsd_get(zfs_geom_probe_vdev_key) != NULL) {
@@ -228,16 +228,14 @@ retry:
 	rw_enter(&zvol_state_lock, ZVOL_RW_READER);
 	zv = pp->private;
 	if (zv == NULL) {
-		if (drop_namespace)
-			mutex_exit(&spa_namespace_lock);
-		rw_exit(&zvol_state_lock);
-		return (SET_ERROR(ENXIO));
+		err = SET_ERROR(ENXIO);
+		goto out_locked;
 	}
 
 	if (zv->zv_open_count == 0 && !mutex_owned(&spa_namespace_lock)) {
 		/*
 		 * We need to guarantee that the namespace lock is held
-		 * to avoid spurious failures in zvol_first_open
+		 * to avoid spurious failures in zvol_first_open.
 		 */
 		drop_namespace = B_TRUE;
 		if (!mutex_tryenter(&spa_namespace_lock)) {
@@ -256,6 +254,7 @@ retry:
 	 * ordering - zv_suspend_lock before zv_state_lock
 	 */
 	if (zv->zv_open_count == 0) {
+		drop_suspend = B_TRUE;
 		if (!rw_tryenter(&zv->zv_suspend_lock, ZVOL_RW_READER)) {
 			mutex_exit(&zv->zv_state_lock);
 			rw_enter(&zv->zv_suspend_lock, ZVOL_RW_READER);
@@ -266,8 +265,6 @@ retry:
 				drop_suspend = B_FALSE;
 			}
 		}
-	} else {
-		drop_suspend = B_FALSE;
 	}
 	rw_exit(&zvol_state_lock);
 
@@ -277,7 +274,7 @@ retry:
 		ASSERT(ZVOL_RW_READ_HELD(&zv->zv_suspend_lock));
 		err = zvol_first_open(zv, !(flag & FWRITE));
 		if (err)
-			goto out_mutex;
+			goto out_locked;
 		pp->mediasize = zv->zv_volsize;
 		pp->stripeoffset = 0;
 		pp->stripesize = zv->zv_volblocksize;
@@ -290,34 +287,27 @@ retry:
 	if ((flag & FWRITE) && ((zv->zv_flags & ZVOL_RDONLY) ||
 	    dmu_objset_incompatible_encryption_version(zv->zv_objset))) {
 		err = SET_ERROR(EROFS);
-		goto out_open_count;
+		goto out_opened;
 	}
 	if (zv->zv_flags & ZVOL_EXCL) {
 		err = SET_ERROR(EBUSY);
-		goto out_open_count;
+		goto out_opened;
 	}
 #ifdef FEXCL
 	if (flag & FEXCL) {
 		if (zv->zv_open_count != 0) {
 			err = SET_ERROR(EBUSY);
-			goto out_open_count;
+			goto out_opened;
 		}
 		zv->zv_flags |= ZVOL_EXCL;
 	}
 #endif
 
 	zv->zv_open_count += count;
-	if (drop_namespace)
-		mutex_exit(&spa_namespace_lock);
-	mutex_exit(&zv->zv_state_lock);
-	if (drop_suspend)
-		rw_exit(&zv->zv_suspend_lock);
-	return (0);
-
-out_open_count:
+out_opened:
 	if (zv->zv_open_count == 0)
 		zvol_last_close(zv);
-out_mutex:
+out_locked:
 	if (drop_namespace)
 		mutex_exit(&spa_namespace_lock);
 	mutex_exit(&zv->zv_state_lock);
@@ -826,23 +816,21 @@ zvol_cdev_open(struct cdev *dev, int flags, int fmt, struct thread *td)
 	zvol_state_t *zv;
 	struct zvol_state_dev *zsd;
 	int err = 0;
-	boolean_t drop_suspend = B_TRUE;
+	boolean_t drop_suspend = B_FALSE;
 	boolean_t drop_namespace = B_FALSE;
 
 retry:
 	rw_enter(&zvol_state_lock, ZVOL_RW_READER);
 	zv = dev->si_drv2;
 	if (zv == NULL) {
-		if (drop_namespace)
-			mutex_exit(&spa_namespace_lock);
-		rw_exit(&zvol_state_lock);
-		return (SET_ERROR(ENXIO));
+		err = SET_ERROR(ENXIO);
+		goto out_locked;
 	}
 
 	if (zv->zv_open_count == 0 && !mutex_owned(&spa_namespace_lock)) {
 		/*
 		 * We need to guarantee that the namespace lock is held
-		 * to avoid spurious failures in zvol_first_open
+		 * to avoid spurious failures in zvol_first_open.
 		 */
 		drop_namespace = B_TRUE;
 		if (!mutex_tryenter(&spa_namespace_lock)) {
@@ -861,6 +849,7 @@ retry:
 	 * ordering - zv_suspend_lock before zv_state_lock
 	 */
 	if (zv->zv_open_count == 0) {
+		drop_suspend = B_TRUE;
 		if (!rw_tryenter(&zv->zv_suspend_lock, ZVOL_RW_READER)) {
 			mutex_exit(&zv->zv_state_lock);
 			rw_enter(&zv->zv_suspend_lock, ZVOL_RW_READER);
@@ -871,8 +860,6 @@ retry:
 				drop_suspend = B_FALSE;
 			}
 		}
-	} else {
-		drop_suspend = B_FALSE;
 	}
 	rw_exit(&zvol_state_lock);
 
@@ -911,13 +898,6 @@ retry:
 		    (zv->zv_flags & ZVOL_WRITTEN_TO) != 0)
 			zil_async_to_sync(zv->zv_zilog, ZVOL_OBJ);
 	}
-	if (drop_namespace)
-		mutex_exit(&spa_namespace_lock);
-	mutex_exit(&zv->zv_state_lock);
-	if (drop_suspend)
-		rw_exit(&zv->zv_suspend_lock);
-	return (0);
-
 out_opened:
 	if (zv->zv_open_count == 0)
 		zvol_last_close(zv);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
zvol_first_open can fail with EINTR if spa_namespace_lock is not held
and cannot be taken without waiting.

### Description
<!--- Describe your changes in detail -->
Apply the same logic that was done for zvol_geom_open to take
spa_namespace_lock if not already held on first open in zvol_cdev_open.

As a bonus zvol_geom_open and zvol_cdev_open can be simplified:

We can consolidate the unlocking procedure into one place by starting
with drop_suspend set to B_FALSE and moving the open count check up.

While here, a little code cleanup. Match the out labels between
zvol_geom_open and zvol_cdev_open, and add a missing period in some
comments.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passes the zvol tests in ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
