### PR TITLE
zpool: correctly align columns with -p, also manpage typo

### DIFF
--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -64,7 +64,7 @@ nvlist_t *split_mirror_vdev(zpool_handle_t *zhp, char *newname,
  * Pool list functions
  */
 int for_each_pool(int, char **, boolean_t unavail, zprop_list_t **,
-    zpool_iter_f, void *);
+    boolean_t, zpool_iter_f, void *);
 
 /* Vdev list functions */
 typedef int (*pool_vdev_iter_f)(zpool_handle_t *, nvlist_t *, void *);
@@ -72,7 +72,7 @@ int for_each_vdev(zpool_handle_t *zhp, pool_vdev_iter_f func, void *data);
 
 typedef struct zpool_list zpool_list_t;
 
-zpool_list_t *pool_list_get(int, char **, zprop_list_t **, int *);
+zpool_list_t *pool_list_get(int, char **, zprop_list_t **, boolean_t, int *);
 void pool_list_update(zpool_list_t *);
 int pool_list_iter(zpool_list_t *, int unavail, zpool_iter_f, void *);
 void pool_list_free(zpool_list_t *);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -556,7 +556,7 @@ extern void zfs_prune_proplist(zfs_handle_t *, uint8_t *);
 /*
  * zpool property management
  */
-extern int zpool_expand_proplist(zpool_handle_t *, zprop_list_t **);
+extern int zpool_expand_proplist(zpool_handle_t *, zprop_list_t **, boolean_t);
 extern int zpool_prop_get_feature(zpool_handle_t *, const char *, char *,
     size_t);
 extern const char *zpool_prop_default_string(zpool_prop_t);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -783,7 +783,8 @@ zpool_set_prop(zpool_handle_t *zhp, const char *propname, const char *propval)
 }
 
 int
-zpool_expand_proplist(zpool_handle_t *zhp, zprop_list_t **plp)
+zpool_expand_proplist(zpool_handle_t *zhp, zprop_list_t **plp,
+    boolean_t literal)
 {
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	zprop_list_t *entry;
@@ -862,13 +863,12 @@ zpool_expand_proplist(zpool_handle_t *zhp, zprop_list_t **plp)
 	}
 
 	for (entry = *plp; entry != NULL; entry = entry->pl_next) {
-
-		if (entry->pl_fixed)
+		if (entry->pl_fixed && !literal)
 			continue;
 
 		if (entry->pl_prop != ZPROP_INVAL &&
 		    zpool_get_prop(zhp, entry->pl_prop, buf, sizeof (buf),
-		    NULL, B_FALSE) == 0) {
+		    NULL, literal) == 0) {
 			if (strlen(buf) > entry->pl_width)
 				entry->pl_width = strlen(buf);
 		}

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -111,7 +111,7 @@ See
 .It Fl v
 Verbose statistics.
 Reports usage statistics for individual vdevs within the pool, in addition to
-the pool-wise statistics.
+the pool-wide statistics.
 .El
 .El
 .Sh SEE ALSO


### PR DESCRIPTION
### Motivation and Context
This sucks:
```
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ ./zpool list -p
NAME      SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
babzoot  489626271744  12491923456  477134348288        -         -      0      2   1.00    ONLINE  -
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ ./zpool list
NAME      SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
babzoot   456G  11.6G   444G        -         -     0%     2%  1.00x    ONLINE  -
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ git log -1
commit 3fcd737478217ab3f4cc518fadb20e1931f13dfe (HEAD -> master, origin/master, origin/HEAD)
```

This doesn't:
```
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ ./zpool list -p
NAME             SIZE        ALLOC          FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
babzoot  489626271744  12544172032  477082099712        -         -      0      2   1.00    ONLINE  -
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ ./zpool list
NAME      SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
babzoot   456G  11.7G   444G        -         -     0%     2%  1.00x    ONLINE  -
nabijaczleweli@babtop:~/code/zfs/cmd/zpool$ git log -1
commit 299b4e2db5f38ce8892647590ac5393d99ef1b88 (HEAD -> whats-an-alignment, nab/whats-an-alignment)
```

### Description
`zpool_expand_proplist()` now ignores `pl_fixed` if its new `literal` argument is true.
The rest is collateral damage to pass that down. This also, sadly, affects libzfs, but it's not like there's any guarantees on that.

Also there's a typo in the manpage.

### How Has This Been Tested?
I ran `zpool list`, `zpool get`, and `zpool iostat` with `-p` and they were usable.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. ‒ N/A
- [ ] I have run the ZFS Test Suite with this change applied. ‒ I dunno how to, nor did I change any core funxionality
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
