### PR TITLE
vdev_id: Create symlinks even if no /dev/mapper/

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -298,8 +298,15 @@ sas_handler() {
 
 		# Utilize DM device name to gather subordinate block devices
 		# using sysfs to avoid userspace utilities
-		DMDEV=$(ls -l --full-time /dev/mapper | grep $DM_NAME |
+
+		# If our DEVNAME is something like /dev/dm-177, then we may be
+		# able to get our DMDEV from it.
+		DMDEV=$(echo $DEVNAME | sed 's;/dev/;;g')
+		if [ ! -e /sys/block/$DMDEV/slaves/* ] ; then
+			# It's not there, try looking in /dev/mapper
+			DMDEV=$(ls -l --full-time /dev/mapper | grep $DM_NAME |
 			awk '{gsub("../", " "); print $NF}')
+		fi
 
 		# Use sysfs pointers in /sys/block/dm-X/slaves because using
 		# userspace tools creates lots of overhead and should be avoided


### PR DESCRIPTION
### Motivation and Context
Fix `vdev_id` not working on some nodes.

### Description
`vdev_id` uses the `/dev/mapper/` symlinks to resolve a UUID to a dm name (like dm-1).  However on some multipath setups, there is no `/dev/mapper/` entry for the UUID at the time `vdev_id` is called by udev.  However, this isn't necessarily needed, as we may be able to resolve the dm name from the `$DEVNAME` that udev passes us (like DEVNAME="/dev/dm-1").

This patch tries to resolve the dm name from `$DEVNAME` first, before falling back to looking in `/dev/mapper/`.  This fixed an issue where the by-vdev names weren't reliably showing up on one of our nodes.

### How Has This Been Tested?
Tested on one RHEL 8 node where the by-vdev links weren't being created at boot time, and verified that this fixed it.  Also saw it fix the reproducer case of removing/reloading the multipath devices (`multipath -F && multipath -r`).  Further sanity tested on two other enclosures type nodes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
