### PR TITLE
Fix typo in Python method name

### DIFF
--- a/contrib/pyzfs/libzfs_core/test/test_libzfs_core.py
+++ b/contrib/pyzfs/libzfs_core/test/test_libzfs_core.py
@@ -1062,7 +1062,7 @@ class ZFSTest(unittest.TestCase):
         lzc.lzc_bookmark({})
 
     @skipUnlessBookmarksSupported
-    def test_bookmarks_foregin_source(self):
+    def test_bookmarks_foreign_source(self):
         snaps = [ZFSTest.pool.makeName(b'fs1@snap1')]
         bmarks = [ZFSTest.pool.makeName(b'fs2#bmark1')]
         bmark_dict = {x: y for x, y in zip(bmarks, snaps)}


### PR DESCRIPTION
Thanks a lot for your work.

This is just a stupid patch to fix a Python method name.
I separated this from the typos one, just because this is a tiny piece of code, so I prefer to keep it separated.

It passed the usual "make -j && make checkstyle && make lint"