### PR TITLE
dracut: Fix race condition between load-key and import

### DIFF
--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -59,4 +59,12 @@ echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR"/sysr
 [ -d "$GENERATOR_DIR"/initrd-root-fs.target.requires ] || mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
 ln -s ../sysroot.mount "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
 
+
+[ -d "$GENERATOR_DIR"/dracut-pre-mount.service.d ] || mkdir "$GENERATOR_DIR"/dracut-pre-mount.service.d
+
+{
+    echo "[Unit]"
+    echo "After=zfs-import.target"
+} > "$GENERATOR_DIR"/dracut-pre-mount.service.d/zfs-enhancement.conf
+
 echo "zfs-generator: finished" >> /dev/kmsg


### PR DESCRIPTION
### Motivation
Another dracut issue that surfaces for me on openSUSE. With this commit (and the recently merged #11487) I can boot from an encrypted dataset just fine.
(Note that I have a separate `/boot` partition with the kernels, as I don't want to deal with grub's zfs support for now)

### Description
zfs-load-key.sh is called by the dracut-pre-mount.service unit which has no explicit 'After' dependency on zfs-import.target. That way it can be that the pool has not yet been imported and the zfs-load-key.sh finishes without ever seeing the relevant pool.

### How Has This Been Tested?
I build zfs packages for openSUSE, available at https://build.opensuse.org/project/show/home:lorenz:filesystems
This commit and the recently merged #11487 are included as a patch there, and the resulting packages are in active use by myself and a few others. With the patch, the affected dracut initrd zfs services are then active also on openSUSE.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
