### PR TITLE
[WIP] Linux block device API updates.

### DIFF
--- a/config/kernel-blkdev.m4
+++ b/config/kernel-blkdev.m4
@@ -158,6 +158,13 @@ dnl # 2.6.27, lookup_bdev() was exported.
 dnl # 4.4.0-6.21 - lookup_bdev() takes 2 arguments.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_LOOKUP_BDEV], [
+	ZFS_LINUX_TEST_SRC([lookup_bdev_devt], [
+		#include <linux/blkdev.h>
+	], [
+		dev_t dev;
+		lookup_bdev(NULL, &dev);
+	])
+
 	ZFS_LINUX_TEST_SRC([lookup_bdev_1arg], [
 		#include <linux/fs.h>
 		#include <linux/blkdev.h>
@@ -173,23 +180,33 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_LOOKUP_BDEV], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_LOOKUP_BDEV], [
-	AC_MSG_CHECKING([whether lookup_bdev() wants 1 arg])
-	ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_1arg],
+	AC_MSG_CHECKING([whether lookup_bdev() takes a dev_t*])
+	ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_devt],
 	    [lookup_bdev], [fs/block_dev.c], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_1ARG_LOOKUP_BDEV, 1,
-		    [lookup_bdev() wants 1 arg])
+		AC_DEFINE(HAVE_DEVT_LOOKUP_BDEV, 1,
+		    [lookup_bdev() takes a dev_t*])
 	], [
 		AC_MSG_RESULT(no)
 
-		AC_MSG_CHECKING([whether lookup_bdev() wants 2 args])
-		ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_2args],
+		AC_MSG_CHECKING([whether lookup_bdev() wants 1 arg])
+		ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_1arg],
 		    [lookup_bdev], [fs/block_dev.c], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_2ARGS_LOOKUP_BDEV, 1,
-			    [lookup_bdev() wants 2 args])
+			AC_DEFINE(HAVE_1ARG_LOOKUP_BDEV, 1,
+			    [lookup_bdev() wants 1 arg])
 		], [
-			ZFS_LINUX_TEST_ERROR([lookup_bdev()])
+			AC_MSG_RESULT(no)
+
+			AC_MSG_CHECKING([whether lookup_bdev() wants 2 args])
+			ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_2args],
+			    [lookup_bdev], [fs/block_dev.c], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_2ARGS_LOOKUP_BDEV, 1,
+				    [lookup_bdev() wants 2 args])
+			], [
+				ZFS_LINUX_TEST_ERROR([lookup_bdev()])
+			])
 		])
 	])
 ])

--- a/config/kernel-get-disk-and-module.m4
+++ b/config/kernel-get-disk-and-module.m4
@@ -9,6 +9,13 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_GET_DISK_AND_MODULE], [
 		struct gendisk *disk = NULL;
 		(void) get_disk_and_module(disk);
 	])
+
+	ZFS_LINUX_TEST_SRC([get_disk], [
+		#include <linux/genhd.h>
+	], [
+		struct gendisk *disk = NULL;
+		(void) get_disk(disk);
+	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_GET_DISK_AND_MODULE], [
@@ -20,5 +27,16 @@ AC_DEFUN([ZFS_AC_KERNEL_GET_DISK_AND_MODULE], [
 		    1, [get_disk_and_module() is available])
 	], [
 		AC_MSG_RESULT(no)
+
+		AC_MSG_CHECKING([whether get_disk() is available])
+		ZFS_LINUX_TEST_RESULT_SYMBOL([get_disk],
+		    [get_disk], [block/genhd.c], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_GET_DISK,
+			    1, [get_disk() is available])
+		], [
+			AC_MSG_RESULT(no)
+		])
+
 	])
 ])

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -68,15 +68,13 @@ typedef struct zv_request {
 static boolean_t
 zvol_is_zvol_impl(const char *device)
 {
-	struct block_device *bdev;
+	dev_t dev;
 	unsigned int major;
 
-	bdev = vdev_lookup_bdev(device);
-	if (IS_ERR(bdev))
+	if (!vdev_lookup_bdev(device, &dev))
 		return (B_FALSE);
 
-	major = MAJOR(bdev->bd_dev);
-	bdput(bdev);
+	major = MAJOR(dev);
 
 	if (major == zvol_major)
 		return (B_TRUE);


### PR DESCRIPTION
WORK IN PROGRESS PLEASE DO NOT MERGE

In 4e7b5671c6a883d94b5428e1a9c141bbd56cb2a6 Linux makes major changes to
the block device API.

To accommodate this, change the vdev_lookup_bdev() API signature to:

boolean_t vdev_lookup_bdev(const char *path, dev_t *dev);

and handle calling bdput(struct block_device *) for the older variants,
as this is no longer required.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

Compatibility with linux git master.

#11387

Block dev API changes are in:

torvalds/linux@4e7b5671c6a883d94b5428e1a9c141bbd56cb2a6

get_disk_and_module() removed in:

torvalds/linux@4e7b5671c6a883d94b5428e1a9c141bbd56cb2a6

### Description

There are more problems to fix here, `./configure` now works, but the build still fails on errors like:

```
In file included from /usr/src/zfs/include/os/linux/spl/sys/uio.h:31,
                 from /usr/src/zfs/include/os/linux/spl/sys/sunddi.h:28,
                 from /usr/src/zfs/include/sys/zfs_context.h:69,
                 from /usr/src/zfs/module/zfs/dnode_sync.c:29:
/usr/src/zfs/include/os/linux/kernel/linux/blkdev_compat.h: В функции «get_disk_and_module»:
/usr/src/zfs/include/os/linux/kernel/linux/blkdev_compat.h:106:10: ошибка: неявная декларация функции «get_disk»; имелось в виду «put_disk»? [-Werror=implicit-function-declaration]
  106 |  return (get_disk(disk));
      |          ^~~~~~~~
      |          put_disk
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
