### PR TITLE
dracut: use /bin/sh instead of bash as the intepreter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -159,6 +159,7 @@ checkbashisms:
 				-o -name 'smart' -prune \
 				-o -name 'paxcheck.sh' -prune \
 				-o -name 'make_gitrev.sh' -prune \
+				-o -name '90zfs' -prune \
 				-o -type f ! -name 'config*' \
 				! -name 'libtool' \
 			-exec sh -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \

--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . /lib/dracut-zfs-lib.sh
 

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . /lib/dracut-zfs-lib.sh
 

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . /lib/dracut-lib.sh
 

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 echo "zfs-generator: starting" >> /dev/kmsg
 
@@ -11,7 +11,7 @@ GENERATOR_DIR="$1"
 [ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
 [ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
 
-type getarg >/dev/null 2>&1 || {
+command -v getarg >/dev/null 2>&1 || {
     echo "zfs-generator: loading Dracut library from $dracutlib" >> /dev/kmsg
     . "$dracutlib"
 }
@@ -22,16 +22,17 @@ type getarg >/dev/null 2>&1 || {
 
 # If root is not ZFS= or zfs: or rootfstype is not zfs
 # then we are not supposed to handle it.
-[ "${root##zfs:}" = "${root}" -a "${root##ZFS=}" = "${root}" -a "$rootfstype" != "zfs" ] && exit 0
+[ "${root##zfs:}" = "${root}" ] &&
+	[ "${root##ZFS=}" = "${root}" ] &&
+	[ "$rootfstype" != "zfs" ] &&
+	exit 0
 
 rootfstype=zfs
-if echo "${rootflags}" | grep -Eq '^zfsutil$|^zfsutil,|,zfsutil$|,zfsutil,' ; then
-    true
-elif test -n "${rootflags}" ; then
-    rootflags="zfsutil,${rootflags}"
-else
-    rootflags=zfsutil
-fi
+case ",${rootflags}," in
+	*,zfsutil,*) ;;
+	,,)	rootflags=zfsutil ;;
+	*)	rootflags="zfsutil,${rootflags}" ;;
+esac
 
 echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR"/sysroot.mount.d/zfs-enhancement.conf >> /dev/kmsg
 

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
 command -v getargbool >/dev/null || {
@@ -144,7 +144,7 @@ ask_for_password() {
 
     { flock -s 9;
         # Prompt for password with plymouth, if installed and running.
-        if type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null; then
+        if plymouth --ping 2>/dev/null; then
             plymouth ask-for-password \
                 --prompt "$ply_prompt" --number-of-tries="$ply_tries" \
                 --command="$ply_cmd"

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # only run this on systemd systems, we handle the decrypt in mount-zfs.sh in the mount hook otherwise
 [ -e /bin/systemctl ] || return 0

--- a/contrib/dracut/90zfs/zfs-needshutdown.sh.in
+++ b/contrib/dracut/90zfs/zfs-needshutdown.sh.in
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+command -v getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 if zpool list 2>&1 | grep -q 'no pools available' ; then
     info "ZFS: No active pools, no need to export anything."


### PR DESCRIPTION
Despite that dracut has a hard dependency on bash,
its modules doesn't, dracut only has a hard dependency on bash for
module-setup (on a fully usable machine). Inside initramfs, dracut
allows users choose from a list of handful other shells, e.g. bash,
busybox, dash, mkfsh.

In fact, my local machine's initramfs is being built with dash,
and it's functional for a very long time.

Before 64025fa3a (Silence 'make checkbashisms', 2020-08-20), we also
allows our users to have that right, too.

Let's fix the problem 'make checkbashisms' reported and allows our users
to have that right, again.

For 'plymouth' case, let's simply run the command inside the if instead
of checking for the existence of command before running it, because the status is also failture if plymouth is unavailable.

While we're at it, let's remove an unnecessary fork for grep in
zfs-generator.sh.in and its following complicated 'if elif fi' with
a simple 'case ... esac'.

Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>

---

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Before 64025fa3a (Silence 'make checkbashisms', 2020-08-20), we also
allows our users to use other shells with dracut+zfs. After that changes, we don't

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

~This is not tested, yet. I will arrange the test later today.~
Tested by applying on top of zfs 2.0.0-rc7
I create this PR now to notify that this change may break some users with the next release.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
