### PR TITLE
WIP ZSTD compression/decompression optimizations

### DIFF
--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -63,7 +63,9 @@ extern	int printk(const char *fmt, ...);
 #else
 #define aprint(...) printf(__VA_ARGS__)
 #endif
-#define XASSERT3U(L,C,R) do{const uintptr_t lll=(L); const uintptr_t rrr=(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s():%s %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3(L,C,R) do{const intptr_t lll=(intptr_t)(L); const intptr_t rrr=(intptr_t)(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s:%s %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3U XASSERT
+// ^ bleh, fixme
 
 //#define __KERNEL__
 //#include <linux/kernel.h>

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -561,7 +561,6 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 	size_t src_remain = s_len;
 	char* src_ptr = s_start;
 	size_t compressedSize = /*hack*/ (size_t)-ZSTD_error_GENERIC;
-	ZSTD_inBuffer inBuff;
 	{
 
 		ZSTD_outBuffer outBuff = {hdr->data, d_len - sizeof(*hdr), 0};
@@ -578,7 +577,6 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 			ZSTD_inBuffer thisInBuff = {src_ptr, this_gulp_size, 0};
 			size_t status = ZSTD_compressStream2(cctx, &outBuff, &thisInBuff,
 			    is_final_gulp? ZSTD_e_end : ZSTD_e_continue);
-			inBuff = thisInBuff;
 			if (ZSTD_isError(status))
 			{
 				compressedSize = status;

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -63,7 +63,7 @@ extern	int printk(const char *fmt, ...);
 #else
 #define aprint(...) printf(__VA_ARGS__)
 #endif
-#define XASSERT3U(L,C,R) do{const uintptr_t lll=(L); const uintptr_t rrr=(R); if(!(lll C rrr))aprintf("ADAM ASSERT FAILURE: %s(%lld) %s %s(%lld) failed", #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3U(L,C,R) do{const uintptr_t lll=(L); const uintptr_t rrr=(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s(%lld) %s %s(%lld) failed", #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
 
 //#define __KERNEL__
 //#include <linux/kernel.h>

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -547,10 +547,10 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 				break; // good, now flush/end stream
 			}
 #ifdef __KERNEL__
-			kpreempt();
+			//kpreempt();
 #else
 #endif
-			//cond_resched(); // possibly yield before taking next gulp
+			cond_resched(); // possibly yield before taking next gulp
 		}
 		(void)inBuff;
 #if 1

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -448,6 +448,7 @@ static void* GrabCCtx(void)
 				}
 				else
 				{
+					ZSTD_freeCCtx(newlist[0]);
 					kmem_free(newlist, newlistbytes);
 					aprint("ADAM: failed to alloc new locklist");
 				}
@@ -462,6 +463,7 @@ static void* GrabCCtx(void)
 		{
 			aprint("ADAM: failed to alloc larger list");
 		}
+		aprint("ADAM: resulting cctx is %p", found);
 	}
 	mutex_exit(&cctx_pool.outerlock);
 	return found;

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -43,6 +43,7 @@
 //#include <sys/param.h>
 //#include <sys/sysmacros.h>
 ///#include <sys/zfs_context.h>
+#include <sys/zfs_context.h>
 #include <sys/zio_compress.h>
 #include <sys/spa.h>
 #include <sys/zstd/zstd.h>
@@ -55,7 +56,7 @@
 //#define __KERNEL__
 #include <sys/debug.h>
 #include <sys/sysmacros.h>
-
+//#include <os/linux/spl/sys/thread.h>
 
 extern	int printk(const char *fmt, ...);
 #ifdef __KERNEL__
