### PR TITLE
fix panic with zvol as log device

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5410,6 +5410,9 @@ spa_get_stats(const char *name, nvlist_t **config,
 
 	*config = NULL;
 	error = spa_open_common(name, &spa, FTAG, NULL, config);
+	if(error == ENOENT) {
+		return (error);
+	}
 
 	if (spa != NULL) {
 		/*
@@ -5454,7 +5457,7 @@ spa_get_stats(const char *name, nvlist_t **config,
 		if (spa == NULL) {
 			mutex_enter(&spa_namespace_lock);
 			spa = spa_lookup(name);
-			if (spa)
+			if (spa != NULL)
 				spa_altroot(spa, altroot, buflen);
 			else
 				altroot[0] = '\0';


### PR DESCRIPTION
Signed-off-by: Igor Kozhukhov <igor@dilos.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
we have found of panic with remove zvol as log device on DilOS

### Description
<!--- Describe your changes in detail -->
steps for reproduce

1. create pool on one vdev
`zpool create t1 VDEV1`
2. create zvol on this vdev:
`zpool create -V 1G VDEV1/zvol1`
3. create another zpool with ZVOL as log device:
`zpool create t2 VDEV2 log /dev/zvol/dsk/VDEV1/zvol1`
4. export of new pool:
`zpool export t2`
5. destroy first zpool with zvol:
`zpool destroy t1`
6. try to check available pool for import by:
`zpool import`
with this one we have panic with stack:
```
panic[cpu3]/thread=fffffe0fbb4b9be0:
recursive mutex_enter, lp=ffffffffc00af618 owner=fffffe0fbb4b9be0 thread=fffffe0fbb4b9be0


fffffe0011564bf0 unix:mutex_panic+4a ()
fffffe0011564c60 unix:mutex_vector_enter+30f ()
fffffe0011564ce0 zfs:spa_get_stats+1a1 ()
fffffe0011564d30 zfs:zfs_ioc_pool_stats+35 ()
fffffe0011564dd0 zfs:zfsdev_ioctl_common+466 ()
fffffe0011564e50 zfs:zfsdev_ioctl+11d ()
fffffe0011564e90 genunix:cdev_ioctl+25 ()
fffffe0011564ef0 genunix:ldi_ioctl+99 ()
fffffe0011564f70 dev:devzvol_handle_ioctl+b6 ()
fffffe0011564fd0 dev:devzvol_objset_check+14f ()
fffffe0011565060 dev:devzvol_lookup+135 ()
fffffe0011565110 genunix:fop_lookup+a2 ()
fffffe0011565350 genunix:lookuppnvp+28c ()
fffffe00115653f0 genunix:lookuppnatcred+181 ()
fffffe00115654f0 genunix:lookupnameatcred+d5 ()
fffffe0011565540 genunix:lookupnameat+29 ()
fffffe00115655b0 genunix:ldi_vp_from_name+da ()
fffffe0011565630 genunix:ldi_open_by_name+b2 ()
fffffe0011565700 zfs:vdev_disk_open+3ac ()
fffffe0011565790 zfs:vdev_open+1dd ()
fffffe00115657e0 zfs:vdev_open_children+5f ()
fffffe0011565850 zfs:vdev_root_open+85 ()
fffffe00115658e0 zfs:vdev_open+1dd ()
fffffe0011565910 zfs:spa_ld_open_vdevs+53 ()
fffffe00115659a0 zfs:spa_ld_trusted_config+1b8 ()
fffffe00115659f0 zfs:spa_ld_mos_with_trusted_config+4d ()
fffffe0011565a60 zfs:spa_load_impl+95 ()
fffffe0011565ac0 zfs:spa_load+4e ()
fffffe0011565b40 zfs:spa_tryimport+f9 ()
fffffe0011565b90 zfs:zfs_ioc_pool_tryimport+61 ()
fffffe0011565c30 zfs:zfsdev_ioctl_common+466 ()
fffffe0011565cb0 zfs:zfsdev_ioctl+11d ()
fffffe0011565cf0 genunix:cdev_ioctl+25 ()
fffffe0011565d40 specfs:spec_ioctl+4d ()
fffffe0011565dd0 genunix:fop_ioctl+55 ()
fffffe0011565ef0 genunix:ioctl+b1 ()
fffffe0011565f00 unix:brand_sys_syscall+32f ()
```
we try to check pool with ZVOL where zpool not available, where error= ENOENT

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
