### PR TITLE
Refactor zfsdev state init/destroy to share common code

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -77,8 +77,6 @@ typedef struct zfs_soft_state {
 	void *zss_data;
 } zfs_soft_state_t;
 
-extern minor_t zfsdev_minor_alloc(void);
-
 /*
  * Range locking rules
  * --------------------

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -567,7 +567,6 @@ typedef struct zfsdev_state {
 
 extern void *zfsdev_get_state(minor_t minor, enum zfsdev_state_type which);
 extern int zfsdev_getminor(int fd, minor_t *minorp);
-extern minor_t zfsdev_minor_alloc(void);
 
 extern uint_t zfs_fsyncer_key;
 extern uint_t zfs_allow_log_key;

--- a/include/sys/zfs_ioctl_impl.h
+++ b/include/sys/zfs_ioctl_impl.h
@@ -91,6 +91,10 @@ void zfs_vfs_rele(zfsvfs_t *);
 long zfsdev_ioctl_common(uint_t, zfs_cmd_t *, int);
 int zfsdev_attach(void);
 void zfsdev_detach(void);
+void zfsdev_private_set_state(void *, zfsdev_state_t *);
+zfsdev_state_t *zfsdev_private_get_state(void *);
+int zfsdev_state_init(void *);
+void zfsdev_state_destroy(void *);
 int zfs_kmod_init(void);
 void zfs_kmod_fini(void);
 

--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -113,7 +113,6 @@ static int zfs__fini(void);
 static void zfs_shutdown(void *, int);
 
 static eventhandler_tag zfs_shutdown_event_tag;
-extern zfsdev_state_t *zfsdev_state_list;
 
 #define	ZFS_MIN_KSTACK_PAGES 4
 
@@ -182,66 +181,29 @@ out:
 static void
 zfsdev_close(void *data)
 {
-	zfsdev_state_t *zs = data;
-
-	ASSERT(zs != NULL);
-	ASSERT3S(zs->zs_minor, >, 0);
-
-	zfs_onexit_destroy(zs->zs_onexit);
-	zfs_zevent_destroy(zs->zs_zevent);
-	zs->zs_onexit = NULL;
-	zs->zs_zevent = NULL;
-	membar_producer();
-	zs->zs_minor = -1;
+	zfsdev_state_destroy(data);
 }
 
-static int
-zfs_ctldev_init(struct cdev *devp)
+void
+zfsdev_private_set_state(void *priv __unused, zfsdev_state_t *zs)
 {
-	boolean_t newzs = B_FALSE;
-	minor_t minor;
-	zfsdev_state_t *zs, *zsprev = NULL;
-
-	ASSERT(MUTEX_HELD(&zfsdev_state_lock));
-
-	minor = zfsdev_minor_alloc();
-	if (minor == 0)
-		return (SET_ERROR(ENXIO));
-
-	for (zs = zfsdev_state_list; zs != NULL; zs = zs->zs_next) {
-		if (zs->zs_minor == -1)
-			break;
-		zsprev = zs;
-	}
-
-	if (!zs) {
-		zs = kmem_zalloc(sizeof (zfsdev_state_t), KM_SLEEP);
-		newzs = B_TRUE;
-	}
-
 	devfs_set_cdevpriv(zs, zfsdev_close);
+}
 
-	zfs_onexit_init((zfs_onexit_t **)&zs->zs_onexit);
-	zfs_zevent_init((zfs_zevent_t **)&zs->zs_zevent);
-
-	if (newzs) {
-		zs->zs_minor = minor;
-		wmb();
-		zsprev->zs_next = zs;
-	} else {
-		wmb();
-		zs->zs_minor = minor;
-	}
-	return (0);
+zfsdev_state_t *
+zfsdev_private_get_state(void *priv)
+{
+	return (priv);
 }
 
 static int
-zfsdev_open(struct cdev *devp, int flag, int mode, struct thread *td)
+zfsdev_open(struct cdev *devp __unused, int flag __unused, int mode __unused,
+    struct thread *td __unused)
 {
 	int error;
 
 	mutex_enter(&zfsdev_state_lock);
-	error = zfs_ctldev_init(devp);
+	error = zfsdev_state_init(NULL);
 	mutex_exit(&zfsdev_state_lock);
 
 	return (error);

--- a/module/os/linux/zfs/zfs_ioctl_os.c
+++ b/module/os/linux/zfs/zfs_ioctl_os.c
@@ -118,7 +118,7 @@ zfsdev_state_init(struct file *filp)
 
 	/*
 	 * In order to provide for lock-free concurrent read access
-	 * to the minor list in zfsdev_get_state_impl(), new entries
+	 * to the minor list in zfsdev_get_state(), new entries
 	 * must be completely written before linking them into the
 	 * list whereas existing entries are already linked; the last
 	 * operation must be updating zs_minor (from -1 to the new

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7352,8 +7352,8 @@ zfsdev_getminor(int fd, minor_t *minorp)
 	return (SET_ERROR(EBADF));
 }
 
-static void *
-zfsdev_get_state_impl(minor_t minor, enum zfsdev_state_type which)
+void *
+zfsdev_get_state(minor_t minor, enum zfsdev_state_type which)
 {
 	zfsdev_state_t *zs;
 
@@ -7374,16 +7374,6 @@ zfsdev_get_state_impl(minor_t minor, enum zfsdev_state_type which)
 	return (NULL);
 }
 
-void *
-zfsdev_get_state(minor_t minor, enum zfsdev_state_type which)
-{
-	void *ptr;
-
-	ptr = zfsdev_get_state_impl(minor, which);
-
-	return (ptr);
-}
-
 /*
  * Find a free minor number.  The zfsdev_state_list is expected to
  * be short since it is only a list of currently open file handles.
@@ -7399,7 +7389,7 @@ zfsdev_minor_alloc(void)
 	for (m = last_minor + 1; m != last_minor; m++) {
 		if (m > ZFSDEV_MAX_MINOR)
 			m = 1;
-		if (zfsdev_get_state_impl(m, ZST_ALL) == NULL) {
+		if (zfsdev_get_state(m, ZST_ALL) == NULL) {
 			last_minor = m;
 			return (m);
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code cleanup to share more platform independent code.

### Description
<!--- Describe your changes in detail -->
Make zfsdev_get_state_impl() into zfsdev_get_state(), as the latter is currently a direct wrapper for the former.

Move zfsdev_state_{init,destroy} to common code, adding platform-dependent procedures for getting and setting the private state for the zfsdev descriptor.

Add a comment describing the lockless destroy logic.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD and Linux

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
