### PR TITLE
Backports for zfs-2.0.2

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -50,6 +50,21 @@ libzfs_handle_t *g_zfs;
 static void
 parse_dataset(const char *target, char **dataset)
 {
+	/*
+	 * Prior to util-linux 2.36.2, if a file or directory in the
+	 * current working directory was named 'dataset' then mount(8)
+	 * would prepend the current working directory to the dataset.
+	 * Check for it and strip the prepended path when it is added.
+	 */
+	char cwd[PATH_MAX];
+	if (getcwd(cwd, PATH_MAX) == NULL) {
+		perror("getcwd");
+		return;
+	}
+	int len = strlen(cwd);
+	if (strncmp(cwd, target, len) == 0)
+		target += len;
+
 	/* Assume pool/dataset is more likely */
 	strlcpy(*dataset, target, PATH_MAX);
 

--- a/cmd/zgenhostid/Makefile.am
+++ b/cmd/zgenhostid/Makefile.am
@@ -1,5 +1,5 @@
 include $(top_srcdir)/config/Rules.am
 
-bin_PROGRAMS = zgenhostid
+sbin_PROGRAMS = zgenhostid
 
 zgenhostid_SOURCES = zgenhostid.c

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -5,7 +5,7 @@ check() {
 	[ "${1}" = "-d" ] && return 0
 
 	# Verify the zfs tool chain
-	for tool in "@bindir@/zgenhostid" "@sbindir@/zpool" "@sbindir@/zfs" "@mounthelperdir@/mount.zfs" ; do
+	for tool in "@sbindir@/zgenhostid" "@sbindir@/zpool" "@sbindir@/zfs" "@mounthelperdir@/mount.zfs" ; do
 		test -x "$tool" || return 1
 	done
 	# Verify grep exists
@@ -38,7 +38,7 @@ install() {
 	inst_rules @udevruledir@/60-zvol.rules
 	dracut_install hostid
 	dracut_install grep
-	dracut_install @bindir@/zgenhostid
+	dracut_install @sbindir@/zgenhostid
 	dracut_install @sbindir@/zfs
 	dracut_install @sbindir@/zpool
 	# Workaround for https://github.com/openzfs/zfs/issues/4749 by

--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -8,7 +8,7 @@ Before=zfs-import.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
+ExecStart=/bin/sh -c "systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
 
 [Install]
 WantedBy=zfs-import.target

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # only run this on systemd systems, we handle the decrypt in mount-zfs.sh in the mount hook otherwise
-[ -e /bin/systemctl ] || return 0
+[ -e /bin/systemctl ] || [ -e /usr/bin/systemctl ] || return 0
 
 # This script only gets executed on systemd systems, see mount-zfs.sh for non-systemd systems
 

--- a/contrib/pyzfs/libzfs_core/test/test_libzfs_core.py
+++ b/contrib/pyzfs/libzfs_core/test/test_libzfs_core.py
@@ -154,8 +154,8 @@ def os_open(name, mode):
 
 @contextlib.contextmanager
 def dev_null():
-    with os_open('/dev/null', os.O_WRONLY) as fd:
-        yield fd
+    with tempfile.TemporaryFile(suffix='.zstream') as fd:
+        yield fd.fileno()
 
 
 @contextlib.contextmanager

--- a/include/os/freebsd/spl/sys/types.h
+++ b/include/os/freebsd/spl/sys/types.h
@@ -64,7 +64,7 @@ typedef u_int		uint_t;
 typedef u_char		uchar_t;
 typedef u_short		ushort_t;
 typedef u_long		ulong_t;
-typedef	u_int		minor_t;
+typedef	int		minor_t;
 /* END CSTYLED */
 #ifndef	_OFF64_T_DECLARED
 #define	_OFF64_T_DECLARED

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4050,7 +4050,7 @@ arc_evict_state_impl(multilist_t *ml, int idx, arc_buf_hdr_t *marker,
 	mutex_enter(&arc_evict_lock);
 	arc_evict_count += bytes_evicted;
 
-	if ((int64_t)(arc_free_memory() - arc_sys_free / 2) > 0) {
+	if (arc_free_memory() > arc_sys_free / 2) {
 		arc_evict_waiter_t *aw;
 		while ((aw = list_head(&arc_evict_waiters)) != NULL &&
 		    aw->aew_count <= arc_evict_count) {
@@ -5136,14 +5136,20 @@ arc_wait_for_eviction(uint64_t amount)
 			list_link_init(&aw.aew_node);
 			cv_init(&aw.aew_cv, NULL, CV_DEFAULT, NULL);
 
-			arc_evict_waiter_t *last =
-			    list_tail(&arc_evict_waiters);
-			if (last != NULL) {
-				ASSERT3U(last->aew_count, >, arc_evict_count);
-				aw.aew_count = last->aew_count + amount;
-			} else {
-				aw.aew_count = arc_evict_count + amount;
+			uint64_t last_count = 0;
+			if (!list_is_empty(&arc_evict_waiters)) {
+				arc_evict_waiter_t *last =
+				    list_tail(&arc_evict_waiters);
+				last_count = last->aew_count;
 			}
+			/*
+			 * Note, the last waiter's count may be less than
+			 * arc_evict_count if we are low on memory in which
+			 * case arc_evict_state_impl() may have deferred
+			 * wakeups (but still incremented arc_evict_count).
+			 */
+			aw.aew_count =
+			    MAX(last_count, arc_evict_count) + amount;
 
 			list_insert_tail(&arc_evict_waiters, &aw);
 

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -442,7 +442,7 @@ systemctl --system daemon-reload >/dev/null || true
 # Core utilities
 %{_sbindir}/*
 %{_bindir}/raidz_test
-%{_bindir}/zgenhostid
+%{_sbindir}/zgenhostid
 %{_bindir}/zvol_wait
 # Optional Python 2/3 scripts
 %{_bindir}/arc_summary

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_005_neg.ksh
@@ -82,8 +82,8 @@ log_must zfs snapshot $init_snap
 log_must eval "zfs send $init_snap > $full_bkup"
 
 log_note "'zfs receive' fails with invalid send streams."
-log_mustnot eval "zfs receive $rst_init_snap < /dev/zero"
-log_mustnot eval "zfs receive -d $rst_root </dev/zero"
+log_mustnot eval "cat </dev/zero | zfs receive $rst_init_snap"
+log_mustnot eval "cat </dev/zero | zfs receive -d $rst_root"
 
 log_must eval "zfs receive $rst_init_snap < $full_bkup"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
@@ -80,6 +80,7 @@ function test_n_check #opt num_snap_clone num_rollback
 	if datasetexists $VOL; then
 		if ismounted $TESTDIR1 $NEWFS_DEFAULT_FS; then
 			log_must umount -f $TESTDIR1
+			sleep 0.1
 		fi
 
 		log_must zfs destroy -Rf $VOL

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
@@ -58,13 +58,13 @@ log_must zfs set "org.openzfs:snapprop=val" "$SENDFS@s1"
 # 2. Verify command line options interact with '-b' correctly
 typeset opts=("" "p" "Rp" "cew" "nv" "D" "DLPRcenpvw")
 for opt in ${opts[@]}; do
-	log_must eval "zfs send -b$opt $SENDFS@s1 > /dev/null"
-	log_must eval "zfs send -b$opt -i $SENDFS@s1 $SENDFS@s2 > /dev/null"
-	log_must eval "zfs send -b$opt -I $SENDFS@s1 $SENDFS@s2 > /dev/null"
+	log_must eval "zfs send -b$opt $SENDFS@s1 >$TEST_BASE_DIR/devnull"
+	log_must eval "zfs send -b$opt -i $SENDFS@s1 $SENDFS@s2 >$TEST_BASE_DIR/devnull"
+	log_must eval "zfs send -b$opt -I $SENDFS@s1 $SENDFS@s2 >$TEST_BASE_DIR/devnull"
 done
 for opt in ${opts[@]}; do
-	log_mustnot eval "zfs send -b$opt $SENDFS > /dev/null"
-	log_mustnot eval "zfs send -b$opt $SENDFS#bm > /dev/null"
+	log_mustnot eval "zfs send -b$opt $SENDFS >$TEST_BASE_DIR/devnull"
+	log_mustnot eval "zfs send -b$opt $SENDFS#bm >$TEST_BASE_DIR/devnull"
 done
 
 # Do 3..6 in a loop to verify various combination of "zfs send" options

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_003_pos.ksh
@@ -61,7 +61,7 @@ log_must zfs snapshot $snap2
 
 typeset -i i=0
 while (( i < ${#args[*]} )); do
-	log_must eval "zfs send -i ${args[i]} > /dev/null"
+	log_must eval "zfs send -i ${args[i]} >$TEST_BASE_DIR/devnull"
 
 	(( i += 1 ))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_004_neg.ksh
@@ -96,7 +96,7 @@ log_must zfs snapshot $snap3
 typeset -i i=0
 while (( i < ${#badargs[*]} ))
 do
-	log_mustnot eval "zfs send ${badargs[i]} >/dev/null"
+	log_mustnot eval "zfs send ${badargs[i]} >$TEST_BASE_DIR/devnull"
 
 	(( i = i + 1 ))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_005_pos.ksh
@@ -61,6 +61,6 @@ log_must zfs snapshot -r $TESTPOOL@snap
 log_must zpool export $TESTPOOL
 log_must zpool import -o readonly=on $TESTPOOL
 
-log_must eval "zfs send -R $TESTPOOL@snap >/dev/null"
+log_must eval "zfs send -R $TESTPOOL@snap >$TEST_BASE_DIR/devnull"
 
 log_pass "'zfs send -R' can send from read-only pools"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted.ksh
@@ -62,15 +62,15 @@ log_must eval "echo $passphrase1 | zfs create -o encryption=on" \
 
 log_must zfs snapshot -r $snap
 
-log_must eval "zfs send $snap > /dev/null"
-log_mustnot eval "zfs send -p $snap > /dev/null"
-log_mustnot eval "zfs send -R $snap > /dev/null"
+log_must eval "zfs send $snap >$TEST_BASE_DIR/devnull"
+log_mustnot eval "zfs send -p $snap >$TEST_BASE_DIR/devnull"
+log_mustnot eval "zfs send -R $snap >$TEST_BASE_DIR/devnull"
 
 log_must zfs unmount $TESTPOOL/$TESTFS1
 log_must zfs unload-key $TESTPOOL/$TESTFS1
 
-log_mustnot eval "zfs send $snap > /dev/null"
-log_must eval "zfs send $TESTPOOL/$TESTFS1/child@snap > /dev/null"
+log_mustnot eval "zfs send $snap >$TEST_BASE_DIR/devnull"
+log_must eval "zfs send $TESTPOOL/$TESTFS1/child@snap >$TEST_BASE_DIR/devnull"
 
 log_pass "ZFS performs unencrypted sends of encrypted datasets, unless the" \
 	"'-p' or '-R' options are specified"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted_unloaded.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted_unloaded.ksh
@@ -53,7 +53,7 @@ log_must eval "echo $passphrase | zfs create -o encryption=on" \
 log_must zfs snapshot $snap
 log_must zfs unmount $TESTPOOL/$TESTFS1
 log_must zfs unload-key $TESTPOOL/$TESTFS1
-log_mustnot eval "zfs send $snap > /dev/null"
+log_mustnot eval "zfs send $snap >$TEST_BASE_DIR/devnull"
 
 log_pass "ZFS does not perform unencrypted sends from encrypted datasets" \
 	"with unloaded keys."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_raw.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_raw.ksh
@@ -59,21 +59,21 @@ log_must eval "echo $passphrase | zfs create -o encryption=on" \
 log_must zfs snapshot $snap
 log_must zfs snapshot $snap1
 
-log_must eval "zfs send -w $snap > /dev/null"
-log_must eval "zfs send -w $snap1 > /dev/null"
+log_must eval "zfs send -w $snap >$TEST_BASE_DIR/devnull"
+log_must eval "zfs send -w $snap1 >$TEST_BASE_DIR/devnull"
 
 log_note "Verify ZFS can perform raw sends with properties"
-log_must eval "zfs send -wp $snap > /dev/null"
-log_must eval "zfs send -wp $snap1 > /dev/null"
+log_must eval "zfs send -wp $snap >$TEST_BASE_DIR/devnull"
+log_must eval "zfs send -wp $snap1 >$TEST_BASE_DIR/devnull"
 
 log_note "Verify ZFS can perform raw replication sends"
-log_must eval "zfs send -wR $snap > /dev/null"
-log_must eval "zfs send -wR $snap1 > /dev/null"
+log_must eval "zfs send -wR $snap >$TEST_BASE_DIR/devnull"
+log_must eval "zfs send -wR $snap1 >$TEST_BASE_DIR/devnull"
 
 log_note "Verify ZFS can perform a raw send of an encrypted datasets with" \
 	"its key unloaded"
 log_must zfs unmount $TESTPOOL/$TESTFS1
 log_must zfs unload-key $TESTPOOL/$TESTFS1
-log_must eval "zfs send -w $snap1 > /dev/null"
+log_must eval "zfs send -w $snap1 >$TEST_BASE_DIR/devnull"
 
 log_pass "ZFS performs raw sends of datasets"

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
@@ -45,11 +45,11 @@ log_must zfs snapshot $clone2@snap
 
 # Incompatible flags
 log_must zfs redact $sendfs@snap2 book $clone1@snap
-log_mustnot eval "zfs send -R --redact book $sendfs@snap2 >/dev/null"
+log_mustnot eval "zfs send -R --redact book $sendfs@snap2 >$TEST_BASE_DIR/devnull"
 
 typeset arg
 for arg in "$sendfs" "$clone1#book"; do
-	log_mustnot eval "zfs send --redact book $arg >/dev/null"
+	log_mustnot eval "zfs send --redact book $arg >$TEST_BASE_DIR/devnull"
 done
 
 # Bad redaction list arguments
@@ -58,7 +58,7 @@ log_mustnot zfs redact $sendfs@snap1 book
 log_mustnot zfs redact $sendfs#book1 book4 $clone1
 log_mustnot zfs redact $sendfs@snap1 book snap2 snap3
 log_mustnot zfs redact $sendfs@snap1 book @snap2 @snap3
-log_mustnot eval "zfs send --redact $sendfs#book $sendfs@snap >/dev/null"
+log_mustnot eval "zfs send --redact $sendfs#book $sendfs@snap >$TEST_BASE_DIR/devnull"
 
 # Redaction snapshots not a descendant of tosnap
 log_mustnot zfs redact $sendfs@snap2 book $sendfs@snap2
@@ -66,7 +66,7 @@ log_must zfs redact $sendfs@snap2 book2 $clone1@snap $clone2@snap
 log_must eval "zfs send --redact book2 $sendfs@snap2 >$stream"
 log_must zfs redact $sendfs@snap2 book3 $clone1@snap $clone2@snap
 log_must eval "zfs send -i $sendfs@snap1 --redact book3 $sendfs@snap2 \
-    >/dev/null"
+    >$TEST_BASE_DIR/devnull"
 log_mustnot zfs redact $sendfs@snap3 $sendfs@snap3 $clone1@snap
 
 # Full redacted sends of redacted datasets are not allowed.

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_resume.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_resume.ksh
@@ -81,7 +81,7 @@ log_must eval "zfs send --redact book1 $sendfs@snap >$stream"
 dd if=$stream bs=64k count=1 | log_mustnot zfs receive -s $recvfs
 [[ "-" = $(get_prop receive_resume_token $recvfs) ]] && \
     log_fail "Receive token not found."
-log_mustnot eval "zfs send --saved --redact book1 $recvfs > /dev/null"
+log_mustnot eval "zfs send --saved --redact book1 $recvfs >$TEST_BASE_DIR/devnull"
 log_must zfs recv -A $recvfs
 log_must datasetnonexists $recvfs
 

--- a/tests/zfs-tests/tests/functional/removal/removal_with_send.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_send.ksh
@@ -28,7 +28,7 @@ function callback
 {
 	create_snapshot $TESTPOOL/$TESTFS $TESTSNAP
 	log_must ksh -c \
-	    "zfs send $TESTPOOL/$TESTFS@$TESTSNAP >/dev/null"
+	    "zfs send $TESTPOOL/$TESTFS@$TESTSNAP >$TEST_BASE_DIR/devnull"
 	return 0
 }
 

--- a/tests/zfs-tests/tests/functional/rsend/send_invalid.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_invalid.ksh
@@ -44,7 +44,7 @@ log_must zfs snap $testfs@snap0
 log_must zfs snap $testfs@snap1
 
 # Test bad send with the CLI
-log_mustnot eval "zfs send -i $testfs@snap1 $testfs@snap0 >/dev/null"
+log_mustnot eval "zfs send -i $testfs@snap1 $testfs@snap0 >$TEST_BASE_DIR/devnull"
 
 # Test bad send with libzfs/libzfs_core
 log_must badsend $testfs@snap0 $testfs@snap1

--- a/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
@@ -103,7 +103,7 @@ set -A badargs \
 
 while (( i < ${#badargs[*]} ))
 do
-	log_mustnot eval "zfs send --saved ${badargs[i]} >/dev/null"
+	log_mustnot eval "zfs send --saved ${badargs[i]} >$TEST_BASE_DIR/devnull"
 	(( i = i + 1 ))
 done
 


### PR DESCRIPTION
### Motivation and Context

Backported changes from master for zfs-2.0.2.

### Description

4281eb595 dracut: Support /usr/bin as 'systemctl' path
e3a62a379 Install zgenhostid to sbindir
b21ed8170 Re-apply path sanitizer, as mount(8) still mangles it
8667cc211 ZTS: avoid piping to special devices
376240fe5 ZTS: avoid race to unmount in zfs_rollback_001
668fc295e assertion failed in arc_wait_for_eviction()
612b74745 FreeBSD: minor_t needs to be signed so that -1 is recognized as such

### How Has This Been Tested?

Locally compiled, pending full CI run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).