### PR TITLE
RFC: zfs_log: refactor zfs_log_write

### DIFF
--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -275,7 +275,7 @@ extern void zfs_log_symlink(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 extern void zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
     znode_t *sdzp, const char *sname, znode_t *tdzp, const char *dname,
     znode_t *szp);
-extern void zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
+extern void zfs_log_write(zilog_t *zilog, dmu_tx_t *tx,
     znode_t *zp, offset_t off, ssize_t len, int ioflag,
     zil_callback_t callback, void *callback_data);
 extern void zfs_log_truncate(zilog_t *zilog, dmu_tx_t *tx, int txtype,

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -491,6 +491,7 @@ extern void	zil_destroy_sync(zilog_t *zilog, dmu_tx_t *tx);
 
 extern itx_t	*zil_itx_create(uint64_t txtype, size_t lrsize);
 extern void	zil_itx_destroy(itx_t *itx);
+extern void	zil_itx_free_do_not_run_callback(itx_t *itx);
 extern void	zil_itx_assign(zilog_t *zilog, itx_t *itx, dmu_tx_t *tx);
 
 extern void	zil_async_to_sync(zilog_t *zilog, uint64_t oid);

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -4267,7 +4267,7 @@ zfs_putpages(struct vnode *vp, vm_page_t *ma, size_t len, int flags,
 		 * XXX we should be passing a callback to undirty
 		 * but that would make the locking messier
 		 */
-		zfs_log_write(zfsvfs->z_log, tx, TX_WRITE, zp, off,
+		zfs_log_write(zfsvfs->z_log, tx, zp, off,
 		    len, 0, NULL, NULL);
 
 		zfs_vmobject_wlock(object);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -3609,7 +3609,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc)
 
 	err = sa_bulk_update(zp->z_sa_hdl, bulk, cnt, tx);
 
-	zfs_log_write(zfsvfs->z_log, tx, TX_WRITE, zp, pgoff, pglen, 0,
+	zfs_log_write(zfsvfs->z_log, tx, zp, pgoff, pglen, 0,
 	    zfs_putpage_commit_cb, pp);
 	dmu_tx_commit(tx);
 

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -531,8 +531,52 @@ zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype, znode_t *sdzp,
  */
 long zfs_immediate_write_sz = 32768;
 
+static inline itx_t *
+zfs_log_write_itx_create(size_t copied_len,
+    size_t __maybe_unused max_wr_copied_lr_length,
+    itx_wr_state_t write_state,
+    znode_t *zp, offset_t off, ssize_t len, boolean_t sync,
+    zil_callback_t callback, void *callback_data, void **copied_start)
+{
+	itx_t *itx;
+	lr_write_t *lr;
+
+	itx = zil_itx_create(TX_WRITE, sizeof (*lr) + copied_len);
+	lr = (lr_write_t *)&itx->itx_lr;
+	itx->itx_wr_state = write_state;
+	lr->lr_foid = zp->z_id;
+	lr->lr_offset = off;
+	lr->lr_length = len;
+	lr->lr_blkoff = 0;
+	BP_ZERO(&lr->lr_blkptr);
+
+	itx->itx_private = ZTOZSB(zp);
+	itx->itx_sync = sync;
+
+	itx->itx_callback = callback;
+	itx->itx_callback_data = callback_data;
+
+	switch (write_state) {
+	case WR_COPIED:
+		ASSERT3U(copied_len, <=, max_wr_copied_lr_length);
+		ASSERT(copied_start);
+		*copied_start = (uint8_t *)(lr + 1);
+		break;
+	case WR_NEED_COPY:
+		/* fallthrough */
+	case WR_INDIRECT:
+		ASSERT3U(copied_len, ==, 0);
+		ASSERT3P(copied_start, ==, NULL);
+		break;
+	default:
+		panic("unexpected write_state %d", write_state);
+	}
+
+	return (itx);
+}
+
 void
-zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
+zfs_log_write(zilog_t *zilog, dmu_tx_t *tx,
     znode_t *zp, offset_t off, ssize_t resid, int ioflag,
     zil_callback_t callback, void *callback_data)
 {
@@ -558,68 +602,97 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	else
 		write_state = WR_NEED_COPY;
 
+	/*
+	 * A WR_COPIED record must fit entirely in one log block.
+	 * Large writes can use WR_NEED_COPY, which the ZIL will
+	 * split into multiple records across several log blocks
+	 * if necessary.
+	 */
+	uint64_t max_wr_copied_lr_length = zil_max_copied_data(zilog);
+	if (write_state == WR_COPIED && resid > max_wr_copied_lr_length)
+		write_state = WR_NEED_COPY;
+
 	if ((fsync_cnt = (uintptr_t)tsd_get(zfs_fsyncer_key)) != 0) {
 		(void) tsd_set(zfs_fsyncer_key, (void *)(fsync_cnt - 1));
 	}
 
-	while (resid) {
-		itx_t *itx;
-		lr_write_t *lr;
-		itx_wr_state_t wr_state = write_state;
-		ssize_t len = resid;
+	boolean_t sync = B_TRUE;
+	if (!(ioflag & (O_SYNC | O_DSYNC)) && (zp->z_sync_cnt == 0) &&
+	    (fsync_cnt == 0))
+		sync = B_FALSE;
 
-		/*
-		 * A WR_COPIED record must fit entirely in one log block.
-		 * Large writes can use WR_NEED_COPY, which the ZIL will
-		 * split into multiple records across several log blocks
-		 * if necessary.
-		 */
-		if (wr_state == WR_COPIED &&
-		    resid > zil_max_copied_data(zilog))
-			wr_state = WR_NEED_COPY;
-		else if (wr_state == WR_INDIRECT)
-			len = MIN(blocksize - P2PHASE(off, blocksize), resid);
-
-		itx = zil_itx_create(txtype, sizeof (*lr) +
-		    (wr_state == WR_COPIED ? len : 0));
-		lr = (lr_write_t *)&itx->itx_lr;
-
-		/*
-		 * For WR_COPIED records, copy the data into the lr_write_t.
-		 */
-		if (wr_state == WR_COPIED) {
-			int err;
-			DB_DNODE_ENTER(db);
-			err = dmu_read_by_dnode(DB_DNODE(db), off, len, lr + 1,
-			    DMU_READ_NO_PREFETCH);
-			if (err != 0) {
-				zil_itx_destroy(itx);
-				itx = zil_itx_create(txtype, sizeof (*lr));
-				lr = (lr_write_t *)&itx->itx_lr;
-				wr_state = WR_NEED_COPY;
-			}
-			DB_DNODE_EXIT(db);
-		}
-
-		itx->itx_wr_state = wr_state;
-		lr->lr_foid = zp->z_id;
-		lr->lr_offset = off;
-		lr->lr_length = len;
-		lr->lr_blkoff = 0;
-		BP_ZERO(&lr->lr_blkptr);
-
-		itx->itx_private = ZTOZSB(zp);
-
-		if (!(ioflag & (O_SYNC | O_DSYNC)) && (zp->z_sync_cnt == 0) &&
-		    (fsync_cnt == 0))
-			itx->itx_sync = B_FALSE;
-
-		itx->itx_callback = callback;
-		itx->itx_callback_data = callback_data;
+	itx_t *itx;
+	if (write_state == WR_NEED_COPY) {
+		itx = zfs_log_write_itx_create(
+		    0,
+		    max_wr_copied_lr_length,
+		    write_state,
+		    zp,
+		    off,
+		    resid,
+		    sync,
+		    callback,
+		    callback_data,
+		    NULL);
 		zil_itx_assign(zilog, itx, tx);
+	} else if (write_state == WR_INDIRECT) {
+		while (resid) {
+			ssize_t len =
+			    MIN(blocksize - P2PHASE(off, blocksize), resid);
+			itx = zfs_log_write_itx_create(
+			    0,
+			    max_wr_copied_lr_length,
+			    write_state,
+			    zp,
+			    off,
+			    len,
+			    sync,
+			    callback,
+			    callback_data,
+			    NULL);
+			zil_itx_assign(zilog, itx, tx);
+			off += len;
+			resid -= len;
+		}
+	} else {
+		ASSERT3S(write_state, ==, WR_COPIED);
 
-		off += len;
-		resid -= len;
+		ASSERT3U(resid, <=, zil_max_wr_copied_lr_length(zilog));
+
+		void *copied_start;
+		itx = zfs_log_write_itx_create(
+		    resid,
+		    max_wr_copied_lr_length,
+		    write_state,
+		    zp,
+		    off,
+		    resid,
+		    sync,
+		    callback,
+		    callback_data,
+		    &copied_start);
+
+		int err;
+		DB_DNODE_ENTER(db);
+		err = dmu_read_by_dnode(DB_DNODE(db), off, resid, copied_start,
+		    DMU_READ_NO_PREFETCH);
+		if (err != 0) {
+			zil_itx_free_do_not_run_callback(itx);
+			itx = zfs_log_write_itx_create(
+			    0,
+			    max_wr_copied_lr_length,
+			    WR_NEED_COPY,
+			    zp,
+			    off,
+			    resid,
+			    sync,
+			    callback,
+			    callback_data,
+			    &copied_start);
+		}
+		DB_DNODE_EXIT(db);
+
+		zil_itx_assign(zilog, itx, tx);
 	}
 }
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -648,7 +648,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 
 		error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 
-		zfs_log_write(zilog, tx, TX_WRITE, zp, woff, tx_bytes, ioflag,
+		zfs_log_write(zilog, tx, zp, woff, tx_bytes, ioflag,
 		    NULL, NULL);
 		dmu_tx_commit(tx);
 

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1803,6 +1803,12 @@ zil_itx_create(uint64_t txtype, size_t lrsize)
 }
 
 void
+zil_itx_free_do_not_run_callback(itx_t *itx)
+{
+	zio_data_buf_free(itx, itx->itx_size);
+}
+
+void
 zil_itx_destroy(itx_t *itx)
 {
 	IMPLY(itx->itx_lr.lrc_txtype == TX_COMMIT, itx->itx_callback == NULL);
@@ -1811,7 +1817,7 @@ zil_itx_destroy(itx_t *itx)
 	if (itx->itx_callback != NULL)
 		itx->itx_callback(itx->itx_callback_data);
 
-	zio_data_buf_free(itx, itx->itx_size);
+	zil_itx_free_do_not_run_callback(itx);
 }
 
 /*


### PR DESCRIPTION
This commit should not change any functionality, performance or
behavior.  I find that it makes the selection logic for the different
WR_* kinds significantly easier to follow.

If this patch is well-received we should apply the same refactoring to
zvol_log_write, maybe explore an opportunity for code sharing as well.
