### PR TITLE
[skip ci] Fix a man page link in zfs-program.8

### DIFF
--- a/man/man8/zfs-program.8
+++ b/man/man8/zfs-program.8
@@ -12,7 +12,7 @@
 .\" Copyright (c) 2019, 2020 by Christian Schwarz. All Rights Reserved.
 .\" Copyright 2020 Joyent, Inc.
 .\"
-.Dd February 3, 2020
+.Dd January 26, 2021
 .Dt ZFS-PROGRAM 8
 .Os
 .Sh NAME
@@ -290,7 +290,7 @@ EBADF     EXDEV       EFBIG
 .Ss API Functions
 For detailed descriptions of the exact behavior of any zfs administrative
 operations, see the main
-.Xr zfs 1
+.Xr zfs 8
 manual page.
 .Bl -tag -width "xx"
 .It Em zfs.debug(msg)


### PR DESCRIPTION
https://svnweb.freebsd.org/base?view=revision&revision=360080

Obtained from: FreeBSD

### Motivation and Context

zfs-program.8 has an orphan link

### Description
Fix the link

### How Has This Been Tested?
None necessary

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
