### PR TITLE
abd_get_offset_struct() may allocate new abd

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -555,8 +555,12 @@ abd_get_offset_impl(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 abd_t *
 abd_get_offset_struct(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 {
+	abd_t *result;
 	abd_init_struct(abd);
-	return (abd_get_offset_impl(abd, sabd, off, size));
+	result = abd_get_offset_impl(abd, sabd, off, size);
+	if (result != abd)
+		abd_fini_struct(abd);
+	return (result);
 }
 
 abd_t *


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

ABD can be initialised twice - which is a panic on some platforms.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensure any call to `abd_init_struct();` has a corresponding call to `abd_fini_struct();`

### Description
<!--- Describe your changes in detail -->

Even when supplied with an `abd` to `abd_get_offset_struct()`, the call
to `abd_get_offset_impl()` can allocate a different `abd`. Ensure to
call `abd_fini_struct()` on the `abd` that is not used.

This was easily triggered on macOS with `zpool_upgrade` zfs-tests. With the stack:

```
 : mach_kernel : _panic + 0x54
 : _abd_get_offset_struct.cold.1 + 0x37
 : _abd_get_offset_struct + 0x8b
 : _vdev_raidz_map_alloc + 0x2e1
 : _vdev_raidz_io_start + 0x33
 : _zio_vdev_io_start + 0x21c
 : _zio_nowait + 0x20c
```


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Lots of tests on macOS - now to make sure it doesn't break for others.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
