### PR TITLE
Return finer grain errors in libzfs unmount_one

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2021 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 RackTop Systems.
  * Copyright (c) 2018 Datto Inc.
@@ -553,7 +553,28 @@ unmount_one(libzfs_handle_t *hdl, const char *mountpoint, int flags)
 
 	error = do_unmount(mountpoint, flags);
 	if (error != 0) {
-		return (zfs_error_fmt(hdl, EZFS_UMOUNTFAILED,
+		int libzfs_err;
+
+		switch (error) {
+		case EBUSY:
+			libzfs_err = EZFS_BUSY;
+			break;
+		case EIO:
+			libzfs_err = EZFS_IO;
+			break;
+		case ENOENT:
+			libzfs_err = EZFS_NOENT;
+			break;
+		case ENOMEM:
+			libzfs_err = EZFS_NOMEM;
+			break;
+		case EPERM:
+			libzfs_err = EZFS_PERM;
+			break;
+		default:
+			libzfs_err = EZFS_UMOUNTFAILED;
+		}
+		return (zfs_error_fmt(hdl, libzfs_err,
 		    dgettext(TEXT_DOMAIN, "cannot unmount '%s'"),
 		    mountpoint));
 	}

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -128,8 +128,9 @@ do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts, int flags)
 int
 do_unmount(const char *mntpt, int flags)
 {
-
-	return (unmount(mntpt, flags));
+	if (unmount(mntpt, flags) < 0)
+		return (errno);
+	return (0);
 }
 
 int

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2021 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 RackTop Systems.
  * Copyright (c) 2018 Datto Inc.
@@ -377,7 +377,9 @@ int
 do_unmount(const char *mntpt, int flags)
 {
 	if (!libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
-		return (umount2(mntpt, flags));
+		int rv = umount2(mntpt, flags);
+
+		return (rv < 0 ? errno : 0);
 	}
 
 	char force_opt[] = "-f";


### PR DESCRIPTION
### Motivation and Context
For zfs CLI users and libzfs clients of `zfs_unmount()`,  a failed mount reports a generic "_umount failed, cannot unmount_" error.  Ideally a more specific error, like "_dataset is busy_" or "_permission denied_" could be returned.

The underlying posix `umount(2)` system call returns more specific errors that are currently all mapped to `EZFS_UMOUNTFAILED`.

### Description
Added errno mappings to unmount_one() in libzfs.

~~Also for the Linux implementation of `do_unmount()` made the process exec version follow the same error protocol as the `umount(2)` system call:  on error, -1 is returned, and `errno` is set appropriately.~~

Changed `do_unmount()` implementation to return errno errors directly like is done for `do_mount()` and others.

### How Has This Been Tested?
**ZTS** -- ran mount related tests:
- [x] functional/mount
- [x] functional/cli_root/zfs_mount
- [x] functional/cli_root/zfs_unmount
	
**CLI** -- confirmed results for failed mounts
_Before_
```
$ zfs unmount wool/parent
cannot unmount '/wool/parent': unmount failed
```
_After_ (2 examples)
```
$ zfs unmount wool/parent
cannot unmount '/wool/parent': permission denied

$ sudo zfs unmount wool/parent
cannot unmount '/wool/parent/child': pool or dataset is busy
```

**Libzfs consumer** -- confirmed results from `libzfs_errno()` and  `libzfs_error_description()`
_Before_
```
ZfsDataServiceImpl$UnmountFailedException: UMOUNTFAILED: umount failed, cannot unmount '/domain0/group-2/oracle_db_container-220243/oracle_timeflow-220245/datafile'
```
_After_
```
ZfsDataServiceImpl$UnmountFailedException: BUSY: pool or dataset is busy, cannot unmount '/domain0/group-2/oracle_db_container-6/oracle_timeflow-7/datafile'
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
