### PR TITLE
zed: infanticide fixes

### DIFF
--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -173,6 +173,7 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 		zed_log_msg(LOG_WARNING, "Killing hung \"%s\" pid=%d",
 		    prog, pid);
 		(void) kill(pid, SIGKILL);
+		(void) waitpid(pid, &status, 0);
 	}
 }
 

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -234,8 +234,8 @@ Terminate the daemon.
 Events are processed synchronously by a single thread.  This can delay the
 processing of simultaneous zevents.
 .PP
-There is no maximum timeout for ZEDLET execution.  Consequently, a misbehaving
-ZEDLET can delay the processing of subsequent zevents.
+ZEDLETs are killed after a maximum of ten seconds.
+This can lead to a violation of a ZEDLET's atomicity assumptions.
 .PP
 The ownership and permissions of the \fIenabled-zedlets\fR directory (along
 with all parent directories) are not checked.  If any of these directories


### PR DESCRIPTION
### Motivation and Context
Confer #11769

### Description
`waitpid()` after the `kill()` and the other side of the zedlets-being-killed coin in the manpage

### How Has This Been Tested?
I added a big ole sleep to a zedlet and it didn't stick around

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
