### PR TITLE
zfsprops.8: fix mispluralisation in "Default values is"

### DIFF
--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -1766,7 +1766,7 @@ where
 and
 .Sy none
 are encoded as 1, 2 and 3 respectively.
-The default values is
+The default value is
 .Sy full .
 .It Sy vscan Ns = Ns Sy on Ns | Ns Sy off
 Controls whether regular files should be scanned for viruses when a file is


### PR DESCRIPTION
### Motivation and Context
It read bad.

### Description
It no longer does.

### How Has This Been Tested?
I looked at it really hard.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – ?
- [ ] I have run the ZFS Test Suite with this change applied. – Not sure how that's relevant
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
