### PR TITLE
ICP: Add missing stack frame info to SHA asm files

### DIFF
--- a/module/icp/asm-x86_64/sha1/sha1-x86_64.S
+++ b/module/icp/asm-x86_64/sha1/sha1-x86_64.S
@@ -69,16 +69,27 @@ sha1_block_data_order(SHA1_CTX *ctx, const void *inpp, size_t blocks)
 #define _ASM
 #include <sys/asm_linkage.h>
 ENTRY_NP(sha1_block_data_order)
-	push	%rbx
-	push	%rbp
-	push	%r12
+.cfi_startproc
 	mov	%rsp,%rax
+.cfi_def_cfa_register %rax
+	push	%rbx
+.cfi_offset	%rbx,-16
+	push	%rbp
+.cfi_offset	%rbp,-24
+	push	%r12
+.cfi_offset	%r12,-32
 	mov	%rdi,%r8	# reassigned argument
+.cfi_register	%rdi, %r8
 	sub	$72,%rsp
 	mov	%rsi,%r9	# reassigned argument
+.cfi_register	%rsi, %r9
 	and	$-64,%rsp
 	mov	%rdx,%r10	# reassigned argument
+.cfi_register	%rdx, %r10
 	mov	%rax,64(%rsp)
+# echo ".cfi_cfa_expression %rsp+64,deref,+8" |
+#	openssl/crypto/perlasm/x86_64-xlate.pl
+.cfi_escape	0x0f,0x06,0x77,0xc0,0x00,0x06,0x23,0x08
 
 	mov	0(%r8),%edx
 	mov	4(%r8),%esi
@@ -1337,10 +1348,15 @@ ENTRY_NP(sha1_block_data_order)
 	sub	$1,%r10
 	jnz	.Lloop
 	mov	64(%rsp),%rsp
-	pop	%r12
-	pop	%rbp
-	pop	%rbx
+.cfi_def_cfa	%rsp,8
+	movq	-24(%rsp),%r12
+.cfi_restore	%r12
+	movq	-16(%rsp),%rbp
+.cfi_restore	%rbp
+	movq	-8(%rsp),%rbx
+.cfi_restore	%rbx
 	ret
+.cfi_endproc
 SET_SIZE(sha1_block_data_order)
 
 .data

--- a/module/icp/asm-x86_64/sha2/sha256_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha256_impl.S
@@ -83,12 +83,21 @@ SHA256TransformBlocks(SHA2_CTX *ctx, const void *in, size_t num)
 #include <sys/asm_linkage.h>
 
 ENTRY_NP(SHA256TransformBlocks)
+.cfi_startproc
+	movq	%rsp, %rax
+.cfi_def_cfa_register %rax
 	push	%rbx
+.cfi_offset	%rbx,-16
 	push	%rbp
+.cfi_offset	%rbp,-24
 	push	%r12
+.cfi_offset	%r12,-32
 	push	%r13
+.cfi_offset	%r13,-40
 	push	%r14
+.cfi_offset	%r14,-48
 	push	%r15
+.cfi_offset	%r15,-56
 	mov	%rsp,%rbp		# copy %rsp
 	shl	$4,%rdx		# num*16
 	sub	$16*4+4*8,%rsp
@@ -99,6 +108,9 @@ ENTRY_NP(SHA256TransformBlocks)
 	mov	%rsi,16*4+1*8(%rsp)		# save inp, 2nd arg
 	mov	%rdx,16*4+2*8(%rsp)		# save end pointer, "3rd" arg
 	mov	%rbp,16*4+3*8(%rsp)		# save copy of %rsp
+# echo ".cfi_cfa_expression %rsp+88,deref,+56" |
+#	openssl/crypto/perlasm/x86_64-xlate.pl
+.cfi_escape	0x0f,0x06,0x77,0xd8,0x00,0x06,0x23,0x38
 
 	#.picmeup %rbp
 	# The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
@@ -2026,14 +2038,28 @@ ENTRY_NP(SHA256TransformBlocks)
 	jb	.Lloop
 
 	mov	16*4+3*8(%rsp),%rsp
+.cfi_def_cfa	%rsp,56
 	pop	%r15
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r15
 	pop	%r14
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r14
 	pop	%r13
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r13
 	pop	%r12
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r12
 	pop	%rbp
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%rbp
 	pop	%rbx
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%rbx
 
 	ret
+.cfi_endproc
 SET_SIZE(SHA256TransformBlocks)
 
 .data

--- a/module/icp/asm-x86_64/sha2/sha512_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha512_impl.S
@@ -84,12 +84,21 @@ SHA512TransformBlocks(SHA2_CTX *ctx, const void *in, size_t num)
 #include <sys/asm_linkage.h>
 
 ENTRY_NP(SHA512TransformBlocks)
+.cfi_startproc
+	movq	%rsp, %rax
+.cfi_def_cfa_register %rax
 	push	%rbx
+.cfi_offset	%rbx,-16
 	push	%rbp
+.cfi_offset	%rbp,-24
 	push	%r12
+.cfi_offset	%r12,-32
 	push	%r13
+.cfi_offset	%r13,-40
 	push	%r14
+.cfi_offset	%r14,-48
 	push	%r15
+.cfi_offset	%r15,-56
 	mov	%rsp,%rbp		# copy %rsp
 	shl	$4,%rdx		# num*16
 	sub	$16*8+4*8,%rsp
@@ -100,6 +109,9 @@ ENTRY_NP(SHA512TransformBlocks)
 	mov	%rsi,16*8+1*8(%rsp)		# save inp, 2nd arg
 	mov	%rdx,16*8+2*8(%rsp)		# save end pointer, "3rd" arg
 	mov	%rbp,16*8+3*8(%rsp)		# save copy of %rsp
+# echo ".cfi_cfa_expression %rsp+152,deref,+56" |
+#	openssl/crypto/perlasm/x86_64-xlate.pl
+.cfi_escape	0x0f,0x06,0x77,0x98,0x01,0x06,0x23,0x38
 
 	#.picmeup %rbp
 	# The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
@@ -2027,14 +2039,28 @@ ENTRY_NP(SHA512TransformBlocks)
 	jb	.Lloop
 
 	mov	16*8+3*8(%rsp),%rsp
+.cfi_def_cfa	%rsp,56
 	pop	%r15
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r15
 	pop	%r14
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r14
 	pop	%r13
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r13
 	pop	%r12
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%r12
 	pop	%rbp
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%rbp
 	pop	%rbx
+.cfi_adjust_cfa_offset -8
+.cfi_restore	%rbx
 
 	ret
+.cfi_endproc
 SET_SIZE(SHA512TransformBlocks)
 
 .data


### PR DESCRIPTION
### Motivation and Context
Since the assembly routines calculating SHA checksums don't use a standard stack layout, CFI directives are needed to unroll the
stack.

### Description
Add the needed directives.

### How Has This Been Tested?
Just a local build.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
