### PR TITLE
dracut/{zfs-load-key,mount-zfs}.sh: simplification, quoting

### DIFF
--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -58,7 +58,7 @@ ZFS_POOL="${ZFS_DATASET%%/*}"
 
 if import_pool "${ZFS_POOL}" ; then
 	# Load keys if we can or if we need to
-	if [ $(zpool list -H -o feature@encryption $(echo "${ZFS_POOL}" | awk -F\/ '{print $1}')) = 'active' ]; then
+	if [ "$(zpool list -H -o feature@encryption "$(echo "${ZFS_POOL}" | awk -F/ '{print $1}')")" = 'active' ]; then
 		# if the root dataset has encryption enabled
 		ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${ZFS_DATASET}")"
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -17,10 +17,8 @@
 [ "${root##zfs:}" = "${root}" ] && [ "${root##ZFS=}" = "${root}" ] && [ "$rootfstype" != "zfs" ] && exit 0
 
 # There is a race between the zpool import and the pre-mount hooks, so we wait for a pool to be imported
-while true; do
-    zpool list -H | grep -q -v '^$' && break
-    [ "$(systemctl is-failed zfs-import-cache.service)" = 'failed' ] && exit 1
-    [ "$(systemctl is-failed zfs-import-scan.service)" = 'failed' ] && exit 1
+while [ "$(zpool list -H)" = "" ]; do
+    systemctl is-failed --quiet zfs-import-cache.service zfs-import-scan.service && exit 1
     sleep 0.1s
 done
 
@@ -34,11 +32,11 @@ else
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'
-if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{print $1}'))" = 'active' ]; then
+if [ "$(zpool list -H -o feature@encryption "$(echo "${BOOTFS}" | awk -F/ '{print $1}')")" = 'active' ]; then
     # if the root dataset has encryption enabled
-    ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
+    ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${BOOTFS}")"
     # where the key is stored (in a file or loaded via prompt)
-    KEYLOCATION=$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")
+    KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
         KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
         # continue only if the key needs to be loaded


### PR DESCRIPTION
### Motivation and Context
Dunno, noticed these when writing a plug-in for this.

### Description
The loop now has a less confusing condition and properly uses systemctl(1) is-failed's return code instead of that entire mess.

In zfs-load-key.sh, the assignments could turn into "var=val program" if encryptionroot or keylocation had whitespace in them. In mount-zfs.sh, zpool(8) could error out on a bootfs with spaces, I think.

### How Has This Been Tested?
It boots, I guess. Also looking really hard.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. — N/A
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. — N/A
- [ ] I have run the ZFS Test Suite with this change applied. — dunno how to, nor do I think it matters
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
