### PR TITLE
Dangling reference from dmu_objset_upgrade

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1428,10 +1428,15 @@ dmu_objset_upgrade_task_cb(void *data)
 	mutex_enter(&os->os_upgrade_lock);
 	os->os_upgrade_status = EINTR;
 	if (!os->os_upgrade_exit) {
+		int status;
+
 		mutex_exit(&os->os_upgrade_lock);
 
-		os->os_upgrade_status = os->os_upgrade_cb(os);
+		status = os->os_upgrade_cb(os);
+
 		mutex_enter(&os->os_upgrade_lock);
+
+		os->os_upgrade_status = status;
 	}
 	os->os_upgrade_exit = B_TRUE;
 	os->os_upgrade_id = 0;
@@ -1459,6 +1464,8 @@ dmu_objset_upgrade(objset_t *os, dmu_objset_upgrade_cb_t cb)
 			dsl_dataset_long_rele(dmu_objset_ds(os), upgrade_tag);
 			os->os_upgrade_status = ENOMEM;
 		}
+	} else {
+		dsl_dataset_long_rele(dmu_objset_ds(os), upgrade_tag);
 	}
 	mutex_exit(&os->os_upgrade_lock);
 }


### PR DESCRIPTION
After porting the fix for https://github.com/openzfs/zfs/issues/5295
over to illumos, we started hitting an assertion failure when running the
testsuite:

	assertion failed: rc->rc_count == number, file: .../refcount.c

and the unexpected hold has this stack:

	dsl_dataset_long_hold+0x59
	dmu_objset_upgrade+0x73
	dmu_objset_id_quota_upgrade+0x15
	dmu_objset_own+0x14f

The simplest reproducer for this in illumos is

    zpool create -f -O version=1 testpool c3t0d0; zpool destroy testpool

which is run as part of the zpool_create_tempname test, but I can't get this
to trigger on FreeBSD. This appears to be because of the call to
txg_wait_synced() in dmu_objset_upgrade_stop() (which was missing in illumos),
slows down dmu_objset_disown() enough to avoid the condition.

### Motivation and Context

Fix dangling dataset long hold encountered on illumos:

```
> ::stack
vpanic()
0xfffffffffbdcd395()
zfs_refcount_destroy_many+0x30(fffffe172cbad768, 0)
zfs_refcount_destroy+0x10(fffffe172cbad768)
dsl_dataset_evict_async+0x12a(fffffe172cbad440)
taskq_thread+0x315(fffffe170cee0eb0)
thread_start+0xb()
> fffffe172cbad768::zfs_refcount
zfs_refcount_t at fffffe172cbad768 has 1 current holds, 3 recently released holds
current holds:
reference with tag fffffffff79decca "upgrade_tag", held at:
fffffe1c6a649300 is allocated from reference_cache:
            ADDR          BUFADDR        TIMESTAMP           THREAD
                            CACHE          LASTLOG         CONTENTS
fffffe1c67d829d0 fffffe1c6a649300      4e89b292133 fffffe1c9e3387c0
                 fffffe170ce92888 fffffe16e20e9cc0 fffffe16f4b6d850
                 kmem_cache_alloc_debug+0x2fc
                 kmem_cache_alloc+0x135
                 zfs_refcount_add_many+0x82
                 zfs_refcount_add+0x13
                 dsl_dataset_long_hold+0x59
                 dmu_objset_upgrade+0x73
                 dmu_objset_id_quota_upgrade+0x15
                 dmu_objset_own+0x14f
                 zfsvfs_create+0x6c
                 zfs_domount+0x50
                 zfs_mount+0x2a7
                 fsop_mount+0x14
                 domount+0xa78
                 mount+0xfe
                 syscall_ap+0x98

> fffffe170cee0eb0::taskq
ADDR             NAME                             ACT/THDS Q'ED  MAXQ INST
fffffe170cee0eb0 dbu_evict                          1/   1    1   390    -
```
### How Has This Been Tested?

The fix has been tested on illumos by running their ZFS testsuite in a loop on multiple systems booted in a DEBUG environment (which enables assertions like the one triggered here).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
