### PR TITLE
Allow zfs to send replication streams with missing snapshots

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4378,6 +4378,7 @@ zfs_do_send(int argc, char **argv)
 
 	struct option long_options[] = {
 		{"replicate",	no_argument,		NULL, 'R'},
+		{"skip-missing",	no_argument,		NULL, 's'},
 		{"redact",	required_argument,	NULL, 'd'},
 		{"props",	no_argument,		NULL, 'p'},
 		{"parsable",	no_argument,		NULL, 'P'},
@@ -4396,7 +4397,7 @@ zfs_do_send(int argc, char **argv)
 	};
 
 	/* check options */
-	while ((c = getopt_long(argc, argv, ":i:I:RDpvnPLeht:cwbd:S",
+	while ((c = getopt_long(argc, argv, ":i:I:RsDpvnPLeht:cwbd:S",
 	    long_options, NULL)) != -1) {
 		switch (c) {
 		case 'i':
@@ -4412,6 +4413,9 @@ zfs_do_send(int argc, char **argv)
 			break;
 		case 'R':
 			flags.replicate = B_TRUE;
+			break;
+		case 's':
+			flags.skipmissing = B_TRUE;
 			break;
 		case 'd':
 			redactbook = optarg;
@@ -4575,6 +4579,13 @@ zfs_do_send(int argc, char **argv)
 	} else if (resume_token != NULL) {
 		return (zfs_send_resume(g_zfs, &flags, STDOUT_FILENO,
 		    resume_token));
+	}
+
+	if (flags.skipmissing && !flags.replicate) {
+		(void) fprintf(stderr,
+		    gettext("skip-missing flag can only be used in "
+		    "conjunction with replicate\n"));
+		usage(B_FALSE);
 	}
 
 	/*

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -666,6 +666,9 @@ typedef struct sendflags {
 	/* recursive send  (ie, -R) */
 	boolean_t replicate;
 
+	/* for recursive send, skip sending missing snapshots */
+	boolean_t skipmissing;
+
 	/* for incrementals, do all intermediate snapshots */
 	boolean_t doall;
 

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -39,12 +39,12 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm send
-.Op Fl DLPRbcehnpvw
+.Op Fl DLPRsbcehnpvw
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Nm zfs
 .Cm send
-.Op Fl DLPRcenpvw
+.Op Fl DLPRscenpvw
 .Op Fl i Ar snapshot Ns | Ns Ar bookmark
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Nm zfs
@@ -139,6 +139,12 @@ do not exist on the sending side are destroyed. If the
 flag is used to send encrypted datasets, then
 .Fl w
 must also be specified.
+.It Fl s, -skip-missing
+Allows sending a replication stream even when there are snapshots missing in the
+hierarchy. When a snapshot is missing, instead of throwing an error and aborting
+the send, a warning is printed to STDERR and the dataset to which it belongs
+and its descendents are skipped. This flag can only be used in conjunction with
+.Fl R .
 .It Fl e, -embed
 Generate a more compact stream by using
 .Sy WRITE_EMBEDDED

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -254,7 +254,7 @@ tags = ['functional', 'cli_root', 'zfs_rollback']
 tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
     'zfs_send_004_neg', 'zfs_send_005_pos', 'zfs_send_006_pos',
     'zfs_send_007_pos', 'zfs_send_encrypted', 'zfs_send_raw',
-    'zfs_send_sparse', 'zfs_send-b']
+    'zfs_send_sparse', 'zfs_send-b', 'zfs_send_skip_missing']
 tags = ['functional', 'cli_root', 'zfs_send']
 
 [tests/functional/cli_root/zfs_set]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
@@ -13,7 +13,8 @@ dist_pkgdata_SCRIPTS = \
 	zfs_send_encrypted_unloaded.ksh \
 	zfs_send_raw.ksh \
 	zfs_send_sparse.ksh \
-	zfs_send-b.ksh
+	zfs_send-b.ksh \
+	zfs_send_skip_missing.ksh
 
 dist_pkgdata_DATA = \
 	zfs_send.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_skip_missing.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_skip_missing.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2016, loli10K. All rights reserved.
+# Copyright (c) 2021, Pablo Correa Gómez. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/cli_root/cli_common.kshlib
+. $STF_SUITE/tests/functional/cli_root/zfs_send/zfs_send.cfg
+
+#
+# DESCRIPTION:
+#	Verify 'zfs send' will avoid sending replication send
+#	streams when we're missing snapshots in the dataset
+#	hierarchy, unless -s|--skip-missing provided
+#
+# STRATEGY:
+#	1. Create a parent and child fs and then only snapshot the parent
+#	2. Verify sending with replication will fail
+#	3. Verify sending with skip-missing will print a warning but succeed
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	snapexists $SNAP && log_must zfs destroy -f $SNAP
+
+	datasetexists $PARENT && log_must zfs destroy -rf $PARENT
+
+	[[ -e $WARNF ]] && log_must rm -f $WARNF
+	rm -f $TEST_BASE_DIR/devnull
+}
+
+log_assert "Verify 'zfs send -Rs' works as expected."
+log_onexit cleanup
+
+PARENT=$TESTPOOL/parent
+CHILD=$PARENT/child
+SNAP=$PARENT@snap
+WARNF=$TEST_BASE_DIR/warn.2
+
+log_note "Verify 'zfs send -R' fails to generate replication stream"\
+	 " for datasets created before"
+
+log_must zfs create $PARENT
+log_must zfs create $CHILD
+log_must zfs snapshot $SNAP
+log_mustnot eval "zfs send -R $SNAP >$TEST_BASE_DIR/devnull"
+
+log_note "Verify 'zfs send -Rs' warns about missing snapshots, "\
+	 "but still succeeds"
+
+log_must eval "zfs send -Rs $SNAP 2> $WARNF >$TEST_BASE_DIR/devnull"
+log_must eval "[[ -s $WARNF ]]"
+
+log_pass "Verify 'zfs send -Rs' works as expected."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A similar change was proposed previously in #5285 by @loli10K. In the pull request, it was discussed that the integration of OpenZFS 6111 ([6635624](https://github.com/openzfs/zfs/commit/6635624020506a76cb79c65c7ff5a580c4685a0b)) reduced the utility of sending replication streams. If there are any datasets in the hierarchy which are not snapshoted, a replication send of any parent will fail due to the missing snapshots. The rationale for that decision is to avoid administrators to think that they've sent all the data when in reality that is not the case. According to #5285, the right way to do this would be to add an extra flag (I chose ~~-f|--force~~ --skip-missing|-s) which modifies that behavior for administrators which request it.

Also, this is my first contribution to the OpenZFS project, so I apologize for any possible newbie mistakes. ~~I have not added documentation on purpose, because I would like to be sure that the ideas here make sense before putting extra effort into it.~~

### Description
<!--- Describe your changes in detail -->
This patch adds an extra option (`--skip-missing|-s`) to `zfs send`. The skip flag can only be used in conjunction with `-R`. In the regular replication behavior, if zfs encounters a dataset without the corresponding snapshot and that was created before the parent snapshot, then an error will occur and the send will be aborted. This MR modifies that behavior, so that if skip flag is also provided, then the dataset and its children will be ignored. Instead of an error, a warning text will be written to stderr and the send will continue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
One small test has been added to the testsuite, which I could extend if required and some local testing worked without issues. ~~I have not done any further tests in a real system, but I could also possibly do if needed.~~ I have placed the test under `functional/cli_root/zfs_send` because it is just a small feature... But I hesitated whether it would fit best under `functional/rsend` with a bit extra testing. Any suggestions?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
