### PR TITLE
spa: avoid type narrowing warning

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -378,7 +378,7 @@ struct spa {
 	kcondvar_t	spa_proc_cv;		/* spa_proc_state transitions */
 	spa_proc_state_t spa_proc_state;	/* see definition */
 	proc_t		*spa_proc;		/* "zpool-poolname" process */
-	uint64_t	spa_did;		/* if procp != p0, did of t1 */
+	uintptr_t	spa_did;		/* if procp != p0, did of t1 */
 	boolean_t	spa_autoreplace;	/* autoreplace set in open */
 	int		spa_vdev_locks;		/* locks grabbed */
 	uint64_t	spa_creation_version;	/* version at pool creation */


### PR DESCRIPTION
Building the spa module for i386 caused gcc to emit
-Wint-to-pointer-cast "cast to pointer from integer of different size"
because spa.spa_did was uint64_t but pthread_join (via thread_join in
spa_deactivate) takes a pointer (32-bit on i386).  Define spa_did to be
pointer-size instead.  For now spa_did is in fact never non-zero and the
thread_join could instead be ifdef'd out, but changing the size of
spa_did may be more useful for the future.

Signed-off-by: Ryan Libby <rlibby@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of a small set of changes for building with gcc on FreeBSD.

This addresses an issue with the amd64 gcc build on FreeBSD.  When gcc builds the spa module for i386 it emits the following warning due to the size difference between uint64_t and pthread_t:
```
Building /usr/obj/gcc6/usr/src/freebsd/amd64.amd64/obj-lib32/cddl/lib/libzpool/spa.o
In file included from /usr/src/freebsd/sys/contrib/openzfs/module/zfs/spa.c:45:0:
/usr/src/freebsd/sys/contrib/openzfs/module/zfs/spa.c: In function 'spa_deactivate':
/usr/src/freebsd/sys/contrib/openzfs/include/sys/zfs_context.h:235:37: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
 #define thread_join(t) pthread_join((pthread_t)(t), NULL)
                                     ^
/usr/src/freebsd/sys/contrib/openzfs/module/zfs/spa.c:1388:3: note: in expansion of macro 'thread_join'
   thread_join(spa->spa_did);
   ^~~~~~~~~~~
```

### Description
<!--- Describe your changes in detail -->

The solution here is to define spa_did as uintptr_t, which will match pointer size, avoiding the warning.  In fact, for now, spa_did is never assigned non-zero because the code is ifdef'd out.  Even in the ifdef'd code, it is never assigned a pthread_t, but only a kernel thread id.  Perhaps this may change in the future.  Regardless, neither a kernel thread id nor a pthread_t should be larger than uintptr_t.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Compile tested in the downstream FreeBSD build with gcc and clang.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
