### PR TITLE
ZTS: Update zfs_share_concurrent_shares.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
@@ -29,7 +29,7 @@
 #
 # DESCRIPTION:
 # Verify that 'zfs set sharenfs=on', 'zfs share', and 'zfs unshare' can
-# run concurrently. The test creates 300 filesystem and 300 threads.
+# run concurrently. The test creates 50 filesystem and 50 threads.
 # Each thread will run through the test strategy in parallel.
 #
 # STRATEGY:
@@ -47,7 +47,7 @@ verify_runnable "global"
 function cleanup
 {
 	wait
-	for fs in $(seq 0 100)
+	for fs in $(seq 0 50)
 	do
 		log_must zfs set sharenfs=off $TESTPOOL/$TESTFS1/$fs
 		log_must zfs set sharenfs=off $TESTPOOL/$TESTFS2/$fs
@@ -79,7 +79,7 @@ function cleanup
 
 function create_filesystems
 {
-	for fs in $(seq 0 100)
+	for fs in $(seq 0 50)
 	do
 		log_must zfs create -p $TESTPOOL/$TESTFS1/$fs
 		log_must zfs create -p $TESTPOOL/$TESTFS2/$fs
@@ -137,7 +137,7 @@ log_onexit cleanup
 create_filesystems
 
 child_pids=()
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	test_share $TESTPOOL/$TESTFS1/$fs &
 	child_pids+=($!)
@@ -158,7 +158,7 @@ log_note "Verify 'zfs share -a' succeeds."
 # Unshare each of the file systems.
 #
 child_pids=()
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	unshare_fs $TESTPOOL/$TESTFS1/$fs &
 	child_pids+=($!)
@@ -181,7 +181,7 @@ log_must zfs share -a
 #
 unset __ZFS_POOL_EXCLUDE
 
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	is_shared $TESTPOOL/$TESTFS1/$fs || \
 	    log_fail "File system $TESTPOOL/$TESTFS1/$fs is not shared"


### PR DESCRIPTION
### Motivation and Context

Occasional ZTS failures:

http://build.zfsonlinux.org/builders/Fedora%2033%20x86_64%20%28TEST%29/builds/505

### Description

Occasionally an out of memory error is hit by this test case
when mounting the filesystems.  Try and reduce the likelyhood
of this occurring by reducing the thread count from 100 to 50.
It also has the advantage of slightly speeding up the test.

    cannot mount 'testpool/testfs3/79': Cannot allocate memory
        filesystem successfully created, but not mounted

### How Has This Been Tested?

Relying on the CI for this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).