### PR TITLE
Delete rw_semaphore.wait_lock configure check

### DIFF
--- a/config/kernel-rwsem.m4
+++ b/config/kernel-rwsem.m4
@@ -1,30 +1,4 @@
 dnl #
-dnl # 3.1 API Change
-dnl #
-dnl # The rw_semaphore.wait_lock member was changed from spinlock_t to
-dnl # raw_spinlock_t at commit ddb6c9b58a19edcfac93ac670b066c836ff729f1.
-dnl #
-AC_DEFUN([ZFS_AC_KERNEL_SRC_RWSEM_SPINLOCK_IS_RAW], [
-	ZFS_LINUX_TEST_SRC([rwsem_spinlock_is_raw], [
-		#include <linux/rwsem.h>
-	],[
-		struct rw_semaphore dummy_semaphore __attribute__ ((unused));
-		raw_spinlock_t dummy_lock __attribute__ ((unused)) =
-		    __RAW_SPIN_LOCK_INITIALIZER(dummy_lock);
-		dummy_semaphore.wait_lock = dummy_lock;
-	])
-])
-
-AC_DEFUN([ZFS_AC_KERNEL_RWSEM_SPINLOCK_IS_RAW], [
-	AC_MSG_CHECKING([whether struct rw_semaphore member wait_lock is raw])
-	ZFS_LINUX_TEST_RESULT([rwsem_spinlock_is_raw], [
-		AC_MSG_RESULT(yes)
-	],[
-		ZFS_LINUX_TEST_ERROR([rwsem_spinlock_is_raw])
-	])
-])
-
-dnl #
 dnl # 3.16 API Change
 dnl #
 dnl # rwsem-spinlock "->activity" changed to "->count"
@@ -76,13 +50,11 @@ AC_DEFUN([ZFS_AC_KERNEL_RWSEM_ATOMIC_LONG_COUNT], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_RWSEM], [
-	ZFS_AC_KERNEL_SRC_RWSEM_SPINLOCK_IS_RAW
 	ZFS_AC_KERNEL_SRC_RWSEM_ACTIVITY
 	ZFS_AC_KERNEL_SRC_RWSEM_ATOMIC_LONG_COUNT
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_RWSEM], [
-	ZFS_AC_KERNEL_RWSEM_SPINLOCK_IS_RAW
 	ZFS_AC_KERNEL_RWSEM_ACTIVITY
 	ZFS_AC_KERNEL_RWSEM_ATOMIC_LONG_COUNT
 ])


### PR DESCRIPTION
### Motivation and Context

Last use of wait_lock was removed in "Linux 5.3 compat: retire rw_tryupgrade()" (e7a99dab2b065ac2f8736a65d1b226d21754d771).

Fixes the issue reported in https://github.com/openzfs/zfs/issues/11097#issuecomment-714532367 (Does not fix the original issue with `migrate_enable`.)

### Description

### How Has This Been Tested?

Tried to build against linux-rt, now the build passes the configure phase and breaks on #11097.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
