### PR TITLE
kmem_alloc(KM_SLEEP) should use kvmalloc()

### DIFF
--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -256,7 +256,7 @@ spl_kmem_alloc_impl(size_t size, int flags, int node)
 			 * vmalloc).
 			 */
 #ifdef CONFIG_HIGHMEM
-			if (flags & KM_VMEM)) {
+			if (flags & KM_VMEM) {
 #else
 			if ((flags & KM_VMEM) || !(flags & KM_NOSLEEP)) {
 #endif

--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -245,7 +245,21 @@ spl_kmem_alloc_impl(size_t size, int flags, int node)
 				return (NULL);
 			}
 		} else {
-			if (flags & KM_VMEM) {
+			/*
+			 * We use kmalloc when doing kmem_alloc(KM_NOSLEEP),
+			 * because kvmalloc/vmalloc may sleep.  We also use
+			 * kmalloc on systems with limited kernel VA space (e.g.
+			 * 32-bit), which have HIGHMEM.  Otherwise we use
+			 * kvmalloc, which tries to get contiguous physical
+			 * memory (fast, like kmalloc) and falls back on using
+			 * virtual memory to stitch together pages (slow, like
+			 * vmalloc).
+			 */
+#ifdef CONFIG_HIGHMEM
+			if (flags & KM_VMEM)) {
+#else
+			if ((flags & KM_VMEM) || !(flags & KM_NOSLEEP)) {
+#endif
 				ptr = spl_kvmalloc(size, lflags);
 			} else {
 				ptr = kmalloc_node(size, lflags, node);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`kmem_alloc(size>PAGESIZE, KM_SLEEP)` is backed by `kmalloc()`, which finds
contiguous physical memory.  If there isn't enough contiguous physical
memory available (e.g. due to physical page fragmentation), the OOM
killer will be invoked to make more memory available.  This is not ideal
because processes may be killed when there is still plenty of free
memory (it just happens to be in individual pages, not contiguous runs
of pages).  We have observed this when allocating the ~13KB `zfs_cmd_t`,
for example in `zfsdev_ioctl()`.

### Description
<!--- Describe your changes in detail -->
This commit changes the behavior of `kmem_alloc(size>PAGESIZE, KM_SLEEP)` when there are insufficient contiguous free pages.  In this case we will find individual pages and stitch them together using virtual memory.  This is accomplished by using `kvmalloc()`, which implements the described behavior by trying `kmalloc(__GFP_NORETRY)` and falling back on `vmalloc()`.

The behavior of `kmem_alloc(KM_NOSLEEP)` is not changed; it continues to
use `kmalloc(GPF_ATOMIC | __GFP_NORETRY)`.  This is because `vmalloc()`
may sleep.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

ZFS test suite (on a 64-bit system with ~8GB RAM).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
