### PR TITLE
Fixed issue with processing of EC_dev_remove event

### DIFF
--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -13,6 +13,7 @@
 /*
  * Copyright (c) 2016, Intel Corporation.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>
+ * Copyright (c) 2021 Hewlett Packard Enterprise Development LP
  */
 
 #include <libnvpair.h>

--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -211,12 +211,18 @@ zfs_agent_post_event(const char *class, const char *subclass, nvlist_t *nvl)
 		 * For multipath, spare and l2arc devices ZFS_EV_VDEV_GUID or
 		 * ZFS_EV_POOL_GUID may be missing so find them.
 		 */
-		(void) nvlist_lookup_string(nvl, DEV_IDENTIFIER,
-		    &search.gs_devid);
-		(void) zpool_iter(g_zfs_hdl, zfs_agent_iter_pool, &search);
-		pool_guid = search.gs_pool_guid;
-		vdev_guid = search.gs_vdev_guid;
-		devtype = search.gs_vdev_type;
+		if (pool_guid == 0 || vdev_guid == 0) {
+			if ((nvlist_lookup_string(nvl, DEV_IDENTIFIER,
+			    &search.gs_devid) == 0) &&
+			    (zpool_iter(g_zfs_hdl, zfs_agent_iter_pool, &search)
+			    == 1)) {
+				if (pool_guid == 0)
+					pool_guid = search.gs_pool_guid;
+				if (vdev_guid == 0)
+					vdev_guid = search.gs_vdev_guid;
+				devtype = search.gs_vdev_type;
+			}
+		}
 
 		/*
 		 * We want to avoid reporting "remove" events coming from


### PR DESCRIPTION
Co-authored-by: Vipin Kumar Verma <vipin.verma@hpe.com>

Distribution Name: CentOS Linux release
Distribution Version: 7.9.2009 (Core)
Linux Kernel: 3.10.0
Architecture: x86_64
ZFS Version: 2.0.0-rc1_375_g84268b0

1. More than 1 drive failure (all at once) in draid1:1d:12c:1s configuration
2. Powered off slot 4 and slot 14 at once.
3. Zpool status remains ONLINE.

ZED did receive EC_dev_remove but did not process it

`
Jan  7 04:33:49 kjlmo802 zed[103037]: zed_disk_event:
--
Jan  7 04:33:49 kjlmo802 zed[103037]: class: EC_dev_remove
Jan  7 04:33:49 kjlmo802 zed[103037]: subclass: disk
Jan  7 04:33:49 kjlmo802 zed[103037]: dev_name: /dev/nvme21n1p1
Jan  7 04:33:49 kjlmo802 zed[103037]: path: /devices/pci0000:00/0000:00:01.2/0000:02:00.0/nvme/nvme21/nvme21n1/nvme21n1p1
 
 
Jan  7 04:33:50 kjlmo803 zed[43583]: zed_disk_event:
Jan  7 04:33:50 kjlmo803 zed[43583]: class: EC_dev_remove
Jan  7 04:33:50 kjlmo803 zed[43583]: subclass: disk
Jan  7 04:33:50 kjlmo803 zed[43583]: dev_name: /dev/nvme7n1p1
Jan  7 04:33:50 kjlmo803 zed[43583]: path: /devices/pci0000:c0/0000:c0:03.6/0000:ce:00.0/nvme/nvme7/nvme7n1/nvme7n1p1
`
After debugging figured out that the pool guid and vdev guid received by zfs_agent_post_event(), which calls zfs_retire_recv(), are non-zero. But later in the method zfs_agent_post_event we do something like below which resets pool guid and vdev guid to zero. This is the root cause for EC_dev_remove not being handled.

`
/* For multipath, spare and l2arc devices ZFS_EV_VDEV_GUID or
* ZFS_EV_POOL_GUID may be missing so find them.
*/
                (void) nvlist_lookup_string(nvl, DEV_IDENTIFIER,
                    &search.gs_devid);
                (void) zpool_iter(g_zfs_hdl, zfs_agent_iter_pool, &search);
                pool_guid = search.gs_pool_guid;
                vdev_guid = search.gs_vdev_guid;
                devtype = search.gs_vdev_type;
`