### PR TITLE
zpool: Three small fixes for #11167

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
@@ -25,9 +25,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
 
-typeset TMPFILE_PREFIX="$TEST_BASE_DIR/zpool_add_dryrun_output"
 typeset STR_DRYRUN="would update '$TESTPOOL' to the following configuration:"
 typeset VDEV_PREFIX="$TEST_BASE_DIR/filedev"
 
@@ -136,7 +134,7 @@ verify_runnable "global"
 function cleanup
 {
 	destroy_pool "$TESTPOOL"
-	rm -f "$TMPFILE_PREFIX"* "$VDEV_PREFIX"*
+	rm -f "$VDEV_PREFIX"*
 }
 
 log_assert "'zpool add -n <pool> <vdev> ...' can display the configuration"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
@@ -25,9 +25,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
 
-typeset TMPFILE_PREFIX="$TEST_BASE_DIR/zpool_create_dryrun_output"
 typeset STR_DRYRUN="would create '$TESTPOOL' with the following layout:"
 typeset VDEV_PREFIX="$TEST_BASE_DIR/filedev"
 
@@ -36,7 +34,7 @@ typeset VDEV_PREFIX="$TEST_BASE_DIR/filedev"
 # 'zpool create -n <pool> <vdev> ...' can display the correct configuration
 #
 # STRATEGY:
-# 1. Create a storage pool
+# 1. Create -n a storage pool and verify the output is as expected.
 #
 
 typeset -a dev=(
@@ -112,13 +110,12 @@ verify_runnable "global"
 
 function cleanup
 {
-	rm -f "$TMPFILE_PREFIX"* "$VDEV_PREFIX"*
+	rm -f "$VDEV_PREFIX"*
 }
 
 log_assert "'zpool add -n <pool> <vdev> ...' can display the configuration"
 
 log_onexit cleanup
-typeset disk1=$(create_blockfile $FILESIZE)
 
 # Create needed file vdevs.
 for (( i=0; i < ${#dev[@]}; i+=1 )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
@@ -118,6 +118,7 @@ verify_runnable "global"
 function cleanup
 {
 	destroy_pool "$TESTPOOL"
+	rm -f "$VDEV_PREFIX"*
 }
 
 log_assert \


### PR DESCRIPTION
### Motivation and Context
Follow up fix for 0cb40fa3.

### Description
Remove unused variables, don't source unused libs and add missed cleanup.

### How Has This Been Tested?
zfs-test

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
