### PR TITLE
Extending FreeBSD UIO Struct

### DIFF
--- a/include/os/freebsd/spl/sys/uio.h
+++ b/include/os/freebsd/spl/sys/uio.h
@@ -62,6 +62,12 @@ zfs_uio_init(zfs_uio_t *uio, struct uio *uio_s)
 	GET_UIO_STRUCT(uio) = uio_s;
 }
 
+static __inline void
+zfs_uio_setoffset(zfs_uio_t *uio, offset_t off)
+{
+	zfs_uio_offset(uio) = off;
+}
+
 static __inline int
 zfs_uiomove(void *cp, size_t n, zfs_uio_rw_t dir, zfs_uio_t *uio)
 {

--- a/include/os/freebsd/spl/sys/uio.h
+++ b/include/os/freebsd/spl/sys/uio.h
@@ -35,55 +35,66 @@
 #include <sys/_uio.h>
 #include <sys/debug.h>
 
-
-
-#define	uio_loffset	uio_offset
-
-typedef	struct uio	uio_t;
 typedef	struct iovec	iovec_t;
-typedef	enum uio_seg	uio_seg_t;
+typedef	enum uio_seg	zfs_uio_seg_t;
+typedef	enum uio_rw	zfs_uio_rw_t;
+
+typedef struct zfs_uio {
+	struct uio	*uio;
+} zfs_uio_t;
+
+#define	GET_UIO_STRUCT(u)	(u)->uio
+#define	zfs_uio_segflg(u)	GET_UIO_STRUCT(u)->uio_segflg
+#define	zfs_uio_offset(u)	GET_UIO_STRUCT(u)->uio_offset
+#define	zfs_uio_resid(u)	GET_UIO_STRUCT(u)->uio_resid
+#define	zfs_uio_iovcnt(u)	GET_UIO_STRUCT(u)->uio_iovcnt
+#define	zfs_uio_iovlen(u, idx)	GET_UIO_STRUCT(u)->uio_iov[(idx)].iov_len
+#define	zfs_uio_iovbase(u, idx)	GET_UIO_STRUCT(u)->uio_iov[(idx)].iov_base
+#define	zfs_uio_td(u)		GET_UIO_STRUCT(u)->uio_td
+#define	zfs_uio_rw(u)		GET_UIO_STRUCT(u)->uio_rw
+#define	zfs_uio_fault_disable(u, set)
+#define	zfs_uio_prefaultpages(size, u)	(0)
+
+
+static __inline void
+zfs_uio_init(zfs_uio_t *uio, struct uio *uio_s)
+{
+	GET_UIO_STRUCT(uio) = uio_s;
+}
 
 static __inline int
-zfs_uiomove(void *cp, size_t n, enum uio_rw dir, uio_t *uio)
+zfs_uiomove(void *cp, size_t n, zfs_uio_rw_t dir, zfs_uio_t *uio)
 {
-
-	ASSERT(uio->uio_rw == dir);
-	return (uiomove(cp, (int)n, uio));
+	ASSERT(zfs_uio_rw(uio) == dir);
+	return (uiomove(cp, (int)n, GET_UIO_STRUCT(uio)));
 }
-#define	uiomove(cp, n, dir, uio)	zfs_uiomove((cp), (n), (dir), (uio))
 
-int uiocopy(void *p, size_t n, enum uio_rw rw, struct uio *uio, size_t *cbytes);
-void uioskip(uio_t *uiop, size_t n);
-
-#define	uio_segflg(uio)			(uio)->uio_segflg
-#define	uio_offset(uio)			(uio)->uio_loffset
-#define	uio_resid(uio)			(uio)->uio_resid
-#define	uio_iovcnt(uio)			(uio)->uio_iovcnt
-#define	uio_iovlen(uio, idx)		(uio)->uio_iov[(idx)].iov_len
-#define	uio_iovbase(uio, idx)		(uio)->uio_iov[(idx)].iov_base
-#define	uio_fault_disable(uio, set)
-#define	uio_prefaultpages(size, uio)	(0)
+int zfs_uiocopy(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
+    size_t *cbytes);
+void zfs_uioskip(zfs_uio_t *uiop, size_t n);
+int zfs_uio_fault_move(void *p, size_t n, zfs_uio_rw_t dir, zfs_uio_t *uio);
 
 static inline void
-uio_iov_at_index(uio_t *uio, uint_t idx, void **base, uint64_t *len)
+zfs_uio_iov_at_index(zfs_uio_t *uio, uint_t idx, void **base, uint64_t *len)
 {
-	*base = uio_iovbase(uio, idx);
-	*len = uio_iovlen(uio, idx);
+	*base = zfs_uio_iovbase(uio, idx);
+	*len = zfs_uio_iovlen(uio, idx);
 }
 
 static inline void
-uio_advance(uio_t *uio, size_t size)
+zfs_uio_advance(zfs_uio_t *uio, size_t size)
 {
-	uio->uio_resid -= size;
-	uio->uio_loffset += size;
+	zfs_uio_resid(uio) -= size;
+	zfs_uio_offset(uio) += size;
 }
 
 static inline offset_t
-uio_index_at_offset(uio_t *uio, offset_t off, uint_t *vec_idx)
+zfs_uio_index_at_offset(zfs_uio_t *uio, offset_t off, uint_t *vec_idx)
 {
 	*vec_idx = 0;
-	while (*vec_idx < uio_iovcnt(uio) && off >= uio_iovlen(uio, *vec_idx)) {
-		off -= uio_iovlen(uio, *vec_idx);
+	while (*vec_idx < zfs_uio_iovcnt(uio) &&
+	    off >= zfs_uio_iovlen(uio, *vec_idx)) {
+		off -= zfs_uio_iovlen(uio, *vec_idx);
 		(*vec_idx)++;
 	}
 

--- a/include/os/freebsd/zfs/sys/freebsd_crypto.h
+++ b/include/os/freebsd/zfs/sys/freebsd_crypto.h
@@ -92,7 +92,7 @@ int freebsd_crypt_newsession(freebsd_crypt_session_t *sessp,
 void freebsd_crypt_freesession(freebsd_crypt_session_t *sessp);
 
 int freebsd_crypt_uio(boolean_t, freebsd_crypt_session_t *,
-	struct zio_crypt_info *, uio_t *, crypto_key_t *, uint8_t *,
+	struct zio_crypt_info *, zfs_uio_t *, crypto_key_t *, uint8_t *,
 	size_t, size_t);
 
 #endif /* _ZFS_FREEBSD_CRYPTO_H */

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -40,6 +40,7 @@
 #include <sys/zil.h>
 #include <sys/zfs_project.h>
 #include <vm/vm_object.h>
+#include <sys/uio.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -117,7 +118,8 @@ extern minor_t zfsdev_minor_alloc(void);
 #define	Z_ISDIR(type) ((type) == VDIR)
 
 #define	zn_has_cached_data(zp)	vn_has_cached_data(ZTOV(zp))
-#define	zn_rlimit_fsize(zp, uio, td)	vn_rlimit_fsize(ZTOV(zp), (uio), (td))
+#define	zn_rlimit_fsize(zp, uio) \
+    vn_rlimit_fsize(ZTOV(zp), GET_UIO_STRUCT(uio), zfs_uio_td(uio))
 
 /* Called on entry to each ZFS vnode and vfs operation  */
 #define	ZFS_ENTER(zfsvfs) \

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -79,6 +79,12 @@ typedef struct zfs_uio {
 #define	zfs_uio_fault_move(p, n, rw, u)	zfs_uiomove((p), (n), (rw), (u))
 
 static inline void
+zfs_uio_setoffset(zfs_uio_t *uio, offset_t off)
+{
+	uio->uio_loffset = off;
+}
+
+static inline void
 zfs_uio_iov_at_index(zfs_uio_t *uio, uint_t idx, void **base, uint64_t *len)
 {
 	*base = zfs_uio_iovbase(uio, idx);

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -36,21 +36,21 @@
 
 typedef struct iovec iovec_t;
 
-typedef enum uio_rw {
+typedef enum zfs_uio_rw {
 	UIO_READ =		0,
 	UIO_WRITE =		1,
-} uio_rw_t;
+} zfs_uio_rw_t;
 
-typedef enum uio_seg {
+typedef enum zfs_uio_seg {
 	UIO_USERSPACE =		0,
 	UIO_SYSSPACE =		1,
 	UIO_BVEC =		2,
 #if defined(HAVE_VFS_IOV_ITER)
 	UIO_ITER =		3,
 #endif
-} uio_seg_t;
+} zfs_uio_seg_t;
 
-typedef struct uio {
+typedef struct zfs_uio {
 	union {
 		const struct iovec	*uio_iov;
 		const struct bio_vec	*uio_bvec;
@@ -60,42 +60,45 @@ typedef struct uio {
 	};
 	int		uio_iovcnt;
 	offset_t	uio_loffset;
-	uio_seg_t	uio_segflg;
+	zfs_uio_seg_t	uio_segflg;
 	boolean_t	uio_fault_disable;
 	uint16_t	uio_fmode;
 	uint16_t	uio_extflg;
 	ssize_t		uio_resid;
 	size_t		uio_skip;
-} uio_t;
+} zfs_uio_t;
 
-#define	uio_segflg(uio)			(uio)->uio_segflg
-#define	uio_offset(uio)			(uio)->uio_loffset
-#define	uio_resid(uio)			(uio)->uio_resid
-#define	uio_iovcnt(uio)			(uio)->uio_iovcnt
-#define	uio_iovlen(uio, idx)		(uio)->uio_iov[(idx)].iov_len
-#define	uio_iovbase(uio, idx)		(uio)->uio_iov[(idx)].iov_base
-#define	uio_fault_disable(uio, set)	(uio)->uio_fault_disable = set
+#define	zfs_uio_segflg(u)		(u)->uio_segflg
+#define	zfs_uio_offset(u)		(u)->uio_loffset
+#define	zfs_uio_resid(u)		(u)->uio_resid
+#define	zfs_uio_iovcnt(u)		(u)->uio_iovcnt
+#define	zfs_uio_iovlen(u, idx)		(u)->uio_iov[(idx)].iov_len
+#define	zfs_uio_iovbase(u, idx)		(u)->uio_iov[(idx)].iov_base
+#define	zfs_uio_fault_disable(u, set)	(u)->uio_fault_disable = set
+#define	zfs_uio_rlimit_fsize(z, u)	(0)
+#define	zfs_uio_fault_move(p, n, rw, u)	zfs_uiomove((p), (n), (rw), (u))
 
 static inline void
-uio_iov_at_index(uio_t *uio, uint_t idx, void **base, uint64_t *len)
+zfs_uio_iov_at_index(zfs_uio_t *uio, uint_t idx, void **base, uint64_t *len)
 {
-	*base = uio_iovbase(uio, idx);
-	*len = uio_iovlen(uio, idx);
+	*base = zfs_uio_iovbase(uio, idx);
+	*len = zfs_uio_iovlen(uio, idx);
 }
 
 static inline void
-uio_advance(uio_t *uio, size_t size)
+zfs_uio_advance(zfs_uio_t *uio, size_t size)
 {
 	uio->uio_resid -= size;
 	uio->uio_loffset += size;
 }
 
 static inline offset_t
-uio_index_at_offset(uio_t *uio, offset_t off, uint_t *vec_idx)
+zfs_uio_index_at_offset(zfs_uio_t *uio, offset_t off, uint_t *vec_idx)
 {
 	*vec_idx = 0;
-	while (*vec_idx < uio_iovcnt(uio) && off >= uio_iovlen(uio, *vec_idx)) {
-		off -= uio_iovlen(uio, *vec_idx);
+	while (*vec_idx < zfs_uio_iovcnt(uio) &&
+	    off >= zfs_uio_iovlen(uio, *vec_idx)) {
+		off -= zfs_uio_iovlen(uio, *vec_idx);
 		(*vec_idx)++;
 	}
 
@@ -116,8 +119,9 @@ iov_iter_init_compat(struct iov_iter *iter, unsigned int dir,
 }
 
 static inline void
-uio_iovec_init(uio_t *uio, const struct iovec *iov, unsigned long nr_segs,
-    offset_t offset, uio_seg_t seg, ssize_t resid, size_t skip)
+zfs_uio_iovec_init(zfs_uio_t *uio, const struct iovec *iov,
+    unsigned long nr_segs, offset_t offset, zfs_uio_seg_t seg, ssize_t resid,
+    size_t skip)
 {
 	ASSERT(seg == UIO_USERSPACE || seg == UIO_SYSSPACE);
 
@@ -133,7 +137,7 @@ uio_iovec_init(uio_t *uio, const struct iovec *iov, unsigned long nr_segs,
 }
 
 static inline void
-uio_bvec_init(uio_t *uio, struct bio *bio)
+zfs_uio_bvec_init(zfs_uio_t *uio, struct bio *bio)
 {
 	uio->uio_bvec = &bio->bi_io_vec[BIO_BI_IDX(bio)];
 	uio->uio_iovcnt = bio->bi_vcnt - BIO_BI_IDX(bio);
@@ -148,7 +152,7 @@ uio_bvec_init(uio_t *uio, struct bio *bio)
 
 #if defined(HAVE_VFS_IOV_ITER)
 static inline void
-uio_iov_iter_init(uio_t *uio, struct iov_iter *iter, offset_t offset,
+zfs_uio_iov_iter_init(zfs_uio_t *uio, struct iov_iter *iter, offset_t offset,
     ssize_t resid, size_t skip)
 {
 	uio->uio_iter = iter;

--- a/include/os/linux/zfs/sys/zfs_vnops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vnops_os.h
@@ -60,7 +60,7 @@ extern int zfs_rename(znode_t *sdzp, char *snm, znode_t *tdzp,
     char *tnm, cred_t *cr, int flags);
 extern int zfs_symlink(znode_t *dzp, char *name, vattr_t *vap,
     char *link, znode_t **zpp, cred_t *cr, int flags);
-extern int zfs_readlink(struct inode *ip, uio_t *uio, cred_t *cr);
+extern int zfs_readlink(struct inode *ip, zfs_uio_t *uio, cred_t *cr);
 extern int zfs_link(znode_t *tdzp, znode_t *szp,
     char *name, cred_t *cr, int flags);
 extern void zfs_inactive(struct inode *ip);

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -70,8 +70,8 @@ extern "C" {
 #define	Z_ISDEV(type)	(S_ISCHR(type) || S_ISBLK(type) || S_ISFIFO(type))
 #define	Z_ISDIR(type)	S_ISDIR(type)
 
-#define	zn_has_cached_data(zp)	((zp)->z_is_mapped)
-#define	zn_rlimit_fsize(zp, uio, td)	(0)
+#define	zn_has_cached_data(zp)		((zp)->z_is_mapped)
+#define	zn_rlimit_fsize(zp, uio)	(0)
 
 #define	zhold(zp)	igrab(ZTOI((zp)))
 #define	zrele(zp)	iput(ZTOI((zp)))

--- a/include/sys/crypto/common.h
+++ b/include/sys/crypto/common.h
@@ -244,7 +244,7 @@ typedef struct crypto_data {
 		iovec_t cdu_raw;		/* Pointer and length	    */
 
 		/* uio scatter-gather format */
-		uio_t	*cdu_uio;
+		zfs_uio_t	*cdu_uio;
 
 	} cdu;	/* Crypto Data Union */
 } crypto_data_t;

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -847,14 +847,14 @@ void dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 void dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_tx_t *tx);
 #ifdef _KERNEL
-int dmu_read_uio(objset_t *os, uint64_t object, struct uio *uio, uint64_t size);
-int dmu_read_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size);
-int dmu_read_uio_dnode(dnode_t *dn, struct uio *uio, uint64_t size);
-int dmu_write_uio(objset_t *os, uint64_t object, struct uio *uio, uint64_t size,
+int dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size);
+int dmu_read_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size);
+int dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size);
+int dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
-int dmu_write_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size,
+int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
-int dmu_write_uio_dnode(dnode_t *dn, struct uio *uio, uint64_t size,
+int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);

--- a/include/sys/sa.h
+++ b/include/sys/sa.h
@@ -158,7 +158,7 @@ void sa_handle_lock(sa_handle_t *);
 void sa_handle_unlock(sa_handle_t *);
 
 #ifdef _KERNEL
-int sa_lookup_uio(sa_handle_t *, sa_attr_type_t, uio_t *);
+int sa_lookup_uio(sa_handle_t *, sa_attr_type_t, zfs_uio_t *);
 int sa_add_projid(sa_handle_t *, dmu_tx_t *, uint64_t);
 #endif
 

--- a/include/sys/uio_impl.h
+++ b/include/sys/uio_impl.h
@@ -41,9 +41,9 @@
 
 #include <sys/uio.h>
 
-extern int uiomove(void *, size_t, enum uio_rw, uio_t *);
-extern int uio_prefaultpages(ssize_t, uio_t *);
-extern int uiocopy(void *, size_t, enum uio_rw, uio_t *, size_t *);
-extern void uioskip(uio_t *, size_t);
+extern int zfs_uiomove(void *, size_t, zfs_uio_rw_t, zfs_uio_t *);
+extern int zfs_uio_prefaultpages(ssize_t, zfs_uio_t *);
+extern int zfs_uiocopy(void *, size_t, zfs_uio_rw_t, zfs_uio_t *, size_t *);
+extern void zfs_uioskip(zfs_uio_t *, size_t);
 
 #endif	/* _SYS_UIO_IMPL_H */

--- a/include/sys/zfs_sa.h
+++ b/include/sys/zfs_sa.h
@@ -134,7 +134,7 @@ typedef struct znode_phys {
 #define	DXATTR_MAX_ENTRY_SIZE	(32768)
 #define	DXATTR_MAX_SA_SIZE	(SPA_OLD_MAXBLOCKSIZE >> 1)
 
-int zfs_sa_readlink(struct znode *, uio_t *);
+int zfs_sa_readlink(struct znode *, zfs_uio_t *);
 void zfs_sa_symlink(struct znode *, char *link, int len, dmu_tx_t *);
 void zfs_sa_get_scanstamp(struct znode *, xvattr_t *);
 void zfs_sa_set_scanstamp(struct znode *, xvattr_t *, dmu_tx_t *);

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -27,16 +27,16 @@
 #include <sys/zfs_vnops_os.h>
 
 extern int zfs_fsync(znode_t *, int, cred_t *);
-extern int zfs_read(znode_t *, uio_t *, int, cred_t *);
-extern int zfs_write(znode_t *, uio_t *, int, cred_t *);
+extern int zfs_read(znode_t *, zfs_uio_t *, int, cred_t *);
+extern int zfs_write(znode_t *, zfs_uio_t *, int, cred_t *);
 extern int zfs_holey(znode_t *, ulong_t, loff_t *);
 extern int zfs_access(znode_t *, int, int, cred_t *);
 
 extern int zfs_getsecattr(znode_t *, vsecattr_t *, int, cred_t *);
 extern int zfs_setsecattr(znode_t *, vsecattr_t *, int, cred_t *);
 
-extern int mappedread(znode_t *, int, uio_t *);
-extern int mappedread_sf(znode_t *, int, uio_t *);
+extern int mappedread(znode_t *, int, zfs_uio_t *);
+extern int mappedread_sf(znode_t *, int, zfs_uio_t *);
 extern void update_pages(znode_t *, int64_t, int, objset_t *);
 
 /*

--- a/lib/libspl/include/sys/uio.h
+++ b/lib/libspl/include/sys/uio.h
@@ -51,58 +51,58 @@
 typedef struct iovec iovec_t;
 
 #if defined(__linux__) || defined(__APPLE__)
-typedef enum uio_rw {
+typedef enum zfs_uio_rw {
 	UIO_READ =	0,
 	UIO_WRITE =	1,
-} uio_rw_t;
+} zfs_uio_rw_t;
 
-typedef enum uio_seg {
+typedef enum zfs_uio_seg {
 	UIO_USERSPACE =	0,
 	UIO_SYSSPACE =	1,
-} uio_seg_t;
+} zfs_uio_seg_t;
 
 #elif defined(__FreeBSD__)
-typedef enum uio_seg  uio_seg_t;
+typedef enum uio_seg  zfs_uio_seg_t;
 #endif
 
-typedef struct uio {
+typedef struct zfs_uio {
 	struct iovec	*uio_iov;	/* pointer to array of iovecs */
 	int		uio_iovcnt;	/* number of iovecs */
 	offset_t	uio_loffset;	/* file offset */
-	uio_seg_t	uio_segflg;	/* address space (kernel or user) */
+	zfs_uio_seg_t	uio_segflg;	/* address space (kernel or user) */
 	uint16_t	uio_fmode;	/* file mode flags */
 	uint16_t	uio_extflg;	/* extended flags */
 	ssize_t		uio_resid;	/* residual count */
-} uio_t;
+} zfs_uio_t;
 
-#define	uio_segflg(uio)			(uio)->uio_segflg
-#define	uio_offset(uio)			(uio)->uio_loffset
-#define	uio_resid(uio)			(uio)->uio_resid
-#define	uio_iovcnt(uio)			(uio)->uio_iovcnt
-#define	uio_iovlen(uio, idx)		(uio)->uio_iov[(idx)].iov_len
-#define	uio_iovbase(uio, idx)		(uio)->uio_iov[(idx)].iov_base
+#define	zfs_uio_segflg(uio)		(uio)->uio_segflg
+#define	zfs_uio_offset(uio)		(uio)->uio_loffset
+#define	zfs_uio_resid(uio)		(uio)->uio_resid
+#define	zfs_uio_iovcnt(uio)		(uio)->uio_iovcnt
+#define	zfs_uio_iovlen(uio, idx)	(uio)->uio_iov[(idx)].iov_len
+#define	zfs_uio_iovbase(uio, idx)	(uio)->uio_iov[(idx)].iov_base
 
 static inline void
-uio_iov_at_index(uio_t *uio, uint_t idx, void **base, uint64_t *len)
+zfs_uio_iov_at_index(zfs_uio_t *uio, uint_t idx, void **base, uint64_t *len)
 {
-	*base = uio_iovbase(uio, idx);
-	*len = uio_iovlen(uio, idx);
+	*base = zfs_uio_iovbase(uio, idx);
+	*len = zfs_uio_iovlen(uio, idx);
 }
 
 static inline void
-uio_advance(uio_t *uio, size_t size)
+zfs_uio_advance(zfs_uio_t *uio, size_t size)
 {
 	uio->uio_resid -= size;
 	uio->uio_loffset += size;
 }
 
 static inline offset_t
-uio_index_at_offset(uio_t *uio, offset_t off, uint_t *vec_idx)
+zfs_uio_index_at_offset(zfs_uio_t *uio, offset_t off, uint_t *vec_idx)
 {
 	*vec_idx = 0;
-	while (*vec_idx < (uint_t)uio_iovcnt(uio) &&
-	    off >= (offset_t)uio_iovlen(uio, *vec_idx)) {
-		off -= uio_iovlen(uio, *vec_idx);
+	while (*vec_idx < (uint_t)zfs_uio_iovcnt(uio) &&
+	    off >= (offset_t)zfs_uio_iovlen(uio, *vec_idx)) {
+		off -= zfs_uio_iovlen(uio, *vec_idx);
 		(*vec_idx)++;
 	}
 

--- a/module/icp/algs/modes/modes.c
+++ b/module/icp/algs/modes/modes.c
@@ -43,11 +43,11 @@ crypto_init_ptrs(crypto_data_t *out, void **iov_or_mp, offset_t *current_offset)
 		break;
 
 	case CRYPTO_DATA_UIO: {
-		uio_t *uiop = out->cd_uio;
+		zfs_uio_t *uiop = out->cd_uio;
 		uint_t vec_idx;
 
 		offset = out->cd_offset;
-		offset = uio_index_at_offset(uiop, offset, &vec_idx);
+		offset = zfs_uio_index_at_offset(uiop, offset, &vec_idx);
 
 		*current_offset = offset;
 		*iov_or_mp = (void *)(uintptr_t)vec_idx;
@@ -85,7 +85,7 @@ crypto_get_ptrs(crypto_data_t *out, void **iov_or_mp, offset_t *current_offset,
 	}
 
 	case CRYPTO_DATA_UIO: {
-		uio_t *uio = out->cd_uio;
+		zfs_uio_t *uio = out->cd_uio;
 		offset_t offset;
 		uint_t vec_idx;
 		uint8_t *p;
@@ -94,7 +94,7 @@ crypto_get_ptrs(crypto_data_t *out, void **iov_or_mp, offset_t *current_offset,
 
 		offset = *current_offset;
 		vec_idx = (uintptr_t)(*iov_or_mp);
-		uio_iov_at_index(uio, vec_idx, &iov_base, &iov_len);
+		zfs_uio_iov_at_index(uio, vec_idx, &iov_base, &iov_len);
 		p = (uint8_t *)iov_base + offset;
 		*out_data_1 = p;
 
@@ -106,10 +106,10 @@ crypto_get_ptrs(crypto_data_t *out, void **iov_or_mp, offset_t *current_offset,
 		} else {
 			/* one block spans two iovecs */
 			*out_data_1_len = iov_len - offset;
-			if (vec_idx == uio_iovcnt(uio))
+			if (vec_idx == zfs_uio_iovcnt(uio))
 				return;
 			vec_idx++;
-			uio_iov_at_index(uio, vec_idx, &iov_base, &iov_len);
+			zfs_uio_iov_at_index(uio, vec_idx, &iov_base, &iov_len);
 			*out_data_2 = (uint8_t *)iov_base;
 			*current_offset = amt - *out_data_1_len;
 		}

--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -272,18 +272,18 @@ skein_digest_update_uio(skein_ctx_t *ctx, const crypto_data_t *data)
 	size_t		length = data->cd_length;
 	uint_t		vec_idx = 0;
 	size_t		cur_len;
-	uio_t		*uio = data->cd_uio;
+	zfs_uio_t	*uio = data->cd_uio;
 
 	/* we support only kernel buffer */
-	if (uio_segflg(uio) != UIO_SYSSPACE)
+	if (zfs_uio_segflg(uio) != UIO_SYSSPACE)
 		return (CRYPTO_ARGUMENTS_BAD);
 
 	/*
 	 * Jump to the first iovec containing data to be
 	 * digested.
 	 */
-	offset = uio_index_at_offset(uio, offset, &vec_idx);
-	if (vec_idx == uio_iovcnt(uio)) {
+	offset = zfs_uio_index_at_offset(uio, offset, &vec_idx);
+	if (vec_idx == zfs_uio_iovcnt(uio)) {
 		/*
 		 * The caller specified an offset that is larger than the
 		 * total size of the buffers it provided.
@@ -294,16 +294,16 @@ skein_digest_update_uio(skein_ctx_t *ctx, const crypto_data_t *data)
 	/*
 	 * Now do the digesting on the iovecs.
 	 */
-	while (vec_idx < uio_iovcnt(uio) && length > 0) {
-		cur_len = MIN(uio_iovlen(uio, vec_idx) - offset, length);
-		SKEIN_OP(ctx, Update, (uint8_t *)uio_iovbase(uio, vec_idx)
+	while (vec_idx < zfs_uio_iovcnt(uio) && length > 0) {
+		cur_len = MIN(zfs_uio_iovlen(uio, vec_idx) - offset, length);
+		SKEIN_OP(ctx, Update, (uint8_t *)zfs_uio_iovbase(uio, vec_idx)
 		    + offset, cur_len);
 		length -= cur_len;
 		vec_idx++;
 		offset = 0;
 	}
 
-	if (vec_idx == uio_iovcnt(uio) && length > 0) {
+	if (vec_idx == zfs_uio_iovcnt(uio) && length > 0) {
 		/*
 		 * The end of the specified iovec's was reached but
 		 * the length requested could not be processed, i.e.
@@ -322,19 +322,19 @@ static int
 skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
-	off_t	offset = digest->cd_offset;
-	uint_t	vec_idx = 0;
-	uio_t	*uio = digest->cd_uio;
+	off_t offset = digest->cd_offset;
+	uint_t vec_idx = 0;
+	zfs_uio_t *uio = digest->cd_uio;
 
 	/* we support only kernel buffer */
-	if (uio_segflg(uio) != UIO_SYSSPACE)
+	if (zfs_uio_segflg(uio) != UIO_SYSSPACE)
 		return (CRYPTO_ARGUMENTS_BAD);
 
 	/*
 	 * Jump to the first iovec containing ptr to the digest to be returned.
 	 */
-	offset = uio_index_at_offset(uio, offset, &vec_idx);
-	if (vec_idx == uio_iovcnt(uio)) {
+	offset = zfs_uio_index_at_offset(uio, offset, &vec_idx);
+	if (vec_idx == zfs_uio_iovcnt(uio)) {
 		/*
 		 * The caller specified an offset that is larger than the
 		 * total size of the buffers it provided.
@@ -342,10 +342,10 @@ skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
 		return (CRYPTO_DATA_LEN_RANGE);
 	}
 	if (offset + CRYPTO_BITS2BYTES(ctx->sc_digest_bitlen) <=
-	    uio_iovlen(uio, vec_idx)) {
+	    zfs_uio_iovlen(uio, vec_idx)) {
 		/* The computed digest will fit in the current iovec. */
 		SKEIN_OP(ctx, Final,
-		    (uchar_t *)uio_iovbase(uio, vec_idx) + offset);
+		    (uchar_t *)zfs_uio_iovbase(uio, vec_idx) + offset);
 	} else {
 		uint8_t *digest_tmp;
 		off_t scratch_offset = 0;
@@ -357,11 +357,11 @@ skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
 		if (digest_tmp == NULL)
 			return (CRYPTO_HOST_MEMORY);
 		SKEIN_OP(ctx, Final, digest_tmp);
-		while (vec_idx < uio_iovcnt(uio) && length > 0) {
-			cur_len = MIN(uio_iovlen(uio, vec_idx) - offset,
+		while (vec_idx < zfs_uio_iovcnt(uio) && length > 0) {
+			cur_len = MIN(zfs_uio_iovlen(uio, vec_idx) - offset,
 			    length);
 			bcopy(digest_tmp + scratch_offset,
-			    uio_iovbase(uio, vec_idx) + offset, cur_len);
+			    zfs_uio_iovbase(uio, vec_idx) + offset, cur_len);
 
 			length -= cur_len;
 			vec_idx++;
@@ -370,7 +370,7 @@ skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
 		}
 		kmem_free(digest_tmp, CRYPTO_BITS2BYTES(ctx->sc_digest_bitlen));
 
-		if (vec_idx == uio_iovcnt(uio) && length > 0) {
+		if (vec_idx == zfs_uio_iovcnt(uio) && length > 0) {
 			/*
 			 * The end of the specified iovec's was reached but
 			 * the length requested could not be processed, i.e.

--- a/module/os/freebsd/zfs/crypto_os.c
+++ b/module/os/freebsd/zfs/crypto_os.c
@@ -197,7 +197,7 @@ static void
 freebsd_crypt_uio_debug_log(boolean_t encrypt,
     freebsd_crypt_session_t *input_sessionp,
     struct zio_crypt_info *c_info,
-    uio_t *data_uio,
+    zfs_uio_t *data_uio,
     crypto_key_t *key,
     uint8_t *ivbuf,
     size_t datalen,
@@ -222,13 +222,13 @@ freebsd_crypt_uio_debug_log(boolean_t encrypt,
 		printf("%02x ", b[i]);
 	}
 	printf("}\n");
-	for (int i = 0; i < data_uio->uio_iovcnt; i++) {
+	for (int i = 0; i < zfs_uio_iovcnt(data_uio); i++) {
 		printf("\tiovec #%d: <%p, %u>\n", i,
-		    data_uio->uio_iov[i].iov_base,
-		    (unsigned int)data_uio->uio_iov[i].iov_len);
-		total += data_uio->uio_iov[i].iov_len;
+		    zfs_uio_iovbase(data_uio, i),
+		    (unsigned int)zfs_uio_iovlen(data_uio, i));
+		total += zfs_uio_iovlen(data_uio, i);
 	}
-	data_uio->uio_resid = total;
+	zfs_uio_resid(data_uio) = total;
 #endif
 }
 /*
@@ -310,7 +310,7 @@ int
 freebsd_crypt_uio(boolean_t encrypt,
     freebsd_crypt_session_t *input_sessionp,
     struct zio_crypt_info *c_info,
-    uio_t *data_uio,
+    zfs_uio_t *data_uio,
     crypto_key_t *key,
     uint8_t *ivbuf,
     size_t datalen,
@@ -323,9 +323,9 @@ freebsd_crypt_uio(boolean_t encrypt,
 
 	freebsd_crypt_uio_debug_log(encrypt, input_sessionp, c_info, data_uio,
 	    key, ivbuf, datalen, auth_len);
-	for (int i = 0; i < data_uio->uio_iovcnt; i++)
-		total += data_uio->uio_iov[i].iov_len;
-	data_uio->uio_resid = total;
+	for (int i = 0; i < zfs_uio_iovcnt(data_uio); i++)
+		total += zfs_uio_iovlen(data_uio, i);
+	zfs_uio_resid(data_uio) = total;
 	if (input_sessionp == NULL) {
 		session = kmem_zalloc(sizeof (*session), KM_SLEEP);
 		error = freebsd_crypt_newsession(session, c_info, key);
@@ -343,7 +343,7 @@ freebsd_crypt_uio(boolean_t encrypt,
 		    CRYPTO_OP_VERIFY_DIGEST;
 	}
 	crp->crp_flags = CRYPTO_F_CBIFSYNC | CRYPTO_F_IV_SEPARATE;
-	crypto_use_uio(crp, data_uio);
+	crypto_use_uio(crp, GET_UIO_STRUCT(data_uio));
 
 	crp->crp_aad_start = 0;
 	crp->crp_aad_length = auth_len;
@@ -480,7 +480,7 @@ int
 freebsd_crypt_uio(boolean_t encrypt,
     freebsd_crypt_session_t *input_sessionp,
     struct zio_crypt_info *c_info,
-    uio_t *data_uio,
+    zfs_uio_t *data_uio,
     crypto_key_t *key,
     uint8_t *ivbuf,
     size_t datalen,
@@ -564,7 +564,7 @@ freebsd_crypt_uio(boolean_t encrypt,
 
 	crp->crp_session = session->fs_sid;
 	crp->crp_ilen = auth_len + datalen;
-	crp->crp_buf = (void*)data_uio;
+	crp->crp_buf = (void*)GET_UIO_STRUCT(data_uio);
 	crp->crp_flags = CRYPTO_F_IOV | CRYPTO_F_CBIFSYNC;
 
 	auth_desc->crd_skip = 0;

--- a/module/os/freebsd/zfs/zfs_ctldir.c
+++ b/module/os/freebsd/zfs/zfs_ctldir.c
@@ -1082,7 +1082,7 @@ zfsctl_snapdir_readdir(struct vop_readdir_args *ap)
 			ZFS_EXIT(zfsvfs);
 			return (SET_ERROR(error));
 		}
-		zfs_uio_offset(&uio) = cookie + dots_offset;
+		zfs_uio_setoffset(&uio, cookie + dots_offset);
 	}
 	/* NOTREACHED */
 }

--- a/module/os/freebsd/zfs/zfs_ctldir.c
+++ b/module/os/freebsd/zfs/zfs_ctldir.c
@@ -251,7 +251,7 @@ sfs_reclaim_vnode(vnode_t *vp)
 
 static int
 sfs_readdir_common(uint64_t parent_id, uint64_t id, struct vop_readdir_args *ap,
-    uio_t *uio, off_t *offp)
+    zfs_uio_t *uio, off_t *offp)
 {
 	struct dirent entry;
 	int error;
@@ -260,26 +260,26 @@ sfs_readdir_common(uint64_t parent_id, uint64_t id, struct vop_readdir_args *ap,
 	if (ap->a_ncookies != NULL)
 		*ap->a_ncookies = 0;
 
-	if (uio->uio_resid < sizeof (entry))
+	if (zfs_uio_resid(uio) < sizeof (entry))
 		return (SET_ERROR(EINVAL));
 
-	if (uio->uio_offset < 0)
+	if (zfs_uio_offset(uio) < 0)
 		return (SET_ERROR(EINVAL));
-	if (uio->uio_offset == 0) {
+	if (zfs_uio_offset(uio) == 0) {
 		entry.d_fileno = id;
 		entry.d_type = DT_DIR;
 		entry.d_name[0] = '.';
 		entry.d_name[1] = '\0';
 		entry.d_namlen = 1;
 		entry.d_reclen = sizeof (entry);
-		error = vfs_read_dirent(ap, &entry, uio->uio_offset);
+		error = vfs_read_dirent(ap, &entry, zfs_uio_offset(uio));
 		if (error != 0)
 			return (SET_ERROR(error));
 	}
 
-	if (uio->uio_offset < sizeof (entry))
+	if (zfs_uio_offset(uio) < sizeof (entry))
 		return (SET_ERROR(EINVAL));
-	if (uio->uio_offset == sizeof (entry)) {
+	if (zfs_uio_offset(uio) == sizeof (entry)) {
 		entry.d_fileno = parent_id;
 		entry.d_type = DT_DIR;
 		entry.d_name[0] = '.';
@@ -287,7 +287,7 @@ sfs_readdir_common(uint64_t parent_id, uint64_t id, struct vop_readdir_args *ap,
 		entry.d_name[2] = '\0';
 		entry.d_namlen = 2;
 		entry.d_reclen = sizeof (entry);
-		error = vfs_read_dirent(ap, &entry, uio->uio_offset);
+		error = vfs_read_dirent(ap, &entry, zfs_uio_offset(uio));
 		if (error != 0)
 			return (SET_ERROR(error));
 	}
@@ -666,21 +666,23 @@ zfsctl_root_readdir(struct vop_readdir_args *ap)
 	vnode_t *vp = ap->a_vp;
 	zfsvfs_t *zfsvfs = vp->v_vfsp->vfs_data;
 	zfsctl_root_t *node = vp->v_data;
-	uio_t *uio = ap->a_uio;
+	zfs_uio_t uio;
 	int *eofp = ap->a_eofflag;
 	off_t dots_offset;
 	int error;
 
+	zfs_uio_init(&uio, ap->a_uio);
+
 	ASSERT(vp->v_type == VDIR);
 
-	error = sfs_readdir_common(zfsvfs->z_root, ZFSCTL_INO_ROOT, ap, uio,
+	error = sfs_readdir_common(zfsvfs->z_root, ZFSCTL_INO_ROOT, ap, &uio,
 	    &dots_offset);
 	if (error != 0) {
 		if (error == ENAMETOOLONG) /* ran out of destination space */
 			error = 0;
 		return (error);
 	}
-	if (uio->uio_offset != dots_offset)
+	if (zfs_uio_offset(&uio) != dots_offset)
 		return (SET_ERROR(EINVAL));
 
 	CTASSERT(sizeof (node->snapdir->sn_name) <= sizeof (entry.d_name));
@@ -689,7 +691,7 @@ zfsctl_root_readdir(struct vop_readdir_args *ap)
 	strcpy(entry.d_name, node->snapdir->sn_name);
 	entry.d_namlen = strlen(entry.d_name);
 	entry.d_reclen = sizeof (entry);
-	error = vfs_read_dirent(ap, &entry, uio->uio_offset);
+	error = vfs_read_dirent(ap, &entry, zfs_uio_offset(&uio));
 	if (error != 0) {
 		if (error == ENAMETOOLONG)
 			error = 0;
@@ -1030,15 +1032,17 @@ zfsctl_snapdir_readdir(struct vop_readdir_args *ap)
 	struct dirent entry;
 	vnode_t *vp = ap->a_vp;
 	zfsvfs_t *zfsvfs = vp->v_vfsp->vfs_data;
-	uio_t *uio = ap->a_uio;
+	zfs_uio_t uio;
 	int *eofp = ap->a_eofflag;
 	off_t dots_offset;
 	int error;
 
+	zfs_uio_init(&uio, ap->a_uio);
+
 	ASSERT(vp->v_type == VDIR);
 
-	error = sfs_readdir_common(ZFSCTL_INO_ROOT, ZFSCTL_INO_SNAPDIR, ap, uio,
-	    &dots_offset);
+	error = sfs_readdir_common(ZFSCTL_INO_ROOT, ZFSCTL_INO_SNAPDIR, ap,
+	    &uio, &dots_offset);
 	if (error != 0) {
 		if (error == ENAMETOOLONG) /* ran out of destination space */
 			error = 0;
@@ -1050,7 +1054,7 @@ zfsctl_snapdir_readdir(struct vop_readdir_args *ap)
 		uint64_t cookie;
 		uint64_t id;
 
-		cookie = uio->uio_offset - dots_offset;
+		cookie = zfs_uio_offset(&uio) - dots_offset;
 
 		dsl_pool_config_enter(dmu_objset_pool(zfsvfs->z_os), FTAG);
 		error = dmu_snapshot_list_next(zfsvfs->z_os, sizeof (snapname),
@@ -1071,14 +1075,14 @@ zfsctl_snapdir_readdir(struct vop_readdir_args *ap)
 		strcpy(entry.d_name, snapname);
 		entry.d_namlen = strlen(entry.d_name);
 		entry.d_reclen = sizeof (entry);
-		error = vfs_read_dirent(ap, &entry, uio->uio_offset);
+		error = vfs_read_dirent(ap, &entry, zfs_uio_offset(&uio));
 		if (error != 0) {
 			if (error == ENAMETOOLONG)
 				error = 0;
 			ZFS_EXIT(zfsvfs);
 			return (SET_ERROR(error));
 		}
-		uio->uio_offset = cookie + dots_offset;
+		zfs_uio_offset(&uio) = cookie + dots_offset;
 	}
 	/* NOTREACHED */
 }

--- a/module/os/freebsd/zfs/zfs_file_os.c
+++ b/module/os/freebsd/zfs/zfs_file_os.c
@@ -290,7 +290,7 @@ zfs_file_private(zfs_file_t *fp)
 int
 zfs_file_unlink(const char *fnamep)
 {
-	enum uio_seg seg = UIO_SYSSPACE;
+	zfs_uio_seg_t seg = UIO_SYSSPACE;
 	int rc;
 
 #if __FreeBSD_version >= 1300018

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -518,7 +518,7 @@ update_pages(znode_t *zp, int64_t start, int len, objset_t *os)
  * in one single dmu_read() call.
  */
 int
-mappedread_sf(znode_t *zp, int nbytes, uio_t *uio)
+mappedread_sf(znode_t *zp, int nbytes, zfs_uio_t *uio)
 {
 	vnode_t *vp = ZTOV(zp);
 	objset_t *os = zp->z_zfsvfs->z_os;
@@ -530,14 +530,14 @@ mappedread_sf(znode_t *zp, int nbytes, uio_t *uio)
 	int len = nbytes;
 	int error = 0;
 
-	ASSERT(uio->uio_segflg == UIO_NOCOPY);
+	ASSERT(zfs_uio_segflg(uio) == UIO_NOCOPY);
 	ASSERT(vp->v_mount != NULL);
 	obj = vp->v_object;
 	ASSERT(obj != NULL);
-	ASSERT((uio->uio_loffset & PAGEOFFSET) == 0);
+	ASSERT((zfs_uio_offset(uio) & PAGEOFFSET) == 0);
 
 	zfs_vmobject_wlock_12(obj);
-	for (start = uio->uio_loffset; len > 0; start += PAGESIZE) {
+	for (start = zfs_uio_offset(uio); len > 0; start += PAGESIZE) {
 		int bytes = MIN(PAGESIZE, len);
 
 		pp = vm_page_grab_unlocked(obj, OFF_TO_IDX(start),
@@ -584,8 +584,8 @@ mappedread_sf(znode_t *zp, int nbytes, uio_t *uio)
 		}
 		if (error)
 			break;
-		uio->uio_resid -= bytes;
-		uio->uio_offset += bytes;
+		zfs_uio_resid(uio) -= bytes;
+		zfs_uio_offset(uio) += bytes;
 		len -= bytes;
 	}
 	zfs_vmobject_wunlock_12(obj);
@@ -603,7 +603,7 @@ mappedread_sf(znode_t *zp, int nbytes, uio_t *uio)
  *	 the file is memory mapped.
  */
 int
-mappedread(znode_t *zp, int nbytes, uio_t *uio)
+mappedread(znode_t *zp, int nbytes, zfs_uio_t *uio)
 {
 	vnode_t *vp = ZTOV(zp);
 	vm_object_t obj;
@@ -616,7 +616,7 @@ mappedread(znode_t *zp, int nbytes, uio_t *uio)
 	obj = vp->v_object;
 	ASSERT(obj != NULL);
 
-	start = uio->uio_loffset;
+	start = zfs_uio_offset(uio);
 	off = start & PAGEOFFSET;
 	zfs_vmobject_wlock_12(obj);
 	for (start &= PAGEMASK; len > 0; start += PAGESIZE) {
@@ -629,7 +629,8 @@ mappedread(znode_t *zp, int nbytes, uio_t *uio)
 
 			zfs_vmobject_wunlock_12(obj);
 			va = zfs_map_page(pp, &sf);
-			error = vn_io_fault_uiomove(va + off, bytes, uio);
+			error = vn_io_fault_uiomove(va + off, bytes,
+			    GET_UIO_STRUCT(uio));
 			zfs_unmap_page(sf);
 			zfs_vmobject_wlock_12(obj);
 			page_unhold(pp);
@@ -1653,7 +1654,7 @@ zfs_rmdir(znode_t *dzp, const char *name, znode_t *cwd, cred_t *cr, int flags)
  */
 /* ARGSUSED */
 static int
-zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
+zfs_readdir(vnode_t *vp, zfs_uio_t *uio, cred_t *cr, int *eofp,
     int *ncookies, ulong_t **cookies)
 {
 	znode_t		*zp = VTOZ(vp);
@@ -1698,7 +1699,7 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
 	/*
 	 * Check for valid iov_len.
 	 */
-	if (uio->uio_iov->iov_len <= 0) {
+	if (GET_UIO_STRUCT(uio)->uio_iov->iov_len <= 0) {
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EINVAL));
 	}
@@ -1713,7 +1714,7 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
 
 	error = 0;
 	os = zfsvfs->z_os;
-	offset = uio->uio_loffset;
+	offset = zfs_uio_offset(uio);
 	prefetch = zp->z_zn_prefetch;
 
 	/*
@@ -1734,9 +1735,9 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
 	/*
 	 * Get space to change directory entries into fs independent format.
 	 */
-	iovp = uio->uio_iov;
+	iovp = GET_UIO_STRUCT(uio)->uio_iov;
 	bytes_wanted = iovp->iov_len;
-	if (uio->uio_segflg != UIO_SYSSPACE || uio->uio_iovcnt != 1) {
+	if (zfs_uio_segflg(uio) != UIO_SYSSPACE || zfs_uio_iovcnt(uio) != 1) {
 		bufsize = bytes_wanted;
 		outbuf = kmem_alloc(bufsize, KM_SLEEP);
 		odp = (struct dirent64 *)outbuf;
@@ -1751,7 +1752,7 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
 		/*
 		 * Minimum entry size is dirent size and 1 byte for a file name.
 		 */
-		ncooks = uio->uio_resid / (sizeof (struct dirent) -
+		ncooks = zfs_uio_resid(uio) / (sizeof (struct dirent) -
 		    sizeof (((struct dirent *)NULL)->d_name) + 1);
 		cooks = malloc(ncooks * sizeof (ulong_t), M_TEMP, M_WAITOK);
 		*cookies = cooks;
@@ -1931,20 +1932,21 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp,
 	if (ncookies != NULL)
 		*ncookies -= ncooks;
 
-	if (uio->uio_segflg == UIO_SYSSPACE && uio->uio_iovcnt == 1) {
+	if (zfs_uio_segflg(uio) == UIO_SYSSPACE && zfs_uio_iovcnt(uio) == 1) {
 		iovp->iov_base += outcount;
 		iovp->iov_len -= outcount;
-		uio->uio_resid -= outcount;
-	} else if ((error = uiomove(outbuf, (long)outcount, UIO_READ, uio))) {
+		zfs_uio_resid(uio) -= outcount;
+	} else if ((error =
+	    zfs_uiomove(outbuf, (long)outcount, UIO_READ, uio))) {
 		/*
 		 * Reset the pointer.
 		 */
-		offset = uio->uio_loffset;
+		offset = zfs_uio_offset(uio);
 	}
 
 update:
 	zap_cursor_fini(&zc);
-	if (uio->uio_segflg != UIO_SYSSPACE || uio->uio_iovcnt != 1)
+	if (zfs_uio_segflg(uio) != UIO_SYSSPACE || zfs_uio_iovcnt(uio) != 1)
 		kmem_free(outbuf, bufsize);
 
 	if (error == ENOENT)
@@ -1952,7 +1954,7 @@ update:
 
 	ZFS_ACCESSTIME_STAMP(zfsvfs, zp);
 
-	uio->uio_loffset = offset;
+	zfs_uio_offset(uio) = offset;
 	ZFS_EXIT(zfsvfs);
 	if (error != 0 && cookies != NULL) {
 		free(*cookies, M_TEMP);
@@ -3635,7 +3637,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
  */
 /* ARGSUSED */
 static int
-zfs_readlink(vnode_t *vp, uio_t *uio, cred_t *cr, caller_context_t *ct)
+zfs_readlink(vnode_t *vp, zfs_uio_t *uio, cred_t *cr, caller_context_t *ct)
 {
 	znode_t		*zp = VTOZ(vp);
 	zfsvfs_t	*zfsvfs = zp->z_zfsvfs;
@@ -4418,8 +4420,9 @@ struct vop_read_args {
 static int
 zfs_freebsd_read(struct vop_read_args *ap)
 {
-
-	return (zfs_read(VTOZ(ap->a_vp), ap->a_uio, ioflags(ap->a_ioflag),
+	zfs_uio_t uio;
+	zfs_uio_init(&uio, ap->a_uio);
+	return (zfs_read(VTOZ(ap->a_vp), &uio, ioflags(ap->a_ioflag),
 	    ap->a_cred));
 }
 
@@ -4435,8 +4438,9 @@ struct vop_write_args {
 static int
 zfs_freebsd_write(struct vop_write_args *ap)
 {
-
-	return (zfs_write(VTOZ(ap->a_vp), ap->a_uio, ioflags(ap->a_ioflag),
+	zfs_uio_t uio;
+	zfs_uio_init(&uio, ap->a_uio);
+	return (zfs_write(VTOZ(ap->a_vp), &uio, ioflags(ap->a_ioflag),
 	    ap->a_cred));
 }
 
@@ -4688,8 +4692,9 @@ struct vop_readdir_args {
 static int
 zfs_freebsd_readdir(struct vop_readdir_args *ap)
 {
-
-	return (zfs_readdir(ap->a_vp, ap->a_uio, ap->a_cred, ap->a_eofflag,
+	zfs_uio_t uio;
+	zfs_uio_init(&uio, ap->a_uio);
+	return (zfs_readdir(ap->a_vp, &uio, ap->a_cred, ap->a_eofflag,
 	    ap->a_ncookies, ap->a_cookies));
 }
 
@@ -4979,8 +4984,9 @@ struct vop_readlink_args {
 static int
 zfs_freebsd_readlink(struct vop_readlink_args *ap)
 {
-
-	return (zfs_readlink(ap->a_vp, ap->a_uio, ap->a_cred, NULL));
+	zfs_uio_t uio;
+	zfs_uio_init(&uio, ap->a_uio);
+	return (zfs_readlink(ap->a_vp, &uio, ap->a_cred, NULL));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -5448,11 +5454,14 @@ zfs_listextattr(struct vop_listextattr_args *ap)
 	uint8_t dirbuf[sizeof (struct dirent)];
 	struct dirent *dp;
 	struct iovec aiov;
-	struct uio auio, *uio = ap->a_uio;
+	struct uio auio;
 	size_t *sizep = ap->a_size;
 	size_t plen;
 	vnode_t *xvp = NULL, *vp;
 	int done, error, eof, pos;
+	zfs_uio_t uio;
+
+	zfs_uio_init(&uio, ap->a_uio);
 
 	/*
 	 * If the xattr property is off, refuse the request.
@@ -5534,15 +5543,16 @@ zfs_listextattr(struct vop_listextattr_args *ap)
 			nlen = dp->d_namlen - plen;
 			if (sizep != NULL)
 				*sizep += 1 + nlen;
-			else if (uio != NULL) {
+			else if (GET_UIO_STRUCT(&uio) != NULL) {
 				/*
 				 * Format of extattr name entry is one byte for
 				 * length and the rest for name.
 				 */
-				error = uiomove(&nlen, 1, uio->uio_rw, uio);
+				error = zfs_uiomove(&nlen, 1, zfs_uio_rw(&uio),
+				    &uio);
 				if (error == 0) {
-					error = uiomove(dp->d_name + plen, nlen,
-					    uio->uio_rw, uio);
+					error = zfs_uiomove(dp->d_name + plen,
+					    nlen, zfs_uio_rw(&uio), &uio);
 				}
 				if (error != 0)
 					break;

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -584,8 +584,7 @@ mappedread_sf(znode_t *zp, int nbytes, zfs_uio_t *uio)
 		}
 		if (error)
 			break;
-		zfs_uio_resid(uio) -= bytes;
-		zfs_uio_offset(uio) += bytes;
+		zfs_uio_advance(uio, bytes);
 		len -= bytes;
 	}
 	zfs_vmobject_wunlock_12(obj);
@@ -1954,7 +1953,7 @@ update:
 
 	ZFS_ACCESSTIME_STAMP(zfsvfs, zp);
 
-	zfs_uio_offset(uio) = offset;
+	zfs_uio_setoffset(uio, offset);
 	ZFS_EXIT(zfsvfs);
 	if (error != 0 && cookies != NULL) {
 		free(*cookies, M_TEMP);

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -746,12 +746,15 @@ out:
  */
 
 static int
-zvol_cdev_read(struct cdev *dev, struct uio *uio, int ioflag)
+zvol_cdev_read(struct cdev *dev, struct uio *uio_s, int ioflag)
 {
 	zvol_state_t *zv;
 	uint64_t volsize;
 	zfs_locked_range_t *lr;
 	int error = 0;
+	zfs_uio_t uio;
+
+	zfs_uio_init(&uio, uio_s);
 
 	zv = dev->si_drv2;
 
@@ -760,20 +763,20 @@ zvol_cdev_read(struct cdev *dev, struct uio *uio, int ioflag)
 	 * uio_loffset == volsize isn't an error as
 	 * its required for EOF processing.
 	 */
-	if (uio->uio_resid > 0 &&
-	    (uio->uio_loffset < 0 || uio->uio_loffset > volsize))
+	if (zfs_uio_resid(&uio) > 0 &&
+	    (zfs_uio_offset(&uio) < 0 || zfs_uio_offset(&uio) > volsize))
 		return (SET_ERROR(EIO));
 
-	lr = zfs_rangelock_enter(&zv->zv_rangelock, uio->uio_loffset,
-	    uio->uio_resid, RL_READER);
-	while (uio->uio_resid > 0 && uio->uio_loffset < volsize) {
-		uint64_t bytes = MIN(uio->uio_resid, DMU_MAX_ACCESS >> 1);
+	lr = zfs_rangelock_enter(&zv->zv_rangelock, zfs_uio_offset(&uio),
+	    zfs_uio_resid(&uio), RL_READER);
+	while (zfs_uio_resid(&uio) > 0 && zfs_uio_offset(&uio) < volsize) {
+		uint64_t bytes = MIN(zfs_uio_resid(&uio), DMU_MAX_ACCESS >> 1);
 
 		/* don't read past the end */
-		if (bytes > volsize - uio->uio_loffset)
-			bytes = volsize - uio->uio_loffset;
+		if (bytes > volsize - zfs_uio_offset(&uio))
+			bytes = volsize - zfs_uio_offset(&uio);
 
-		error =  dmu_read_uio_dnode(zv->zv_dn, uio, bytes);
+		error =  dmu_read_uio_dnode(zv->zv_dn, &uio, bytes);
 		if (error) {
 			/* convert checksum errors into IO errors */
 			if (error == ECKSUM)
@@ -787,20 +790,23 @@ zvol_cdev_read(struct cdev *dev, struct uio *uio, int ioflag)
 }
 
 static int
-zvol_cdev_write(struct cdev *dev, struct uio *uio, int ioflag)
+zvol_cdev_write(struct cdev *dev, struct uio *uio_s, int ioflag)
 {
 	zvol_state_t *zv;
 	uint64_t volsize;
 	zfs_locked_range_t *lr;
 	int error = 0;
 	boolean_t sync;
+	zfs_uio_t uio;
 
 	zv = dev->si_drv2;
 
 	volsize = zv->zv_volsize;
 
-	if (uio->uio_resid > 0 &&
-	    (uio->uio_loffset < 0 || uio->uio_loffset > volsize))
+	zfs_uio_init(&uio, uio_s);
+
+	if (zfs_uio_resid(&uio) > 0 &&
+	    (zfs_uio_offset(&uio) < 0 || zfs_uio_offset(&uio) > volsize))
 		return (SET_ERROR(EIO));
 
 	sync = (ioflag & IO_SYNC) ||
@@ -809,11 +815,11 @@ zvol_cdev_write(struct cdev *dev, struct uio *uio, int ioflag)
 	rw_enter(&zv->zv_suspend_lock, ZVOL_RW_READER);
 	zvol_ensure_zilog(zv);
 
-	lr = zfs_rangelock_enter(&zv->zv_rangelock, uio->uio_loffset,
-	    uio->uio_resid, RL_WRITER);
-	while (uio->uio_resid > 0 && uio->uio_loffset < volsize) {
-		uint64_t bytes = MIN(uio->uio_resid, DMU_MAX_ACCESS >> 1);
-		uint64_t off = uio->uio_loffset;
+	lr = zfs_rangelock_enter(&zv->zv_rangelock, zfs_uio_offset(&uio),
+	    zfs_uio_resid(&uio), RL_WRITER);
+	while (zfs_uio_resid(&uio) > 0 && zfs_uio_offset(&uio) < volsize) {
+		uint64_t bytes = MIN(zfs_uio_resid(&uio), DMU_MAX_ACCESS >> 1);
+		uint64_t off = zfs_uio_offset(&uio);
 		dmu_tx_t *tx = dmu_tx_create(zv->zv_objset);
 
 		if (bytes > volsize - off)	/* don't write past the end */
@@ -825,7 +831,7 @@ zvol_cdev_write(struct cdev *dev, struct uio *uio, int ioflag)
 			dmu_tx_abort(tx);
 			break;
 		}
-		error = dmu_write_uio_dnode(zv->zv_dn, uio, bytes, tx);
+		error = dmu_write_uio_dnode(zv->zv_dn, &uio, bytes, tx);
 		if (error == 0)
 			zvol_log_write(zv, tx, off, bytes, sync);
 		dmu_tx_commit(tx);

--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -55,7 +55,7 @@
  * a non-zero errno on failure.
  */
 static int
-uiomove_iov(void *p, size_t n, enum uio_rw rw, struct uio *uio)
+zfs_uiomove_iov(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 {
 	const struct iovec *iov = uio->uio_iov;
 	size_t skip = uio->uio_skip;
@@ -126,7 +126,7 @@ uiomove_iov(void *p, size_t n, enum uio_rw rw, struct uio *uio)
 }
 
 static int
-uiomove_bvec(void *p, size_t n, enum uio_rw rw, struct uio *uio)
+zfs_uiomove_bvec(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 {
 	const struct bio_vec *bv = uio->uio_bvec;
 	size_t skip = uio->uio_skip;
@@ -160,7 +160,7 @@ uiomove_bvec(void *p, size_t n, enum uio_rw rw, struct uio *uio)
 
 #if defined(HAVE_VFS_IOV_ITER)
 static int
-uiomove_iter(void *p, size_t n, enum uio_rw rw, struct uio *uio,
+zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
     boolean_t revert)
 {
 	size_t cnt = MIN(n, uio->uio_resid);
@@ -182,7 +182,7 @@ uiomove_iter(void *p, size_t n, enum uio_rw rw, struct uio *uio,
 		return (EFAULT);
 
 	/*
-	 * Revert advancing the uio_iter.  This is set by uiocopy()
+	 * Revert advancing the uio_iter.  This is set by zfs_uiocopy()
 	 * to avoid consuming the uio and its iov_iter structure.
 	 */
 	if (revert)
@@ -196,21 +196,21 @@ uiomove_iter(void *p, size_t n, enum uio_rw rw, struct uio *uio,
 #endif
 
 int
-uiomove(void *p, size_t n, enum uio_rw rw, struct uio *uio)
+zfs_uiomove(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 {
 	if (uio->uio_segflg == UIO_BVEC)
-		return (uiomove_bvec(p, n, rw, uio));
+		return (zfs_uiomove_bvec(p, n, rw, uio));
 #if defined(HAVE_VFS_IOV_ITER)
 	else if (uio->uio_segflg == UIO_ITER)
-		return (uiomove_iter(p, n, rw, uio, B_FALSE));
+		return (zfs_uiomove_iter(p, n, rw, uio, B_FALSE));
 #endif
 	else
-		return (uiomove_iov(p, n, rw, uio));
+		return (zfs_uiomove_iov(p, n, rw, uio));
 }
-EXPORT_SYMBOL(uiomove);
+EXPORT_SYMBOL(zfs_uiomove);
 
 int
-uio_prefaultpages(ssize_t n, struct uio *uio)
+zfs_uio_prefaultpages(ssize_t n, zfs_uio_t *uio)
 {
 	struct iov_iter iter, *iterp = NULL;
 
@@ -230,40 +230,40 @@ uio_prefaultpages(ssize_t n, struct uio *uio)
 #endif
 	return (0);
 }
-EXPORT_SYMBOL(uio_prefaultpages);
+EXPORT_SYMBOL(zfs_uio_prefaultpages);
 
 /*
- * The same as uiomove() but doesn't modify uio structure.
+ * The same as zfs_uiomove() but doesn't modify uio structure.
  * return in cbytes how many bytes were copied.
  */
 int
-uiocopy(void *p, size_t n, enum uio_rw rw, struct uio *uio, size_t *cbytes)
+zfs_uiocopy(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio, size_t *cbytes)
 {
-	struct uio uio_copy;
+	zfs_uio_t uio_copy;
 	int ret;
 
-	bcopy(uio, &uio_copy, sizeof (struct uio));
+	bcopy(uio, &uio_copy, sizeof (zfs_uio_t));
 
 	if (uio->uio_segflg == UIO_BVEC)
-		ret = uiomove_bvec(p, n, rw, &uio_copy);
+		ret = zfs_uiomove_bvec(p, n, rw, &uio_copy);
 #if defined(HAVE_VFS_IOV_ITER)
 	else if (uio->uio_segflg == UIO_ITER)
-		ret = uiomove_iter(p, n, rw, &uio_copy, B_TRUE);
+		ret = zfs_uiomove_iter(p, n, rw, &uio_copy, B_TRUE);
 #endif
 	else
-		ret = uiomove_iov(p, n, rw, &uio_copy);
+		ret = zfs_uiomove_iov(p, n, rw, &uio_copy);
 
 	*cbytes = uio->uio_resid - uio_copy.uio_resid;
 
 	return (ret);
 }
-EXPORT_SYMBOL(uiocopy);
+EXPORT_SYMBOL(zfs_uiocopy);
 
 /*
  * Drop the next n chars out of *uio.
  */
 void
-uioskip(uio_t *uio, size_t n)
+zfs_uioskip(zfs_uio_t *uio, size_t n)
 {
 	if (n > uio->uio_resid)
 		return;
@@ -292,5 +292,6 @@ uioskip(uio_t *uio, size_t n)
 	uio->uio_loffset += n;
 	uio->uio_resid -= n;
 }
-EXPORT_SYMBOL(uioskip);
+EXPORT_SYMBOL(zfs_uioskip);
+
 #endif /* _KERNEL */

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -298,7 +298,7 @@ update_pages(znode_t *zp, int64_t start, int len, objset_t *os)
  *	 the file is memory mapped.
  */
 int
-mappedread(znode_t *zp, int nbytes, uio_t *uio)
+mappedread(znode_t *zp, int nbytes, zfs_uio_t *uio)
 {
 	struct inode *ip = ZTOI(zp);
 	struct address_space *mp = ip->i_mapping;
@@ -320,7 +320,7 @@ mappedread(znode_t *zp, int nbytes, uio_t *uio)
 			unlock_page(pp);
 
 			pb = kmap(pp);
-			error = uiomove(pb + off, bytes, UIO_READ, uio);
+			error = zfs_uiomove(pb + off, bytes, UIO_READ, uio);
 			kunmap(pp);
 
 			if (mapping_writably_mapped(mp))
@@ -372,8 +372,8 @@ zfs_write_simple(znode_t *zp, const void *data, size_t len,
 	iov.iov_base = (void *)data;
 	iov.iov_len = len;
 
-	uio_t uio;
-	uio_iovec_init(&uio, &iov, 1, pos, UIO_SYSSPACE, len, 0);
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, &iov, 1, pos, UIO_SYSSPACE, len, 0);
 
 	cookie = spl_fstrans_mark();
 	error = zfs_write(zp, &uio, 0, kcred);
@@ -381,8 +381,8 @@ zfs_write_simple(znode_t *zp, const void *data, size_t len,
 
 	if (error == 0) {
 		if (residp != NULL)
-			*residp = uio_resid(&uio);
-		else if (uio_resid(&uio) != 0)
+			*residp = zfs_uio_resid(&uio);
+		else if (zfs_uio_resid(&uio) != 0)
 			error = SET_ERROR(EIO);
 	}
 
@@ -3198,7 +3198,7 @@ top:
  */
 /* ARGSUSED */
 int
-zfs_readlink(struct inode *ip, uio_t *uio, cred_t *cr)
+zfs_readlink(struct inode *ip, zfs_uio_t *uio, cred_t *cr)
 {
 	znode_t		*zp = ITOZ(ip);
 	zfsvfs_t	*zfsvfs = ITOZSB(ip);

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -242,13 +242,13 @@ zpl_file_accessed(struct file *filp)
  * Otherwise, for older kernels extract the iovec and pass it instead.
  */
 static void
-zpl_uio_init(uio_t *uio, struct kiocb *kiocb, struct iov_iter *to,
+zpl_uio_init(zfs_uio_t *uio, struct kiocb *kiocb, struct iov_iter *to,
     loff_t pos, ssize_t count, size_t skip)
 {
 #if defined(HAVE_VFS_IOV_ITER)
-	uio_iov_iter_init(uio, to, pos, count, skip);
+	zfs_uio_iov_iter_init(uio, to, pos, count, skip);
 #else
-	uio_iovec_init(uio, to->iov, to->nr_segs, pos,
+	zfs_uio_iovec_init(uio, to->iov, to->nr_segs, pos,
 	    to->type & ITER_KVEC ? UIO_SYSSPACE : UIO_USERSPACE,
 	    count, skip);
 #endif
@@ -261,7 +261,7 @@ zpl_iter_read(struct kiocb *kiocb, struct iov_iter *to)
 	fstrans_cookie_t cookie;
 	struct file *filp = kiocb->ki_filp;
 	ssize_t count = iov_iter_count(to);
-	uio_t uio;
+	zfs_uio_t uio;
 
 	zpl_uio_init(&uio, kiocb, to, kiocb->ki_pos, count, 0);
 
@@ -317,7 +317,7 @@ zpl_iter_write(struct kiocb *kiocb, struct iov_iter *from)
 	fstrans_cookie_t cookie;
 	struct file *filp = kiocb->ki_filp;
 	struct inode *ip = filp->f_mapping->host;
-	uio_t uio;
+	zfs_uio_t uio;
 	size_t count = 0;
 	ssize_t ret;
 
@@ -364,8 +364,8 @@ zpl_aio_read(struct kiocb *kiocb, const struct iovec *iov,
 	if (ret)
 		return (ret);
 
-	uio_t uio;
-	uio_iovec_init(&uio, iov, nr_segs, kiocb->ki_pos, UIO_USERSPACE,
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, iov, nr_segs, kiocb->ki_pos, UIO_USERSPACE,
 	    count, 0);
 
 	crhold(cr);
@@ -407,8 +407,8 @@ zpl_aio_write(struct kiocb *kiocb, const struct iovec *iov,
 	if (ret)
 		return (ret);
 
-	uio_t uio;
-	uio_iovec_init(&uio, iov, nr_segs, kiocb->ki_pos, UIO_USERSPACE,
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, iov, nr_segs, kiocb->ki_pos, UIO_USERSPACE,
 	    count, 0);
 
 	crhold(cr);

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -499,8 +499,8 @@ zpl_get_link_common(struct dentry *dentry, struct inode *ip, char **link)
 	iov.iov_len = MAXPATHLEN;
 	iov.iov_base = kmem_zalloc(MAXPATHLEN, KM_SLEEP);
 
-	uio_t uio;
-	uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, MAXPATHLEN - 1, 0);
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, MAXPATHLEN - 1, 0);
 
 	cookie = spl_fstrans_mark();
 	error = -zfs_readlink(ip, &uio, cr);

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -306,15 +306,15 @@ zpl_xattr_get_dir(struct inode *ip, const char *name, void *value,
 	iov.iov_base = (void *)value;
 	iov.iov_len = size;
 
-	uio_t uio;
-	uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, size, 0);
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, &iov, 1, 0, UIO_SYSSPACE, size, 0);
 
 	cookie = spl_fstrans_mark();
 	error = -zfs_read(ITOZ(xip), &uio, 0, cr);
 	spl_fstrans_unmark(cookie);
 
 	if (error == 0)
-		error = size - uio_resid(&uio);
+		error = size - zfs_uio_resid(&uio);
 out:
 	if (xzp)
 		zrele(xzp);

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -85,9 +85,9 @@ zvol_write(void *arg)
 	zv_request_t *zvr = arg;
 	struct bio *bio = zvr->bio;
 	int error = 0;
-	uio_t uio;
+	zfs_uio_t uio;
 
-	uio_bvec_init(&uio, bio);
+	zfs_uio_bvec_init(&uio, bio);
 
 	zvol_state_t *zv = zvr->zv;
 	ASSERT3P(zv, !=, NULL);
@@ -247,9 +247,9 @@ zvol_read(void *arg)
 	zv_request_t *zvr = arg;
 	struct bio *bio = zvr->bio;
 	int error = 0;
-	uio_t uio;
+	zfs_uio_t uio;
 
-	uio_bvec_init(&uio, bio);
+	zfs_uio_bvec_init(&uio, bio);
 
 	zvol_state_t *zv = zvr->zv;
 	ASSERT3P(zv, !=, NULL);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1210,7 +1210,7 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size)
 /*
  * Read 'size' bytes into the uio buffer.
  * From object zdb->db_object.
- * Starting at offset uio->uio_loffset.
+ * Starting at zfs_uio_offset(uio).
  *
  * If the caller already has a dbuf in the target object
  * (e.g. its bonus buffer), this routine is faster than dmu_read_uio(),
@@ -1237,7 +1237,7 @@ dmu_read_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size)
 /*
  * Read 'size' bytes into the uio buffer.
  * From the specified object
- * Starting at offset uio->uio_loffset.
+ * Starting at offset zfs_uio_offset(uio).
  */
 int
 dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size)
@@ -1314,7 +1314,7 @@ dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx)
 /*
  * Write 'size' bytes from the uio buffer.
  * To object zdb->db_object.
- * Starting at offset uio->uio_loffset.
+ * Starting at offset zfs_uio_offset(uio).
  *
  * If the caller already has a dbuf in the target object
  * (e.g. its bonus buffer), this routine is faster than dmu_write_uio(),
@@ -1342,7 +1342,7 @@ dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 /*
  * Write 'size' bytes from the uio buffer.
  * To the specified object.
- * Starting at offset uio->uio_loffset.
+ * Starting at offset zfs_uio_offset(uio).
  */
 int
 dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1170,7 +1170,7 @@ dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 
 #ifdef _KERNEL
 int
-dmu_read_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size)
+dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size)
 {
 	dmu_buf_t **dbp;
 	int numbufs, i, err;
@@ -1179,7 +1179,7 @@ dmu_read_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size)
 	 * NB: we could do this block-at-a-time, but it's nice
 	 * to be reading in parallel.
 	 */
-	err = dmu_buf_hold_array_by_dnode(dn, uio_offset(uio), size,
+	err = dmu_buf_hold_array_by_dnode(dn, zfs_uio_offset(uio), size,
 	    TRUE, FTAG, &numbufs, &dbp, 0);
 	if (err)
 		return (err);
@@ -1191,16 +1191,12 @@ dmu_read_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size)
 
 		ASSERT(size > 0);
 
-		bufoff = uio_offset(uio) - db->db_offset;
+		bufoff = zfs_uio_offset(uio) - db->db_offset;
 		tocpy = MIN(db->db_size - bufoff, size);
 
-#ifdef __FreeBSD__
-			err = vn_io_fault_uiomove((char *)db->db_data + bufoff,
-			    tocpy, uio);
-#else
-			err = uiomove((char *)db->db_data + bufoff, tocpy,
-			    UIO_READ, uio);
-#endif
+		err = zfs_uio_fault_move((char *)db->db_data + bufoff, tocpy,
+		    UIO_READ, uio);
+
 		if (err)
 			break;
 
@@ -1221,7 +1217,7 @@ dmu_read_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size)
  * because we don't have to find the dnode_t for the object.
  */
 int
-dmu_read_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size)
+dmu_read_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)zdb;
 	dnode_t *dn;
@@ -1244,7 +1240,7 @@ dmu_read_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size)
  * Starting at offset uio->uio_loffset.
  */
 int
-dmu_read_uio(objset_t *os, uint64_t object, uio_t *uio, uint64_t size)
+dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size)
 {
 	dnode_t *dn;
 	int err;
@@ -1264,14 +1260,14 @@ dmu_read_uio(objset_t *os, uint64_t object, uio_t *uio, uint64_t size)
 }
 
 int
-dmu_write_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size, dmu_tx_t *tx)
+dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx)
 {
 	dmu_buf_t **dbp;
 	int numbufs;
 	int err = 0;
 	int i;
 
-	err = dmu_buf_hold_array_by_dnode(dn, uio_offset(uio), size,
+	err = dmu_buf_hold_array_by_dnode(dn, zfs_uio_offset(uio), size,
 	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
 	if (err)
 		return (err);
@@ -1283,7 +1279,7 @@ dmu_write_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size, dmu_tx_t *tx)
 
 		ASSERT(size > 0);
 
-		bufoff = uio_offset(uio) - db->db_offset;
+		bufoff = zfs_uio_offset(uio) - db->db_offset;
 		tocpy = MIN(db->db_size - bufoff, size);
 
 		ASSERT(i == 0 || i == numbufs-1 || tocpy == db->db_size);
@@ -1294,18 +1290,14 @@ dmu_write_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size, dmu_tx_t *tx)
 			dmu_buf_will_dirty(db, tx);
 
 		/*
-		 * XXX uiomove could block forever (eg.nfs-backed
+		 * XXX zfs_uiomove could block forever (eg.nfs-backed
 		 * pages).  There needs to be a uiolockdown() function
-		 * to lock the pages in memory, so that uiomove won't
+		 * to lock the pages in memory, so that zfs_uiomove won't
 		 * block.
 		 */
-#ifdef __FreeBSD__
-		err = vn_io_fault_uiomove((char *)db->db_data + bufoff,
-		    tocpy, uio);
-#else
-		err = uiomove((char *)db->db_data + bufoff, tocpy,
-		    UIO_WRITE, uio);
-#endif
+		err = zfs_uio_fault_move((char *)db->db_data + bufoff,
+		    tocpy, UIO_WRITE, uio);
+
 		if (tocpy == db->db_size)
 			dmu_buf_fill_done(db, tx);
 
@@ -1329,7 +1321,7 @@ dmu_write_uio_dnode(dnode_t *dn, uio_t *uio, uint64_t size, dmu_tx_t *tx)
  * because we don't have to find the dnode_t for the object.
  */
 int
-dmu_write_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size,
+dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
     dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)zdb;
@@ -1353,7 +1345,7 @@ dmu_write_uio_dbuf(dmu_buf_t *zdb, uio_t *uio, uint64_t size,
  * Starting at offset uio->uio_loffset.
  */
 int
-dmu_write_uio(objset_t *os, uint64_t object, uio_t *uio, uint64_t size,
+dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
     dmu_tx_t *tx)
 {
 	dnode_t *dn;

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1502,7 +1502,7 @@ sa_lookup(sa_handle_t *hdl, sa_attr_type_t attr, void *buf, uint32_t buflen)
 
 #ifdef _KERNEL
 int
-sa_lookup_uio(sa_handle_t *hdl, sa_attr_type_t attr, uio_t *uio)
+sa_lookup_uio(sa_handle_t *hdl, sa_attr_type_t attr, zfs_uio_t *uio)
 {
 	int error;
 	sa_bulk_attr_t bulk;
@@ -1515,8 +1515,8 @@ sa_lookup_uio(sa_handle_t *hdl, sa_attr_type_t attr, uio_t *uio)
 
 	mutex_enter(&hdl->sa_lock);
 	if ((error = sa_attr_op(hdl, &bulk, 1, SA_LOOKUP, NULL)) == 0) {
-		error = uiomove((void *)bulk.sa_addr, MIN(bulk.sa_size,
-		    uio_resid(uio)), UIO_READ, uio);
+		error = zfs_uiomove((void *)bulk.sa_addr, MIN(bulk.sa_size,
+		    zfs_uio_resid(uio)), UIO_READ, uio);
 	}
 	mutex_exit(&hdl->sa_lock);
 	return (error);

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -71,7 +71,7 @@ sa_attr_reg_t zfs_attr_table[ZPL_END+1] = {
 
 #ifdef _KERNEL
 int
-zfs_sa_readlink(znode_t *zp, uio_t *uio)
+zfs_sa_readlink(znode_t *zp, zfs_uio_t *uio)
 {
 	dmu_buf_t *db = sa_get_db(zp->z_sa_hdl);
 	size_t bufsz;
@@ -79,15 +79,16 @@ zfs_sa_readlink(znode_t *zp, uio_t *uio)
 
 	bufsz = zp->z_size;
 	if (bufsz + ZFS_OLD_ZNODE_PHYS_SIZE <= db->db_size) {
-		error = uiomove((caddr_t)db->db_data +
+		error = zfs_uiomove((caddr_t)db->db_data +
 		    ZFS_OLD_ZNODE_PHYS_SIZE,
-		    MIN((size_t)bufsz, uio_resid(uio)), UIO_READ, uio);
+		    MIN((size_t)bufsz, zfs_uio_resid(uio)), UIO_READ, uio);
 	} else {
 		dmu_buf_t *dbp;
 		if ((error = dmu_buf_hold(ZTOZSB(zp)->z_os, zp->z_id,
 		    0, FTAG, &dbp, DMU_READ_NO_PREFETCH)) == 0) {
-			error = uiomove(dbp->db_data,
-			    MIN((size_t)bufsz, uio_resid(uio)), UIO_READ, uio);
+			error = zfs_uiomove(dbp->db_data,
+			    MIN((size_t)bufsz, zfs_uio_resid(uio)), UIO_READ,
+			    uio);
 			dmu_buf_rele(dbp, FTAG);
 		}
 	}

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -399,7 +399,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			 */
 			woff = zp->z_size;
 		}
-		zfs_uio_offset(uio) = woff;
+		zfs_uio_setoffset(uio, woff);
 	} else {
 		/*
 		 * Note that if the file block size will change as a result of

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -544,7 +544,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 				 * error, and we may break the loop early.
 				 */
 				if (tx_bytes != zfs_uio_resid(uio))
-					n -= tx_bytes - uio->uio_resid;
+					n -= tx_bytes - zfs_uio_resid(uio);
 				if (zfs_uio_prefaultpages(MIN(n, max_blksz),
 				    uio)) {
 					break;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -187,7 +187,7 @@ static unsigned long zfs_vnops_read_chunk_size = 1024 * 1024; /* Tunable */
  */
 /* ARGSUSED */
 int
-zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
+zfs_read(struct znode *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 {
 	int error = 0;
 	boolean_t frsync = B_FALSE;
@@ -210,7 +210,7 @@ zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
 	/*
 	 * Validate file offset
 	 */
-	if (uio->uio_loffset < (offset_t)0) {
+	if (zfs_uio_offset(uio) < (offset_t)0) {
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EINVAL));
 	}
@@ -218,7 +218,7 @@ zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
 	/*
 	 * Fasttrack empty reads
 	 */
-	if (uio->uio_resid == 0) {
+	if (zfs_uio_resid(uio) == 0) {
 		ZFS_EXIT(zfsvfs);
 		return (0);
 	}
@@ -242,26 +242,26 @@ zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
 	 * Lock the range against changes.
 	 */
 	zfs_locked_range_t *lr = zfs_rangelock_enter(&zp->z_rangelock,
-	    uio->uio_loffset, uio->uio_resid, RL_READER);
+	    zfs_uio_offset(uio), zfs_uio_resid(uio), RL_READER);
 
 	/*
 	 * If we are reading past end-of-file we can skip
 	 * to the end; but we might still need to set atime.
 	 */
-	if (uio->uio_loffset >= zp->z_size) {
+	if (zfs_uio_offset(uio) >= zp->z_size) {
 		error = 0;
 		goto out;
 	}
 
-	ASSERT(uio->uio_loffset < zp->z_size);
-	ssize_t n = MIN(uio->uio_resid, zp->z_size - uio->uio_loffset);
+	ASSERT(zfs_uio_offset(uio) < zp->z_size);
+	ssize_t n = MIN(zfs_uio_resid(uio), zp->z_size - zfs_uio_offset(uio));
 	ssize_t start_resid = n;
 
 	while (n > 0) {
 		ssize_t nbytes = MIN(n, zfs_vnops_read_chunk_size -
-		    P2PHASE(uio->uio_loffset, zfs_vnops_read_chunk_size));
+		    P2PHASE(zfs_uio_offset(uio), zfs_vnops_read_chunk_size));
 #ifdef UIO_NOCOPY
-		if (uio->uio_segflg == UIO_NOCOPY)
+		if (zfs_uio_segflg(uio) == UIO_NOCOPY)
 			error = mappedread_sf(zp, nbytes, uio);
 		else
 #endif
@@ -314,10 +314,10 @@ out:
 
 /* ARGSUSED */
 int
-zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
+zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 {
 	int error = 0;
-	ssize_t start_resid = uio->uio_resid;
+	ssize_t start_resid = zfs_uio_resid(uio);
 
 	/*
 	 * Fasttrack empty write
@@ -354,7 +354,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	 */
 	if ((zp->z_pflags & (ZFS_IMMUTABLE | ZFS_READONLY)) ||
 	    ((zp->z_pflags & ZFS_APPENDONLY) && !(ioflag & O_APPEND) &&
-	    (uio->uio_loffset < zp->z_size))) {
+	    (zfs_uio_offset(uio) < zp->z_size))) {
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EPERM));
 	}
@@ -362,7 +362,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	/*
 	 * Validate file offset
 	 */
-	offset_t woff = ioflag & O_APPEND ? zp->z_size : uio->uio_loffset;
+	offset_t woff = ioflag & O_APPEND ? zp->z_size : zfs_uio_offset(uio);
 	if (woff < 0) {
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EINVAL));
@@ -375,7 +375,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	 * don't hold up txg.
 	 * Skip this if uio contains loaned arc_buf.
 	 */
-	if (uio_prefaultpages(MIN(n, max_blksz), uio)) {
+	if (zfs_uio_prefaultpages(MIN(n, max_blksz), uio)) {
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EFAULT));
 	}
@@ -399,7 +399,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 			 */
 			woff = zp->z_size;
 		}
-		uio->uio_loffset = woff;
+		zfs_uio_offset(uio) = woff;
 	} else {
 		/*
 		 * Note that if the file block size will change as a result of
@@ -409,7 +409,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 		lr = zfs_rangelock_enter(&zp->z_rangelock, woff, n, RL_WRITER);
 	}
 
-	if (zn_rlimit_fsize(zp, uio, uio->uio_td)) {
+	if (zn_rlimit_fsize(zp, uio)) {
 		zfs_rangelock_exit(lr);
 		ZFS_EXIT(zfsvfs);
 		return (SET_ERROR(EFBIG));
@@ -439,7 +439,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	 * and allows us to do more fine-grained space accounting.
 	 */
 	while (n > 0) {
-		woff = uio->uio_loffset;
+		woff = zfs_uio_offset(uio);
 
 		if (zfs_id_overblockquota(zfsvfs, DMU_USERUSED_OBJECT, uid) ||
 		    zfs_id_overblockquota(zfsvfs, DMU_GROUPUSED_OBJECT, gid) ||
@@ -467,7 +467,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 			    max_blksz);
 			ASSERT(abuf != NULL);
 			ASSERT(arc_buf_size(abuf) == max_blksz);
-			if ((error = uiocopy(abuf->b_data, max_blksz,
+			if ((error = zfs_uiocopy(abuf->b_data, max_blksz,
 			    UIO_WRITE, uio, &cbytes))) {
 				dmu_return_arcbuf(abuf);
 				break;
@@ -528,11 +528,11 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 
 		ssize_t tx_bytes;
 		if (abuf == NULL) {
-			tx_bytes = uio->uio_resid;
-			uio_fault_disable(uio, B_TRUE);
+			tx_bytes = zfs_uio_resid(uio);
+			zfs_uio_fault_disable(uio, B_TRUE);
 			error = dmu_write_uio_dbuf(sa_get_db(zp->z_sa_hdl),
 			    uio, nbytes, tx);
-			uio_fault_disable(uio, B_FALSE);
+			zfs_uio_fault_disable(uio, B_FALSE);
 #ifdef __linux__
 			if (error == EFAULT) {
 				dmu_tx_commit(tx);
@@ -540,12 +540,13 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 				 * Account for partial writes before
 				 * continuing the loop.
 				 * Update needs to occur before the next
-				 * uio_prefaultpages, or prefaultpages may
+				 * zfs_uio_prefaultpages, or prefaultpages may
 				 * error, and we may break the loop early.
 				 */
-				if (tx_bytes != uio->uio_resid)
+				if (tx_bytes != zfs_uio_resid(uio))
 					n -= tx_bytes - uio->uio_resid;
-				if (uio_prefaultpages(MIN(n, max_blksz), uio)) {
+				if (zfs_uio_prefaultpages(MIN(n, max_blksz),
+				    uio)) {
 					break;
 				}
 				continue;
@@ -555,7 +556,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 				dmu_tx_commit(tx);
 				break;
 			}
-			tx_bytes -= uio->uio_resid;
+			tx_bytes -= zfs_uio_resid(uio);
 		} else {
 			/* Implied by abuf != NULL: */
 			ASSERT3S(n, >=, max_blksz);
@@ -580,8 +581,8 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 				dmu_tx_commit(tx);
 				break;
 			}
-			ASSERT3S(nbytes, <=, uio->uio_resid);
-			uioskip(uio, nbytes);
+			ASSERT3S(nbytes, <=, zfs_uio_resid(uio));
+			zfs_uioskip(uio, nbytes);
 			tx_bytes = nbytes;
 		}
 		if (tx_bytes && zn_has_cached_data(zp) &&
@@ -631,9 +632,9 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 		 * Update the file size (zp_size) if it has changed;
 		 * account for possible concurrent updates.
 		 */
-		while ((end_size = zp->z_size) < uio->uio_loffset) {
+		while ((end_size = zp->z_size) < zfs_uio_offset(uio)) {
 			(void) atomic_cas_64(&zp->z_size, end_size,
-			    uio->uio_loffset);
+			    zfs_uio_offset(uio));
 			ASSERT(error == 0);
 		}
 		/*
@@ -656,7 +657,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 		n -= nbytes;
 
 		if (n > 0) {
-			if (uio_prefaultpages(MIN(n, max_blksz), uio)) {
+			if (zfs_uio_prefaultpages(MIN(n, max_blksz), uio)) {
 				error = SET_ERROR(EFAULT);
 				break;
 			}
@@ -671,7 +672,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	 * uio data is inaccessible return an error.  Otherwise, it's
 	 * at least a partial write, so it's successful.
 	 */
-	if (zfsvfs->z_replay || uio->uio_resid == start_resid ||
+	if (zfsvfs->z_replay || zfs_uio_resid(uio) == start_resid ||
 	    error == EFAULT) {
 		ZFS_EXIT(zfsvfs);
 		return (error);
@@ -681,7 +682,7 @@ zfs_write(znode_t *zp, uio_t *uio, int ioflag, cred_t *cr)
 	    zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS)
 		zil_commit(zilog, zp->z_id);
 
-	const int64_t nwritten = start_resid - uio->uio_resid;
+	const int64_t nwritten = start_resid - zfs_uio_resid(uio);
 	dataset_kstats_update_write_kstats(&zfsvfs->z_kstat, nwritten);
 	task_io_account_write(nwritten);
 

--- a/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
@@ -42,8 +42,8 @@
  * 2. In the same process, context #2, mmap page fault (which means the mm_sem
  *    is hold) occurred, zfs_dirty_inode open a txg failed, and wait previous
  *    txg "n" completed.
- * 3. context #1 call uiomove to write, however page fault is occurred in
- *    uiomove, which means it needs mm_sem, but mm_sem is hold by
+ * 3. context #1 call zfs_uiomove to write, however page fault is occurred in
+ *    zfs_uiomove, which means it needs mm_sem, but mm_sem is hold by
  *    context #2, so it stuck and can't complete, then txg "n" will not
  *    complete.
  *


### PR DESCRIPTION
In FreeBSD the struct uio was just a typedef to uio_t. In order to
extend this struct, outside of the definition for the struct uio, the
struct uio has been embedded inside of a uio_t struct.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This patch is to allow for the FreeBSD to extend the uio_t struct. Originally, uio_t was just a typedef to a
struct uio. By embedding the struct uio inside of a uio_t struct further member variables can be added
for FreeBSD.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
One such case where there is a advantage to this is PR #10018. In order to move the mappings of user pages
in to kernel space into the VFS layers, FreeBSD's uio_t struct can be extended to contain a vm_page_t * and
uio_extflg variables.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
I removed the typedef of stuct uio to uio_t and instead placed a struct uio pointer inside of a
uio_t struct. I also added/updated some macros for accessing the member variables of the
underlying struct uio in the uio_t. This allows for common code to still use uio_t's for both
FreeBSD and Linux as was already the case. 
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran zloop for 30 mins both Linux and FreeBSD.
<!--- Include details of your testing environment, and the tests you ran to -->
Linux: 4.18.0-193
FreeBSD: 12.1 STABLE
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
