### PR TITLE
Fix trivial typo in zfs-diff.8

### DIFF
--- a/man/man8/zfs-diff.8
+++ b/man/man8/zfs-diff.8
@@ -66,7 +66,7 @@ R       The path has been renamed
 .Bl -tag -width "-F"
 .It Fl F
 Display an indication of the type of file, in a manner similar to the
-.Fl
+.Fl F
 option of
 .Xr ls 1 .
 .Bd -literal


### PR DESCRIPTION
Closes #11268

Signed-off-by: Tamas TEVESZ <ice@extreme.hu>

### Motivation and Context
### Description
Fix a trivial typo in `zfs-diff.8`

### How Has This Been Tested?
By running `man man/man8/zfs-diff.8`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
