### PR TITLE
Rename zfs_inode_update to zfs_vm_update_size

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -180,7 +180,6 @@ extern int zfsfstype;
 
 extern int zfs_znode_parent_and_name(struct znode *zp, struct znode **dzpp,
     char *buf);
-extern void	zfs_inode_update(struct znode *);
 #ifdef	__cplusplus
 }
 #endif

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -158,7 +158,6 @@ struct znode;
 extern int	zfs_sync(struct super_block *, int, cred_t *);
 extern int	zfs_inode_alloc(struct super_block *, struct inode **ip);
 extern void	zfs_inode_destroy(struct inode *);
-extern void	zfs_inode_update(struct znode *);
 extern void	zfs_mark_inode_dirty(struct inode *);
 extern boolean_t zfs_relatime_need_update(const struct inode *);
 

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -287,6 +287,8 @@ extern void zfs_log_acl(zilog_t *zilog, dmu_tx_t *tx, znode_t *zp,
 extern void zfs_xvattr_set(znode_t *zp, xvattr_t *xvap, dmu_tx_t *tx);
 extern void zfs_upgrade(zfsvfs_t *zfsvfs, dmu_tx_t *tx);
 
+extern void zfs_znode_update_vfs(struct znode *);
+
 #endif
 #ifdef	__cplusplus
 }

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -2013,7 +2013,7 @@ zfs_obj_to_stats(objset_t *osp, uint64_t obj, zfs_stat_t *sb,
 
 
 void
-zfs_inode_update(znode_t *zp)
+zfs_znode_update_vfs(znode_t *zp)
 {
 	vm_object_t object;
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1772,7 +1772,7 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 
 	*ipp = ZTOI(zp);
 	if (*ipp)
-		zfs_inode_update(ITOZ(*ipp));
+		zfs_znode_update_vfs(ITOZ(*ipp));
 
 	ZFS_EXIT(zfsvfs);
 	return (0);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -526,7 +526,7 @@ zfs_lookup(znode_t *zdp, char *nm, znode_t **zpp, int flags, cred_t *cr,
 
 	error = zfs_dirlook(zdp, nm, zpp, flags, direntflags, realpnp);
 	if ((error == 0) && (*zpp))
-		zfs_inode_update(*zpp);
+		zfs_znode_update_vfs(*zpp);
 
 	ZFS_EXIT(zfsvfs);
 	return (error);
@@ -789,8 +789,8 @@ out:
 		if (zp)
 			zrele(zp);
 	} else {
-		zfs_inode_update(dzp);
-		zfs_inode_update(zp);
+		zfs_znode_update_vfs(dzp);
+		zfs_znode_update_vfs(zp);
 		*zpp = zp;
 	}
 
@@ -912,8 +912,8 @@ out:
 		if (zp)
 			zrele(zp);
 	} else {
-		zfs_inode_update(dzp);
-		zfs_inode_update(zp);
+		zfs_znode_update_vfs(dzp);
+		zfs_znode_update_vfs(zp);
 		*ipp = ZTOI(zp);
 	}
 
@@ -1139,8 +1139,8 @@ out:
 		pn_free(realnmp);
 
 	zfs_dirent_unlock(dl);
-	zfs_inode_update(dzp);
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(dzp);
+	zfs_znode_update_vfs(zp);
 
 	if (delete_now)
 		zrele(zp);
@@ -1148,7 +1148,7 @@ out:
 		zfs_zrele_async(zp);
 
 	if (xzp) {
-		zfs_inode_update(xzp);
+		zfs_znode_update_vfs(xzp);
 		zfs_zrele_async(xzp);
 	}
 
@@ -1345,8 +1345,8 @@ out:
 	if (error != 0) {
 		zrele(zp);
 	} else {
-		zfs_inode_update(dzp);
-		zfs_inode_update(zp);
+		zfs_znode_update_vfs(dzp);
+		zfs_znode_update_vfs(zp);
 	}
 	ZFS_EXIT(zfsvfs);
 	return (error);
@@ -1471,8 +1471,8 @@ top:
 out:
 	zfs_dirent_unlock(dl);
 
-	zfs_inode_update(dzp);
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(dzp);
+	zfs_znode_update_vfs(zp);
 	zrele(zp);
 
 	if (zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS)
@@ -2542,7 +2542,7 @@ out:
 				err2 = zfs_setattr_dir(attrzp);
 			zrele(attrzp);
 		}
