### PR TITLE
Tighten up 'zpool remove' space check

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -784,7 +784,8 @@ tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
     'removal_with_send_recv', 'removal_with_snapshot',
     'removal_with_write', 'removal_with_zdb', 'remove_expanded',
     'remove_mirror', 'remove_mirror_sanity', 'remove_raidz',
-    'remove_indirect', 'remove_attach_mirror']
+    'remove_indirect', 'remove_attach_mirror', 'remove_minimum',
+    'remove_unbalanced']
 tags = ['functional', 'removal']
 
 [tests/functional/rename_dirs]

--- a/tests/zfs-tests/tests/functional/removal/Makefile.am
+++ b/tests/zfs-tests/tests/functional/removal/Makefile.am
@@ -30,7 +30,7 @@ dist_pkgdata_SCRIPTS = \
 	removal_with_snapshot.ksh removal_with_write.ksh \
 	removal_with_zdb.ksh remove_mirror.ksh remove_mirror_sanity.ksh \
 	remove_raidz.ksh remove_expanded.ksh remove_indirect.ksh \
-	remove_attach_mirror.ksh
+	remove_attach_mirror.ksh remove_minimum.ksh remove_unbalanced.ksh
 
 dist_pkgdata_DATA = \
 	removal.kshlib

--- a/tests/zfs-tests/tests/functional/removal/remove_minimum.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_minimum.ksh
@@ -1,0 +1,56 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+#
+# DESCRIPTION:
+# Device removal is possible for minimum sized vdevs.
+#
+# STRATEGY:
+# 1. Create a pool with minimum sized removable devices
+# 2. Remove a top-level device
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must rm -f $TEST_BASE_DIR/device-{1,2}
+}
+
+log_assert "Device removal is possible for minimum sized vdevs."
+log_onexit cleanup
+
+# 1. Create a pool with minimum sized removable devices
+log_must truncate -s $MINVDEVSIZE $TEST_BASE_DIR/device-{1,2}
+log_must default_setup_noexit "$TEST_BASE_DIR/device-1 $TEST_BASE_DIR/device-2"
+
+log_must dd if=/dev/urandom of=$TESTDIR/$TESTFILE0 bs=1M count=64
+
+# 2. Remove a top-level device
+log_must zpool remove $TESTPOOL $TEST_BASE_DIR/device-1
+log_must wait_for_removal $TESTPOOL
+
+log_note "Capacity $(get_pool_prop capacity $TESTPOOL)"
+
+log_pass "Device removal is possible for minimum sized vdevs"

--- a/tests/zfs-tests/tests/functional/removal/remove_unbalanced.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_unbalanced.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+#
+# DESCRIPTION:
+# Device removal is possible for highly unbalanced vdevs.
+#
+# STRATEGY:
+# 1. Create a pool with unbalanced removable devices
+# 2. Remove the large top-level device
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must rm -f $TEST_BASE_DIR/device-{1,2}
+}
+
+log_assert "Device removal is possible for highly unbalanced vdevs."
+log_onexit cleanup
+
+# 1. Create a pool with unbalanced removable devices
+log_must truncate -s 10G $TEST_BASE_DIR/device-1
+log_must truncate -s 1T $TEST_BASE_DIR/device-2
+log_must default_setup_noexit "$TEST_BASE_DIR/device-1 $TEST_BASE_DIR/device-2"
+
+log_must dd if=/dev/urandom of=$TESTDIR/$TESTFILE0 bs=1M count=32
+
+# 2. Remove the large top-level device
+log_must zpool remove $TESTPOOL $TEST_BASE_DIR/device-1
+log_must wait_for_removal $TESTPOOL
+
+log_note "Capacity $(get_pool_prop capacity $TESTPOOL)"
+
+log_pass "Device removal is possible for highly unbalanced vdevs"


### PR DESCRIPTION
### Motivation and Context

Issue #11356.  Handle additional cases where device removal should
be possible but is prevented by an overly aggressive free space check.

### Description

The available space check in `spa_vdev_remove_top_check()` is intended
to verify there is enough available space on the other devices before
starting the removal process.  This is obviously a good idea but the
current check can significantly overestimate the space requirements
and often prevent removal when it clearly should be possible.

This change reworks the check to use the per-vdev vs_stats.  This
is sufficiently accurate and is convenient because it allows a direct
comparison to the allocated space.  If using `dsl_dir_space_available()`
then the available space of the device being removed is also included
in the return value and must somehow be accounted for.

Additionally, we reduce the slop space requirement to be inline with
with the capacity of the pool after the device has been removed.
This way if a large device is accidentally added to a small pool the
vastly increased slop requirement of the larger pool won't prevent
removal.  For example, it was previously possible that even newly
added empty vdevs couldn't be removed due to the increased slop
requirement.  This was particularly unfortunate since one of the
main motivations for this feature was to allow such mistakes to be
corrected.

Lastly it's worth mentioning that by allowing the removal to start
with close to the minimum required free space it is more likely that
an active pool close to capacity may fail the removal process.  This
failure case has always been possible since we can't know what new
data will be written during the removal process.  It is correctly
handled and there's no danger to the pool.

### How Has This Been Tested?

Added a new `remove_unbalanced` ZTS test which verifies that
when adding new large vdev (1TB) to an existing small pool (1GB)
it may still be removed as long as it hasn't been used.  This would
previously fail.

Additionally, locally ran the "removal" ZTS test group.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
