### PR TITLE
zfs-list.8: clarify listing snapshots

### DIFF
--- a/man/man8/zfs-list.8
+++ b/man/man8/zfs-list.8
@@ -63,12 +63,17 @@ If specified, you can list property information by the absolute pathname or the
 relative pathname.
 By default, all file systems and volumes are displayed.
 Snapshots are displayed if the
-.Sy listsnaps
-property is
+.Sy listsnapshots
+pool property is
 .Sy on
 .Po the default is
 .Sy off
-.Pc .
+.Pc ,
+or if the
+.Fl t Sy snapshot
+or
+.Fl t Sy all
+options are specified.
 The following fields are displayed:
 .Sy name Ns \&, Sy used Ns \&, Sy available Ns \&, Sy referenced Ns \&, Sy mountpoint Ns .
 .Bl -tag -width "-H"


### PR DESCRIPTION
### Motivation and Context

Issue #11562.

cc: @ThePythonicCow

### Description

Clarify how to include snapshots in the `zpool list` outpool by
referencing the full name of the l`istsnapshots` pool property, and
the `zpool list -t snapshot` option.

### How Has This Been Tested?

Proofread via `man/man8/zfs-list.8`, snippet:

       If specified, you can list property information by the absolute path‐
       name or the relative pathname.  By default, all file systems and vol‐
       umes are displayed.  Snapshots are displayed if the listsnapshots pool
       property is on (the default is off), or if the -t snapshot or -t all
       options are specified.  The following fields are displayed: name, used,
       available, referenced, mountpoint.

[updated]

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
