### PR TITLE
When specifying raidz vdev name, parity count should match

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2675,13 +2675,15 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 			 * specified, make sure it matches.
 			 */
 			int rzlen = strlen(VDEV_TYPE_RAIDZ);
+			assert(rzlen == strlen(VDEV_TYPE_DRAID));
 			int typlen = strlen(type);
-			if (strncmp(type, VDEV_TYPE_RAIDZ, rzlen) == 0 &&
+			if ((strncmp(type, VDEV_TYPE_RAIDZ, rzlen) == 0 ||
+			    strncmp(type, VDEV_TYPE_DRAID, rzlen) == 0) &&
 			    typlen != rzlen) {
 				uint64_t vdev_parity;
 				int parity = *(type + rzlen) - '0';
 
-				if (parity < 0 || parity > 3 ||
+				if (parity <= 0 || parity > 3 ||
 				    (typlen - rzlen) != 1) {
 					/*
 					 * Nonsense parity specified, can

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2670,6 +2670,34 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 			errno = 0;
 			vdev_id = strtoull(idx, &end, 10);
 
+			/*
+			 * If we are looking for a raidz and a parity is
+			 * specified, make sure it matches.
+			 */
+			int rzlen = strlen(VDEV_TYPE_RAIDZ);
+			int typlen = strlen(type);
+			if (strncmp(type, VDEV_TYPE_RAIDZ, rzlen) == 0 &&
+			    typlen != rzlen) {
+				uint64_t vdev_parity;
+				int parity = *(type + rzlen) - '0';
+
+				if (parity < 0 || parity > 3 ||
+				    (typlen - rzlen) != 1) {
+					/*
+					 * Nonsense parity specified, can
+					 * never match
+					 */
+					free(type);
+					return (NULL);
+				}
+				verify(nvlist_lookup_uint64(nv,
+				    ZPOOL_CONFIG_NPARITY, &vdev_parity) == 0);
+				if ((int)vdev_parity != parity) {
+					free(type);
+					break;
+				}
+			}
+
 			free(type);
 			if (errno != 0)
 				return (NULL);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When specifying the name of a RAIDZ vdev on the command line, it can be
specified as `raidz-<vdevID>` or `raidzP-<vdevID>`.
e.g. `zpool clear poolname raidz-0` or `zpool clear poolname raidz2-0`

### Description
<!--- Describe your changes in detail -->
If the parity is specified in the vdev name, it should match the actual
parity of that RAIDZ vdev, otherwise the command should fail.  This
commit makes it so.

cc @stuartmaybee @fuporovvStack

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
manual testing:

```
$ zpool status
  pool: test
 state: ONLINE
config:

	NAME                  STATE     READ WRITE CKSUM
	test                  ONLINE       0     0     0
	  raidz3-0            ONLINE       0     0     0
	    /var/tmp/vdevs/a  ONLINE       0     0     0
	    /var/tmp/vdevs/b  ONLINE       0     0     0
	    /var/tmp/vdevs/c  ONLINE       0     0     0
	    /var/tmp/vdevs/d  ONLINE       0     0     0
	    /var/tmp/vdevs/e  ONLINE       0     0     0
	    /var/tmp/vdevs/f  ONLINE       0     0     0
	    /var/tmp/vdevs/g  ONLINE       0     0     0

$ sudo zpool clear test raidz1-0
cannot clear errors for raidz1-0: no such device in pool
$ sudo zpool clear test raidz3-0
$ sudo zpool clear test raidz-0
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