@@ -389,12 +390,14 @@ static void* GrabCCtx(void)
 {
 	void* found = NULL;
 	mutex_enter(&cctx_pool.outerlock);
+	const int threadpid = (int)getpid();
 	for (int i=0; i<cctx_pool.count; ++i)
 	{
-		XASSERT3U(cctx_pool.list[i], !=, NULL);
-		if (mutex_tryenter(&cctx_pool.listlocks[i]))
+		int j = (i + threadpid) % cctx_pool.count;
+		XASSERT3U(cctx_pool.list[j], !=, NULL);
+		if (mutex_tryenter(&cctx_pool.listlocks[j]))
 		{
-			found = cctx_pool.list[i];
+			found = cctx_pool.list[j];
 			break;
 		}
 	}
@@ -475,15 +478,17 @@ static void UnGrabCCtx(void* cctx)
 {
 	XASSERT3U(cctx, !=, NULL);
 	mutex_enter(&cctx_pool.outerlock);
+	const int threadpid = (int)getpid();
 	for (int i = 0; i < cctx_pool.count; ++i)
 	{
-		if (cctx_pool.list[i] == cctx)
+		int j = (i + threadpid) % cctx_pool.count;
+		if (cctx_pool.list[j] == cctx)
 		{
-			if (mutex_tryenter(&cctx_pool.listlocks[i]))
+			if (mutex_tryenter(&cctx_pool.listlocks[j]))
 			{
 				aprint("ADAM: uhh damn, managed to get lock on ungrab ptr %p, but should be locked already if it was grabbed", cctx);
 			}
-			mutex_exit(&cctx_pool.listlocks[i]);
+			mutex_exit(&cctx_pool.listlocks[j]);
 			break;
 		}
 	}
@@ -491,6 +496,124 @@ static void UnGrabCCtx(void* cctx)
 }
 /////////////////////////////////////////// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 /////////////////////////////////////////// CCTX OBJECT POOLING ROUGH DRAFT
+
+/////////////////////////////////////////// DCTX OBJECT POOLING ROUGH DRAFT
+/////////////////////////////////////////// VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+// this is more complicated and less generic than it should eventually be.
+static struct
+{
+	kmutex_t outerlock;
+	int count;
+	kmutex_t *listlocks;
+	void **list;
+} dctx_pool;
+
+static void *GrabDCtx(void)
+{
+	void *found = NULL;
+	mutex_enter(&dctx_pool.outerlock);
+	for (int i = 0; i < dctx_pool.count; ++i)
+	{
+		XASSERT3U(dctx_pool.list[i], !=, NULL);
+		if (mutex_tryenter(&dctx_pool.listlocks[i]))
+		{
+			found = dctx_pool.list[i];
+			break;
+		}
+	}
+	if (likely(found != NULL))
+	{
+		// slightly subtle optimization; decompressor needs to reset *stream* (only on error), we reset *parameters*
+		ZSTD_DCtx_reset(found, ZSTD_reset_parameters);
+	}
+	else
+	{
+		aprint("ADAM: growing dctx list from %d to %d entries", dctx_pool.count, 1 + dctx_pool.count);
+		int newlistbytes = sizeof(void *) * (dctx_pool.count + 1);
+		void **newlist = kmem_alloc(newlistbytes, KM_SLEEP);
+		if (likely(newlist != NULL))
+		{
+			//aprint("ADAM: 1");
+			newlist[0] = ZSTD_createDCtx_advanced(zstd_dctx_malloc);
+			//aprint("ADAM: 2");
+			if (likely(newlist[0] != NULL))
+			{
+				//aprint("ADAM: 3");
+				int newlocklistbytes = sizeof(kmutex_t) * (dctx_pool.count + 1);
+				kmutex_t *newlocklist = kmem_alloc(newlocklistbytes, KM_SLEEP);
+				//aprint("ADAM: 4");
+				if (likely(newlocklist != NULL))
+				{
+					//aprint("ADAM: 5");
+					mutex_init(&newlocklist[0], NULL, MUTEX_DEFAULT, NULL);
+					//aprint("ADAM: 6");
+					if (likely(dctx_pool.count > 0))
+					{
+						XASSERT3U(dctx_pool.list, !=, NULL);
+						XASSERT3U(dctx_pool.listlocks, !=, NULL);
+						memcpy(&newlist[1], &dctx_pool.list[0], sizeof(void *) * (dctx_pool.count));
+						memcpy(&newlocklist[1], &dctx_pool.listlocks[0], sizeof(kmutex_t) * dctx_pool.count);
+						kmem_free(dctx_pool.list, sizeof(void *) * (dctx_pool.count));
+						kmem_free(dctx_pool.listlocks, sizeof(kmutex_t) * dctx_pool.count);
+					}
+					else
+					{
+						XASSERT3U(dctx_pool.list, ==, NULL);
+						XASSERT3U(dctx_pool.listlocks, ==, NULL);
+					}
+					//aprint("ADAM: 7");
+					dctx_pool.list = newlist;
+					dctx_pool.listlocks = newlocklist;
+					found = dctx_pool.list[0];
+					mutex_enter(&dctx_pool.listlocks[0]);
+					++dctx_pool.count;
+					//aprint("ADAM: 8");
+
+					// total success
+					aprint("ADAM: expanded lists and grabbed new entry %p", found);
+				}
+				else
+				{
+					ZSTD_freeDCtx(newlist[0]);
+					kmem_free(newlist, newlistbytes);
+					aprint("ADAM: failed to alloc new locklist");
+				}
+			}
+			else
+			{
+				kmem_free(newlist, newlistbytes);
+				aprint("ADAM: failed to alloc new dctx for list");
+			}
+		}
+		else
+		{
+			aprint("ADAM: failed to alloc larger list");
+		}
+		aprint("ADAM: resulting dctx is %p", found);
+	}
+	mutex_exit(&dctx_pool.outerlock);
+	return found;
+}
+static void UnGrabDCtx(void *dctx)
+{
+	XASSERT3U(dctx, !=, NULL);
+	mutex_enter(&dctx_pool.outerlock);
+	for (int i = 0; i < dctx_pool.count; ++i)
+	{
+		if (dctx_pool.list[i] == dctx)
+		{
+			if (mutex_tryenter(&dctx_pool.listlocks[i]))
+			{
+				aprint("ADAM: uhh damn, managed to get lock on ungrab ptr %p, but should be locked already if it was grabbed", dctx);
+			}
+			mutex_exit(&dctx_pool.listlocks[i]);
+			break;
+		}
+	}
+	mutex_exit(&dctx_pool.outerlock);
+}
+/////////////////////////////////////////// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/////////////////////////////////////////// DCTX OBJECT POOLING ROUGH DRAFT
 
 /* Convert ZFS internal enum to ZSTD level */
 static int
@@ -721,7 +844,7 @@ zfs_zstd_decompress_level(void *s_start, void *d_start, size_t s_len,
 		return (1);
 	}
 
-	dctx = ZSTD_createDCtx_advanced(zstd_dctx_malloc);
+	dctx = GrabDCtx();//ZSTD_createDCtx_advanced(zstd_dctx_malloc);
 	if (!dctx) {
 		ZSTDSTAT_BUMP(zstd_stat_dec_alloc_fail);
 		return (1);
@@ -732,7 +855,6 @@ zfs_zstd_decompress_level(void *s_start, void *d_start, size_t s_len,
 
 	/* Decompress the data and release the context */
 	result = ZSTD_decompressDCtx(dctx, d_start, d_len, hdr->data, c_len);
-	ZSTD_freeDCtx(dctx);
 
 	/*
 	 * Returns 0 on success (decompression function returned non-negative)
@@ -740,8 +862,12 @@ zfs_zstd_decompress_level(void *s_start, void *d_start, size_t s_len,
 	 */
 	if (ZSTD_isError(result)) {
 		ZSTDSTAT_BUMP(zstd_stat_dec_fail);
+		ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
+		UnGrabDCtx(dctx);
 		return (1);
 	}
+
+	UnGrabDCtx(dctx); // ZSTD_freeDCtx(dctx);
 
 	if (level) {
 		*level = hdr_copy.level;
@@ -864,6 +990,7 @@ create_fallback_mem(struct zstd_fallback_mem *mem, size_t size)
 static void __init
 zstd_mempool_init(void)
 {
+	// CCTX RECYCLER...
 	mutex_init(&cctx_pool.outerlock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_enter(&cctx_pool.outerlock);
 	cctx_pool.count = 0;
@@ -871,6 +998,15 @@ zstd_mempool_init(void)
 	cctx_pool.listlocks = NULL;
 	mutex_exit(&cctx_pool.outerlock);
 
+	// DCTX RECYCLER...
+	mutex_init(&dctx_pool.outerlock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_enter(&dctx_pool.outerlock);
+	dctx_pool.count = 0;
+	dctx_pool.list = NULL;
+	dctx_pool.listlocks = NULL;
+	mutex_exit(&dctx_pool.outerlock);
+
+	// OTHER STUFF...
 	zstd_mempool_cctx = (struct zstd_pool *)
 	    kmem_zalloc(ZSTD_POOL_MAX * sizeof (struct zstd_pool), KM_SLEEP);
 	zstd_mempool_dctx = (struct zstd_pool *)
@@ -944,6 +1080,37 @@ zstd_mempool_deinit(void)
 	cctx_pool.list = NULL;
 	cctx_pool.listlocks = NULL;
 	mutex_exit(&cctx_pool.outerlock);
+	// ADAM: above is sketch
+
+	// TODO: ADAM: deinit dctx_pool
+	mutex_enter(&dctx_pool.outerlock);
+	for (int i = 0; i < dctx_pool.count; ++i)
+	{
+		if (!mutex_tryenter(&dctx_pool.listlocks[i]))
+		{
+			aprint("ADAM: nuts, trying to deinit dctx pool but idx#%d still locked, waiting for it to unlock...", i);
+			//mutex_enter(&dctx_pool.listlocks[i]);
+			// ^ nope, not while holding outerlock - need to restart outer loop
+		}
+		ZSTD_freeDCtx(dctx_pool.list[i]);
+		mutex_exit(&dctx_pool.listlocks[i]);
+	}
+	if (dctx_pool.count > 0)
+	{
+		XASSERT3U(dctx_pool.list, !=, NULL);
+		XASSERT3U(dctx_pool.listlocks, !=, NULL);
+		kmem_free(dctx_pool.list, sizeof(void *) * dctx_pool.count);
+		kmem_free(dctx_pool.listlocks, sizeof(kmutex_t) * dctx_pool.count);
+	}
+	else
+	{
+		XASSERT3U(dctx_pool.list, ==, NULL);
+		XASSERT3U(dctx_pool.listlocks, ==, NULL);
+	}
+	dctx_pool.count = 0;
+	dctx_pool.list = NULL;
+	dctx_pool.listlocks = NULL;
+	mutex_exit(&dctx_pool.outerlock);
 	// ADAM: above is sketch
 
 	for (int i = 0; i < ZSTD_POOL_MAX; i++) {

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -547,10 +547,10 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 				break; // good, now flush/end stream
 			}
 #ifdef __KERNEL__
-			//kpreempt();
+			kpreempt();
 #else
 #endif
-			cond_resched(); // possibly yield before taking next gulp
+			//cond_resched(); // possibly yield before taking next gulp
 		}
 		(void)inBuff;
 #if 1

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -1016,7 +1016,8 @@ zstd_mempool_deinit(void)
 		if (!mutex_tryenter(&cctx_pool.listlocks[i]))
 		{
 			aprint("ADAM: nuts, trying to deinit pool but idx#%d still locked, waiting for it to unlock...", i);
-			mutex_enter(&cctx_pool.listlocks[i]);
+			//mutex_enter(&cctx_pool.listlocks[i]);
+			// ^ nope, not while holding outerlock - need to restart outer loop
 		}
 		ZSTD_freeCCtx(cctx_pool.list[i]);
 		mutex_exit(&cctx_pool.listlocks[i]);

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -441,24 +441,26 @@ static void* GrabCCtx(void)
 					mutex_enter(&cctx_pool.listlocks[0]);
 					++cctx_pool.count;
 					//aprint("ADAM: 8");
+
+					// total success
+					aprint("ADAM: expanded lists and grabbed new entry %p", found);
 				}
 				else
 				{
 					kmem_free(newlist, newlistbytes);
-					//aprint("ADAM: failed to alloc new locklist");
+					aprint("ADAM: failed to alloc new locklist");
 				}
 			}
 			else
 			{
 				kmem_free(newlist, newlistbytes);
-				//aprint("ADAM: failed to alloc new cctx for list");
+				aprint("ADAM: failed to alloc new cctx for list");
 			}
 		}
 		else
 		{
 			aprint("ADAM: failed to alloc larger list");
 		}
-		aprint("ADAM: expanded lists and grabbed new entry %p", found);
 	}
 	mutex_exit(&cctx_pool.outerlock);
 	return found;
@@ -472,7 +474,7 @@ static void UnGrabCCtx(void* cctx)
 		{
 			if (mutex_tryenter(&cctx_pool.listlocks[i]))
 			{
-				aprint("ADAM: uhh damn, managed to get lock on ungrab ptr %p", cctx);
+				aprint("ADAM: uhh damn, managed to get lock on ungrab ptr %p, but should be locked already if it was grabbed", cctx);
 			}
 			mutex_exit(&cctx_pool.listlocks[i]);
 		}

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -389,6 +389,7 @@ static void* GrabCCtx(void)
 	mutex_enter(&cctx_pool.outerlock);
 	for (int i=0; i<cctx_pool.count; ++i)
 	{
+		XASSERT3U(cctx_pool.list[i], !=, NULL);
 		if (mutex_tryenter(&cctx_pool.listlocks[i]))
 		{
 			found = cctx_pool.list[i];
@@ -470,6 +471,7 @@ static void* GrabCCtx(void)
 }
 static void UnGrabCCtx(void* cctx)
 {
+	XASSERT3U(cctx, !=, NULL);
 	mutex_enter(&cctx_pool.outerlock);
 	for (int i = 0; i < cctx_pool.count; ++i)
 	{
@@ -480,6 +482,7 @@ static void UnGrabCCtx(void* cctx)
 				aprint("ADAM: uhh damn, managed to get lock on ungrab ptr %p, but should be locked already if it was grabbed", cctx);
 			}
 			mutex_exit(&cctx_pool.listlocks[i]);
+			break;
 		}
 	}
 	mutex_exit(&cctx_pool.outerlock);

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -521,6 +521,7 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 				aprint("status was error: %s", ZSTD_getErrorName(status));
 				goto badc;
 			}
+			/*
 			size_t const iremaining = ZSTD_flushStream(cctx, &outBuff); // have to keep calling this until remaining == error or 0
 			if (ZSTD_isError(iremaining))
 			{
@@ -528,19 +529,20 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 				aprint("status was error3: %s", ZSTD_getErrorName(iremaining));
 				goto badc;
 			}
+			*/
 			if (outBuff.pos == outBuff.size)
 			{
 				compressedSize = /*hack*/ (size_t)-ZSTD_error_dstSize_tooSmall;
 				//aprint("done(output full, input remains); outpos==outsize");
 				goto badc; // ?
 			}
-			ASSERT3U(iremaining, ==, 0);
+			ASSERT3U(thisInBuff.pos, ==, thisInBuff.size);
 			src_ptr += thisInBuff.pos;
 			ASSERT3U(src_remain, >=, thisInBuff.pos);
 			src_remain -= thisInBuff.pos;
 			if (src_remain == 0)
 			{
-				break; // good, now flush
+				break; // good, now flush/end stream
 			}
 			cond_resched(); // possibly yield before taking next gulp
 		}

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -63,7 +63,7 @@ extern	int printk(const char *fmt, ...);
 #else
 #define aprint(...) printf(__VA_ARGS__)
 #endif
