### PR TITLE
Fix overly broad locking in spa_vdev_config_exit()

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1278,9 +1278,9 @@ spa_vdev_config_exit(spa_t *spa, vdev_t *vd, uint64_t txg, int error, char *tag)
 		 */
 		vdev_autotrim_stop_wait(vd);
 
-		spa_config_enter(spa, SCL_ALL, spa, RW_WRITER);
+		spa_config_enter(spa, SCL_STATE_ALL, spa, RW_WRITER);
 		vdev_free(vd);
-		spa_config_exit(spa, SCL_ALL, spa);
+		spa_config_exit(spa, SCL_STATE_ALL, spa);
 	}
 
 	/*


### PR DESCRIPTION
### Motivation and Context

Resolve a deadlock which can occur when the ZED or zpool
command attaches a new device.

### Description

Calling` vdev_free()` only requires the we acquire the spa config
`SCL_STATE_ALL` locks, not the `SCL_ALL` locks.  In particular, we need
need to avoid taking the `SCL_CONFIG` lock (included in `SCL_ALL`) as a
writer since this can lead to a deadlock.  The `txg_sync_thread()` may
block in `spa_txg_history_init_io()` when taking the `SCL_CONFIG` lock
as a reader when it detects there's a pending writer.

```
# `spa_vdev_exit->spa_vdev_config_exit->spa_config_enter` unnecessarily
# taking `SCL_ALL` instead of `SCL_STATE_ALL` as a writer.  Unfortunately,
# I wasn't able to spot the thread holding the `SCL_CONFIG` lock as a reader
# which PID 18970 is waiting on.

PID: 18970  TASK: ffff9a8f3abba080  CPU: 14  COMMAND: "zed"
 #0 [ffff9a8f9c7a7b28] __schedule at ffffffffb216ab17
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/kernel/sched/core.c: 2574
 #1 [ffff9a8f9c7a7bb8] schedule at ffffffffb216b019
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/kernel/sched/core.c: 3642
 #2 [ffff9a8f9c7a7bc8] cv_wait_common at ffffffffc073f325 [spl]
 #3 [ffff9a8f9c7a7c30] __cv_wait at ffffffffc073f365 [spl]
 #4 [ffff9a8f9c7a7c40] spa_config_enter at ffffffffc0c38e92 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/spa_misc.c: 512
 #5 [ffff9a8f9c7a7c90] spa_vdev_config_exit at ffffffffc0c3b694 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/spa_misc.c: 1279
 #6 [ffff9a8f9c7a7cd0] spa_vdev_exit at ffffffffc0c3b811 [zfs]
    /usr/src/kernels/3.10.0-957.1.3957.1.3.x4.3.20.x86_64/include/linux/spinlock.h: 337
 #7 [ffff9a8f9c7a7d00] spa_vdev_attach at ffffffffc0c31f61 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/spa.c: 6864
 #8 [ffff9a8f9c7a7d80] zfs_ioc_vdev_attach at ffffffffc0c86df3 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/zfs_ioctl.c: 1946
 #9 [ffff9a8f9c7a7dc8] zfsdev_ioctl_common at ffffffffc0c90137 [zfs]
    /usr/src/debug/zfs-2.0.0/include/os/linux/spl/sys/kmem.h: 126
#10 [ffff9a8f9c7a7e58] zfsdev_ioctl at ffffffffc0cbbb06 [zfs]
    /usr/src/debug/zfs-2.0.0/module/os/linux/zfs/zfs_ioctl_os.c: 196
#11 [ffff9a8f9c7a7e80] do_vfs_ioctl at ffffffffb1c567e0
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/fs/ioctl.c: 44
#12 [ffff9a8f9c7a7f00] sys_ioctl at ffffffffb1c56a81
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/fs/ioctl.c: 646
#13 [ffff9a8f9c7a7f50] system_call_fastpath at ffffffffb2177ddb
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/arch/x86/kernel/entry_64.S: 503
    RIP: 00007fcfb372d8d7  RSP: 00007fcfb1d6fdd0  RFLAGS: 00010246
    RAX: 0000000000000010  RBX: 00007fcfa400d750  RCX: 00007fcfb4455b28
    RDX: 00007fcfb1d70280  RSI: 0000000000005a0e  RDI: 000000000000000d
    RBP: 00007fcfb1d73c70   R8: 0000000000000080   R9: 0000000800000001
    R10: 6f6c735f76656476  R11: 0000000000000246  R12: 00007fcfb1d70280
    R13: 0000000000000000  R14: 0000000000000001  R15: 00007fcfb1d73830
    ORIG_RAX: 0000000000000010  CS: 0033  SS: 002b

# txg_sync thread blocked due to queued SCL_CONFIG writer (PID 18970)

PID: 124102  TASK: ffff9a8eab791040  CPU: 10  COMMAND: "txg_sync"
 #0 [ffff9a8eab79fc38] __schedule at ffffffffb216ab17
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/kernel/sched/core.c: 2574
 #1 [ffff9a8eab79fcc8] schedule at ffffffffb216b019
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/kernel/sched/core.c: 3642
 #2 [ffff9a8eab79fcd8] cv_wait_common at ffffffffc073f325 [spl]
 #3 [ffff9a8eab79fd40] __cv_wait at ffffffffc073f365 [spl]
 #4 [ffff9a8eab79fd50] spa_config_enter at ffffffffc0c38ef1 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/spa_misc.c: 504
 #5 [ffff9a8eab79fda0] spa_txg_history_init_io at ffffffffc0c3e4b2 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/spa_stats.c: 410
 #6 [ffff9a8eab79fde8] txg_sync_thread at ffffffffc0c42c46 [zfs]
    /usr/src/debug/zfs-2.0.0/module/zfs/txg.c: 570
 #7 [ffff9a8eab79fe98] thread_generic_wrapper at ffffffffc0746bb3 [spl]
 #8 [ffff9a8eab79fec8] kthread at ffffffffb1ac1f81
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/kernel/kthread.c: 202
 #9 [ffff9a8eab79ff50] ret_from_fork_nospec_begin at ffffffffb2177c1d
    /usr/src/debug/kernel-3.10.0-957.1.3.x4.3.20/linux-3.10.0-957.1.3957.1.3.x4.3.20.x86_64/arch/x86/kernel/entry_64.S: 410
```

### How Has This Been Tested?

Locally by running `ztest` for multiple hours.  Additional, manual
testing has so far been able to reproduce the issue with the
patch applied.  Previously similar testing would recreate the
issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
