### PR TITLE
ZTS: avoid race to unmount in zfs_rollback_001

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
@@ -80,6 +80,7 @@ function test_n_check #opt num_snap_clone num_rollback
 	if datasetexists $VOL; then
 		if ismounted $TESTDIR1 $NEWFS_DEFAULT_FS; then
 			log_must umount -f $TESTDIR1
+			sleep 0.1
 		fi
 
 		log_must zfs destroy -Rf $VOL


### PR DESCRIPTION
### Motivation and Context

The zfs_rollback_001 test modifies files in a temporary, test dataset repeatedly.  Before each iteration, any preexisting dataset is removed, after unmounted with umount -f, if necessary.

### Description

Add a short delay after the forced unmount, avoiding a race that can prevent zfs destroy from succeeding, leading to a test failure.

This is the last change I need to get a clean ZTS run on Debian.

### How Has This Been Tested?

I ran the ZTS locally with this on Linux 5.10 (along with a patch to change `>/dev/null` to `>$TMPFILE` to avoid another, unrelated, issue).  This gave me a clean ZTS run.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
