### PR TITLE
Bump libzfs.so revision

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -43,9 +43,9 @@ deb-utils: deb-local rpm-utils-initramfs
 	pkg1=$${name}-$${version}.$${arch}.rpm; \
 	pkg2=libnvpair3-$${version}.$${arch}.rpm; \
 	pkg3=libuutil3-$${version}.$${arch}.rpm; \
-	pkg4=libzfs4-$${version}.$${arch}.rpm; \
-	pkg5=libzpool4-$${version}.$${arch}.rpm; \
-	pkg6=libzfs4-devel-$${version}.$${arch}.rpm; \
+	pkg4=libzfs5-$${version}.$${arch}.rpm; \
+	pkg5=libzpool5-$${version}.$${arch}.rpm; \
+	pkg6=libzfs5-devel-$${version}.$${arch}.rpm; \
 	pkg7=$${name}-test-$${version}.$${arch}.rpm; \
 	pkg8=$${name}-dracut-$${version}.noarch.rpm; \
 	pkg9=$${name}-initramfs-$${version}.$${arch}.rpm; \
@@ -56,7 +56,7 @@ deb-utils: deb-local rpm-utils-initramfs
 	path_prepend=`mktemp -d /tmp/intercept.XXXXXX`; \
 	echo "#$(SHELL)" > $${path_prepend}/dh_shlibdeps; \
 	echo "`which dh_shlibdeps` -- \
-	 -xlibuutil3linux -xlibnvpair3linux -xlibzfs4linux -xlibzpool4linux" \
+	 -xlibuutil3linux -xlibnvpair3linux -xlibzfs5linux -xlibzpool5linux" \
 	 >> $${path_prepend}/dh_shlibdeps; \
 ## These -x arguments are passed to dpkg-shlibdeps, which exclude the
 ## Debianized packages from the auto-generated dependencies of the new debs,

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -87,7 +87,7 @@ if BUILD_FREEBSD
 libzfs_la_LIBADD += -lutil -lgeom
 endif
 
-libzfs_la_LDFLAGS += -version-info 4:0:0
+libzfs_la_LDFLAGS += -version-info 5:0:1
 
 include $(top_srcdir)/config/CppCheck.am
 

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -230,7 +230,7 @@ if BUILD_FREEBSD
 libzpool_la_LIBADD += -lgeom
 endif
 
-libzpool_la_LDFLAGS += -version-info 4:0:0
+libzpool_la_LDFLAGS += -version-info 5:0:0
 
 if TARGET_CPU_POWERPC
 vdev_raidz_math_powerpc_altivec.$(OBJEXT): CFLAGS += -maltivec

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -120,10 +120,10 @@ License:        @ZFS_META_LICENSE@
 URL:            https://github.com/openzfs/zfs
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires:       libzpool4 = %{version}
+Requires:       libzpool5 = %{version}
 Requires:       libnvpair3 = %{version}
 Requires:       libuutil3 = %{version}
-Requires:       libzfs4 = %{version}
+Requires:       libzfs5 = %{version}
 Requires:       %{name}-kmod = %{version}
 Provides:       %{name}-kmod-common = %{version}
 Obsoletes:      spl
@@ -162,17 +162,17 @@ Requires:  sysstat
 %description
 This package contains the core ZFS command line utilities.
 
-%package -n libzpool4
+%package -n libzpool5
 Summary:        Native ZFS pool library for Linux
 Group:          System Environment/Kernel
 Obsoletes:      libzpool2
 
-%description -n libzpool4
+%description -n libzpool5
 This package contains the zpool library, which provides support
 for managing zpools
 
-%post -n libzpool4 -p /sbin/ldconfig
-%postun -n libzpool4 -p /sbin/ldconfig
+%post -n libzpool5 -p /sbin/ldconfig
+%postun -n libzpool5 -p /sbin/ldconfig
 
 %package -n libnvpair3
 Summary:        Solaris name-value library for Linux
