### PR TITLE
Linux 5.12 compat: inode_owner_or_capable()

### DIFF
--- a/config/kernel-is_owner_or_cap.m4
+++ b/config/kernel-is_owner_or_cap.m4
@@ -11,13 +11,32 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OWNER_OR_CAPABLE], [
 		struct inode *ip = NULL;
 		(void) inode_owner_or_capable(ip);
 	])
+
+	ZFS_LINUX_TEST_SRC([inode_owner_or_capable_idmapped], [
+		#include <linux/fs.h>
+	],[
+		struct inode *ip = NULL;
+		(void) inode_owner_or_capable(&init_user_ns, ip);
+	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_INODE_OWNER_OR_CAPABLE], [
 	AC_MSG_CHECKING([whether inode_owner_or_capable() exists])
 	ZFS_LINUX_TEST_RESULT([inode_owner_or_capable], [
 		AC_MSG_RESULT(yes)
-	],[
-		ZFS_LINUX_TEST_ERROR([capability])
+		AC_DEFINE(HAVE_INODE_OWNER_OR_CAPABLE, 1,
+		    [inode_owner_or_capable() exists])
+	], [
+		AC_MSG_RESULT(no)
+
+		AC_MSG_CHECKING(
+		    [whether inode_owner_or_capable() takes user_ns])
+		ZFS_LINUX_TEST_RESULT([inode_owner_or_capable_idmapped], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_INODE_OWNER_OR_CAPABLE_IDMAPPED, 1,
+			    [inode_owner_or_capable() takes user_ns])
+		],[
+			ZFS_LINUX_TEST_ERROR([capability])
+		])
 	])
 ])

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -171,4 +171,12 @@ zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
 	timespec_trunc(ts, (ip)->i_sb->s_time_gran)
 #endif
 
+#if defined(HAVE_INODE_OWNER_OR_CAPABLE)
+#define	zpl_inode_owner_or_capable(ns, ip)	inode_owner_or_capable(ip)
+#elif defined(HAVE_INODE_OWNER_OR_CAPABLE_IDMAPPED)
+#define	zpl_inode_owner_or_capable(ns, ip)	inode_owner_or_capable(ns, ip)
+#else
+#error "Unsupported kernel"
+#endif
+
 #endif	/* _SYS_ZPL_H */

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -124,7 +124,7 @@ secpolicy_vnode_any_access(const cred_t *cr, struct inode *ip, uid_t owner)
 	if (crgetfsuid(cr) == owner)
 		return (0);
 
-	if (inode_owner_or_capable(ip))
+	if (zpl_inode_owner_or_capable(kcred->user_ns, ip))
 		return (0);
 
 #if defined(CONFIG_USER_NS)

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -869,7 +869,7 @@ __zpl_ioctl_setflags(struct inode *ip, uint32_t ioctl_flags, xvattr_t *xva)
 	    !capable(CAP_LINUX_IMMUTABLE))
 		return (-EACCES);
 
-	if (!inode_owner_or_capable(ip))
+	if (!zpl_inode_owner_or_capable(kcred->user_ns, ip))
 		return (-EACCES);
 
 	xva_init(xva);

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1233,7 +1233,7 @@ __zpl_xattr_acl_set_access(struct inode *ip, const char *name,
 	if (ITOZSB(ip)->z_acl_type != ZFS_ACLTYPE_POSIX)
 		return (-EOPNOTSUPP);
 
-	if (!inode_owner_or_capable(ip))
+	if (!zpl_inode_owner_or_capable(kcred->user_ns, ip))
 		return (-EPERM);
 
 	if (value) {
@@ -1273,7 +1273,7 @@ __zpl_xattr_acl_set_default(struct inode *ip, const char *name,
 	if (ITOZSB(ip)->z_acl_type != ZFS_ACLTYPE_POSIX)
 		return (-EOPNOTSUPP);
 
-	if (!inode_owner_or_capable(ip))
+	if (!zpl_inode_owner_or_capable(kcred->user_ns, ip))
 		return (-EPERM);
 
 	if (value) {


### PR DESCRIPTION
### Motivation and Context

Resolve Linux 5.12 compatibility build failure.

### Description

The inode_owner_or_capable() function was updated in the 5.12 kernel
to support idmapped mounts.  As part of this change the user namespace
is now passed as the first argument.  For non-idmapped mounts, which
are currently not supported, the initial user namespace may be passed
which will result in identical behavior as before.

### How Has This Been Tested?

Locally compiled against the 5.12-rc1 kernel and basic functionality
was tested. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
