### PR TITLE
Fixes 5.12 bio bi_bdev additions and GPL issues with bio_*_io_acct functions

### DIFF
--- a/config/kernel-bio.m4
+++ b/config/kernel-bio.m4
@@ -369,6 +369,33 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKG_TRYGET], [
 	])
 ])
 
+dnl #
+dnl # Linux 5.12 API,
+dnl #
+dnl # The Linux 5.12 kernel updated struct bio to create a new bi_bdev member
+dnl # and bio->bi_disk was moved to bio->bi_bdev->bd_disk
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BIO_BDEV_DISK], [
+	ZFS_LINUX_TEST_SRC([bio_bdev_disk], [
+		#include <linux/blk_types.h>
+		#include <linux/blkdev.h>
+	],[
+		struct bio *b = NULL;
+		struct gendisk *d = b->bi_bdev->bd_disk;
+		blk_register_queue(d);
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_BIO_BDEV_DISK], [
+	AC_MSG_CHECKING([whether bio->bi_bdev->bd_disk exists])
+	ZFS_LINUX_TEST_RESULT([bio_bdev_disk], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BIO_BDEV_DISK, 1, [bio->bi_bdev->bd_disk exists])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_BIO], [
 	ZFS_AC_KERNEL_SRC_REQ
 	ZFS_AC_KERNEL_SRC_BIO_OPS
@@ -379,6 +406,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BIO], [
 	ZFS_AC_KERNEL_SRC_BIO_SUBMIT_BIO
 	ZFS_AC_KERNEL_SRC_BIO_CURRENT_BIO_LIST
 	ZFS_AC_KERNEL_SRC_BLKG_TRYGET
+	ZFS_AC_KERNEL_SRC_BIO_BDEV_DISK
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_BIO], [
@@ -400,4 +428,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BIO], [
 	ZFS_AC_KERNEL_BIO_SUBMIT_BIO
 	ZFS_AC_KERNEL_BIO_CURRENT_BIO_LIST
 	ZFS_AC_KERNEL_BLKG_TRYGET
+	ZFS_AC_KERNEL_BIO_BDEV_DISK
 ])

--- a/config/kernel-generic_io_acct.m4
+++ b/config/kernel-generic_io_acct.m4
@@ -2,6 +2,17 @@ dnl #
 dnl # Check for generic io accounting interface.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_GENERIC_IO_ACCT], [
+	ZFS_LINUX_TEST_SRC([disk_io_acct], [
+		#include <linux/blkdev.h>
+	], [
+		struct gendisk *disk = NULL;
+		struct bio *bio = NULL;
+		unsigned long start_time;
+
+		start_time = disk_start_io_acct(disk, bio_sectors(bio), bio_op(bio));
+		disk_end_io_acct(disk, bio_op(bio), start_time);
+	])
+
 	ZFS_LINUX_TEST_SRC([bio_io_acct], [
 		#include <linux/blkdev.h>
 	], [
@@ -39,48 +50,62 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_GENERIC_IO_ACCT], [
 
 AC_DEFUN([ZFS_AC_KERNEL_GENERIC_IO_ACCT], [
 	dnl #
-	dnl # 5.7 API,
+	dnl # 5.12 API,
 	dnl #
-	dnl # Added bio_start_io_acct() and bio_end_io_acct() helpers.
+	dnl # bio_start_io_acct() and bio_end_io_acct() became GPL-exported
+	dnl # so use disk_start_io_acct() and disk_end_io_acct() instead
 	dnl #
-	AC_MSG_CHECKING([whether generic bio_*_io_acct() are available])
-	ZFS_LINUX_TEST_RESULT([bio_io_acct], [
+	AC_MSG_CHECKING([whether generic disk_*_io_acct() are available])
+	ZFS_LINUX_TEST_RESULT([disk_io_acct], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_BIO_IO_ACCT, 1, [bio_*_io_acct() available])
+		AC_DEFINE(HAVE_DISK_IO_ACCT, 1, [disk_*_io_acct() available])
 	], [
 		AC_MSG_RESULT(no)
 
 		dnl #
-		dnl # 4.14 API,
+		dnl # 5.7 API,
 		dnl #
-		dnl # generic_start_io_acct/generic_end_io_acct now require
-		dnl # request_queue to be provided. No functional changes,
-		dnl # but preparation for inflight accounting.
+		dnl # Added bio_start_io_acct() and bio_end_io_acct() helpers.
 		dnl #
-		AC_MSG_CHECKING([whether generic_*_io_acct wants 4 args])
-		ZFS_LINUX_TEST_RESULT_SYMBOL([generic_acct_4args],
-		    [generic_start_io_acct], [block/bio.c], [
+		AC_MSG_CHECKING([whether generic bio_*_io_acct() are available])
+		ZFS_LINUX_TEST_RESULT([bio_io_acct], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_GENERIC_IO_ACCT_4ARG, 1,
-			    [generic_*_io_acct() 4 arg available])
+			AC_DEFINE(HAVE_BIO_IO_ACCT, 1, [bio_*_io_acct() available])
 		], [
 			AC_MSG_RESULT(no)
 
 			dnl #
-			dnl # 3.19 API addition
+			dnl # 4.14 API,
 			dnl #
-			dnl # torvalds/linux@394ffa50 allows us to increment
-			dnl # iostat counters without generic_make_request().
+			dnl # generic_start_io_acct/generic_end_io_acct now require
+			dnl # request_queue to be provided. No functional changes,
+			dnl # but preparation for inflight accounting.
 			dnl #
-			AC_MSG_CHECKING(
-			    [whether generic_*_io_acct wants 3 args])
-			ZFS_LINUX_TEST_RESULT_SYMBOL([generic_acct_3args],
+			AC_MSG_CHECKING([whether generic_*_io_acct wants 4 args])
+			ZFS_LINUX_TEST_RESULT_SYMBOL([generic_acct_4args],
 			    [generic_start_io_acct], [block/bio.c], [
 				AC_MSG_RESULT(yes)
-				AC_DEFINE(HAVE_GENERIC_IO_ACCT_3ARG, 1,
-				    [generic_*_io_acct() 3 arg available])
+				AC_DEFINE(HAVE_GENERIC_IO_ACCT_4ARG, 1,
+				    [generic_*_io_acct() 4 arg available])
 			], [
 				AC_MSG_RESULT(no)
+
+				dnl #
+				dnl # 3.19 API addition
+				dnl #
+				dnl # torvalds/linux@394ffa50 allows us to increment
+				dnl # iostat counters without generic_make_request().
+				dnl #
+				AC_MSG_CHECKING(
+				    [whether generic_*_io_acct wants 3 args])
+				ZFS_LINUX_TEST_RESULT_SYMBOL([generic_acct_3args],
+				    [generic_start_io_acct], [block/bio.c], [
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_GENERIC_IO_ACCT_3ARG, 1,
+					    [generic_*_io_acct() 3 arg available])
+				], [
+					AC_MSG_RESULT(no)
+				])
 			])
 		])
 	])

--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -520,7 +520,9 @@ blk_generic_start_io_acct(struct request_queue *q __attribute__((unused)),
     struct gendisk *disk __attribute__((unused)),
     int rw __attribute__((unused)), struct bio *bio)
 {
-#if defined(HAVE_BIO_IO_ACCT)
+#if defined(HAVE_DISK_IO_ACCT)
+	return (disk_start_io_acct(disk, bio_sectors(bio), bio_op(bio)));
+#elif defined(HAVE_BIO_IO_ACCT)
 	return (bio_start_io_acct(bio));
 #elif defined(HAVE_GENERIC_IO_ACCT_3ARG)
 	unsigned long start_time = jiffies;
@@ -541,7 +543,9 @@ blk_generic_end_io_acct(struct request_queue *q __attribute__((unused)),
     struct gendisk *disk __attribute__((unused)),
     int rw __attribute__((unused)), struct bio *bio, unsigned long start_time)
 {
-#if defined(HAVE_BIO_IO_ACCT)
+#if defined(HAVE_DISK_IO_ACCT)
+	disk_end_io_acct(disk, bio_op(bio), start_time);
+#elif defined(HAVE_BIO_IO_ACCT)
 	bio_end_io_acct(bio, start_time);
 #elif defined(HAVE_GENERIC_IO_ACCT_3ARG)
 	generic_end_io_acct(rw, &disk->part0, start_time);

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -494,7 +494,11 @@ vdev_blkg_tryget(struct blkcg_gq *blkg)
 static inline void
 vdev_bio_associate_blkg(struct bio *bio)
 {
+#if defined(HAVE_BIO_BDEV_DISK)
+	struct request_queue *q = bio->bi_bdev->bd_disk->queue;
+#else
 	struct request_queue *q = bio->bi_disk->queue;
+#endif
 
 	ASSERT3P(q, !=, NULL);
 	ASSERT3P(bio->bi_blkg, ==, NULL);

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -307,7 +307,11 @@ zvol_request(struct request_queue *q, struct bio *bio)
 #endif
 {
 #ifdef HAVE_SUBMIT_BIO_IN_BLOCK_DEVICE_OPERATIONS
+#if defined(HAVE_BIO_BDEV_DISK)
+	struct request_queue *q = bio->bi_bdev->bd_disk->queue;
+#else
 	struct request_queue *q = bio->bi_disk->queue;
+#endif
 #endif
 	zvol_state_t *zv = q->queuedata;
 	fstrans_cookie_t cookie = spl_fstrans_mark();


### PR DESCRIPTION
### Motivation and Context
Recent changes in the Linux kernel 5.12 merges modified the interfaces in the following breaking manners:

* Functions `bio_start_io_acct` and `bio_end_io_acct` became GPL'd exports
* The `bio->bi_disk` member was moved into a new `struct block_device*` member of `struct bio` such that accessing it now must be done as `bio->bi_bdev->bd_disk`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Replaced calls to `bio_*_io_acct` with corresponding calls to `disk_*_io_acct`, the latter are not GPL-encumbered
<!--- Describe your changes in detail -->

### How Has This Been Tested?
I have been using this in production on my personal system with ZFS root and so far it has been working fine
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
