### PR TITLE
Remove iov_iter_advance() from iter_read

### DIFF
--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -282,9 +282,6 @@ zpl_iter_read(struct kiocb *kiocb, struct iov_iter *to)
 
 	zpl_file_accessed(filp);
 
-	if (read > 0)
-		iov_iter_advance(to, read);
-
 	return (read);
 }
 


### PR DESCRIPTION
### Motivation and Context

Issue #11375 

### Description

There's no need to call iov_iter_advance() in zpl_iter_read().
This was preserved from the previous code where it wasn't needed
but also didn't cause any problems.  Now that the iter functions
also handle pipes that's no longer true.  When fully reading a pipe
buffer iov_iter_advance() may result in the pipe buf release
function being called which will not be registered resulting in
a NULL dereference.

### How Has This Been Tested?

The usual local ZTS run and xfstests which lightly exercise sendfile.

Since the issue was reported with `pip` I ran through installing
and uninstalling various packages to a home directory using ZFS.
No issues were observed and the installed packages worked
correctly in my testing.

For good measure I also checkout out the ZFS source and built
ZFS with gcc in a ZFS filesystem.  No errors were reported and
the resulting kmods worked correctly.  This was just a convenient
way to verify the correct behavior of a fairly wide range of utilities.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
