### PR TITLE
Added extra check to replace Faulted VDEV with Distributed Spare.

### DIFF
--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -334,7 +334,7 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 	 */
 	if (strcmp(class, "resource.fs.zfs.removed") == 0 ||
 	    (strcmp(class, "resource.fs.zfs.statechange") == 0 &&
-	    state == VDEV_STATE_REMOVED)) {
+	    (state == VDEV_STATE_REMOVED || state == VDEV_STATE_FAULTED))) {
 		char *devtype;
 		char *devname;
 


### PR DESCRIPTION
In ZED zfs_retire agent added a check to handle Distributed Spare
replacement for Faulted VDEV also.

Co-authored-by: Vipin Kumar Verma <vipin.verma@hpe.com>
Signed-off-by: Mark Maybee <mark.maybee@hpe.com>
Closes #11354

**Describe the problem you're observing**
zpool was in optimal state and IO was running successfully.
Problem occurred when we failed one drive from zpool.
Observation:-

Failed a drive in zfs pool.
The failed drive got stuck in FAULTED state and the distributed spare was never deployed.
```
pool: pool-1
state: DEGRADED
status: One or more devices are faulted in response to persistent errors.
Sufficient replicas exist for the pool to continue functioning in a
degraded state.
action: Replace the faulted device, or use 'zpool clear' to mark the device
repaired.
scan: scrub repaired 0B in 02:49:32 with 0 errors on Tue Oct 20 18:30:03 2020
config:
NAME STATE READ WRITE CKSUM
pool-1 DEGRADED 0 0 0
draid2-0 DEGRADED 0 0 0
35000c500aebb671f1 ONLINE 0 0 0
35000c500ae67497b1 FAULTED 19 914 0 too many errors
35000c500aef6da0f1 ONLINE 0 0 0
spares
draid2-0-0 AVAIL
draid2-0-1 AVAIL
errors: No known data errors
```

**Describe how to reproduce the problem**
Fail a drive when running IO. This issue is not consistent but get eventually reproduced when tried multiple times.
