### PR TITLE
lua: avoid gcc -Wreturn-local-addr bug

### DIFF
--- a/module/lua/ldo.c
+++ b/module/lua/ldo.c
@@ -33,14 +33,16 @@
 #if defined (_KERNEL) && defined(__linux__)
 #include <asm/current.h>
 static intptr_t stack_remaining(void) {
-  char local;
-  return (intptr_t)(&local - (char *)current->stack);
+  intptr_t local;
+  local = (intptr_t)&local - (intptr_t)current->stack;
+  return local;
 }
 #elif defined (_KERNEL) && defined(__FreeBSD__)
 #include <sys/pcpu.h>
 static intptr_t stack_remaining(void) {
-  char local;
-  return (intptr_t)(&local - (char *)curthread->td_kstack);
+  intptr_t local;
+  local = (intptr_t)&local - (intptr_t)curthread->td_kstack;
+  return local;
 }
 #else
 static intptr_t stack_remaining(void) {


### PR DESCRIPTION
Avoid a bug with gcc's -Wreturn-local-addr warning with some
obfuscation.  In buggy versions of gcc, if a return value is an
expression that involves the address of a local variable, and even if
that address is legally converted to a non-pointer type, a warning may
be emitted and the value of the address may be replaced with zero.
Howerver, buggy versions don't emit the warning or replace the value
when simply returning a local variable of non-pointer type.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90737

Signed-off-by: Ryan Libby <rlibby@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of a small set of changes for building with gcc on FreeBSD.

This change addresses this warning, which also leads to a code generation error.
```
/usr/src/freebsd/sys/contrib/openzfs/module/lua/ldo.c: In function 'stack_remaining':
/usr/src/freebsd/sys/contrib/openzfs/module/lua/ldo.c:43:10: error: function returns address of local variable [-Werror=return-local-addr]
   return (intptr_t)(&local - (char *)curthread->td_kstack);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Description
<!--- Describe your changes in detail -->

Avoid `-Wreturn-local-addr` by reformulating the computation in a way that gcc doesn't recognize as returning the address of a local.

This is admittedly ugly, as there is nothing wrong with the previous formulation, and without examining gcc internals it's not obvious why this formulation is any less likely to encounter the bug.  However, it is a simple solution to the problem.

An alternative solution which may be more clear may be to define `stack_remaining()` as taking a parameter representing the amount of stack space needed and then returning a boolean, rather than returning the available space remaining.  On the other hand, changing the function prototype would cause slightly more code churn.

Note that `-Wno-return-local-addr` is _not_ a solution: that suppresses the warning but still leads to wrong code generation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Compile tested in the downstream FreeBSD build with gcc and clang.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
