### PR TITLE
FreeBSD: Clean up zfsdev_close to match Linux

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -525,7 +525,6 @@ typedef struct zfs_useracct {
 } zfs_useracct_t;
 
 #define	ZFSDEV_MAX_MINOR	(1 << 16)
-#define	ZFS_MIN_MINOR	(ZFSDEV_MAX_MINOR + 1)
 
 #define	ZPOOL_EXPORT_AFTER_SPLIT 0x1
 

--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -182,17 +182,11 @@ out:
 static void
 zfsdev_close(void *data)
 {
-	zfsdev_state_t *zs, *zsp = data;
+	zfsdev_state_t *zs = data;
+
+	ASSERT(zs != NULL);
 
 	mutex_enter(&zfsdev_state_lock);
-	for (zs = zfsdev_state_list; zs != NULL; zs = zs->zs_next) {
-		if (zs == zsp)
-			break;
-	}
-	if (zs == NULL || zs->zs_minor <= 0) {
-		mutex_exit(&zfsdev_state_lock);
-		return;
-	}
 	zs->zs_minor = -1;
 	zfs_onexit_destroy(zs->zs_onexit);
 	zfs_zevent_destroy(zs->zs_zevent);

--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -193,9 +193,10 @@ zfsdev_close(void *data)
 	zs->zs_minor = -1;
 	zfs_onexit_destroy(zs->zs_onexit);
 	zfs_zevent_destroy(zs->zs_zevent);
-	mutex_exit(&zfsdev_state_lock);
 	zs->zs_onexit = NULL;
 	zs->zs_zevent = NULL;
+
+	mutex_exit(&zfsdev_state_lock);
 }
 
 static int

--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -187,6 +187,9 @@ zfsdev_close(void *data)
 	ASSERT(zs != NULL);
 
 	mutex_enter(&zfsdev_state_lock);
+
+	ASSERT(zs->zs_minor != 0);
+
 	zs->zs_minor = -1;
 	zfs_onexit_destroy(zs->zs_onexit);
 	zfs_zevent_destroy(zs->zs_zevent);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We received reports of panics in zfs_onexit_destroy() caused by it being called with a NULL zs_onexit pointer.  Upon investigation I discovered oddities in zfsdev_close() that were not present in the equivalent function for Linux.

When opening /dev/zfs, FreeBSD invokes zfsdev_open(), which takes zfsdev_state_lock around a call to zfs_ctldev_init(). Here we allocate a unique minor number and find a free state object in the global state list or allocate a new one if all existing objects are in use. We assign the state to the per-open filedescriptor data along with the destructor zfsdev_close(). This ensures zfsdev_close() is called when the last reference to the descriptor is dropped.

In zfsdev_close(), we receive the pointer to our state and take zfsdev_state_lock.  It should be safe to assume this points to a valid state, as we are guaranteed to be called exactly once for this descriptor data and nothing else should be reusing the same state. This is where the existing code went off into the weeds. We tried to find the state object in the global state list to verify the state we have actually exists, which it surely must for us to be here. If we did find our state in the list, it was further validated by looking for a sentinel value in zs_minor to check if it had already been destructed, which it surely hasn't (if the code is correct) because we haven't done that yet. Neither of these checks are performed on Linux.

Now we actually invalidate the state and, still under zfsdev_state_lock, begin to destroy it. Then the lock is released, and the rest of the state is nulled out. Because we are not protected by the lock at this point, another open may have claimed this state before we finished nulling it, leading to the observed panic when the destructor is eventually called for that state. On Linux, the state is fully destroyed and nulled under the protection of the lock.

### Description
<!--- Describe your changes in detail -->
Eliminate the gratuitous checks.
Assert that we do not have an impossible value in zs_minor, for consistency with Linux.
Keep zfsdev_state_lock held until we have fully destroyed and nulled the state.
While looking at minor numbers I spotted an unused `#define ZFS_MIN_MINOR (ZFSDEV_MAX_MINOR + 1)`, and pruned it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Many rounds of ZTS, then a fixed module was provided to the reporter who reported back that so far they have been able to push the system much harder without encountering the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
