### PR TITLE
Fix whitespace introduced in ecc277cff

### DIFF
--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -261,15 +261,15 @@ causes the property to be inherited by all descendant datasets, as through
 was run on any descendant datasets that have this property set on the
 sending system.
 .Pp
-If the send stream was sent with 
+If the send stream was sent with
 .Fl c
-then overriding the 
-.Sy compression 
-property will have no affect on received data but the  
+then overriding the
 .Sy compression
-property will be set. To have the data recompressed on receive remove the 
-.Fl c 
-flag from the send stream.  
+property will have no affect on received data but the
+.Sy compression
+property will be set. To have the data recompressed on receive remove the
+.Fl c
+flag from the send stream.
 .Pp
 Any editable property can be set at receive time. Set-once properties bound
 to the received data, such as

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -189,12 +189,12 @@ feature is enabled on the sending system but the
 option is not supplied in conjunction with
 .Fl c ,
 then the data will be decompressed before sending so it can be split into
-smaller block sizes. Streams sent with 
+smaller block sizes. Streams sent with
 .Fl c
 will not have their data recompressed on the receiver side using
 .Fl o compress=value.
 The data will stay compressed as it was from the sender. The new compression
-property will be set for future data. 
+property will be set for future data.
 .It Fl w, -raw
 For encrypted datasets, send data exactly as it exists on disk. This allows
 backups to be taken even if encryption keys are not currently loaded. The


### PR DESCRIPTION
### Motivation and Context
Style conformity

### Description
The manual page change in ecc277cff has introduced whitespace on line ends.

### How Has This Been Tested?
Documentation change only, no testing required

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
