### PR TITLE
Add RELEASES.md file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,8 +26,8 @@ endif
 AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST  = autogen.sh copy-builtin
 EXTRA_DIST += config/config.awk config/rpm.am config/deb.am config/tgz.am
-EXTRA_DIST += META AUTHORS COPYRIGHT LICENSE NEWS NOTICE README.md
-EXTRA_DIST += CODE_OF_CONDUCT.md
+EXTRA_DIST += AUTHORS CODE_OF_CONDUCT.md COPYRIGHT LICENSE META NEWS NOTICE
+EXTRA_DIST += README.md RELEASES.md
 EXTRA_DIST += module/lua/README.zfs module/os/linux/spl/README.md
 
 # Include all the extra licensing information for modules

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,37 @@
+OpenZFS uses the MAJOR.MINOR.PATCH versioning scheme described here:
+
+  * MAJOR - Incremented at the discretion of the OpenZFS developers to indicate
+    a particularly noteworthy feature or change. An increase in MAJOR number
+    does not indicate any incompatible on-disk format change. The ability
+    to import a ZFS pool is controlled by the feature flags enabled on the
+    pool and the feature flags supported by the installed OpenZFS version.
+    Increasing the MAJOR version is expected to be an infrequent occurrence.
+
+  * MINOR - Incremented to indicate new functionality such as a new feature
+    flag, pool/dataset property, zfs/zpool sub-command, new user/kernel
+    interface, etc. MINOR releases may introduce incompatible changes to the
+    user space library APIs (libzfs.so). Existing user/kernel interfaces are
+    considered to be stable to maximize compatibility between OpenZFS releases.
+    Additions to the user/kernel interface are backwards compatible.
+
+  * PATCH - Incremented when applying documentation updates, important bug
+    fixes, minor performance improvements, and kernel compatibility patches.
+    The user space library APIs and user/kernel interface are considered to
+    be stable. PATCH releases for a MAJOR.MINOR are published as needed.
+
+Two release branches are maintained for OpenZFS, they are:
+
+  * OpenZFS LTS - A designated MAJOR.MINOR release with periodic PATCH
+    releases that incorporate important changes backported from newer OpenZFS
+    releases. This branch is intended for use in environments using an
+    LTS, enterprise, or similarly managed kernel (RHEL, Ubuntu LTS, Debian).
+    Minor changes to support these distribution kernels will be applied as
+    needed. New kernel versions released after the OpenZFS LTS release are
+    not supported. LTS releases will receive patches for at least 2 years.
+    The current LTS release is OpenZFS 2.1.
+
+  * OpenZFS current - Tracks the newest MAJOR.MINOR release. This branch
+    includes support for the latest OpenZFS features and recently releases
+    kernels.  When a new MINOR release is tagged the previous MINOR release
+    will no longer be maintained (unless it is an LTS release). New MINOR
+    releases are planned to occur roughly annually.


### PR DESCRIPTION
### Motivation and Context

Document the project's policy regarding publishing and maintaining
official OpenZFS releases.

### Description

For easier reading I've posted the contents of the new RELEASES.md here for
feedback.  We should determine the best place to link to this documentation,
perhaps either from the README.md or https://openzfs.github.io/openzfs-docs/.

---

[updated]

OpenZFS uses the MAJOR.MINOR.PATCH versioning scheme described here:

  * MAJOR - Incremented at the discretion of the OpenZFS developers to indicate
    a particularly noteworthy feature or change. An increase in MAJOR number
    does not indicate any incompatible on-disk format change. The ability
    to import a ZFS pool is controlled by the feature flags enabled on the
    pool and the feature flags supported by the installed OpenZFS version.
    Increasing the MAJOR version is expected to be an infrequent occurrence.

  * MINOR - Incremented to indicate new functionality such as a new feature
    flag, pool/dataset property, zfs/zpool sub-command, new user/kernel
    interface, etc. MINOR releases may introduce incompatible changes to the
    user space library APIs (libzfs.so). Existing user/kernel interfaces are
    considered to be stable to maximize compatibility between OpenZFS releases.
    Additions to the user/kernel interface are backwards compatible.

  * PATCH - Incremented when applying documentation updates, important bug
    fixes, minor performance improvements, and kernel compatibility patches.
    The user space library APIs and user/kernel interface are considered to
    be stable. PATCH releases for a MAJOR.MINOR are published as needed.

Two release branches are maintained for OpenZFS, they are:

  * OpenZFS LTS - A designated MAJOR.MINOR release with periodic PATCH
    releases that incorporate important changes backported from newer OpenZFS
    releases. This branch is intended for use by distributions which use an
    LTS, enterprise, or similarly managed kernel (RHEL, Ubuntu LTS, Debian).
    Minor changes to support these distribution kernels will be applied as
    needed. New kernel versions released after the OpenZFS LTS release are
    not supported. LTS releases will receive patches for at least 2 years.
    The current LTS release is OpenZFS 2.1.

  * OpenZFS current - Tracks the newest MAJOR.MINOR release. This branch
    includes support for the latest OpenZFS features and recently releases
    kernels.  When a new MINOR release is tagged the previous MINOR release
    will no longer be maintained (unless it is an LTS release). New MINOR
    releases are planned to occur roughly annually.

---

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