-#define XASSERT3U(L,C,R) do{const uintptr_t lll=(L); const uintptr_t rrr=(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s(%lld) %s %s(%lld) failed", #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3U(L,C,R) do{const uintptr_t lll=(L); const uintptr_t rrr=(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s():%s %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
 
 //#define __KERNEL__
 //#include <linux/kernel.h>

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -38,10 +38,11 @@
  * [1] Portions of this software were developed by Allan Jude
  *     under sponsorship from the FreeBSD Foundation.
  */
-
-#include <sys/param.h>
-#include <sys/sysmacros.h>
-#include <sys/zfs_context.h>
+//#define MODULE
+//#undef __KERNEL__
+//#include <sys/param.h>
+//#include <sys/sysmacros.h>
+///#include <sys/zfs_context.h>
 #include <sys/zio_compress.h>
 #include <sys/spa.h>
 #include <sys/zstd/zstd.h>
@@ -49,6 +50,34 @@
 #define	ZSTD_STATIC_LINKING_ONLY
 #include "lib/zstd.h"
 #include "lib/zstd_errors.h"
+//#include <linux/printk.h>
+
+//#define __KERNEL__
+#include <sys/debug.h>
+#include <sys/sysmacros.h>
+
+
+extern	int printk(const char *fmt, ...);
+#ifdef __KERNEL__
+#define aprint printk
+#else
+#define aprint(...) printf(__VA_ARGS__)
+#endif
+
+//#define __KERNEL__
+//#include <linux/kernel.h>
+//#include <linux/module.h>
+//#include <linux/fs.h>
+//#include <asm/uaccess.h> // for put_user //
+//#include <linux/ioport.h>
+
+////#include <linux/tracepoint.h>
+////#include "linux/kernel.h"
+//#include <linux/kernel.h>
+//#include <sys/klog.h>
+//#include <sys/zfs_debug.h>
+//#include <linux/module.h>
+//#include <linux/kernel.h>
 
 kstat_t *zstd_ksp = NULL;
 
