### PR TITLE
Linux: Fix mount/unmount when dataname name has a space

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_001_pos.ksh
@@ -51,6 +51,8 @@ function cleanup
 			log_must zfs destroy -f ${datasets[$i]}
 		((i = i + 1))
 	done
+
+	zfs destroy -f "$TESTPOOL/with a space"
 }
 
 log_onexit cleanup
@@ -67,5 +69,9 @@ while (( $i < ${#datasets[*]} )); do
 		log_fail "zfs create ${datasets[$i]} fail."
 	((i = i + 1))
 done
+
+log_must zfs create "$TESTPOOL/with a space"
+log_must zfs unmount "$TESTPOOL/with a space"
+log_must zfs mount "$TESTPOOL/with a space"
 
 log_pass "'zfs create <filesystem>' works as expected."


### PR DESCRIPTION
### Motivation and Context

Issue #11182. 

### Description

The custom `zpl_show_devname()` helper should translate spaces in
to the octal escape sequence `\040`.  The `getmntent(2)` function
is aware of this convention and properly translates the escape
character back to a space when reading the fsname.

Without this change the `zfs mount` and `zfs unmount` commands
incorrectly detect when a dataset with names is mounted.

### How Has This Been Tested?

Manually and by extending the `zfs_create_001_pos` test case to
include a dataset name which includes a space.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
