### PR TITLE
Linux 4.18.0-257.el8 compat: blk_alloc_queue()

### DIFF
--- a/config/kernel-make-request-fn.m4
+++ b/config/kernel-make-request-fn.m4
@@ -27,6 +27,15 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_MAKE_REQUEST_FN], [
 		q = blk_alloc_queue(make_request, NUMA_NO_NODE);
 	])
 
+	ZFS_LINUX_TEST_SRC([blk_alloc_queue_request_fn_rh], [
+		#include <linux/blkdev.h>
+		blk_qc_t make_request(struct request_queue *q,
+		    struct bio *bio) { return (BLK_QC_T_NONE); }
+	],[
+		struct request_queue *q __attribute__ ((unused));
+		q = blk_alloc_queue_rh(make_request, NUMA_NO_NODE);
+	])
+
 	ZFS_LINUX_TEST_SRC([block_device_operations_submit_bio], [
 		#include <linux/blkdev.h>
 	],[
@@ -47,7 +56,9 @@ AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
 
 		AC_DEFINE(HAVE_SUBMIT_BIO_IN_BLOCK_DEVICE_OPERATIONS, 1,
 		    [submit_bio is member of struct block_device_operations])
-		],[
+	],[
+		AC_MSG_RESULT(no)
+
 		dnl # Checked as part of the blk_alloc_queue_request_fn test
 		dnl #
 		dnl # Linux 5.7 API Change
@@ -55,6 +66,9 @@ AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
 		dnl #
 		AC_MSG_CHECKING([whether blk_alloc_queue() expects request function])
 		ZFS_LINUX_TEST_RESULT([blk_alloc_queue_request_fn], [
+			AC_MSG_RESULT(yes)
+
+			dnl # This is currently always the case.
 			AC_MSG_CHECKING([whether make_request_fn() returns blk_qc_t])
 			AC_MSG_RESULT(yes)
 
@@ -66,34 +80,59 @@ AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
 			    [Noting that make_request_fn() returns blk_qc_t])
 		],[
 			dnl #
-			dnl # Linux 3.2 API Change
-			dnl # make_request_fn returns void.
+			dnl # CentOS Stream 4.18.0-257 API Change
+			dnl # The Linux 5.7 blk_alloc_queue() change was back-
+			dnl # ported and the symbol renamed blk_alloc_queue_rh().
+			dnl # As of this kernel version they're not providing
+			dnl # any compatibility code in the kernel for this.
 			dnl #
-			AC_MSG_CHECKING([whether make_request_fn() returns void])
-			ZFS_LINUX_TEST_RESULT([make_request_fn_void], [
+			ZFS_LINUX_TEST_RESULT([blk_alloc_queue_request_fn_rh], [
 				AC_MSG_RESULT(yes)
-				AC_DEFINE(MAKE_REQUEST_FN_RET, void,
+
+				dnl # This is currently always the case.
+				AC_MSG_CHECKING([whether make_request_fn_rh() returns blk_qc_t])
+				AC_MSG_RESULT(yes)
+
+				AC_DEFINE(HAVE_BLK_ALLOC_QUEUE_REQUEST_FN_RH, 1,
+				    [blk_alloc_queue_rh() expects request function])
+				AC_DEFINE(MAKE_REQUEST_FN_RET, blk_qc_t,
 				    [make_request_fn() return type])
-				AC_DEFINE(HAVE_MAKE_REQUEST_FN_RET_VOID, 1,
-				    [Noting that make_request_fn() returns void])
+				AC_DEFINE(HAVE_MAKE_REQUEST_FN_RET_QC, 1,
+				    [Noting that make_request_fn() returns blk_qc_t])
 			],[
 				AC_MSG_RESULT(no)
 
 				dnl #
-				dnl # Linux 4.4 API Change
-				dnl # make_request_fn returns blk_qc_t.
+				dnl # Linux 3.2 API Change
+				dnl # make_request_fn returns void.
 				dnl #
 				AC_MSG_CHECKING(
-				    [whether make_request_fn() returns blk_qc_t])
-				ZFS_LINUX_TEST_RESULT([make_request_fn_blk_qc_t], [
+				    [whether make_request_fn() returns void])
+				ZFS_LINUX_TEST_RESULT([make_request_fn_void], [
 					AC_MSG_RESULT(yes)
-					AC_DEFINE(MAKE_REQUEST_FN_RET, blk_qc_t,
+					AC_DEFINE(MAKE_REQUEST_FN_RET, void,
 					    [make_request_fn() return type])
-					AC_DEFINE(HAVE_MAKE_REQUEST_FN_RET_QC, 1,
-					    [Noting that make_request_fn() ]
-					    [returns blk_qc_t])
+					AC_DEFINE(HAVE_MAKE_REQUEST_FN_RET_VOID, 1,
+					    [Noting that make_request_fn() returns void])
 				],[
-					ZFS_LINUX_TEST_ERROR([make_request_fn])
+					AC_MSG_RESULT(no)
+
+					dnl #
+					dnl # Linux 4.4 API Change
+					dnl # make_request_fn returns blk_qc_t.
+					dnl #
+					AC_MSG_CHECKING(
+					    [whether make_request_fn() returns blk_qc_t])
+					ZFS_LINUX_TEST_RESULT([make_request_fn_blk_qc_t], [
+						AC_MSG_RESULT(yes)
+						AC_DEFINE(MAKE_REQUEST_FN_RET, blk_qc_t,
+						    [make_request_fn() return type])
+						AC_DEFINE(HAVE_MAKE_REQUEST_FN_RET_QC, 1,
+						    [Noting that make_request_fn() ]
+						    [returns blk_qc_t])
+					],[
+						ZFS_LINUX_TEST_ERROR([make_request_fn])
+					])
 				])
 			])
 		])

--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -529,6 +529,8 @@ blk_generic_alloc_queue(make_request_fn make_request, int node_id)
 {
 #if defined(HAVE_BLK_ALLOC_QUEUE_REQUEST_FN)
 	return (blk_alloc_queue(make_request, node_id));
+#elif defined(HAVE_BLK_ALLOC_QUEUE_REQUEST_FN_RH)
+	return (blk_alloc_queue_rh(make_request, node_id));
 #else
 	struct request_queue *q = blk_alloc_queue(GFP_KERNEL);
 	if (q != NULL)


### PR DESCRIPTION
### Motivation and Context

Update OpenZFS to build against the CentOS Stream 4.18.0-257
kernel.

### Description

The CentOS stream 4.18.0-257 kernel appears to have backported
the Linux 5.9 change to make_request_fn and the associated API.
To maintain weak modules compatibility the original symbol was
retained and the new interface blk_alloc_queue_rh() was added.

Unfortunately, blk_alloc_queue() was replaced in the blkdev.h
header by blk_alloc_queue_bh() so there doesn't seem to be a way
to build new kmods against the old interfaces.  Even though they
appear to still be available for weak module binding.

To accommodate this a configure check is added for the new _rh()
variant of the function and used if available.  If compatibility
code gets added to the kernel for the original blk_alloc_queue()
interface this should be fine.  OpenZFS will simply continue to
prefer the new interface and only fallback to blk_alloc_queue()
when blk_alloc_queue_rh() isn't available.

### How Has This Been Tested?

Compiled on CentOS Stream and ran the ZTS sanity run file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
