### PR TITLE
Add compatibility for busybox mktemp to sed --in-place check

### DIFF
--- a/config/always-sed.m4
+++ b/config/always-sed.m4
@@ -4,7 +4,7 @@ dnl #
 AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_SED], [
 	AC_REQUIRE([AC_PROG_SED])dnl
 	AC_CACHE_CHECK([for sed --in-place], [ac_cv_inplace], [
-		tmpfile=$(mktemp conftest.XXX)
+		tmpfile=$(mktemp conftest.XXXXXX)
 		echo foo >$tmpfile
 		AS_IF([$SED --in-place 's#foo#bar#' $tmpfile 2>/dev/null],
 		      [ac_cv_inplace="--in-place"],

--- a/config/deb.am
+++ b/config/deb.am
@@ -53,7 +53,7 @@ deb-utils: deb-local rpm-utils-initramfs
 ## Arguments need to be passed to dh_shlibdeps. Alien provides no mechanism
 ## to do this, so we install a shim onto the path which calls the real
 ## dh_shlibdeps with the required arguments.
-	path_prepend=`mktemp -d /tmp/intercept.XXX`; \
+	path_prepend=`mktemp -d /tmp/intercept.XXXXXX`; \
 	echo "#$(SHELL)" > $${path_prepend}/dh_shlibdeps; \
 	echo "`which dh_shlibdeps` -- \
 	 -xlibuutil3linux -xlibnvpair3linux -xlibzfs4linux -xlibzpool4linux" \

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -265,7 +265,7 @@ constrain_path() {
 		create_links "$DIRS" "$ZFSTEST_FILES"
 	else
 		# Constrained path set to /var/tmp/constrained_path.*
-		SYSTEMDIR=${SYSTEMDIR:-/var/tmp/constrained_path.XXXX}
+		SYSTEMDIR=${SYSTEMDIR:-/var/tmp/constrained_path.XXXXXX}
 		STF_PATH=$(mktemp -d "$SYSTEMDIR")
 		STF_PATH_REMOVE="yes"
 		STF_MISSING_BIN=""
@@ -663,11 +663,11 @@ export PATH=$STF_PATH
 
 if [ "$UNAME" = "FreeBSD" ] ; then
 	mkdir -p "$FILEDIR" || true
-	RESULTS_FILE=$(mktemp -u "${FILEDIR}/zts-results.XXXX")
-	REPORT_FILE=$(mktemp -u "${FILEDIR}/zts-report.XXXX")
+	RESULTS_FILE=$(mktemp -u "${FILEDIR}/zts-results.XXXXXX")
+	REPORT_FILE=$(mktemp -u "${FILEDIR}/zts-report.XXXXXX")
 else
-	RESULTS_FILE=$(mktemp -u -t zts-results.XXXX -p "$FILEDIR")
-	REPORT_FILE=$(mktemp -u -t zts-report.XXXX -p "$FILEDIR")
+	RESULTS_FILE=$(mktemp -u -t zts-results.XXXXXX -p "$FILEDIR")
+	REPORT_FILE=$(mktemp -u -t zts-report.XXXXXX -p "$FILEDIR")
 fi
 
 #


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Busybox's `mktemp` requires six X's in the template, while the current `sed --in-place` check invokes `mktemp` with three. This causes `mktemp` to fail as the pattern isn't what busybox is expecting.

### Description
<!--- Describe your changes in detail -->
This PR changes the `mktemp` template from `conftest.XXX` to `conftest.XXXXXX` in `config/always-sed.m4`. It also extends the templates in `config/deb.am` and `scripts/zfs-tests.sh` to contain six X's.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Change was tested via regeneration of `configure` script in a busybox-based docker container and diffing the results against the current master branch to ensure the only change is the `mktemp` invocation. The resulting script was also run to check if the `sed --in-place` check passes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