-		zfs_inode_update(zp);
+		zfs_znode_update_vfs(zp);
 	}
 
 out2:
@@ -3000,17 +3000,17 @@ out:
 	zfs_dirent_unlock(sdl);
 	zfs_dirent_unlock(tdl);
 
-	zfs_inode_update(sdzp);
+	zfs_znode_update_vfs(sdzp);
 	if (sdzp == tdzp)
 		rw_exit(&sdzp->z_name_lock);
 
 	if (sdzp != tdzp)
-		zfs_inode_update(tdzp);
+		zfs_znode_update_vfs(tdzp);
 
-	zfs_inode_update(szp);
+	zfs_znode_update_vfs(szp);
 	zrele(szp);
 	if (tzp) {
-		zfs_inode_update(tzp);
+		zfs_znode_update_vfs(tzp);
 		zrele(tzp);
 	}
 
@@ -3169,8 +3169,8 @@ top:
 			txtype |= TX_CI;
 		zfs_log_symlink(zilog, tx, txtype, dzp, zp, name, link);
 
-		zfs_inode_update(dzp);
-		zfs_inode_update(zp);
+		zfs_znode_update_vfs(dzp);
+		zfs_znode_update_vfs(zp);
 	}
 
 	zfs_acl_ids_free(&acl_ids);
@@ -3419,8 +3419,8 @@ top:
 	if (is_tmpfile && zfsvfs->z_os->os_sync != ZFS_SYNC_DISABLED)
 		txg_wait_synced(dmu_objset_pool(zfsvfs->z_os), txg);
 
-	zfs_inode_update(tdzp);
-	zfs_inode_update(szp);
+	zfs_znode_update_vfs(tdzp);
+	zfs_znode_update_vfs(szp);
 	ZFS_EXIT(zfsvfs);
 	return (error);
 }

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -486,7 +486,7 @@ zfs_set_inode_flags(znode_t *zp, struct inode *ip)
  * updated to access the inode.  This can be done incrementally.
  */
 void
-zfs_inode_update(znode_t *zp)
+zfs_znode_update_vfs(znode_t *zp)
 {
 	zfsvfs_t	*zfsvfs;
 	struct inode	*ip;
@@ -602,7 +602,7 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 	ZFS_TIME_DECODE(&ip->i_ctime, ctime);
 
 	ip->i_ino = zp->z_id;
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(zp);
 	zfs_inode_set_ops(zfsvfs, ip);
 
 	/*
@@ -1278,7 +1278,7 @@ zfs_rezget(znode_t *zp)
 
 	zp->z_blksz = doi.doi_data_block_size;
 	zp->z_atime_dirty = B_FALSE;
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(zp);
 
 	/*
 	 * If the file has zero links, then it has been unlinked on the send
@@ -1796,7 +1796,7 @@ log:
 
 	dmu_tx_commit(tx);
 
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(zp);
 	error = 0;
 
 out:

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -479,11 +479,7 @@ zfs_set_inode_flags(znode_t *zp, struct inode *ip)
 }
 
 /*
- * Update the embedded inode given the znode.  We should work toward
- * eliminating this function as soon as possible by removing values
- * which are duplicated between the znode and inode.  If the generic
- * inode has the correct field it should be used, and the ZFS code
- * updated to access the inode.  This can be done incrementally.
+ * Update the embedded inode given the znode.
  */
 void
 zfs_znode_update_vfs(znode_t *zp)

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -664,7 +664,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 		}
 	}
 
-	zfs_inode_update(zp);
+	zfs_znode_update_vfs(zp);
 	zfs_rangelock_exit(lr);
 
 	/*


### PR DESCRIPTION
zfs_znode_update_vfs is a more platform-agnostic name than zfs_inode_update.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Give zfs_inode_update() a more platform-agnostic name, since not every OSes has an equivalent concept of "inode". On the other hand since this routine is more or less related to virtual memory subsystem, I suggest the name "zfs_vm_update_size".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
