### PR TITLE
vdev_id: Add error message when $CONFIG is missing

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -545,6 +545,7 @@ while getopts 'c:d:eg:mp:h' OPTION; do
 done
 
 if [ ! -r $CONFIG ] ; then
+	echo "Error: Config file \"$CONFIG\" not found"
 	exit 0
 fi
 


### PR DESCRIPTION
It was observed that vdev_id exists silently when
the $CONFIG file is missing.

This patch adds error message in case vdev_id is
called without default $CONFIG or '-c'. This makes
end user observe the exit message more easily.

```
Before Patch:
~~~~~~~~~~~~~
$ ./cmd/vdev_id/vdev_id
$

After Patch:
~~~~~~~~~~~~
$ ./cmd/vdev_id/vdev_id
Error: Config file "/etc/zfs/vdev_id.conf" not found
$
```

Signed-off-by: Arshad Hussain <arshad.hussain@aeoncomputing.com>

### Motivation and Context
Minor improvement to vdev_id

### Description
Adds Error message to vdev_id as an improvement to existing script/code.

### How Has This Been Tested?
This was tested by running vdev_id script and forcing removal of $CONFIG file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Code cleanup (non-breaking change which makes code smaller or more readable)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
