### PR TITLE
fsck.zfs exit codes

### DIFF
--- a/cmd/fsck_zfs/.gitignore
+++ b/cmd/fsck_zfs/.gitignore
@@ -1,0 +1,1 @@
+/fsck.zfs

--- a/cmd/fsck_zfs/Makefile.am
+++ b/cmd/fsck_zfs/Makefile.am
@@ -1,1 +1,5 @@
+include $(top_srcdir)/config/Substfiles.am
+
 dist_sbin_SCRIPTS = fsck.zfs
+
+SUBSTFILES += $(dist_sbin_SCRIPTS)

--- a/cmd/fsck_zfs/fsck.zfs
+++ b/cmd/fsck_zfs/fsck.zfs
@@ -1,9 +1,0 @@
-#!/bin/sh
-#
-# fsck.zfs: A fsck helper to accommodate distributions that expect
-# to be able to execute a fsck on all filesystem types.  Currently
-# this script does nothing but it could be extended to act as a
-# compatibility wrapper for 'zpool scrub'.
-#
-
-exit 0

--- a/cmd/fsck_zfs/fsck.zfs.in
+++ b/cmd/fsck_zfs/fsck.zfs.in
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# fsck.zfs: A fsck helper to accommodate distributions that expect
+# to be able to execute a fsck on all filesystem types.
+#
+# This script simply bubbles up some already-known-about errors,
+# see fsck.zfs(8)
+#
+
+if [ "$#" = "0" ]; then
+	echo "Usage: $0 [options] dataset…" >&2
+	exit 16
+fi
+
+ret=0
+for dataset in "$@"; do
+	case "$dataset" in
+		-*)
+			continue
+			;;
+		*)
+			;;
+	esac
+
+	pool="${dataset%%/*}"
+
+	case "$(@sbindir@/zpool list -Ho health "$pool")" in
+		DEGRADED)
+			ret=$(( $ret | 4 ))
+			;;
+		FAULTED)
+			awk '!/^([[:space:]]*#.*)?$/ && $1 == "'"$dataset"'" && $3 == "zfs" {exit 1}' /etc/fstab || \
+				ret=$(( $ret | 8 ))
+			;;
+		"")
+			# Pool not found, error printed by zpool(8)
+			ret=$(( $ret | 8 ))
+			;;
+		*)
+			;;
+	esac
+done
+
+exit "$ret"

--- a/man/man8/fsck.zfs.8
+++ b/man/man8/fsck.zfs.8
@@ -22,24 +22,27 @@
 .\"
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
 .\"
-.TH FSCK.ZFS 8 "Aug 24, 2020" OpenZFS
+.TH FSCK.ZFS 8 "Mar 27, 2021" OpenZFS
 
 .SH NAME
 fsck.zfs \- Dummy ZFS filesystem checker.
 
 .SH SYNOPSIS
 .LP
-.BI "fsck.zfs [" "options" "] <" "dataset" ">"
+.BI "fsck.zfs [" "options" "] <" "dataset" ">…"
 
 .SH DESCRIPTION
 .LP
-\fBfsck.zfs\fR is a shell stub that does nothing and always returns
-true. It is installed by ZoL because some Linux distributions expect
-a fsck helper for all filesystems.
+\fBfsck.zfs\fR is a thin shell wrapper that at most checks the status of a
+dataset's container pool. It is installed by OpenZFS because some Linux
+distributions expect a fsck helper for all filesystems.
+.LP
+If more than one \fIdataset\fR is specified, each is checked in turn
+and results binary ored.
 
 .SH OPTIONS
 .HP
-All \fIoptions\fR and the \fIdataset\fR are ignored.
+All \fIoptions\fR are ignored.
 
 .SH "NOTES"
 .LP
@@ -47,14 +50,15 @@ ZFS datasets are checked by running \fBzpool scrub\fR on the
 containing pool. An individual ZFS dataset is never checked
 independently of its pool, which is unlike a regular filesystem.
 
-.SH "BUGS"
 .LP
-On some systems, if the \fIdataset\fR is in a degraded pool, then it
-might be appropriate for \fBfsck.zfs\fR to return exit code 4 to
-indicate an uncorrected filesystem error.
+However, the
+.BR fsck (8)
+interface still allows it to communicate some errors:
+if the \fIdataset\fR is in a degraded pool, then \fBfsck.zfs\fR will
+return exit code 4 to indicate an uncorrected filesystem error.
 .LP
 Similarly, if the \fIdataset\fR is in a faulted pool and has a legacy
-/etc/fstab record, then \fBfsck.zfs\fR should return exit code 8 to
+/etc/fstab record, then \fBfsck.zfs\fR will return exit code 8 to
 indicate a fatal operational error.
 
 .SH "AUTHORS"


### PR DESCRIPTION
### Motivation and Context
Well, the manpage suggested it and it's relatively trivial to do.

### Description
health=degraded => 4/"Filesystem errors left uncorrected"
health=faulted && dataset in /etc/fstab => 8/"Operational error"
pool not found => 8/"Operational error"
everything else => 0

### How Has This Been Tested?
I ran it a bunch, dunno

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
