### PR TITLE
Removing ABD Parent Child Reference Before Freeing ABD

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -576,7 +576,7 @@ abd_get_zeros(size_t size)
 }
 
 /*
- * Allocate a linear ABD structure for buf..
+ * Allocate a linear ABD structure for buf.
  */
 abd_t *
 abd_get_from_buf(void *buf, size_t size)

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -241,7 +241,7 @@ abd_free_linear(abd_t *abd)
 }
 
 static void
-abd_free_gang_abd(abd_t *abd)
+abd_free_gang(abd_t *abd)
 {
 	ASSERT(abd_is_gang(abd));
 	abd_t *cabd;
@@ -292,19 +292,19 @@ abd_free(abd_t *abd)
 	abd_verify(abd);
 	IMPLY(abd->abd_flags & ABD_FLAG_OWNER, abd->abd_parent == NULL);
 
+	if (abd->abd_parent != NULL) {
+		(void) zfs_refcount_remove_many(&abd->abd_parent->abd_children,
+		    abd->abd_size, abd);
+	}
+
 	if (abd_is_gang(abd)) {
-		abd_free_gang_abd(abd);
+		abd_free_gang(abd);
 	} else if (abd_is_linear(abd)) {
 		if (abd->abd_flags & ABD_FLAG_OWNER)
 			abd_free_linear(abd);
 	} else {
 		if (abd->abd_flags & ABD_FLAG_OWNER)
 			abd_free_scatter(abd);
-	}
-
-	if (abd->abd_parent != NULL) {
-		(void) zfs_refcount_remove_many(&abd->abd_parent->abd_children,
-		    abd->abd_size, abd);
 	}
 
 	abd_fini_struct(abd);
@@ -421,7 +421,7 @@ abd_gang_add(abd_t *pabd, abd_t *cabd, boolean_t free_on_free)
 		 * allocated ABD with ABD_FLAG_GANG_FREE, before
 		 * adding it to the gang ABD's list, to make the
 		 * gang ABD aware that it is responsible to call
-		 * abd_put(). We use abd_get_offset() in order
+		 * abd_free(). We use abd_get_offset() in order
 		 * to just allocate a new ABD but avoid copying the
 		 * data over into the newly allocated ABD.
 		 *
@@ -565,8 +565,7 @@ abd_get_offset_size(abd_t *sabd, size_t off, size_t size)
 }
 
 /*
- * Return a size scatter ABD. In order to free the returned
- * ABD abd_put() must be called.
+ * Return a size scatter ABD containing only zeros.
  */
 abd_t *
 abd_get_zeros(size_t size)
@@ -577,8 +576,7 @@ abd_get_zeros(size_t size)
 }
 
 /*
- * Allocate a linear ABD structure for buf. You must free this with abd_put()
- * since the resulting ABD doesn't own its own buffer.
+ * Allocate a linear ABD structure for buf..
  */
 abd_t *
 abd_get_from_buf(void *buf, size_t size)


### PR DESCRIPTION
Moving the call to zfs_refcount_remove_many() in abd_free() to be called
before any of the ABD free variants are called. This is necessary
because abd_free_gang() adjusts the abd_size for the gang ABD. If the
parent's child references are removed after free'ing the gang ABD the
refcount is not adjusted correctly for the parent's children.

I also removed some stray abd_put() in comments and changed
abd_free_gang_abd() -> abd_free_gang().

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Updated abd_free() to remove parent's child references before calling any of the specific ABD free
functions.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is necessary because abd_gang_free() updates the abd_size for the gang ABD. We need to make
sure to remove all of the parent's child reference before free'ing a gang ABD.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran zloop.sh for 30 mins.
<!--- Include details of your testing environment, and the tests you ran to -->
Linux CentOS 8, Kernel 4.18.0-193.el8.x86_64
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
