### PR TITLE
FreeBSD: Use new py-sysctl features, fix some issues in Python commands

### DIFF
--- a/cmd/arc_summary/arc_summary2
+++ b/cmd/arc_summary/arc_summary2
@@ -59,14 +59,20 @@ if sys.platform.startswith('freebsd'):
     # Requires py27-sysctl on FreeBSD
     import sysctl
 
+    def is_value(ctl):
+        return ctl.type != sysctl.CTLTYPE_NODE
+
     def load_kstats(namespace):
         """Collect information on a specific subsystem of the ARC"""
 
         base = 'kstat.zfs.misc.%s.' % namespace
-        return [(kstat.name, D(kstat.value)) for kstat in sysctl.filter(base)]
+        fmt = lambda kstat: (kstat.name, D(kstat.value))
+        kstats = sysctl.filter(base)
+        return [fmt(kstat) for kstat in kstats if is_value(kstat)]
 
     def load_tunables():
-        return dict((ctl.name, ctl.value) for ctl in sysctl.filter('vfs.zfs'))
+        ctls = sysctl.filter('vfs.zfs')
+        return dict((ctl.name, ctl.value) for ctl in ctls if is_value(ctl))
 
 elif sys.platform.startswith('linux'):
 

--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -85,16 +85,24 @@ if sys.platform.startswith('freebsd'):
 
     VDEV_CACHE_SIZE = 'vdev.cache_size'
 
+    def is_value(ctl):
+        return ctl.type != sysctl.CTLTYPE_NODE
+
+    def namefmt(ctl, base='vfs.zfs.'):
+        # base is removed from the name
+        cut = len(base)
+        return ctl.name[cut:]
+
     def load_kstats(section):
         base = 'kstat.zfs.misc.{section}.'.format(section=section)
-        # base is removed from the name
-        fmt = lambda kstat: '{name} : {value}'.format(name=kstat.name[len(base):],
+        fmt = lambda kstat: '{name} : {value}'.format(name=namefmt(kstat, base),
                                                       value=kstat.value)
-        return [fmt(kstat) for kstat in sysctl.filter(base)]
+        kstats = sysctl.filter(base)
+        return [fmt(kstat) for kstat in kstats if is_value(kstat)]
 
     def get_params(base):
-        cut = 8 # = len('vfs.zfs.')
-        return {ctl.name[cut:]: str(ctl.value) for ctl in sysctl.filter(base)}
+        ctls = sysctl.filter(base)
+        return {namefmt(ctl): str(ctl.value) for ctl in ctls if is_value(ctl)}
 
     def get_tunable_params():
         return get_params('vfs.zfs')
@@ -111,25 +119,8 @@ if sys.platform.startswith('freebsd'):
         return '{} version {}'.format(name, version)
 
     def get_descriptions(_request):
-        # py-sysctl doesn't give descriptions, so we have to shell out.
-        command = ['sysctl', '-d', 'vfs.zfs']
-
-        # The recommended way to do this is with subprocess.run(). However,
-        # some installed versions of Python are < 3.5, so we offer them
-        # the option of doing it the old way (for now)
-        if 'run' in dir(subprocess):
-            info = subprocess.run(command, stdout=subprocess.PIPE,
-                                  universal_newlines=True)
-            lines = info.stdout.split('\n')
-        else:
-            info = subprocess.check_output(command, universal_newlines=True)
-            lines = info.split('\n')
-
-        def fmt(line):
-            name, desc = line.split(':', 1)
-            return (name.strip(), desc.strip())
-
-        return dict([fmt(line) for line in lines if len(line) > 0])
+        ctls = sysctl.filter('vfs.zfs')
+        return {namefmt(ctl): ctl.description for ctl in ctls if is_value(ctl)}
 
 
 elif sys.platform.startswith('linux'):

--- a/cmd/arcstat/arcstat.in
+++ b/cmd/arcstat/arcstat.in
@@ -144,13 +144,14 @@ pretty_print = True
 
 
 if sys.platform.startswith('freebsd'):
-    # Requires py27-sysctl on FreeBSD
+    # Requires py-sysctl on FreeBSD
     import sysctl
 
     def kstat_update():
         global kstat
 
-        k = sysctl.filter('kstat.zfs.misc.arcstats')
+        k = [ctl for ctl in sysctl.filter('kstat.zfs.misc.arcstats')
+             if ctl.type != sysctl.CTLTYPE_NODE]
 
         if not k:
             sys.exit(1)

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -229,15 +229,14 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2c_only_size, CTLFLAG_RD,
 static int
 sysctl_vfs_zfs_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 {
-	uint32_t val;
-	int err;
+	int err, val;
 
 	val = arc_no_grow_shift;
-	err = sysctl_handle_32(oidp, &val, 0, req);
+	err = sysctl_handle_int(oidp, &val, 0, req);
 	if (err != 0 || req->newptr == NULL)
 		return (err);
 
-        if (val >= arc_shrink_shift)
+        if (val < 0 || val >= arc_shrink_shift)
 		return (EINVAL);
 
 	arc_no_grow_shift = val;
@@ -245,8 +244,8 @@ sysctl_vfs_zfs_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 }
 
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_no_grow_shift,
-    CTLTYPE_U32 | CTLFLAG_RWTUN | CTLFLAG_MPSAFE, 0, sizeof (uint32_t),
-    sysctl_vfs_zfs_arc_no_grow_shift, "U",
+    CTLTYPE_INT | CTLFLAG_RWTUN | CTLFLAG_MPSAFE, NULL, sizeof (int),
+    sysctl_vfs_zfs_arc_no_grow_shift, "I",
     "log2(fraction of ARC which must be free to allow growing)");
 
 int


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD and py-sysctl have been enhanced with new features for working with sysctls.
FreeBSD now has a mode of iterating through all nodes in the sysctl tree, even hidden ones and nodes, and py-sysctl now uses that mode to build its list of sysctls.
py-sysctl also is able to fetch the description string for a sysctl now.

When the FreeBSD platform glue was implemented for the Python-based commands arcstat, arc_summary, and dbufstat, these features did not exist in py-sysctl.

I found one tunable that was being formatted incorrectly as a bytearray rather than an integer in the arc_summary output while testing these updates. This was identified to be caused by an incorrect format string in the declaration of the sysctl.

### Description
<!--- Describe your changes in detail -->
Due to the lack of descriptions in py-sysctl at the time, we had to shell out to the sysctl command for the descriptions of tunables. Now we can avoid all that and access the `.description` field on a sysctl object instead.

Filter out `CTLTYPE_NODE` type sysctls so we avoid listing nodes as tunables with `None` as the value on FreeBSD head.

Match the type of the `vfs.zfs.arc_no_grow_shift` sysctl to the corresponding variable and use a valid format string so the tunable is correctly formatted as an integer instead of a bytearray in the output of arc_summary3.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Manual testing to confirm output, and ZTS sanity checked on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
