### PR TITLE
pool_state test: check for pool existence in cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
@@ -61,16 +61,18 @@ function cleanup
 			log_must rm -f $BACKUP
 		fi
 
-		# Our disk is back.  Now we can clear errors and destroy the
-		# pool cleanly.
-		log_must zpool clear $TESTPOOL2
+		if poolexists $TESTPOOL2 ; then
+			# Our disk is back.  Now we can clear errors and destroy the
+			# pool cleanly.
+			log_must zpool clear $TESTPOOL2
 
-		# Now that the disk is back and errors cleared, wait for our
-		# hung 'zpool scrub' to finish.
-		wait
+			# Now that the disk is back and errors cleared, wait for our
+			# hung 'zpool scrub' to finish.
+			wait
 
-		destroy_pool $TESTPOOL2
-		log_must rm $REALDISK
+			destroy_pool $TESTPOOL2
+		fi
+		log_must rm -f $REALDISK
 		unload_scsi_debug
 	fi
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If there is no scsi_debug module, then this test
must be skipped, in this case cleanup routine should
be prepared for absent pool.

Before: test failed https://github.com/gmelikov/zfs/runs/1775993803?check_suite_focus=true

After: test skipped https://github.com/gmelikov/zfs/runs/1776188607?check_suite_focus=true

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)