@@ -207,31 +207,31 @@ This library provides a variety of compatibility functions for OpenZFS:
 %post -n libuutil3 -p /sbin/ldconfig
 %postun -n libuutil3 -p /sbin/ldconfig
 
-%package -n libzfs4
+%package -n libzfs5
 Summary:        Native ZFS filesystem library for Linux
 Group:          System Environment/Kernel
 Obsoletes:      libzfs2
 
-%description -n libzfs4
+%description -n libzfs5
 This package provides support for managing ZFS filesystems
 
-%post -n libzfs4 -p /sbin/ldconfig
-%postun -n libzfs4 -p /sbin/ldconfig
+%post -n libzfs5 -p /sbin/ldconfig
+%postun -n libzfs5 -p /sbin/ldconfig
 
-%package -n libzfs4-devel
+%package -n libzfs5-devel
 Summary:        Development headers
 Group:          System Environment/Kernel
-Requires:       libzfs4 = %{version}
-Requires:       libzpool4 = %{version}
+Requires:       libzfs5 = %{version}
+Requires:       libzpool5 = %{version}
 Requires:       libnvpair3 = %{version}
 Requires:       libuutil3 = %{version}
-Provides:       libzpool4-devel
+Provides:       libzpool5-devel
 Provides:       libnvpair3-devel
 Provides:       libuutil3-devel
 Obsoletes:      zfs-devel
 Obsoletes:      libzfs2-devel
 
-%description -n libzfs4-devel
+%description -n libzfs5-devel
 This package contains the header files needed for building additional
 applications against the ZFS libraries.
 
@@ -278,7 +278,7 @@ Summary:        Python %{python_version} wrapper for libzfs_core
 Group:          Development/Languages/Python
 License:        Apache-2.0
 BuildArch:      noarch
-Requires:       libzfs4 = %{version}
+Requires:       libzfs5 = %{version}
 Requires:       libnvpair3 = %{version}
 Requires:       libffi
 Requires:       python%{__python_pkg_version}
@@ -483,7 +483,7 @@ systemctl --system daemon-reload >/dev/null || true
 %{_datadir}/pam-configs/*
 %endif
 
-%files -n libzpool4
+%files -n libzpool5
 %{_libdir}/libzpool.so.*
 
 %files -n libnvpair3
@@ -492,10 +492,10 @@ systemctl --system daemon-reload >/dev/null || true
 %files -n libuutil3
 %{_libdir}/libuutil.so.*
 
-%files -n libzfs4
+%files -n libzfs5
 %{_libdir}/libzfs*.so.*
 
-%files -n libzfs4-devel
+%files -n libzfs5-devel
 %{_pkgconfigdir}/libzfs.pc
 %{_pkgconfigdir}/libzfsbootenv.pc
 %{_pkgconfigdir}/libzfs_core.pc


### PR DESCRIPTION
### Motivation and Context

Prior to releasing OpenZFS 2.1 it needs to be determined how we want to
bump the `libzfs.so` library version.  This change proposes just bumping the
library revision since the changes do not modify any existing interface.  The
OpenZFS 2.0 binaries can use the new library as a drop in replacement.

That said, there's a good argument to be made we should really be bumping
the version instead since the new features in 2.1 do require the updated library.
However, I'd like to avoid unnecessarily inflating the version if possible.

cc: @aerusso @rlaager 

### Description

The added functions and changes variables are used internally and
not part of the library interface.  Bump the libzfs.so revision as
advised by the libtool guidelines due to the source change.  The
specific changes are:

Added functions (2):
- boolean_t zpool_is_draid_spare(const char *);
- zpool_compat_status_t zpool_load_compat(const char *,
      boolean_t *, char *, char *);

Changes variables (2):
- spa_feature_table[SPA_FEATURES] - Added SPA_FEATURE_DRAID.
- zpool_prop_table[ZPOOL_NUM_PROPS] - Added ZPOOL_PROP_COMPATIBILITY.

### How Has This Been Tested?

Locally compiled, and visually inspected the updated revision number. 
Manual compatibility test is still needed.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
