### PR TITLE
zfs-import-{cache,scan}: change condition to FileNotEmpty

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -8,7 +8,7 @@ After=cryptsetup.target
 After=multipathd.target
 After=systemd-remount-fs.service
 Before=zfs-import.target
-ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+ConditionFileNotEmpty=@sysconfdir@/zfs/zpool.cache
 ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -7,7 +7,7 @@ After=systemd-udev-settle.service
 After=cryptsetup.target
 After=multipathd.target
 Before=zfs-import.target
-ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+ConditionFileNotEmpty=!@sysconfdir@/zfs/zpool.cache
 ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]


### PR DESCRIPTION
### Motivation and Context
Sometimes(?) zfs generates an empty cache file for me, and the import fails, which is suboptimal, since this means that dracut fails, and I have to type in zpool import -a to boot, delete the file, and regenerate+reinstall the initrd

### Description
This works around this by ignoring a clearly bogus cache, while still supporting systems that do utilise one

### How Has This Been Tested?
Applied equivalent change to the services on my laptop, regenerated and rebooted for each of the following: no cachefile => -scan, empty cachefile => -scan, non-empty cachefile => -cache. This is superiour to the previous behaviour of empty cachefile => -cache (failed).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. – I didn't, but I don't think there is any, so
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – N/A
- [ ] I have run the ZFS Test Suite with this change applied. – dunno how to, but I don't consider it relevant here
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
