### PR TITLE
ZTS events_002: Improve speed and reliability

### DIFF
--- a/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
@@ -66,7 +66,7 @@ log_must zpool create $MPOOL mirror $VDEV1 $VDEV2
 
 # 2. Start the ZED and verify it handles missed events.
 log_must zed_start
-log_must file_wait $ZED_DEBUG_LOG
+log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.config_sync' 150
 log_must cp $ZED_DEBUG_LOG $TMP_EVENTS_ZED
 
 awk -v event="sysevent.fs.zfs.pool_create" \
@@ -92,12 +92,11 @@ done
 
 # 5. Start the ZED and verify it only handled the new missed events.
 log_must zed_start
-log_must file_wait $ZED_DEBUG_LOG 35
+log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.resilver_finish' 150
 log_must cp $ZED_DEBUG_LOG $TMP_EVENTS_ZED
 
-log_mustnot grep -q "sysevent.fs.zfs.pool_create" $TMP_EVENTS_ZED
+log_mustnot file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.pool_create' 30
 log_must grep -q "sysevent.fs.zfs.vdev_online" $TMP_EVENTS_ZED
 log_must grep -q "sysevent.fs.zfs.resilver_start" $TMP_EVENTS_ZED
-log_must grep -q "sysevent.fs.zfs.resilver_finish" $TMP_EVENTS_ZED
 
 log_pass "Verify ZED handles missed events on when starting"


### PR DESCRIPTION
### Motivation and Context

events_002 exercises the ZED, ensuring that it neither misses events, nor reporting events twice.

On slow test hardware, some of the timeouts are insufficient to allow the ZED to properly settle.  Conversely, on fast hardware these same timeouts are too long, unnecessarily slowing the test run.

I'm running into a spurious test failure on the cheap VPS I run the ZTS on.  This fixes that failure.

### Description

Instead of using a fixed timeout, wait for the expected final event before returning.  Additionally, wait with a timeout for unexepcted events to avoid missing them if they show up late.

Notice the slight change in semantics---I consider this an improvement.

### How Has This Been Tested?

The test succeeds on my slow testbed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
