### PR TITLE
zpool_export: make test suite more usable

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/Makefile.am
@@ -8,4 +8,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_export_004_pos.ksh
 
 dist_pkgdata_DATA = \
-	zpool_export.cfg
+	zpool_export.cfg \
+	zpool_export.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.cfg
@@ -30,30 +30,15 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-export DISK_ARRAY_NUM=0
-export DISK_ARRAY_LIMIT=4
-export DISKSARRAY=""
-export VDEVS_NUM=32
+export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
+export DISK1=$(echo $DISKS | awk '{print $1}')
+export DISK2=$(echo $DISKS | awk '{print $3}')
 
-function set_disks
-{
-        typeset -a disk_array=($(find_disks $DISKS))
-
-	if (( ${#disk_array[*]} <= 1 )); then
-		export DISK=${DISKS%% *}
-	else
-		export DISK=""
-		typeset -i i=0
-		while (( i < ${#disk_array[*]} )); do
-			export DISK${i}="${disk_array[$i]}"
-			DISKSARRAY="$DISKSARRAY ${disk_array[$i]}"
-			(( i = i + 1 ))
-			(( i>$DISK_ARRAY_LIMIT )) && break
-		done
-		export DISK_ARRAY_NUM=$i
-		export DISKSARRAY
-	fi
-}
-
-set_disks
-set_device_dir
+if is_linux; then
+	set_slice_prefix
+	set_device_dir
+	devs_id[0]=$(get_persistent_disk_name $DISK1)
+	devs_id[1]=$(get_persistent_disk_name $DISK2)
+else
+	DEV_DSKDIR="/dev"
+fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -21,13 +20,13 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
+# Copyright (c) 2020, Klara Systems, Inc. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.cfg
 
-DISK=${DISKS%% *}
-
-default_setup $DISK
+function zpool_export_cleanup
+{
+	[[ -d $TESTDIR0 ]] && log_must rm -rf $TESTDIR0
+	default_cleanup
+}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_001_pos.ksh
@@ -29,8 +29,7 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
 
 #
 # DESCRIPTION:
@@ -46,19 +45,7 @@
 
 verify_runnable "global"
 
-function cleanup
-{
-	typeset dir=$(get_device_dir $DISKS)
-
-	datasetexists "$TESTPOOL/$TESTFS" || \
-		log_must zpool import -d $dir $TESTPOOL
-
-	ismounted "$TESTPOOL/$TESTFS"
-	(( $? != 0 )) && \
-	    log_must zfs mount $TESTPOOL/$TESTFS
-}
-
-log_onexit cleanup
+log_onexit zpool_export_cleanup
 
 log_assert "Verify a pool can be exported."
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_002_pos.ksh
@@ -29,7 +29,7 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
 
 #
 # DESCRIPTION:
@@ -45,19 +45,10 @@ verify_runnable "global"
 
 function cleanup
 {
-	typeset dir=$(get_device_dir $DISKS)
 	cd $olddir || \
 	    log_fail "Couldn't cd back to $olddir"
 
-	datasetexists "$TESTPOOL/$TESTFS" || \
-	    log_must zpool import -d $dir $TESTPOOL
-
-	ismounted "$TESTPOOL/$TESTFS"
-	(( $? != 0 )) && \
-	    log_must zfs mount $TESTPOOL/$TESTFS
-
-	[[ -e $TESTDIR/$TESTFILE0 ]] && \
-	    log_must rm -rf $TESTDIR/$TESTFILE0
+	zpool_export_cleanup
 }
 
 olddir=$PWD

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_003_neg.ksh
@@ -29,7 +29,7 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
 
 #
 # DESCRIPTION:
@@ -43,18 +43,7 @@
 
 verify_runnable "global"
 
-function cleanup
-{
-	typeset dir=$(get_device_dir $DISKS)
-	datasetexists "$TESTPOOL/$TESTFS" || \
-		log_must zpool import -d $dir $TESTPOOL
-
-	ismounted "$TESTPOOL/$TESTFS"
-	(( $? != 0 )) && \
-	    log_must zfs mount $TESTPOOL/$TESTFS
-}
-
-log_onexit cleanup
+log_onexit zpool_export_cleanup
 
 set -A args "" "-f" "-? $TESTPOOL" "-QWERTYUIO $TESTPOOL"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
@@ -29,7 +29,7 @@
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
 
 #
 # DESCRIPTION:
@@ -50,25 +50,8 @@
 
 verify_runnable "global"
 
-function cleanup
-{
-	mntpnt=$TESTDIR0
-	datasetexists $TESTPOOL1 || log_must zpool import -d $mntpnt $TESTPOOL1
-	datasetexists $TESTPOOL1 && destroy_pool $TESTPOOL1
-	datasetexists $TESTPOOL2 && destroy_pool $TESTPOOL2
-	typeset -i i=0
-	while ((i < 5)); do
-		if [[ -e $mntpnt/vdev$i ]]; then
-			log_must rm -f $mntpnt/vdev$i
-		fi
-		((i += 1))
-	done
-	log_must rmdir $mntpnt
-}
-
-
 log_assert "Verify zpool export succeed or fail with spare."
-log_onexit cleanup
+log_onexit zpool_export_cleanup
 
 mntpnt=$TESTDIR0
 log_must mkdir -p $mntpnt


### PR DESCRIPTION
- refactor cleanup routines into common kshlib zpool_export_cleanup func
- don't require physical disks to test, just use files

Signed-off-by:	Will Andrews <will@firepipe.net>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
PR #11082 makes use of this change to simplify adding new export test cases.
It also reduces the environmental setup that is otherwise necessary.

### Description
- refactor cleanup routines into common kshlib zpool_export_cleanup func
- don't require physical disks to test, just use files

### How Has This Been Tested?
ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
