### PR TITLE
ZTS: Fix incorrect use of libtest in user_run by xattr_003_neg

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -33,6 +33,7 @@ export SYSTEM_FILES_COMMON='arp
     du
     echo
     egrep
+    env
     expr
     false
     file
@@ -117,7 +118,6 @@ export SYSTEM_FILES_FREEBSD='chflags
     compress
     diskinfo
     dumpon
-    env
     fsck
     getextattr
     gpart

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -41,7 +41,7 @@
 # PATH may have been modified by sudo's secure_path behavior.
 #
 if [ -n "$STF_PATH" ]; then
-	PATH="$STF_PATH"
+	export PATH="$STF_PATH"
 fi
 
 #
@@ -2766,10 +2766,6 @@ function add_user #<group_name> <user_name> <basedir>
 		;;
 	esac
 
-	echo "export PATH=\"$STF_PATH\"" >>$basedir/$user/.profile
-	echo "export PATH=\"$STF_PATH\"" >>$basedir/$user/.bash_profile
-	echo "export PATH=\"$STF_PATH\"" >>$basedir/$user/.login
-
 	return 0
 }
 
@@ -3393,8 +3389,17 @@ function user_run
 	typeset user=$1
 	shift
 
-	log_note "user:$user $@"
-	eval su - \$user -c \"$@\" > $TEST_BASE_DIR/out 2>$TEST_BASE_DIR/err
+	log_note "user: $user"
+	log_note "cmd: $*"
+
+	typeset out=$TEST_BASE_DIR/out
+	typeset err=$TEST_BASE_DIR/err
+
+	sudo -Eu $user env PATH="$PATH" ksh <<<"$*" >$out 2>$err
+	typeset res=$?
+	log_note "out: $(<$out)"
+	log_note "err: $(<$err)"
+	return $res
 }
 
 #

--- a/tests/zfs-tests/tests/functional/xattr/xattr_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_003_neg.ksh
@@ -43,34 +43,40 @@
 #	4. Check that we're unable to write an xattr as a non-root user
 #
 
-function cleanup {
-
-	log_must rm $TESTDIR/myfile.$$
-
+function cleanup
+{
+	rm -f $testfile $tempfile
 }
 
 log_assert "read/write xattr on a file with no permissions fails"
 log_onexit cleanup
 
-log_must touch $TESTDIR/myfile.$$
-create_xattr $TESTDIR/myfile.$$ passwd /etc/passwd
+typeset testfile=$TESTDIR/testfile.$$
+typeset tempfile=/tmp/tempfile.$$
 
-log_must chmod 000 $TESTDIR/myfile.$$
+log_must touch $testfile
+create_xattr $testfile passwd /etc/passwd
+
+log_must chmod 000 $testfile
 if is_illumos; then
-	log_mustnot su $ZFS_USER -c "runat $TESTDIR/myfile.$$ cat passwd"
-	log_mustnot su $ZFS_USER -c "runat $TESTDIR/myfile.$$ cp /etc/passwd ."
+	log_mustnot su $ZFS_USER -c "runat $testfile cat passwd"
+	log_mustnot su $ZFS_USER -c "runat $testfile cp /etc/passwd ."
 else
-	user_run $ZFS_USER eval \
-	    "get_xattr passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$"
-	log_mustnot diff /etc/passwd /tmp/passwd.$$
-	log_must rm /tmp/passwd.$$
+	log_mustnot user_run $ZFS_USER "
+. $STF_SUITE/include/libtest.shlib
+get_xattr passwd $testfile >$tempfile
+"
+	log_mustnot diff -q /etc/passwd $tempfile
+	log_must rm $tempfile
 
-	user_run $ZFS_USER eval \
-	    "set_xattr_stdin passwd $TESTDIR/myfile.$$ </etc/group"
-	log_must chmod 644 $TESTDIR/myfile.$$
-	get_xattr passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$
-	log_must diff /etc/passwd /tmp/passwd.$$
-	log_must rm /tmp/passwd.$$
+	log_mustnot user_run $ZFS_USER "
+. $STF_SUITE/include/libtest.shlib
+set_xattr_stdin passwd $testfile </etc/group
+"
+	log_must chmod 644 $testfile
+	get_xattr passwd $testfile >$tempfile
+	log_must diff -q /etc/passwd $tempfile
+	log_must rm $tempfile
 fi
 
 log_pass "read/write xattr on a file with no permissions fails"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
You can't use user_run to eval ksh functions defined in libtest unless you
include libtest in the user shell.

### Description
<!--- Describe your changes in detail -->
Simplify user_run to preserve the environment and quote the command string
as one argument.

Fix xattr_003_neg by:
* running ksh as the user
* feeding it the commands to include libtest *then* run get_xattr
* assert this fails
* use variables for filenames so they don't change in the user's shell
* don't log the contents of /etc/passwd
* cleanup all byproducts

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I ran the userquota tests on FreeBSD and Linux and the projectquota tests on Linux.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
