### PR TITLE
logapi: cat output file instead of printing

### DIFF
--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -105,7 +105,7 @@ function log_must_retry
 					" assertion failure exited $status"
 				status=1
 			else
-				[[ -n $LOGAPI_DEBUG ]] && print $($out)
+				[[ -n $LOGAPI_DEBUG ]] && cat $logfile
 				_printsuccess "$@"
 			fi
 			break
@@ -244,7 +244,7 @@ function log_neg_expect
 		fi
 
 		if (( $ret == 0 )); then
-			[[ -n $LOGAPI_DEBUG ]] && print $($out)
+			[[ -n $LOGAPI_DEBUG ]] && cat $logfile
 			_printsuccess "$@" "exited $status"
 		fi
 	fi
@@ -284,7 +284,7 @@ function log_pos
 				" exited $status"
 			status=1
 		else
-			[[ -n $LOGAPI_DEBUG ]] && print $($out)
+			[[ -n $LOGAPI_DEBUG ]] && cat $logfile
 			_printsuccess "$@"
 		fi
 	fi


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This avoids globbing together multiple lines in the log, if you happen to
specify LOGAPI_DEBUG because you want to see it.

### Description
Instead of printing the output, cat the log file, so its contents appear unmolested in the test output.

### How Has This Been Tested?
ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
