### PR TITLE
Autoconf 2.70 compat: AM_GNU_GETTEXT

### DIFF
--- a/config/gettext.m4
+++ b/config/gettext.m4
@@ -52,17 +52,17 @@ dnl GNU format catalogs when building on a platform with an X/Open gettext),
 dnl but we keep it in order not to force irrelevant filename changes on the
 dnl maintainers.
 dnl
-AC_DEFUN([AM_GNU_GETTEXT],
+AC_DEFUN([CUSTOM_AM_GNU_GETTEXT],
 [
   dnl Argument checking.
   ifelse([$1], [], , [ifelse([$1], [external], , [ifelse([$1], [use-libtool], ,
-    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
+    [errprint([ERROR: invalid first argument to CUSTOM_AM_GNU_GETTEXT
 ])])])])
   ifelse(ifelse([$1], [], [old])[]ifelse([$1], [no-libtool], [old]), [old],
-    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
+    [errprint([ERROR: Use of CUSTOM_AM_GNU_GETTEXT without [external] argument is no longer supported.
 ])])
   ifelse([$2], [], , [ifelse([$2], [need-ngettext], , [ifelse([$2], [need-formatstring-macros], ,
-    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
+    [errprint([ERROR: invalid second argument to CUSTOM_AM_GNU_GETTEXT
 ])])])])
   define([gt_included_intl],
     ifelse([$1], [external], [no], [yes]))

--- a/config/user-gettext.m4
+++ b/config/user-gettext.m4
@@ -2,5 +2,5 @@ dnl #
 dnl # Check if libintl and possibly libiconv are needed for gettext() functionality
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_USER_GETTEXT], [
-    AM_GNU_GETTEXT([external])
+	CUSTOM_AM_GNU_GETTEXT([external])
 ])


### PR DESCRIPTION
### Motivation and Context

Issue #11413.

### Description

Support for detecting libintl/libiconv, used by gettext(), was added
in commit e8864b1b.  This was an initial step towards being able
to provide language translations.  While the OpenZFS project hasn't
yet added any translations this did make it possible for end users
to add their own.

When this support was added using the AM_GNU_GETTEXT_VERSION macro
was optional.  It was therefore omitted and would be revisited if
OpenZFS ever began providing translations.  As of autoconf 2.70 it is
now mandatory.  Unfortunately, simply adding the missing macro call
isn't desirable since it will result both adding a new dependency on
the autopoint command, and additional macros and directories for
full translation support to the repository.

As a compromise to avoid the autoconf 2.70 error this change renames
the AM_GNU_GETTEXT macro.  This effectively let's us avoid the error
and preserve the current behavior until we either add full support
for translations or remove gettext() support entirely.

### How Has This Been Tested?

Using autoconf 2.7.0:

`./autogen.sh && ./configure && make -s`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
