### PR TITLE
Include the ABI with dist tarball

### DIFF
--- a/lib/libnvpair/Makefile.am
+++ b/lib/libnvpair/Makefile.am
@@ -41,3 +41,6 @@ libnvpair_la_LDFLAGS += -Wl,-z,defs
 endif
 
 libnvpair_la_LDFLAGS += -version-info 3:0:0
+
+# Library ABI
+EXTRA_DIST = libnvpair.abi libnvpair.suppr

--- a/lib/libuutil/Makefile.am
+++ b/lib/libuutil/Makefile.am
@@ -31,3 +31,6 @@ libuutil_la_LDFLAGS += -Wl,-z,defs
 endif
 
 libuutil_la_LDFLAGS += -version-info 3:0:0
+
+# Library ABI
+EXTRA_DIST = libuutil.abi libuutil.suppr

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -91,5 +91,8 @@ endif
 
 libzfs_la_LDFLAGS += -version-info 4:0:0
 
+# Library ABI
+EXTRA_DIST = libzfs.abi libzfs.suppr
+
 # Licensing data
-EXTRA_DIST = THIRDPARTYLICENSE.openssl THIRDPARTYLICENSE.openssl.descrip
+EXTRA_DIST += THIRDPARTYLICENSE.openssl THIRDPARTYLICENSE.openssl.descrip

--- a/lib/libzfs_core/Makefile.am
+++ b/lib/libzfs_core/Makefile.am
@@ -29,3 +29,6 @@ libzfs_core_la_LIBADD += -lutil -lgeom
 endif
 
 libzfs_core_la_LDFLAGS += -version-info 3:0:0
+
+# Library ABI
+EXTRA_DIST = libzfs_core.abi libzfs_core.suppr

--- a/lib/libzfsbootenv/Makefile.am
+++ b/lib/libzfsbootenv/Makefile.am
@@ -33,3 +33,6 @@ libzfsbootenv_la_LDFLAGS += -Wl,-z,defs
 endif
 
 libzfsbootenv_la_LDFLAGS += -version-info 1:0:0
+
+# Library ABI
+EXTRA_DIST = libzfsbootenv.abi libzfsbootenv.suppr


### PR DESCRIPTION
### Motivation and Context

The `make checkabi` target should work given solely the release tarball.

### Description

The ABI should be included when generating the `make dist` tarball
since it's required by the `make checkabi` target.

### How Has This Been Tested?

```
tar -xzf <tarball.tar.gz>
./configure
make
make checkabi
```

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
