### PR TITLE
Make module/Makefile.in pass debug flags to module/Makefile.bsd

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -46,6 +46,9 @@ FMAKEFLAGS = -C @abs_srcdir@ -f Makefile.bsd $(shell $(getflags))
 ifneq (@abs_srcdir@,@abs_builddir@)
 FMAKEFLAGS += MAKEOBJDIR=@abs_builddir@
 endif
+ifeq (@DEBUG_ZFS@,_with_debug)
+FMAKEFLAGS += WITH_DEBUG=true
+endif
 
 FMAKE = env -u MAKEFLAGS make $(FMAKEFLAGS)
 


### PR DESCRIPTION
Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
When using ./configure --enable-debug the FreeBSD kernel module is
still compiled with the NDEBUG and without ZFS_DEBUG

This results in a mismatch on the size of zfs_refcount_t and makes
the sysctls vfs.zfs.mru_size etc return the wrong values, resulting
in top claiming the MRU size is 100s of gigabytes on a VM with only
4 GB of memory.

### Description
Pass the WITH_DEBUG flag to Makefile.bsd if the ./configure flag --enable-debug was used.
This causes the BSD Makefile to add `-DZFS_DEBUG -g` to CFLAGS

Before, this resulted in some sysctls that used the address of `arc_state_t` `ARC_mru.arcs_size.rc_count` to have the offset of the debug version of the struct, but the final module to be compiled without debug, resulting in the sysctl reading the wrong memory location.

### How Has This Been Tested?
The resulting module no longer gives bogus sysctl values, as the pointers are to the correct offset.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
