### PR TITLE
txg and dmu_tx: document monotonicity of txg_hold_open and dmu_tx_create 

### DIFF
--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1012,6 +1012,21 @@ dmu_tx_unassign(dmu_tx_t *tx)
  * details on the throttle). This is used by the VFS operations, after
  * they have already called dmu_tx_wait() (though most likely on a
  * different tx).
+ *
+ * It is guaranteed that subsequent successful calls to dmu_tx_assign
+ * assign the tx to monotonically increasing txgs. Naturally, that is only
+ * monotonicity, not strong monotonicity. This guarantee holds both for
+ * subsequent calls from one thread and for multiple threads. For example,
+ * it is impossible to observe the following sequence of events:
+ *
+ *          Thread 1                            Thread 2
+ *
+ *     dmu_tx_assign(T1, ...)
+ *     1 <- dmu_tx_get_txg(T1)
+ *                                       dmu_tx_assign(T2, ...)
+ *                                       2 <- dmu_tx_get_txg(T2)
+ *     dmu_tx_assign(T3, ...)
+ *     1 <- dmu_tx_get_txg(T3)
  */
 int
 dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -292,6 +292,27 @@ txg_sync_stop(dsl_pool_t *dp)
 	mutex_exit(&tx->tx_sync_lock);
 }
 
+/*
+ * Get a handle on the currently open txg and keep it open.
+ *
+ * The txg is guaranteed to stay open until txg_rele_to_quiesce() is called for
+ * the handle. Once txg_rele_to_quiesce() has been called, the txg stays
+ * in quiescing state until txg_rele_to_sync() is called for the handle.
+ *
+ * It is guaranteed that subsequent calls return monotonically increasing txgs
+ * for the same dsl_pool_t.
+ * Naturally that this is only monotonicity, not strong monotonicity.
+ * This guarantee holds both for subsequent calls from one thread and for
+ * multiple threads. For example, it is impossible to observe the following
+ * sequence of events:
+ *
+ *           Thread 1                            Thread 2
+ *
+ *   1 <- txg_hold_open(P, ...)
+ *                                       2 <- txg_hold_open(P, ...)
+ *   1 <- txg_hold_open(P, ...)
+ *
+ */
 uint64_t
 txg_hold_open(dsl_pool_t *dp, txg_handle_t *th)
 {

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -393,7 +393,8 @@ txg_quiesce(dsl_pool_t *dp, uint64_t txg)
 	spa_txg_history_add(dp->dp_spa, txg + 1, tx_open_time);
 
 	/*
-	 * Quiesce the transaction group by waiting for everyone to txg_exit().
+	 * Quiesce the transaction group by waiting for everyone to
+	 * txg_rele_to_sync().
 	 */
 	for (c = 0; c < max_ncpus; c++) {
 		tx_cpu_t *tc = &tx->tx_cpu[c];


### PR DESCRIPTION
### Motivation and Context
I need the monotonicity guarantee documented in this PR for other work that I'm doing so I figured it would be nice to have them be documented.

### Description
Only comments.
@ reviewers: please be nitpicky about the phrasing, maybe I oversaw something.

### How Has This Been Tested?
Nothing to test.

### Types of changes
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
-  ~~I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.~~
- ~~I have run the ZFS Test Suite with this change applied.~~
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