@@ -407,10 +436,128 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 	ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0);
 	ZSTD_CCtx_setParameter(cctx, ZSTD_c_contentSizeFlag, 0);
 
+#if 0
 	c_len = ZSTD_compress2(cctx,
 	    hdr->data,
 	    d_len - sizeof (*hdr),
 	    s_start, s_len);
+#else
+
+	#if 0
+	ZSTD_outBuffer output = {hdr->data, d_len - sizeof(*hdr), 0};
+	for (;;)
+	{
+		/* read loop */
+		ZSTD_inBuffer input = {s_start, s_len, 0};
+		int const finalChunkIn = 1;
+		//ZSTD_EndDirective const flushmode = finalChunkIn ? ZSTD_e_end : ZSTD_e_continue;
+		int finishedWrite = 0;
+		do {
+			/* write loop */
+			size_t status = ZSTD_compressStream(cctx, &output, &input/*, flushmode*/);
+			if (ZSTD_isError(status))
+			{
+				c_len = status;
+				finishedWrite = 1;
+			}
+			else if (finalChunkIn)
+			{
+				size_t const remainingToWrite = ZSTD_endStream(cctx, &output);
+				if (remainingToWrite != 0)
+				{
+					// frame not flushed, ran out of write space?
+					c_len = ZSTD_error_dstSize_tooSmall;
+				}
+				else
+				{
+					c_len = output.pos;
+				}
+				finishedWrite = 1;
+			}
+			/*
+			finishedWrite = ZSTD_isError(remaining) || (output.pos == output.size) || (finalChunkIn ? (remaining == 0) : (input.pos == input.size));
+			int const outputLimitReached = output.pos == output.size;
+			if (outputLimitReached)
+			{
+				remaining = ZSTD_error_dstSize_tooSmall;
+			}
+			if (ZSTD_isError(remaining))
+			{
+				c_len = remaining;
+			}
+			else
+			{
+				c_len = output.pos;
+			}
+			*/
+		} while (!finishedWrite);
+		//ASSERT3U(input.pos, ==, input.size);
+		if (finalChunkIn)
+		{
+				break;
+		}
+	}
+	#else
+
+	size_t compressedSize = /*hack*/ (size_t)-ZSTD_error_GENERIC;
+	{
+		//aprint("HERE WE GOOOOO");
+		ZSTD_outBuffer outBuff = {hdr->data, d_len - sizeof(*hdr), 0};
+		ZSTD_inBuffer inBuff = {s_start, s_len, 0};
+		size_t status = ZSTD_compressStream(cctx, &outBuff, &inBuff);
+		if (ZSTD_isError(status))
+		{
+			compressedSize = status;
+			aprint("status was error: %s", ZSTD_getErrorName(status));
+			goto badc;
+		}
+		
+		int flushpass=1;
+		for(int i=0;i<1;++i)
+		//for (;;)
+		{
+			size_t const remaining = ZSTD_endStream(cctx, &outBuff); // have to keep calling this until remaining == error or 0
+			if (ZSTD_isError(remaining))
+			{
+				compressedSize = remaining;
+				aprint("status was error2: %s", ZSTD_getErrorName(remaining));
+				goto badc;
+			}
+			aprint("input remaining was: %zu", remaining);
+			if (remaining == 0)
+			{
+				aprint("done; none remaining");
+				if (inBuff.pos != inBuff.size)
+				{
+					aprint("WHUT!!!!!  none remaining but input not consumed?");
+				}
+				ASSERT3U(inBuff.pos, ==, inBuff.size);
+				break; // really done
+			}
+			if (outBuff.pos == outBuff.size)
+			{
+				compressedSize = /*hack*/ (size_t)-ZSTD_error_dstSize_tooSmall;
+				aprint("done(output full, input remains); outpos==outsize");
+				goto badc; // ?
+			}
+			if (inBuff.pos == inBuff.size)
+			{
+				aprint("done; inpos==insize");
+				aprint("WHUT!!!!!  but remaining > 0....?");
+				ASSERT3U(remaining, ==, 0);
+				break; // ?
+			}
+			aprint("finished flushpass#%d", flushpass++);
+		}
+
+		compressedSize = outBuff.pos;
+	}
+badc:
+	aprint("compressedSize: %zu (iserr?%d - %s)", compressedSize, ZSTD_isError(compressedSize), ZSTD_getErrorName(compressedSize));
+	c_len = compressedSize;
+
+#endif
+#endif
 
 	ZSTD_freeCCtx(cctx);
 
