### PR TITLE
Fix a resource leak in uu_avl_pool_destroy:

### DIFF
--- a/lib/libuutil/uu_avl.c
+++ b/lib/libuutil/uu_avl.c
@@ -128,6 +128,7 @@ uu_avl_pool_destroy(uu_avl_pool_t *pp)
 	pp->uap_next->uap_prev = pp->uap_prev;
 	pp->uap_prev->uap_next = pp->uap_next;
 	(void) pthread_mutex_unlock(&uu_apool_list_lock);
+	(void) pthread_mutex_destroy(&pp->uap_lock);
 	pp->uap_prev = NULL;
 	pp->uap_next = NULL;
 	uu_free(pp);


### PR DESCRIPTION
### Motivation and Context

uu_avl_pool_create creates a pthread mutex that never gets destroyed.

### Description

Destroy the pthread mutex created in uu_avl_pool_destroy.

### How Has This Been Tested?

It's been included in FreeBSD since 2014.  I've done no testing on other OSes.

https://svnweb.freebsd.org/base?view=revision&revision=262912

Obtained from:	FreeBSD
Sponsored by:	Spectra Logic Corporation
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
