### PR TITLE
Increase ARC meta data limits

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -981,7 +981,7 @@ Percentage that can be consumed by dnodes of ARC meta buffers.
 See also \fBzfs_arc_dnode_limit\fR which serves a similar purpose but has a
 higher priority if set to nonzero value.
 .sp
-Default value: \fB10\fR%.
+Default value: \fB75\fR%.
 .RE
 
 .sp
@@ -1131,7 +1131,7 @@ See also \fBzfs_arc_meta_limit\fR which serves a similar purpose but has a
 higher priority if set to nonzero value.
 
 .sp
-Default value: \fB75\fR%.
+Default value: \fB100\fR%.
 .RE
 
 .sp

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -443,12 +443,12 @@ int zfs_compressed_arc_enabled = B_TRUE;
  * ARC will evict meta buffers that exceed arc_meta_limit. This
  * tunable make arc_meta_limit adjustable for different workloads.
  */
-unsigned long zfs_arc_meta_limit_percent = 75;
+unsigned long zfs_arc_meta_limit_percent = 100;
 
 /*
  * Percentage that can be consumed by dnodes of ARC meta buffers.
  */
-unsigned long zfs_arc_dnode_limit_percent = 10;
+unsigned long zfs_arc_dnode_limit_percent = 75;
 
 /*
  * These tunables are Linux specific


### PR DESCRIPTION
### Motivation and Context

Issue #9966

### Description

Historically the ARC has limited meta data usage to some fraction
of the total ARC size.  The rational behind this was to ensure that
the more important metadata blocks wouldn't result in all data blocks
(even frequently used ones) being evicted from the cache.

However, this concern doesn't appear to have been entirely warranted.
For meta data heavy workloads we want the entire ARC to be available
for these blocks to improve the cache hit rate.  Furthermore, in
practice the most important data blocks will still remain cached as
long as they are frequently accessed.

For reasons very similar to the above a 10% limit was also imposed
on the faction of the ARC which can be consumed by dnodes.  For many
workloads this is fine.  However, for metadata heavy workloads it can
result in a lot of needless churn in the ARC and wasted CPU time spent
evicting dnodes to honor this limit.  To avoid this it's reasonable
to allow dnodes to take a larger fraction of the ARC when needed and
then be evicted by the VFS which can do this more efficiently.

This change increases the zfs_arc_meta_limit_percent to 100% of the
ARC, and the zfs_arc_dnode_limit_percent to 75% of the meta limit.
### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?

Locally compiled.  Updated values selected based on feedback from
previously filed issues and previous experience manually tuning ZFS
for specific workloads.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
