### PR TITLE
Update man docs to clarify behaviour when sending compressed sends and receiving with overridden compression 

### DIFF
--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -261,6 +261,16 @@ causes the property to be inherited by all descendant datasets, as through
 was run on any descendant datasets that have this property set on the
 sending system.
 .Pp
+If the send stream was sent with 
+.Fl c
+then overriding the 
+.Sy compression 
+property will have no affect on received data but the  
+.Sy compression
+property will be set. To have the data recompressed on receive remove the 
+.Fl c 
+flag from the send stream.  
+.Pp
 Any editable property can be set at receive time. Set-once properties bound
 to the received data, such as
 .Sy normalization

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -191,10 +191,10 @@ option is not supplied in conjunction with
 then the data will be decompressed before sending so it can be split into
 smaller block sizes. Streams sent with 
 .Fl c
-cannot have their compression overwritten on the receiver using 
-.Fl o compress=.
-The compression property will be set on the receiver but the compression used
-will be the one that was set on the sender. 
+will not have their data recompressed on the receiver side using
+.Fl o compress=value.
+The data will stay compressed as it was from the sender. The new compression
+property will be set for future data. 
 .It Fl w, -raw
 For encrypted datasets, send data exactly as it exists on disk. This allows
 backups to be taken even if encryption keys are not currently loaded. The

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -189,7 +189,12 @@ feature is enabled on the sending system but the
 option is not supplied in conjunction with
 .Fl c ,
 then the data will be decompressed before sending so it can be split into
-smaller block sizes.
+smaller block sizes. Streams sent with 
+.Fl c
+cannot have their compression overwritten on the receiver using 
+.Fl o compress=.
+The compression property will be set on the receiver but the compression used
+will be the one that was set on the sender. 
 .It Fl w, -raw
 For encrypted datasets, send data exactly as it exists on disk. This allows
 backups to be taken even if encryption keys are not currently loaded. The


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Docs for send and receive do not explain behaviour when sending a compressed stream then receiving on a host that overrides compression with -o compress=value.

The data from the send stream is written as it was from the send is the compressed form but the compression algorithm set on the receiver is the overridden version which causes some confusion as to what algorithm was actually used. 

In the future it might be nicer if the override on compression actually  did decompress then recompress the data before writing it to disk


### Description
<!--- Describe your changes in detail -->
Updated man docs to clarify behaviour 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
