### PR TITLE
reference_tracking_enable should be a module param

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1,6 +1,6 @@
 '\" te
 .\" Copyright (c) 2013 by Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
-.\" Copyright (c) 2019, 2020 by Delphix. All rights reserved.
+.\" Copyright (c) 2019, 2021 by Delphix. All rights reserved.
 .\" Copyright (c) 2019 Datto Inc.
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
@@ -689,6 +689,29 @@ milliseconds and \fBmetaslab_unload_delay\fR txgs must pass before unloading
 will occur.
 .sp
 Default value: \fB600000\fR (ten minutes).
+.RE
+
+.sp
+.ne 2
+.na
+\fBreference_history\fR (int)
+.ad
+.RS 12n
+Maximum reference holders being tracked when reference_tracking_enable is
+active.
+.sp
+Default value: \fB3\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBreference_tracking_enable\fR (int)
+.ad
+.RS 12n
+Track reference holders to refcount_t objects (debug builds only).
+.sp
+Use \fB1\fR for yes and \fB0\fR for no (default).
 .RE
 
 .sp

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -407,12 +407,6 @@ SYSCTL_INT(_vfs_zfs_metaslab, OID_AUTO, preload_limit, CTLFLAG_RWTUN,
     &metaslab_preload_limit, 0,
     "Max number of metaslabs per group to preload");
 
-/* refcount.c */
-extern int reference_tracking_enable;
-SYSCTL_INT(_vfs_zfs, OID_AUTO, reference_tracking_enable, CTLFLAG_RDTUN,
-    &reference_tracking_enable, 0,
-    "Track reference holders to refcount_t objects, used mostly by ZFS");
-
 /* spa.c */
 extern int zfs_ccw_retry_interval;
 SYSCTL_INT(_vfs_zfs, OID_AUTO, ccw_retry_interval, CTLFLAG_RWTUN,

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2021 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -324,4 +324,12 @@ zfs_refcount_not_held(zfs_refcount_t *rc, const void *holder)
 	mutex_exit(&rc->rc_mtx);
 	return (B_TRUE);
 }
+
+/* BEGIN CSTYLED */
+ZFS_MODULE_PARAM(zfs, ,reference_tracking_enable, INT, ZMOD_RW,
+	"Track reference holders to refcount_t objects");
+
+ZFS_MODULE_PARAM(zfs, ,reference_history, INT, ZMOD_RW,
+	"Maximum reference holders being tracked");
+/* END CSTYLED */
 #endif	/* ZFS_DEBUG */


### PR DESCRIPTION
### Motivation and Context
To make use of `zfs_refcount_held` tunable it should be a module parameter in open-zfs.

### Description
Added `ZFS_MODULE_PARAM` macros.
Also, since the macros will auto-generate OS specific tunables, removed the existing `zfs_refcount_held` reference in `module/os/freebsd/zfs/sysctl_os.c`

### How Has This Been Tested?
Confirmed that `reference_tracking_enable` parameter is available when running a debug zfs module.

With `reference_tracking_enable` set to 1, ran ZTS for functional/cli_root/{zfs_receive, zfs_send}

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
