### PR TITLE
Only add supported features during pool creation

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1653,7 +1653,8 @@ zpool_do_create(int argc, char **argv)
 				if (strcmp(propval, ZFS_FEATURE_DISABLED) == 0)
 					(void) nvlist_remove_all(props,
 					    propname);
-			} else if (enable_all_pool_feat) {
+			} else if (enable_all_pool_feat &&
+			    feat->fi_zfs_mod_supported) {
 				ret = add_prop_list(propname,
 				    ZFS_FEATURE_ENABLED, &props, B_TRUE);
 				if (ret != 0)


### PR DESCRIPTION
### Motivation and Context

When using the `zpool` command from the master branch and
the OpenZFS 2.0.1 kernel modules the `zpool create` command
will always fails as shown.

```
sudo zpool create tank sdb
cannot create 'tank': feature 'draid' unsupported by kernel
```

This is incorrect behavior.  The `zpool` command from the master
branch should be able to create any non-dRAID pool using the
older kmods.  When requesting a dRAID pool be created a
reasonable error message describing why this cannot be done
should be output.

### Description

When creating a pool only features supported by both user and
kernel space should be enabled.  Furthermore, improve the error
messages when attempting to create, or add, a dRAID vdev when
the dRAID feature is not supported by the kernel modules.

### How Has This Been Tested?

```sh
# Start with mixed user and kernel space versions.
$ sudo zpool version
zfs-2.0.0-rc1_323_g4c1bb3226
zfs-kmod-2.0.1-1

$ truncate -s 1G /var/tmp/vdev{1,2,3,4,5}

# Check the error message for trying to create a dRAID vdev.
$ sudo zpool create tank draid /var/tmp/vdev{1,2,3,4,5}
cannot create 'tank': dRAID vdevs are unsupported by the kernel

# Check that a normal pool can be created...
$ sudo zpool create tank /var/tmp/vdev1

# and that a dRAID vdev still cannot be added to it.
$ sudo zpool add -f tank draid /var/tmp/vdev{2,3,4,5}
cannot add to 'tank': dRAID vdevs are unsupported by the kernel

# Load kmods which support dRAID.
$ sudo ./scripts/zfs.sh -u
$ sudo ./scripts/zfs.sh
$ sudo zpool version
zfs-2.0.0-rc1_323_g4c1bb3226
zfs-kmod-2.0.0-rc1_323_g4c1bb3226

$ sudo zpool import -d /var/tmp/ tank

# Try and add a dRAID vdev, this should fail since the draid
# feature has never been enabled on this pool.
$ sudo zpool add -f tank draid /var/tmp/vdev{2,3,4,5}
cannot add to 'tank': pool must be upgraded to add these vdevs

# Enable the feature and add the dRAID vdev.
$ sudo zpool set feature@draid=enabled tank
$ sudo zpool add -f tank draid /var/tmp/vdev{2,3,4,5}

$ sudo zpool status
  pool: tank
 state: ONLINE
config:

        NAME                 STATE     READ WRITE CKSUM
        tank                 ONLINE       0     0     0
          /var/tmp/vdev1     ONLINE       0     0     0
          draid1:3d:4c:0s-1  ONLINE       0     0     0
            /var/tmp/vdev2   ONLINE       0     0     0
            /var/tmp/vdev3   ONLINE       0     0     0
            /var/tmp/vdev4   ONLINE       0     0     0
            /var/tmp/vdev5   ONLINE       0     0     0

errors: No known data errors
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
