### PR TITLE
fix abd_nr_pages_off for gang abd

### DIFF
--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -1021,7 +1021,6 @@ unsigned int
 abd_bio_map_off(struct bio *bio, abd_t *abd,
     unsigned int io_size, size_t off)
 {
-	int i;
 	struct abd_iter aiter;
 
 	ASSERT3U(io_size, <=, abd->abd_size - off);
@@ -1035,7 +1034,7 @@ abd_bio_map_off(struct bio *bio, abd_t *abd,
 	abd_iter_init(&aiter, abd);
 	abd_iter_advance(&aiter, off);
 
-	for (i = 0; i < bio->bi_max_vecs; i++) {
+	for (int i = 0; i < bio->bi_max_vecs; i++) {
 		struct page *pg;
 		size_t len, sgoff, pgoff;
 		struct scatterlist *sg;


### PR DESCRIPTION


---



<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`__vdev_disk_physio()` uses `abd_nr_pages_off()` to allocate a bio with
a sufficient number of iovec's to process this zio (i.e.
`nr_iovecs`/`bi_max_vecs`).  If there are not enough iovec's in the bio,
then additional bio's will be allocated.  However, this is a sub-optimal
code path.  In particular, it requires several abd calls (to
`abd_nr_pages_off()` and `abd_bio_map_off()`) which will have to walk
the constituents of the ABD (the pages or the gang children) because
they are looking for offsets > 0.

For gang ABD's, `abd_nr_pages_off()` returns the number of iovec's
needed for the first constituent, rather than the sum of all
constituents (within the requested range).  This always under-estimates
the required number of iovec's, which causes us to always need several
bio's.  The end result is that `__vdev_disk_physio()` is usually O(n^2)
for gang ABD's (and occasionally O(n^3), when more than 16 bio's are
needed).

### Description
<!--- Describe your changes in detail -->
This commit fixes `abd_nr_pages_off()`'s handling of gang ABD's, to
correctly determine how many iovec's are needed, by adding up the number
of iovec's for each of the gang children in the requested range.

Note: It seems like __vdev_disk_physio() should usually only need one bio, since we allocate it with enough iovec's.  Should we reduce the default bio_count?

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I tested this by writing to a file with recordsize=512. (pool is 1x HDD, with async write queue limit of 1).  This results in the vdev_queue layer creating gang abd's with children of size 512, for i/o aggregation.

Observed with `bpftrace -e 'k:abd_nr_pages_off{printf("abd_nr_pages_off(size=%u, off=%u)\n", arg1, arg2)} kr:abd_nr_pages_off{printf("abd_nr_pages_off -> %u\n", retval)}'`

before: we can see that the nr_pages returned is wrong (initially 4), and we have to keep looping in __vdev_disk_physio().  Each call with off!=0 requires that we search from the beginning, resulting in O(n^2) performance.
```
abd_nr_pages_off(size=12288, off=0)
abd_nr_pages_off -> 4
abd_nr_pages_off(size=12288, off=0)
abd_nr_pages_off -> 4
abd_nr_pages_off(size=10240, off=2048)
abd_nr_pages_off -> 4
abd_nr_pages_off(size=10240, off=2048)
abd_nr_pages_off -> 4
abd_nr_pages_off(size=8192, off=4096)
abd_nr_pages_off -> 3
abd_nr_pages_off(size=8192, off=4096)
abd_nr_pages_off -> 3
abd_nr_pages_off(size=6656, off=5632)
abd_nr_pages_off -> 3
abd_nr_pages_off(size=6656, off=5632)
abd_nr_pages_off -> 3
abd_nr_pages_off(size=5120, off=7168)
abd_nr_pages_off -> 2
abd_nr_pages_off(size=5120, off=7168)
abd_nr_pages_off -> 2
abd_nr_pages_off(size=4096, off=8192)
abd_nr_pages_off -> 2
abd_nr_pages_off(size=4096, off=8192)
abd_nr_pages_off -> 2
abd_nr_pages_off(size=3072, off=9216)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=3072, off=9216)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=2560, off=9728)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=2560, off=9728)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=2048, off=10240)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=2048, off=10240)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=1536, off=10752)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=1536, off=10752)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=1024, off=11264)
abd_nr_pages_off -> 2
abd_nr_pages_off(size=1024, off=11264)
abd_nr_pages_off -> 2
```

after: we return the correct nr_pages of 22, so we don't have to loop.  We see calls to each of the child abd's, which are each size=512 (1 "page").
```
abd_nr_pages_off(size=11264, off=0)
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off(size=512, off=0)
abd_nr_pages_off -> 1
abd_nr_pages_off -> 22
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
