### PR TITLE
Only examine best metaslabs on each vdev

### DIFF
--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -78,6 +78,7 @@ uint64_t metaslab_largest_allocatable(metaslab_t *);
 #define	METASLAB_DONT_THROTTLE		0x10
 #define	METASLAB_MUST_RESERVE		0x20
 #define	METASLAB_FASTWRITE		0x40
+#define	METASLAB_ZIL			0x80
 
 int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t,
     blkptr_t *, int, uint64_t, blkptr_t *, int, zio_alloc_list_t *, zio_t *,

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -540,7 +540,7 @@ If that fails then we will have a multi-layer gang block.
 If set, we will first try normal allocation.
 If that fails then we will do a "try hard" allocation.
 If that fails we will do a gang allocation.
-If that fails we will do a "try hard" gang alloation.
+If that fails we will do a "try hard" gang allocation.
 If that fails then we will have a multi-layer gang block.
 .sp
 Default value: \fB0 (false)\fR

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -529,6 +529,40 @@ Default value: \fB25 percent\fR
 .sp
 .ne 2
 .na
+\fBzfs_metaslab_try_hard_before_gang\fR (int)
+.ad
+.RS 12n
+If not set (the default), we will first try normal allocation.
+If that fails then we will do a gang allocation.
+If that fails then we will do a "try hard" gang allocation.
+If that fails then we will have a multi-layer gang block.
+.sp
+If set, we will first try normal allocation.
+If that fails then we will do a "try hard" allocation.
+If that fails we will do a gang allocation.
+If that fails we will do a "try hard" gang alloation.
+If that fails then we will have a multi-layer gang block.
+.sp
+Default value: \fB0 (false)\fR
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_metaslab_find_max_tries\fR (int)
+.ad
+.RS 12n
+When not trying hard, we only consider this number of the best metaslabs.
+This improves performance, especially when there are many metaslabs per vdev
+and the allocation can't actually be satisfied (so we would otherwise iterate
+all the metaslabs).
+.sp
+Default value: \fB100\fR
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_vdev_default_ms_count\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -5284,13 +5284,6 @@ next:
 	    GANG_ALLOCATION(flags) || (flags & METASLAB_ZIL) != 0 ||
 	    psize <= 1 << spa->spa_min_ashift)) {
 		METASLABSTAT_BUMP(metaslabstat_try_hard);
-		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
-			zfs_dbgmsg("%s: metaslab allocation failure, "
-			    "trying hard: size %llu class %s",
-			    spa_name(spa), psize,
-			    mc == spa_normal_class(spa) ? "normal" :
-			    mc == spa_log_class(spa) ? "log" : "unknown");
-		}
 		try_hard = B_TRUE;
 		goto top;
 	}

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -322,7 +322,7 @@ uint32_t metaslab_by_size_min_shift = 14;
  *
  * If set, we will first try normal allocation.  If that fails then
  * we will do a "try hard" allocation.  If that fails we will do a gang
- * allocation.  If that fails we will do a "try hard" gang alloation.  If
+ * allocation.  If that fails we will do a "try hard" gang allocation.  If
  * that fails then we will have a multi-layer gang block.
  */
 int zfs_metaslab_try_hard_before_gang = B_FALSE;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3585,17 +3585,16 @@ zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg, blkptr_t *new_bp,
 	 * of, so we just hash the objset ID to pick the allocator to get
 	 * some parallelism.
 	 */
-	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp, 1,
-	    txg, NULL, METASLAB_FASTWRITE, &io_alloc_list, NULL,
-	    cityhash4(0, 0, 0, os->os_dsl_dataset->ds_object) %
-	    spa->spa_alloc_count);
+	int flags = METASLAB_FASTWRITE | METASLAB_ZIL;
+	int allocator = cityhash4(0, 0, 0, os->os_dsl_dataset->ds_object) %
+	    spa->spa_alloc_count;
+	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp,
+	    1, txg, NULL, flags, &io_alloc_list, NULL, allocator);
 	if (error == 0) {
 		*slog = TRUE;
 	} else {
-		error = metaslab_alloc(spa, spa_normal_class(spa), size,
-		    new_bp, 1, txg, NULL, METASLAB_FASTWRITE,
-		    &io_alloc_list, NULL, cityhash4(0, 0, 0,
-		    os->os_dsl_dataset->ds_object) % spa->spa_alloc_count);
+		error = metaslab_alloc(spa, spa_normal_class(spa), size, new_bp,
+		    1, txg, NULL, flags, &io_alloc_list, NULL, allocator);
 		if (error == 0)
 			*slog = FALSE;
 	}


### PR DESCRIPTION



<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On a system with very high fragmentation, we may need to do lots of gang
allocations (e.g. most indirect block allocations (~50KB) may need to
gang). Before failing a "normal" allocation and resorting to ganging, we
try every metaslab.  This has the impact of loading every metaslab (not
a huge deal since we now typically keep all metaslabs loaded), and also
iterating over every metaslab for every failing allocation. If there are
many metaslabs (more than the typical ~200, e.g. due to vdev expansion
or very large vdevs), the CPU cost of this iteration can be very
impactful.  This iteration is done with the mg_lock held, creating long
hold times and high lock contention for concurrent allocations,
ultimately causing long txg sync times and poor application performance.

### Description
<!--- Describe your changes in detail -->
To address this, this commit changes the behavior of "normal" (not
try_hard, not ZIL) allocations.  These will now only examine the 100
best metaslabs (as determined by their ms_weight).  If none of these
have a large enough free segment, then the allocation will fail and
we'll fall back on ganging.

To accomplish this, we will now (normally) gang before doing a
`try_hard` allocation.  Non-try_hard allocations will only examine the
100 best metaslabs of each vdev.  In summary, we will first try normal
allocation.  If that fails then we will do a gang allocation.  If that
fails then we will do a "try hard" gang allocation.  If that fails then
we will have a multi-layer gang block.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested on a system with 12,000 metaslabs * 4 vdevs, which was very fragmented and seeing huge CPU times in find_valid_metaslab().

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
