### PR TITLE
CI: Only run actions for listed branches

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -2,7 +2,13 @@ name: checkstyle
 
 on:
   push:
+    branches:
+      - master
+      - 'zfs-*-release'
   pull_request:
+    branches:
+      - master
+      - 'zfs-*-release'
 
 jobs:
   checkstyle:

--- a/.github/workflows/zfs-tests.yml
+++ b/.github/workflows/zfs-tests.yml
@@ -2,7 +2,13 @@ name: zfs-tests-sanity
 
 on:
   push:
+    branches:
+      - master
+      - 'zfs-*-release'
   pull_request:
+    branches:
+      - master
+      - 'zfs-*-release'
 
 jobs:
   tests:

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -2,7 +2,13 @@ name: zloop
 
 on:
   push:
+    branches:
+      - master
+      - 'zfs-*-release'
   pull_request:
+    branches:
+      - master
+      - 'zfs-*-release'
 
 jobs:
   tests:


### PR DESCRIPTION
### Motivation and Context

Avoid unnecessary runs by default.

### Description

By default restrict workflows to only run for pushes to the master
and release branches, and for pull_requests based on these same
branches.

### How Has This Been Tested?

It has not, this change is solely based on the relevant [github documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags). 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
- [x] CI workflow

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
