### PR TITLE
FreeBSD: disable the use of hardware crypto offload drivers for now

### DIFF
--- a/module/os/freebsd/zfs/crypto_os.c
+++ b/module/os/freebsd/zfs/crypto_os.c
@@ -293,8 +293,19 @@ freebsd_crypt_newsession(freebsd_crypt_session_t *sessp,
 		error = ENOTSUP;
 		goto bad;
 	}
-	error = crypto_newsession(&sessp->fs_sid, &csp,
-	    CRYPTOCAP_F_HARDWARE | CRYPTOCAP_F_SOFTWARE);
+
+	/*
+	 * Disable the use of hardware drivers on FreeBSD 13 and later since
+	 * common crypto offload drivers impose constraints on AES-GCM AAD
+	 * lengths that make them unusable for ZFS, and we currently do not have
+	 * a mechanism to fall back to a software driver for requests not
+	 * handled by a hardware driver.
+	 *
+	 * On 12 we continue to permit the use of hardware drivers since
+	 * CPU-accelerated drivers such as aesni(4) register themselves as
+	 * hardware drivers.
+	 */
+	error = crypto_newsession(&sessp->fs_sid, &csp, CRYPTOCAP_F_SOFTWARE);
 	mtx_init(&sessp->fs_lock, "FreeBSD Cryptographic Session Lock",
 	    NULL, MTX_DEF);
 	crypt_sessions++;


### PR DESCRIPTION
Disable the use of hardware crypto offloads when using ZFS' encryption capabilities on FreeBSD.

### Motivation and Context

A couple of problems, detailed in the commit message, prevent ZFS encryption from working properly with hardware offload drivers on FreeBSD. As a temporary measure, prevent ZFS from using such drivers.

### Description

The change modifies FreeBSD-specific crypto session setup code such that only software drivers (e.g., AES-NI wrappers) will be used. I believe this will not present a regression for any users since a bug in the FreeBSD crypto request completion handler means that asynchronous completions are not handled correctly.

### How Has This Been Tested?

Build-tested, made the corresponding modification to FreeBSD's in-tree copy of ZFS and verified that it refuses to attach to hardware drivers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