@@ -421,8 +568,14 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 		 * too small, that is not a failure. Everything else is a
 		 * failure, so increment the compression failure counter.
 		 */
-		if (ZSTD_getErrorCode(c_len) != ZSTD_error_dstSize_tooSmall) {
+		if (ZSTD_getErrorCode(c_len) != ZSTD_error_dstSize_tooSmall)
+		{
+			aprint("ERROR... ending");
 			ZSTDSTAT_BUMP(zstd_stat_com_fail);
+		}
+		else
+		{
+			aprint("(dest was too small?)... ending");
 		}
 		return (s_len);
 	}

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -63,8 +63,8 @@ extern	int printk(const char *fmt, ...);
 #else
 #define aprint(...) printf(__VA_ARGS__)
 #endif
-#define XASSERT3(L,C,R) do{const intptr_t lll=(intptr_t)(L); const intptr_t rrr=(intptr_t)(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s:%s %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
-#define XASSERT3U XASSERT
+#define XASSERT3(L,C,R) do{const intptr_t lll=(intptr_t)(L); const intptr_t rrr=(intptr_t)(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s:%d %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3U XASSERT3
 // ^ bleh, fixme
 
 //#define __KERNEL__

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -63,7 +63,7 @@ extern	int printk(const char *fmt, ...);
 #else
 #define aprint(...) printf(__VA_ARGS__)
 #endif
