### PR TITLE
zfs-kmods: install to /lib/modules instead of /usr/lib/modules

### DIFF
--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -88,10 +88,6 @@ BuildRequires:  %{_bindir}/kmodtool
 %global __global_ldflags %{nil}
 %endif
 
-%if 0%{?fedora} >= 17
-%define prefix  /usr
-%endif
-
 # Kmodtool does its magic here.  A patched version of kmodtool is shipped
 # with the source rpm until kmod development packages are supported upstream.
 # https://bugzilla.rpmfusion.org/show_bug.cgi?id=2714


### PR DESCRIPTION
Before this patch, dracut wouldn't find zfs.ko for inclusion in
initramfs.

**Steps To Reproduce**:

- Install Fedora 33
- Install OpenZFS 2.0 build dependencies
- Install kernel 5.9.14-200.fc33.x86_64 (any will do)
- cd `openzfs-2.0.0`
- ./autogen
- ./configure # finds kernel 5.9.14-200.fc33.x86_64
- make rpm-utils
- make rpm-kmod
- sudo dnf install *x86_64.rpm
- lsinitrd /boot/initramfs-5.9.14-200.fc33.x86_64.img | grep zfs.ko
  => does not find anything, probably some missing script
- dracut -f --kver 5.9.14-200.fc33.x86_64
  ```
    $ dracut -f --kver 5.9.14-200.fc33.x86_64
    dracut-install: Failed to find module 'zfs'
    dracut: FAILED:  /usr/lib/dracut/dracut-install
      -D /var/tmp/dracut.3i2y9q/initramfs
      --kerneldir /lib/modules/5.9.14-200.fc33.x86_64/ -m zfs
  ```
- let's rule out problems in zfs-dracut:
  ```
  # /etc/dracut.conf
  add_drivers+=" zfs "
  ```
- dracut -f --kver 5.9.14-200.fc33.x86_64
  ```
  same error as above
  ```

**Solution**

Install to /lib/modules instead of /usr/lib/modules
=> dracut does the right thing, even without

 ```
 # /etc/dracut.conf
 add_drivers+=" zfs "
 ```

Notably, rpm/redhat/zfs-kmod.spec.in does not contain the definition of
the `prefix` macro that this commit removes in the generic kmod spec.
And https://rpmfusion.org/Packaging/KernelModules/Kmods2 does not
mention `prefix` at all.

Signed-off-by: Christian Schwarz <me@cschwarz.com>

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
