### PR TITLE
Suppress cppcheck invalidSyntax warninigs

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -248,6 +248,7 @@ zfs_redup_stream(int infd, int outfd, boolean_t verbose)
 			fflags = DMU_GET_FEATUREFLAGS(drrb->drr_versioninfo);
 			fflags &= ~(DMU_BACKUP_FEATURE_DEDUP |
 			    DMU_BACKUP_FEATURE_DEDUPPROPS);
+			/* cppcheck-suppress syntaxError */
 			DMU_SET_FEATUREFLAGS(drrb->drr_versioninfo, fflags);
 
 			int sz = drr->drr_payloadlen;

--- a/include/sys/dmu_redact.h
+++ b/include/sys/dmu_redact.h
@@ -39,6 +39,7 @@ redact_block_get_size(redact_block_phys_t *rbp)
 static inline void
 redact_block_set_size(redact_block_phys_t *rbp, uint64_t size)
 {
+	/* cppcheck-suppress syntaxError */
 	BF64_SET_SB((rbp)->rbp_size_count, 48, 16, SPA_MINBLOCKSHIFT, 0, size);
 }
 
@@ -51,6 +52,7 @@ redact_block_get_count(redact_block_phys_t *rbp)
 static inline void
 redact_block_set_count(redact_block_phys_t *rbp, uint64_t count)
 {
+	/* cppcheck-suppress syntaxError */
 	BF64_SET_SB((rbp)->rbp_size_count, 0, 48, 0, 1, count);
 }
 


### PR DESCRIPTION
### Motivation and Context

Resolve cppcheck 1.90 warning in CI on Ubuntu 20.04.

### Description

For some reason cppcheck 1.90 is generating an invalidSyntax warning
when the BF64_SET macro is used in the zstream source.  The same
warning is not reported by cppcheck 2.3, nor is their any evident
problem with the expanded macro.  This appears to be an issue with
this version of cppcheck.  This commit anotates the source to suppress
the warning.

### How Has This Been Tested?

Ran `make lint` locally with cppcheck 1.90 and verified the warnings
were suppressed.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
