### PR TITLE
Add missing checks for unsupported features

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -9030,6 +9030,8 @@ zpool_do_upgrade(int argc, char **argv)
 		    "---------------\n");
 		for (i = 0; i < SPA_FEATURES; i++) {
 			zfeature_info_t *fi = &spa_feature_table[i];
+			if (!fi->fi_zfs_mod_supported)
+				continue;
 			const char *ro =
 			    (fi->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 			    " (read-only compatible)" : "";

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7592,6 +7592,9 @@ ztest_init(ztest_shared_t *zs)
 	for (i = 0; i < SPA_FEATURES; i++) {
 		char *buf;
 
+		if (!spa_feature_table[i].fi_zfs_mod_supported)
+			continue;
+
 		/*
 		 * 75% chance of using the log space map feature. We want ztest
 		 * to exercise both the code paths that use the log space map

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -482,6 +482,8 @@ check_status(nvlist_t *config, boolean_t isimport,
 			return (ZPOOL_STATUS_COMPATIBILITY_ERR);
 		for (i = 0; i < SPA_FEATURES; i++) {
 			zfeature_info_t *fi = &spa_feature_table[i];
+			if (!fi->fi_zfs_mod_supported)
+				continue;
 			if (pool_features[i] &&
 			    !nvlist_exists(feat, fi->fi_guid))
 				return (ZPOOL_STATUS_FEAT_DISABLED);

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -100,6 +100,8 @@ zfeature_is_supported(const char *guid)
 
 	for (spa_feature_t i = 0; i < SPA_FEATURES; i++) {
 		zfeature_info_t *feature = &spa_feature_table[i];
+		if (!feature->fi_zfs_mod_supported)
+			continue;
 		if (strcmp(guid, feature->fi_guid) == 0)
 			return (B_TRUE);
 	}


### PR DESCRIPTION
### Motivation and Context
After I imported 35ec517 (issue #11605) to FreeBSD main, users started complaining that running "zpool status" started showing all pools as upgradable. After digging deeper into this I have discovered that FreeBSD was also able to import pools with active edonr, leading to a panic. 

### Description
The check for unsupported features should be done in zfeature_common.c:zfeature_is_supported() and libzfs_status.c: check_status() as well. When here, fix similar problem in ztest.c:ztest_init() as well.

### How Has This Been Tested?
Manual testing on recent FreeBSD main.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
