### PR TITLE
Obsolete earlier packages due to version bump

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -165,6 +165,7 @@ This package contains the core ZFS command line utilities.
 %package -n libzpool4
 Summary:        Native ZFS pool library for Linux
 Group:          System Environment/Kernel
+Obsoletes:      libzpool2
 
 %description -n libzpool4
 This package contains the zpool library, which provides support
@@ -176,6 +177,7 @@ for managing zpools
 %package -n libnvpair3
 Summary:        Solaris name-value library for Linux
 Group:          System Environment/Kernel
+Obsoletes:      libnvpair1
 
 %description -n libnvpair3
 This package contains routines for packing and unpacking name-value
@@ -189,6 +191,7 @@ to write self describing data structures on disk.
 %package -n libuutil3
 Summary:        Solaris userland utility library for Linux
 Group:          System Environment/Kernel
+Obsoletes:      libuutil1
 
 %description -n libuutil3
 This library provides a variety of compatibility functions for OpenZFS:
@@ -207,6 +210,7 @@ This library provides a variety of compatibility functions for OpenZFS:
 %package -n libzfs4
 Summary:        Native ZFS filesystem library for Linux
 Group:          System Environment/Kernel
+Obsoletes:      libzfs2
 
 %description -n libzfs4
 This package provides support for managing ZFS filesystems
@@ -225,6 +229,7 @@ Provides:       libzpool4-devel
 Provides:       libnvpair3-devel
 Provides:       libuutil3-devel
 Obsoletes:      zfs-devel
+Obsoletes:      libzfs2-devel
 
 %description -n libzfs4-devel
 This package contains the header files needed for building additional


### PR DESCRIPTION
### Motivation and Context

Issue #11230.

### Description

In order for package managers such as dnf to upgrade cleanly after
the package SONAME bump the obsolete package names must be known.
Update the new packages to correctly obsolete the old ones.

@aerusso I believe alien understands the obsoletes tag for the upstream
packaging, but I wanted to make sure you have a similar fix in the Debian
packages.

### How Has This Been Tested?

Performed a `dnf` upgrade on Fedora and CentOS 8 and verified the
old packages were correctly detects as obsolete and replaced.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
