### PR TITLE
Add support for zpool user properties

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -333,6 +333,8 @@ _LIBZFS_H const char *zpool_get_state_str(zpool_handle_t *);
 _LIBZFS_H int zpool_set_prop(zpool_handle_t *, const char *, const char *);
 _LIBZFS_H int zpool_get_prop(zpool_handle_t *, zpool_prop_t, char *,
     size_t proplen, zprop_source_t *, boolean_t literal);
+_LIBZFS_H int zpool_get_userprop(zpool_handle_t *, const char *, char *,
+    size_t proplen, zprop_source_t *);
 _LIBZFS_H uint64_t zpool_get_prop_int(zpool_handle_t *, zpool_prop_t,
     zprop_source_t *);
 _LIBZFS_H int zpool_props_refresh(zpool_handle_t *);

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -259,8 +259,8 @@
     <elf-symbol name='tpool_suspend' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='tpool_suspended' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='tpool_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='use_color' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='update_vdev_config_dev_strs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='use_color' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='vdev_expand_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='vdev_name_to_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='vdev_prop_align_right' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -492,6 +492,7 @@
     <elf-symbol name='zpool_get_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_get_state_str' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_get_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_get_userprop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_get_vdev_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_get_vdev_prop_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_history_unpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -2267,32 +2268,19 @@
       <parameter type-id='58603c44'/>
       <return type-id='9c313c2d'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='zfs_iter_children_v2' mangled-name='zfs_iter_children_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children_v2'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='allowrecursion'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_dependents_v2' mangled-name='zfs_iter_dependents_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents_v2'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='c19b74c3' name='allowrecursion'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='c19b74c3'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
@@ -3324,17 +3312,11 @@
       <parameter type-id='58603c44'/>
       <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='zfs_iter_filesystems_v2' mangled-name='zfs_iter_filesystems_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems_v2'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
@@ -3907,35 +3889,20 @@
       <parameter type-id='b59d7dce'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='simple'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <parameter type-id='9c313c2d' name='min_txg'/>
-      <parameter type-id='9c313c2d' name='max_txg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='zfs_iter_snapshots_v2' mangled-name='zfs_iter_snapshots_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_v2'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <parameter type-id='9c313c2d' name='min_txg'/>
-      <parameter type-id='9c313c2d' name='max_txg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
+      <parameter type-id='9c313c2d'/>
+      <parameter type-id='9c313c2d'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_bookmarks_v2' mangled-name='zfs_iter_bookmarks_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks_v2'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_destroy_snaps_nvl_os' mangled-name='zfs_destroy_snaps_nvl_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl_os'>
@@ -5131,6 +5098,27 @@
       <parameter type-id='5ce45b60'/>
       <return type-id='9200a744'/>
     </function-decl>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='c19b74c3' name='simple'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9c313c2d' name='min_txg'/>
+      <parameter type-id='9c313c2d' name='max_txg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='d8e49ab9' name='callback'/>
@@ -5161,6 +5149,19 @@
       <parameter type-id='80f4b756' name='spec_orig'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='arg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='c19b74c3' name='allowrecursion'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
@@ -5394,9 +5395,6 @@
     <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
       <parameter type-id='9cf59a50'/>
       <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='use_color' mangled-name='use_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='use_color'>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
       <parameter type-id='80f4b756'/>
@@ -6168,6 +6166,14 @@
     <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
       <parameter type-id='4c81de99' name='zhp'/>
       <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zpool_get_userprop' mangled-name='zpool_get_userprop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_userprop'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='len'/>
+      <parameter type-id='debc6aa3' name='srctype'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
       <parameter type-id='4c81de99' name='zhp'/>