-#define XASSERT3(L,C,R) do{const intptr_t lll=(intptr_t)(L); const intptr_t rrr=(intptr_t)(R); if(!(lll C rrr))aprint("ADAM ASSERT FAILURE: %s:%s:%d %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
+#define XASSERT3(L,C,R) do{const intptr_t lll=(intptr_t)(L); const intptr_t rrr=(intptr_t)(R); if(unlikely(!(lll C rrr)))aprint("ADAM ASSERT FAILURE: %s:%s:%d %s(%lld) %s %s(%lld) failed", __FILE__, __FUNCTION__, __LINE__, #L, (long long int)lll, #C, #R, (long long int)rrr);}while(0)
 #define XASSERT3U XASSERT3
 // ^ bleh, fixme
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

The code on this PR needs a bunch of refactoring and style-fixes but I believe it's safe and would like some wider testing from the brave.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There are two issues with ZSTD in ZFS with were bothering me greatly, at least on my i5-2400 system:
1. Write throughput could be agonising, especially at high (zstd-5..zstd-9+) compression levels and smaller recordsizes
2. Mostly orthogonal to the above throughput problems, interactive performance of the system goes to hell when writing ZSTD-compressed data, especially with large recordsize and high compression levels

### Description
<!--- Describe your changes in detail -->
To address write throughput, I recycle+reset ZSTD cctx objects (not just their underlying memory, which the master code does already), which allows partial-reinitialization; fully initializing these objects can become a huge overhead (i.e. ~50% of the entire CPU cost at high compression levels and low block sizes!).  Then I applied the same optimization to decompression, though the overhead/benefit is much smaller there - still measurable.

