### PR TITLE
Raise raidz mindev requirement

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1230,7 +1230,7 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 		if (nparity == 0)
 			return (NULL);
 		if (mindev != NULL)
-			*mindev = nparity + 1;
+			*mindev = nparity + 2;
 		if (maxdev != NULL)
 			*maxdev = 255;
 

--- a/man/man8/zpoolconcepts.8
+++ b/man/man8/zpoolconcepts.8
@@ -89,7 +89,7 @@ vdev type is an alias for
 .Pp
 A raidz group with N disks of size X with P parity disks can hold approximately
 (N-P)*X bytes and can withstand P device(s) failing without losing data.
-The minimum number of devices in a raidz group is one more than the number of
+The minimum number of devices in a raidz group is two more than the number of
 parity disks.
 The recommended number is between 3 and 9 to help increase performance.
 .It Sy draid , draid1 , draid2 , draid3


### PR DESCRIPTION
## Motivation and Context

This came up in #zfsonlinux (IRC) today. Someone accidentally created a two-disk raidz1 pool.

There is no point in creating a two-disk raidz1; one should create a
two-disk mirror instead.  Likewise, a three-disk raidz2 should be a
three-way mirror and a four-disk raidz3 should be a four-disk mirror (or
do something else!).

This change helps prevent people from shooting themselves in the foot.

### Description
Previously, the requirement was nparity + 1.  It is now nparity + 2.

### How Has This Been Tested?
I have done absolutely zero testing of any kind. If this seems like a sane idea, then we should actually test.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