@@ -7850,6 +7856,9 @@
       <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='zfs_version_print' mangled-name='zfs_version_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='use_color' mangled-name='use_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='use_color'>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1774,6 +1774,7 @@ addlist(libzfs_handle_t *hdl, const char *propname, zprop_list_t **listp,
 	 * a user-defined property.
 	 */
 	if (prop == ZPROP_USERPROP && ((type == ZFS_TYPE_POOL &&
+	    !zfs_prop_user(propname) &&
 	    !zpool_prop_feature(propname) &&
 	    !zpool_prop_unsupported(propname)) ||
 	    ((type == ZFS_TYPE_DATASET) && !zfs_prop_user(propname) &&

--- a/man/man7/zpoolprops.7
+++ b/man/man7/zpoolprops.7
@@ -26,8 +26,9 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
+.\" Copyright (c) 2023, Klara Inc.
 .\"
-.Dd May 27, 2021
+.Dd April 18, 2023
 .Dt ZPOOLPROPS 7
 .Os
 .
@@ -39,6 +40,12 @@
 Each pool has several properties associated with it.
 Some properties are read-only statistics while others are configurable and
 change the behavior of the pool.
+.Pp
+User properties have no effect on ZFS behavior.
+Use them to annotate pools in a way that is meaningful in your environment.
+For more information about user properties, see the
+.Sx User Properties
+section.
 .Pp
 The following are read-only properties:
 .Bl -tag -width "unsupported@guid"
@@ -431,3 +438,49 @@ backwards compatibility.
 Once feature flags are enabled on a pool this property will no longer have a
 value.
 .El
+.
+.Ss User Properties
+In addition to the standard native properties, ZFS supports arbitrary user
+properties.
+User properties have no effect on ZFS behavior, but applications or
+administrators can use them to annotate pools.
+.Pp
+User property names must contain a colon
+.Pq Qq Sy \&:
+character to distinguish them from native properties.
+They may contain lowercase letters, numbers, and the following punctuation
+characters: colon
+.Pq Qq Sy \&: ,
+dash
+.Pq Qq Sy - ,
+period
+.Pq Qq Sy \&. ,
+and underscore
+.Pq Qq Sy _ .
+The expected convention is that the property name is divided into two portions
+such as
+.Ar module : Ns Ar property ,
+but this namespace is not enforced by ZFS.
+User property names can be at most 256 characters, and cannot begin with a dash
+.Pq Qq Sy - .
+.Pp
+When making programmatic use of user properties, it is strongly suggested to use
+a reversed DNS domain name for the
+.Ar module
+component of property names to reduce the chance that two
+independently-developed packages use the same property name for different
+purposes.
+.Pp
+The values of user properties are arbitrary strings and
+are never validated.
+All of the commands that operate on properties
+.Po Nm zpool Cm list ,
+.Nm zpool Cm get ,
+.Nm zpool Cm set ,
+and so forth
+.Pc
+can be used to manipulate both native properties and user properties.
+Use
+.Nm zpool Cm set Ar name Ns =
+to clear a user property.
+Property values are limited to 8192 bytes.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -482,7 +482,8 @@ tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
-    'zpool_set_ashift', 'zpool_set_features', 'vdev_set_001_pos']
+    'zpool_set_ashift', 'zpool_set_features', 'vdev_set_001_pos',
+    'user_property_001_pos', 'user_property_002_neg']
 tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1149,10 +1149,13 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_set/setup.ksh \
 	functional/cli_root/zpool/setup.ksh \
 	functional/cli_root/zpool_set/vdev_set_001_pos.ksh \
+	functional/cli_root/zpool_set/zpool_set_common.kshlib \
 	functional/cli_root/zpool_set/zpool_set_001_pos.ksh \
 	functional/cli_root/zpool_set/zpool_set_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_003_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_ashift.ksh \
+	functional/cli_root/zpool_set/user_property_001_pos.ksh \
+	functional/cli_root/zpool_set/user_property_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_features.ksh \
 	functional/cli_root/zpool_split/cleanup.ksh \
 	functional/cli_root/zpool_split/setup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2023 by Klara Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_set/zpool_set_common.kshlib
+
+#
+# DESCRIPTION:
+#	ZFS can set any valid user-defined pool property.
+#
+# STRATEGY:
+#	1. Combine all kind of valid characters into a valid user-defined
+#	   property name.
+#	2. Random get a string as the value.
+#	3. Verify all the valid user-defined pool properties can be set to a
+#	   pool.
+#
+
+verify_runnable "both"
+
+log_assert "ZFS can set any valid user-defined pool property."
+log_onexit cleanup_user_prop $TESTPOOL
+
+typeset -a names=()
+typeset -a values=()
+
+# Longest property name (255 bytes, which is the 256-byte limit minus 1 byte
+# for the null byte)
+names+=("$(awk 'BEGIN { printf "x:"; while (c++ < (256 - 2 - 1)) printf "a" }')")
+values+=("long-property-name")
+# Longest property value (the limits are 1024 on FreeBSD and 4096 on Linux, so
+# pick the right one; the longest value can use limit minus 1 bytes for the
+# null byte)
+if is_linux; then
+	typeset ZFS_MAXPROPLEN=4096
+else
+	typeset ZFS_MAXPROPLEN=1024
+fi
+names+=("long:property:value")
+values+=("$(awk -v max="$ZFS_MAXPROPLEN" 'BEGIN { while (c++ < (max - 1)) printf "A" }')")
+# Valid property names
+for i in {1..10}; do
+	typeset -i len
+	((len = RANDOM % 32))
+	names+=("$(valid_user_property $len)")
+	((len = RANDOM % 512))
+	values+=("$(user_property_value $len)")
+done
+
+typeset -i i=0
+while ((i < ${#names[@]})); do
+	typeset name="${names[$i]}"
+	typeset value="${values[$i]}"
+
+	log_must eval "zpool set $name='$value' $TESTPOOL"
+	log_must eval "check_user_prop $TESTPOOL $name '$value'"
+
+	((i += 1))
+done
+
+log_pass "ZFS can set any valid user-defined pool property passed."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
@@ -1,0 +1,88 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2023 by Klara Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_set/zpool_set_common.kshlib
+
+#
+# DESCRIPTION:
+#	ZFS can handle any invalid user-defined pool property.
+#
+# STRATEGY:
+#	1. Combine all kind of invalid user pool property names.
+#	2. Random get a string as the value.
+#	3. Verify all the invalid user-defined pool properties can not be set
+#	   to the pool.
+#
+
+verify_runnable "both"
+
+log_assert "ZFS can handle any invalid user pool property."
+log_onexit cleanup_user_prop $TESTPOOL
+
+typeset -a names=()
+typeset -a values=()
+
+# Too long property name (256 bytes, which is the 256-byte limit minus 1 byte
+# for the null byte plus 1 byte to reach back over the limit)
+names+=("$(awk 'BEGIN { printf "x:"; while (c++ < (256 - 2 - 1 + 1)) printf "a" }')")
+values+=("too-long-property-name")
+# Too long property value (the limits are 1024 on FreeBSD and 4096 on Linux, so
+# pick the right one; the too long value is, e.g., the limit minus 1 bytes for the
+# null byte plus 1 byte to reach back over the limit)
+if is_linux; then
+	typeset ZFS_MAXPROPLEN=4096
+else
+	typeset ZFS_MAXPROPLEN=1024
+fi
+names+=("too:long:property:value")
+values+=("$(awk -v max="$ZFS_MAXPROPLEN" 'BEGIN { while (c++ < (max - 1 + 1)) printf "A" }')")
+# Invalid property names
+for i in {1..10}; do
+	typeset -i len
+	((len = RANDOM % 32))
+	names+=("$(invalid_user_property $len)")
+	((len = RANDOM % 512))
+	values+=("$(user_property_value $len)")
+done
+
+typeset -i i=0
+while ((i < ${#names[@]})); do
+	typeset name="${names[$i]}"
+	typeset value="${values[$i]}"
+
+	log_mustnot zpool set $name=$value $TESTPOOL
+	log_mustnot check_user_prop $TESTPOOL \"$name\" \"$value\"
+
+	((i += 1))
+done
+
+log_pass "ZFS can handle invalid user pool property passed."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_common.kshlib
@@ -1,0 +1,178 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2023 by Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+set -A VALID_NAME_CHAR a b c d e f g h i j k l m n o p q r s t u v w x y z \
+    0 1 2 3 4 5 6 7 8 9 ':' '-' '.' '_'
+set -A INVALID_NAME_CHAR A B C D E F G H I J K L M N O P Q R S T U V W X Y Z \
+    '`' '~' '!' '@' '#' '$' '%' '^' '&' '(' ')' '+' '=' '|' "\\" '{' '[' ']' \
+    '}' ';' '"' '<' ',' '>' '?' '/' ' '
+set -A ALL_CHAR ${VALID_NAME_CHAR[*]} ${INVALID_NAME_CHAR[*]}
+
+#
+# Cleanup all the user properties of the pool.
+#
+# $1 pool name
+#
+function cleanup_user_prop
+{
+	typeset pool=$1
+
+	typeset user_prop
+	user_prop=$(zpool get -H -o property all $pool | grep ":")
+
+	typeset prop
+	for prop in $user_prop; do
+		zpool set $prop="" $pool ||
+			log_must zpool set $prop="" $pool
+	done
+}
+
+#
+# Random select character from the specified character set and combine into a
+# random string
+#
+# $1 character set name
+# $2 String length
+#
+function random_string
+{
+	typeset char_set=${1:-VALID_NAME_CHAR}
+	typeset -i len=${2:-5}
+
+	eval typeset -i count=\${#$char_set[@]}
+
+	# No consumers want an empty string.
+	((len == 0)) && len=3
+
+	typeset str
+	typeset -i i=0
+	while ((i < len)); do
+		typeset -i ind
+		((ind = RANDOM % count))
+		eval str=\${str}\${$char_set[\$ind]}
+
+		((i += 1))
+	done
+
+	echo "$str"
+}
+
+#
+# Get valid user-defined property name
+#
+# $1 user-defined property name length
+#
+function valid_user_property
+{
+	typeset -i sumlen=${1:-10}
+	((sumlen < 2 )) && sumlen=2
+	typeset -i len
+	((len = RANDOM % sumlen))
+	typeset part1 part2
+
+	while true; do
+		part1="$(random_string VALID_NAME_CHAR $len)"
+		if [[ "$part1" == "-"* ]]; then
+			continue
+		fi
+		break
+	done
+	((len = sumlen - (len + 1)))
+
+	while true; do
+		part2="$(random_string VALID_NAME_CHAR $len)"
+		if [[ -z $part1 && -z $part2 ]]; then
+			continue
+		fi
+		break
+	done
+
+	echo "${part1}:${part2}"
+}
+
+#
+# Get invalid user-defined property name
+#
+# $1 user-defined property name length
+#
+function invalid_user_property
+{
+	typeset -i sumlen=${1:-10}
+	((sumlen == 0)) && sumlen=1
+	typeset -i len
+	((len = RANDOM % sumlen))
+
+	typeset part1 part2
+	while true; do
+		part1="$(random_string VALID_NAME_CHAR $len)"
+		((len = sumlen - len))
+		part2="$(random_string INVALID_NAME_CHAR $len)"
+
+		# Avoid $part1 is *:* and $part2 is "=*"
+		if [[ "$part1" == *":"* && "$part2" == "="* ]]; then
+			continue
+		fi
+		break
+	done
+
+	echo "${part1}${part2}"
+}
+
+#
+# Get user-defined property value
+#
+# $1 user-defined property name length
+#
+function user_property_value
+{
+	typeset -i len=${1:-100}
+
+	random_string ALL_CHAR $len
+}
+
+#
+# Check if the user-defined property is identical to the expected value.
+#
+# $1 pool
+# $2 user property
+# $3 expected value
+#
+function check_user_prop
+{
+	typeset pool=$1
+	typeset user_prop="$2"
+	typeset expect_value="$3"
+	typeset value=$(zpool get -p -H -o value "$user_prop" $pool 2>&1)
+
+	[ "$expect_value" = "$value" ]
+}


### PR DESCRIPTION
`zpool set org.freebsd:comment="this is my pool" poolname`

Signed-off-by: Allan Jude <allan@klarasystems.com>

### Motivation and Context
Allow users to create and set arbitrary pool properties, with the same syntax as dataset user properties (a user property is identified by the colon separator, and by convention is formatted org.name:propername)

### Description
Allows to set and get user properties on the pool (district from dataset properties on the root dataset)

### How Has This Been Tested?
Not very much

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
