### PR TITLE
Cancel TRIM op on non writeable vdevs and notify

### DIFF
--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -553,8 +553,14 @@ vdev_initialize_thread(void *arg)
 	vd->vdev_initialize_tree = NULL;
 
 	mutex_enter(&vd->vdev_initialize_lock);
-	if (!vd->vdev_initialize_exit_wanted && vdev_writeable(vd)) {
-		vdev_initialize_change_state(vd, VDEV_INITIALIZE_COMPLETE);
+	if (!vd->vdev_initialize_exit_wanted) {
+		if (vdev_writeable(vd)) {
+			vdev_initialize_change_state(vd,
+			    VDEV_INITIALIZE_COMPLETE);
+		} else if (vd->vdev_faulted) {
+			vdev_initialize_change_state(vd,
+			    VDEV_INITIALIZE_CANCELED);
+		}
 	}
 	ASSERT(vd->vdev_initialize_thread != NULL ||
 	    vd->vdev_initialize_inflight == 0);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -936,7 +936,7 @@ vdev_trim_thread(void *arg)
 			vdev_trim_change_state(vd, VDEV_TRIM_COMPLETE,
 			    vd->vdev_trim_rate, vd->vdev_trim_partial,
 			    vd->vdev_trim_secure);
-		} else {
+		} else if (vd->vdev_faulted) {
 			vdev_trim_change_state(vd, VDEV_TRIM_CANCELED,
 			    vd->vdev_trim_rate, vd->vdev_trim_partial,
 			    vd->vdev_trim_secure);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2016 by Delphix. All rights reserved.
  * Copyright (c) 2019 by Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2021 Hewlett Packard Enterprise Development LP
  */
 
 #include <sys/spa.h>
@@ -930,10 +931,16 @@ vdev_trim_thread(void *arg)
 	range_tree_destroy(ta.trim_tree);
 
 	mutex_enter(&vd->vdev_trim_lock);
-	if (!vd->vdev_trim_exit_wanted && vdev_writeable(vd)) {
-		vdev_trim_change_state(vd, VDEV_TRIM_COMPLETE,
-		    vd->vdev_trim_rate, vd->vdev_trim_partial,
-		    vd->vdev_trim_secure);
+	if (!vd->vdev_trim_exit_wanted) {
+		if (vdev_writeable(vd)) {
+			vdev_trim_change_state(vd, VDEV_TRIM_COMPLETE,
+			    vd->vdev_trim_rate, vd->vdev_trim_partial,
+			    vd->vdev_trim_secure);
+		} else {
+			vdev_trim_change_state(vd, VDEV_TRIM_CANCELED,
+			    vd->vdev_trim_rate, vd->vdev_trim_partial,
+			    vd->vdev_trim_secure);
+		}
 	}
 	ASSERT(vd->vdev_trim_thread != NULL || vd->vdev_trim_inflight[0] == 0);
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -413,6 +413,7 @@ tags = ['functional', 'cli_root', 'zpool_labelclear']
 
 [tests/functional/cli_root/zpool_initialize]
 tests = ['zpool_initialize_attach_detach_add_remove',
+    'zpool_initialize_fault_export_import_online',
     'zpool_initialize_import_export',
     'zpool_initialize_offline_export_import_online',
     'zpool_initialize_online_offline',
@@ -477,6 +478,7 @@ tags = ['functional', 'cli_root', 'zpool_sync']
 
 [tests/functional/cli_root/zpool_trim]
 tests = ['zpool_trim_attach_detach_add_remove',
+    'zpool_trim_fault_export_import_online',
     'zpool_trim_import_export', 'zpool_trim_multiple', 'zpool_trim_neg',
     'zpool_trim_offline_export_import_online', 'zpool_trim_online_offline',
     'zpool_trim_partial', 'zpool_trim_rate', 'zpool_trim_rate_neg',

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/Makefile.am
@@ -2,6 +2,7 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_init
 dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zpool_initialize_attach_detach_add_remove.ksh \
+	zpool_initialize_fault_export_import_online.ksh \
 	zpool_initialize_import_export.ksh \
 	zpool_initialize_offline_export_import_online.ksh \
 	zpool_initialize_online_offline.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_fault_export_import_online.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_fault_export_import_online.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2021 Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_initialize/zpool_initialize.kshlib
+
+#
+# DESCRIPTION:
+# Miscellaneous complex sequences of operations function as expected.
+#
+# STRATEGY:
+# 1. Create a pool with a two-way mirror.
+# 2. Start initializing, fault, export, import, online and verify along
+#    the way that the initializing was cancelled and not restarted.
+#
+
+DISK1="$(echo $DISKS | cut -d' ' -f1)"
+DISK2="$(echo $DISKS | cut -d' ' -f2)"
+
+log_must zpool create -f $TESTPOOL mirror $DISK1 $DISK2
+
+log_must zpool initialize $TESTPOOL $DISK1
+progress="$(initialize_progress $TESTPOOL $DISK1)"
+[[ -z "$progress" ]] && log_fail "Initializing did not start"
+
+log_must zpool offline -f $TESTPOOL $DISK1
+log_must check_vdev_state $TESTPOOL $DISK1 "FAULTED"
+log_must eval "zpool status -i $TESTPOOL | grep $DISK1 | grep uninitialized"
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+
+log_must check_vdev_state $TESTPOOL $DISK1 "FAULTED"
+log_must eval "zpool status -i $TESTPOOL | grep $DISK1 | grep uninitialized"
+
+log_must zpool online $TESTPOOL $DISK1
+log_must zpool clear $TESTPOOL $DISK1
+log_must check_vdev_state $TESTPOOL $DISK1 "ONLINE"
+log_must eval "zpool status -i $TESTPOOL | grep $DISK1 | grep uninitialized"
+
+log_pass "Initializing behaves as expected at each step of:" \
+    "initialize + fault + export + import + online"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/Makefile.am
@@ -3,6 +3,7 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_trim_attach_detach_add_remove.ksh \
+	zpool_trim_fault_export_import_online.ksh \
 	zpool_trim_import_export.ksh \
 	zpool_trim_multiple.ksh \
 	zpool_trim_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_fault_export_import_online.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_fault_export_import_online.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019 by Tim Chase. All rights reserved.
+# Copyright (c) 2021 Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_trim/zpool_trim.kshlib
+
+#
+# DESCRIPTION:
+# Miscellaneous complex sequences of operations function as expected.
+#
+# STRATEGY:
+# 1. Create a pool with a two-way mirror.
+# 2. Start trimming, fault, export, import, online and verify along
+#    the way that the trim was cancelled and not restarted.
+#
+
+DISK1="$(echo $DISKS | cut -d' ' -f1)"
+DISK2="$(echo $DISKS | cut -d' ' -f2)"
+
+log_must zpool create -f $TESTPOOL mirror $DISK1 $DISK2
+
+log_must zpool trim -r 128M $TESTPOOL $DISK1
+progress="$(trim_progress $TESTPOOL $DISK1)"
+[[ -z "$progress" ]] && log_fail "Trimming did not start"
+
+log_must zpool offline -f $TESTPOOL $DISK1
+log_must check_vdev_state $TESTPOOL $DISK1 "FAULTED"
+log_must eval "zpool status -t $TESTPOOL | grep $DISK1 | grep untrimmed"
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+
+# Note: the expected state here is unsupported since the faulted device
+# cannot be checked to determine if it supports TRIM.
+log_must check_vdev_state $TESTPOOL $DISK1 "FAULTED"
+log_must eval "zpool status -t $TESTPOOL | grep $DISK1 | grep unsupported"
+
+log_must zpool online $TESTPOOL $DISK1
+log_must zpool clear $TESTPOOL $DISK1
+log_must check_vdev_state $TESTPOOL $DISK1 "ONLINE"
+log_must eval "zpool status -t $TESTPOOL | grep $DISK1 | grep untrimmed"
+
+log_pass "Trimming behaves as expected at each step of:" \
+    "trim + fault + export + import + online"


### PR DESCRIPTION
Co-authored-by: Vipin Kumar Verma <vipin.verma@hpe.com>
Signed-off-by: Srikanth N S <srikanth.nagasubbaraoseetharaman@hpe.com>

We had observed an issue with "zpool trim -w" command especially when a drive is failed during trim process. Analysed this and found that "zpool trim -w" thread is left waiting for a signal from a trim thread that is never coming. Specifically, the trim thread for the faulted drive is never sending a "completion" signal

We can see that the signal usually comes from the vdev_trim_change_state() function. At the end of that function we find:

if (new_state != VDEV_TRIM_ACTIVE)
                spa_notify_waiters(spa);

The state normally changes to "COMPLETE" just before the thread exits in vdev_trim_thread():

if (!vd->vdev_trim_exit_wanted && vdev_writeable(vd)) {
                vdev_trim_change_state(vd, VDEV_TRIM_COMPLETE,
                    vd->vdev_trim_rate, vd->vdev_trim_partial,
                    vd->vdev_trim_secure);
        }

But note that the state is only changed to COMPLETE if vdev_writable() is true. For a faulted drive, this will not be true and the thread will exit without ever changing the state.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
