### PR TITLE
zgenhostid: accept hostid arguments equal to zero.

### DIFF
--- a/cmd/zgenhostid/zgenhostid.c
+++ b/cmd/zgenhostid/zgenhostid.c
@@ -47,10 +47,10 @@ usage(void)
 	    "  -h\t\t print this usage and exit\n"
 	    "  -o <filename>\t write hostid to this file\n\n"
 	    "If hostid file is not present, store a hostid in it.\n"
-	    "The optional value must be an 8-digit hex number between"
-	    "1 and 2^32-1.\n"
-	    "If no value is provided, a random one will"
-	    "be generated.\n"
+	    "The optional value should be an 8-digit hex number between"
+	    " 1 and 2^32-1.\n"
+	    "If the value is 0 or no value is provided, a random one"
+	    " will be generated.\n"
 	    "The value must be unique among your systems.\n");
 	exit(EXIT_FAILURE);
 	/* NOTREACHED */
@@ -108,7 +108,7 @@ main(int argc, char **argv)
 			exit(EXIT_FAILURE);
 		}
 
-		if (input_i < 0x1 || input_i > UINT32_MAX) {
+		if (input_i > UINT32_MAX) {
 			fprintf(stderr, "%s\n", strerror(ERANGE));
 			usage();
 		}

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -85,7 +85,13 @@ install() {
 	fi
 
 	# Synchronize initramfs and system hostid
-	zgenhostid -o "${initdir}/etc/hostid" "$(hostid)"
+	if [ -f @sysconfdir@/hostid ]; then
+		inst @sysconfdir@/hostid
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
+	elif HOSTID="$(hostid 2>/dev/null)" && [ "${HOSTID}" != "00000000" ]; then
+		zgenhostid -o "${initdir}@sysconfdir@/hostid" "${HOSTID}"
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
+	fi
 
 	if dracut_module_included "systemd"; then
 		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"

--- a/man/man8/zgenhostid.8
+++ b/man/man8/zgenhostid.8
@@ -54,7 +54,8 @@ instead of default
 .It Ar hostid
 Specifies the value to be placed in
 .Pa /etc/hostid .
-It must be a number with a value between 1 and 2^32-1.
+It should be a number with a value between 1 and 2^32-1.
+If it is 0, zgenhostid will generate a random hostid.
 This value
 .Sy must
 be unique among your systems.


### PR DESCRIPTION
### Motivation and Context

A common usage pattern for zgenhostid, including in the ZFS dracut
module, is running it as:

  zgenhostid $(hostid)

However, zgenhostid only accepted hostid arguments greater than 0, which
meant that, when the output of hostid(1) was "00000000", zgenhostid
would error out, even though 0 is a possible return value for the
gethostid(3) function used by hostid(1):

- On current musl libc, gethostid(3) is a stub that always returns 0.
- On glibc, gethostid(3) will return 0 if /etc/hostid exists but is
  smaller than 4 bytes.

Fixes #11174 

I should note that the current `mmp_set_hostid` test in `tests/zfs-tests/tests/functional/mmp/mmp.kshlib` is simply broken on musl-based systems, due to using the `hostid(1)` utility. An alternative to this PR is extending `zgenhostid` to read `/etc/hostid` by itself instead of relying on the external `hostid` utility, since zfs already avoids using libc's `gethostid(3)` in `libspl`.

### Description

In these cases, it makes more sense for zgenhostid to treat a value of 0
as other parts of the zfs codebase do, meaning that a hostid value
couldn't be determined; therefore, it should attempt to generate a
random value to write into /etc/hostid.

### How Has This Been Tested?

I ran it as `zgenhostid -o /tmp/hostid 00000000` and `/tmp/hostid` was now populated with random values.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
