### PR TITLE
libzfsbootenv: do not depend on libnvpair

### DIFF
--- a/lib/libzfsbootenv/libzfsbootenv.pc.in
+++ b/lib/libzfsbootenv/libzfsbootenv.pc.in
@@ -7,6 +7,6 @@ Name: libzfsbootenv
 Description: LibZFSBootENV library
 Version: @VERSION@
 URL: https://github.com/openzfs/zfs
-Requires: libzfs libnvpair
+Requires: libzfs
 Cflags: -I${includedir}
 Libs: -L${libdir} -lzfsbootenv


### PR DESCRIPTION
### Motivation and Context

We do not build libnvpair.pc.  Moreover, it is automatically pulled in by libzfs.pc, so no additional specific depenency is required.

### Description

This simply removes `libnvpair` from the Requires block of `lib/libzfsbootenv/libzfsbootenv.pc.in`.

### How Has This Been Tested?

```
# pkg-config libzfsbootenv --libs
-lzfsbootenv -lzfs -lnvpair -lzfs_core -lnvpair
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
