### PR TITLE
Fixing m4 iops rename check

### DIFF
--- a/config/kernel-rename.m4
+++ b/config/kernel-rename.m4
@@ -44,6 +44,7 @@ AC_DEFUN([ZFS_AC_KERNEL_RENAME], [
 	],[
 		AC_MSG_RESULT(no)
 
+		AC_MSG_CHECKING([whether iop->rename() wants flags])
 		ZFS_LINUX_TEST_RESULT([inode_operations_rename_flags], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE(HAVE_RENAME_WANTS_FLAGS, 1,


### PR DESCRIPTION
The configure check for iops->reanme wanting flags was missing the
AC_MSG_CHECKING() so it would just print yes without saying what was
being checked.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Just updating m4 file to use AC_MSG_CHECKING().
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Just cleaning up configure output.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
The check for iops->rename() checking for flags was just missing the AC_MSG_CHECKING(). Without it
it would just print yes when running configure without specifying what passed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran configure on CentOS 8.2, kernel: 4.18.0-193.el8.x86_64   
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