To address interactive performance, I use the ZSTD streaming API to efficiently consume an arbitrary fixed amount of the input data at a time (currently hardcoded at 4K), yielding between each 'gulp'.  (Did you know that although Linux has supported a fully-preemptible kernel for many years, no major distribution ships kernels that way?  Sigh.  So `cond_sched()` to the rescue.)  I did not apply the same optimization to decompression since I couldn't really measure decompression of recordsizes<=1M being an appreciable issue for interactive performance.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

ZTS and lots of local data shunting.

A custom clumsy tool for measuring how long a usermode task gets descheduled for, for trying to quantify interactive performance.

Various duct-taped benchmarks copying data of various compressibility to and from datasets with varying recordsizes and compression levels (mostly zstd-3, zstd-8, zstd-19).

Preliminary results indicate ~100%-250%+ disk->userspace->disk zstd write throughput when cpu-bound, especially with smallish recordsizes and largeish compression levels, but it looks like there are wins across the board and no apparent speed regressions.  Similarly, around 100-120% zstd read throughput (ARC->userspace) with no apparently speed regressions, though gains are generally modest.

Interactivity during compression is distinctly better though I still wish it was perfect (still time spikes on the order of 1-10ms, but before the change it was often easily on the order of 10ms-100ms+, so...).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
