### PR TITLE
Fix check for sed --in-place with busybox mktemp

### DIFF
--- a/config/always-sed.m4
+++ b/config/always-sed.m4
@@ -4,7 +4,7 @@ dnl #
 AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_SED], [
 	AC_REQUIRE([AC_PROG_SED])dnl
 	AC_CACHE_CHECK([for sed --in-place], [ac_cv_inplace], [
-		tmpfile=$(mktemp conftest.XXX)
+		tmpfile=$(mktemp conftest.XXXXXX)
 		echo foo >$tmpfile
 		AS_IF([$SED --in-place 's#foo#bar#' $tmpfile 2>/dev/null],
 		      [ac_cv_inplace="--in-place"],


### PR DESCRIPTION
Fix build on Alpine Linux which uses busybox, and busybox mktemp
requires 6 trailing Xes.

Fixes commit 4313a5b4c51e (Detect if sed supports --in-place)

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
Closes #11274

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes build on Alpine Linux which uses busybox.

Fixes #11274

### Description
<!--- Describe your changes in detail -->

Busybox mktemp requires 6 X'es in the given template, while GNU coreutils' mktemp only requries 3.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I have compile tested it in an aarch64 alpine linux lxc container.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
