### PR TITLE
Remove unused iov_iter_init_compat() wrapper

### DIFF
--- a/config/kernel-vfs-iov_iter.m4
+++ b/config/kernel-vfs-iov_iter.m4
@@ -10,31 +10,6 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_VFS_IOV_ITER], [
 		    ITER_IOVEC | ITER_KVEC | ITER_BVEC | ITER_PIPE;
 	])
 
-	ZFS_LINUX_TEST_SRC([iov_iter_init], [
-		#include <linux/fs.h>
-		#include <linux/uio.h>
-	],[
-		struct iov_iter iter = { 0 };
-		struct iovec iov;
-		unsigned long nr_segs = 1;
-		size_t count = 1024;
-
-		iov_iter_init(&iter, WRITE, &iov, nr_segs, count);
-	])
-
-	ZFS_LINUX_TEST_SRC([iov_iter_init_legacy], [
-		#include <linux/fs.h>
-		#include <linux/uio.h>
-	],[
-		struct iov_iter iter = { 0 };
-		struct iovec iov;
-		unsigned long nr_segs = 1;
-		size_t count = 1024;
-		size_t written = 0;
-
-		iov_iter_init(&iter, &iov, nr_segs, count, written);
-	])
-
 	ZFS_LINUX_TEST_SRC([iov_iter_advance], [
 		#include <linux/fs.h>
 		#include <linux/uio.h>
@@ -112,25 +87,6 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_IOV_ITER], [
 	],[
 		AC_MSG_RESULT(no)
 		enable_vfs_iov_iter="no"
-	])
-
-	dnl #
-	dnl # 'iov_iter_init' available in Linux 3.16 and newer.
-	dnl # 'iov_iter_init_legacy' available in Linux 3.15 and older.
-	dnl #
-	AC_MSG_CHECKING([whether iov_iter_init() is available])
-	ZFS_LINUX_TEST_RESULT([iov_iter_init], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_IOV_ITER_INIT, 1,
-		    [iov_iter_init() is available])
-	],[
-		ZFS_LINUX_TEST_RESULT([iov_iter_init_legacy], [
-			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_IOV_ITER_INIT_LEGACY, 1,
-			    [iov_iter_init() is available])
-		],[
-			ZFS_LINUX_TEST_ERROR([iov_iter_init()])
-		])
 	])
 
 	AC_MSG_CHECKING([whether iov_iter_advance() is available])

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -112,19 +112,6 @@ zfs_uio_index_at_offset(zfs_uio_t *uio, offset_t off, uint_t *vec_idx)
 }
 
 static inline void
-iov_iter_init_compat(struct iov_iter *iter, unsigned int dir,
-    const struct iovec *iov, unsigned long nr_segs, size_t count)
-{
-#if defined(HAVE_IOV_ITER_INIT)
-	iov_iter_init(iter, dir, iov, nr_segs, count);
-#elif defined(HAVE_IOV_ITER_INIT_LEGACY)
-	iov_iter_init(iter, iov, nr_segs, count, 0);
-#else
-#error "Unsupported kernel"
-#endif
-}
-
-static inline void
 zfs_uio_iovec_init(zfs_uio_t *uio, const struct iovec *iov,
     unsigned long nr_segs, offset_t offset, zfs_uio_seg_t seg, ssize_t resid,
     size_t skip)


### PR DESCRIPTION
### Motivation and Context

Cleanup which should have been included in 83b91ae1.

### Description

This compatibility code is no longer needed.  For it a while
iov_iter_init_compat() was used by zfs_uio_prefaultpages() but
this code should have been dropped as part of commit 83b91ae1.
Take care of that oversight and remove it.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?

Locally compiled.  Grepped to source to ensure there were no
consumers of this function or other consumers of the removed
`#define` macros.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
