### PR TITLE
Assorted cleanup for ZED, but mostly just the thousand-fold speed improvement

### DIFF
--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -230,8 +230,6 @@ main(int argc, char *argv[])
 	if (geteuid() != 0)
 		zed_log_die("Must be run as root");
 
-	zed_conf_parse_file(zcp);
-
 	zed_file_close_from(STDERR_FILENO + 1);
 
 	(void) umask(0);

--- a/cmd/zed/zed.h
+++ b/cmd/zed/zed.h
@@ -16,11 +16,6 @@
 #define	ZED_H
 
 /*
- * Absolute path for the default zed configuration file.
- */
-#define	ZED_CONF_FILE		SYSCONFDIR "/zfs/zed.conf"
-
-/*
  * Absolute path for the default zed pid file.
  */
 #define	ZED_PID_FILE		RUNSTATEDIR "/zed.pid"

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -53,9 +53,6 @@ zed_conf_create(void)
 	zcp->zevent_fd = -1;		/* opened via zed_event_init() */
 	zcp->max_jobs = 16;
 
-	if (!(zcp->conf_file = strdup(ZED_CONF_FILE)))
-		goto nomem;
-
 	if (!(zcp->pid_file = strdup(ZED_PID_FILE)))
 		goto nomem;
 
@@ -102,10 +99,6 @@ zed_conf_destroy(struct zed_conf *zcp)
 			    "Failed to close PID file \"%s\": %s",
 			    zcp->pid_file, strerror(errno));
 		zcp->pid_fd = -1;
-	}
-	if (zcp->conf_file) {
-		free(zcp->conf_file);
-		zcp->conf_file = NULL;
 	}
 	if (zcp->pid_file) {
 		free(zcp->pid_file);
@@ -163,10 +156,6 @@ _zed_conf_display_help(const char *prog, int got_err)
 	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-Z",
 	    "Zero state file.");
 	fprintf(fp, "\n");
-#if 0
-	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-c FILE",
-	    "Read configuration from FILE.", ZED_CONF_FILE);
-#endif
 	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-d DIR",
 	    "Read enabled ZEDLETs from DIR.", ZED_ZEDLET_DIR);
 	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-p FILE",
@@ -254,7 +243,7 @@ _zed_conf_parse_path(char **resultp, const char *path)
 void
 zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 {
-	const char * const opts = ":hLVc:d:p:P:s:vfFMZIj:";
+	const char * const opts = ":hLVd:p:P:s:vfFMZIj:";
 	int opt;
 	unsigned long raw;
 
@@ -273,9 +262,6 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 			break;
 		case 'V':
 			_zed_conf_display_version();
-			break;
-		case 'c':
-			_zed_conf_parse_path(&zcp->conf_file, optarg);
 			break;
 		case 'd':
 			_zed_conf_parse_path(&zcp->zedlet_dir, optarg);
@@ -329,18 +315,6 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 			break;
 		}
 	}
-}
-
-/*
- * Parse the configuration file into the configuration [zcp].
- *
- * FIXME: Not yet implemented.
- */
-void
-zed_conf_parse_file(struct zed_conf *zcp)
-{
-	if (!zcp)
-		zed_log_die("Failed to parse config: %s", strerror(EINVAL));
 }
 
 /*

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -324,8 +324,6 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
  *
  * Return 0 on success with an updated set of zedlets,
  * or -1 on error with errno set.
- *
- * FIXME: Check if zedlet_dir and all parent dirs are secure.
  */
 int
 zed_conf_scan_dir(struct zed_conf *zcp)

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -515,7 +515,7 @@ zed_conf_write_pid(struct zed_conf *zcp)
 		errno = ERANGE;
 		zed_log_msg(LOG_ERR, "Failed to write PID file \"%s\": %s",
 		    zcp->pid_file, strerror(errno));
-	} else if (zed_file_write_n(zcp->pid_fd, buf, n) != n) {
+	} else if (write(zcp->pid_fd, buf, n) != n) {
 		zed_log_msg(LOG_ERR, "Failed to write PID file \"%s\": %s",
 		    zcp->pid_file, strerror(errno));
 	} else if (fdatasync(zcp->pid_fd) < 0) {

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -29,7 +29,6 @@ struct zed_conf {
 	int		syslog_facility;	/* syslog facility value */
 	int		min_events;		/* RESERVED FOR FUTURE USE */
 	int		max_events;		/* RESERVED FOR FUTURE USE */
-	char		*conf_file;		/* abs path to config file */
 	char		*pid_file;		/* abs path to pid file */
 	int		pid_fd;			/* fd to pid file for lock */
 	char		*zedlet_dir;		/* abs path to zedlet dir */
@@ -47,8 +46,6 @@ struct zed_conf *zed_conf_create(void);
 void zed_conf_destroy(struct zed_conf *zcp);
 
 void zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv);
-
-void zed_conf_parse_file(struct zed_conf *zcp);
 
 int zed_conf_scan_dir(struct zed_conf *zcp);
 

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -249,7 +249,7 @@ _zed_event_value_is_hex(const char *name)
  *
  * All environment variables in [zsp] should be added through this function.
  */
-static int
+static __attribute__((format(printf, 5, 6))) int
 _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
     const char *prefix, const char *name, const char *fmt, ...)
 {
@@ -624,8 +624,6 @@ _zed_event_add_string_array(uint64_t eid, zed_strings_t *zsp,
  * Convert the nvpair [nvp] to a string which is added to the environment
  * of the child process.
  * Return 0 on success, -1 on error.
- *
- * FIXME: Refactor with cmd/zpool/zpool_main.c:zpool_do_events_nvprint()?
  */
 static void
 _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
@@ -724,22 +722,10 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 		_zed_event_add_var(eid, zsp, prefix, name,
 		    "%llu", (u_longlong_t)i64);
 		break;
-	case DATA_TYPE_NVLIST:
-		_zed_event_add_var(eid, zsp, prefix, name,
-		    "%s", "_NOT_IMPLEMENTED_");			/* FIXME */
-		break;
 	case DATA_TYPE_STRING:
 		(void) nvpair_value_string(nvp, &str);
 		_zed_event_add_var(eid, zsp, prefix, name,
 		    "%s", (str ? str : "<NULL>"));
-		break;
-	case DATA_TYPE_BOOLEAN_ARRAY:
-		_zed_event_add_var(eid, zsp, prefix, name,
-		    "%s", "_NOT_IMPLEMENTED_");			/* FIXME */
-		break;
-	case DATA_TYPE_BYTE_ARRAY:
-		_zed_event_add_var(eid, zsp, prefix, name,
-		    "%s", "_NOT_IMPLEMENTED_");			/* FIXME */
 		break;
 	case DATA_TYPE_INT8_ARRAY:
 		_zed_event_add_int8_array(eid, zsp, prefix, nvp);
@@ -768,9 +754,11 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	case DATA_TYPE_STRING_ARRAY:
 		_zed_event_add_string_array(eid, zsp, prefix, nvp);
 		break;
+	case DATA_TYPE_NVLIST:
+	case DATA_TYPE_BOOLEAN_ARRAY:
+	case DATA_TYPE_BYTE_ARRAY:
 	case DATA_TYPE_NVLIST_ARRAY:
-		_zed_event_add_var(eid, zsp, prefix, name,
-		    "%s", "_NOT_IMPLEMENTED_");			/* FIXME */
+		_zed_event_add_var(eid, zsp, prefix, name, "_NOT_IMPLEMENTED_");
 		break;
 	default:
 		errno = EINVAL;

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -25,35 +25,6 @@
 #include "zed_log.h"
 
 /*
- * Read up to [n] bytes from [fd] into [buf].
- * Return the number of bytes read, 0 on EOF, or -1 on error.
- */
-ssize_t
-zed_file_read_n(int fd, void *buf, size_t n)
-{
-	unsigned char *p;
-	size_t n_left;
-	ssize_t n_read;
-
-	p = buf;
-	n_left = n;
-	while (n_left > 0) {
-		if ((n_read = read(fd, p, n_left)) < 0) {
-			if (errno == EINTR)
-				continue;
-			else
-				return (-1);
-
-		} else if (n_read == 0) {
-			break;
-		}
-		n_left -= n_read;
-		p += n_read;
-	}
-	return (n - n_left);
-}
-
-/*
  * Write [n] bytes from [buf] out to [fd].
  * Return the number of bytes written, or -1 on error.
  */

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -25,33 +25,6 @@
 #include "zed_log.h"
 
 /*
- * Write [n] bytes from [buf] out to [fd].
- * Return the number of bytes written, or -1 on error.
- */
-ssize_t
-zed_file_write_n(int fd, void *buf, size_t n)
-{
-	const unsigned char *p;
-	size_t n_left;
-	ssize_t n_written;
-
-	p = buf;
-	n_left = n;
-	while (n_left > 0) {
-		if ((n_written = write(fd, p, n_left)) < 0) {
-			if (errno == EINTR)
-				continue;
-			else
-				return (-1);
-
-		}
-		n_left -= n_written;
-		p += n_written;
-	}
-	return (n);
-}
-
-/*
  * Set an exclusive advisory lock on the open file descriptor [fd].
  * Return 0 on success, 1 if a conflicting lock is held by another process,
  * or -1 on error (with errno set).

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -119,9 +118,7 @@ zed_file_is_locked(int fd)
 void
 zed_file_close_from(int lowfd)
 {
-	static const int maxfd_def = 256;
 	int errno_bak = errno;
-	struct rlimit rl;
 	int maxfd = 0;
 	int fd;
 	DIR *fddir;
@@ -134,11 +131,8 @@ zed_file_close_from(int lowfd)
 				maxfd = fd;
 		}
 		(void) closedir(fddir);
-	} else if (getrlimit(RLIMIT_NOFILE, &rl) < 0 ||
-	    rl.rlim_max == RLIM_INFINITY) {
-		maxfd = maxfd_def;
 	} else {
-		maxfd = rl.rlim_max;
+		maxfd = sysconf(_SC_OPEN_MAX);
 	}
 	for (fd = lowfd; fd < maxfd; fd++)
 		(void) close(fd);

--- a/cmd/zed/zed_file.h
+++ b/cmd/zed/zed_file.h
@@ -18,8 +18,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-ssize_t zed_file_write_n(int fd, void *buf, size_t n);
-
 int zed_file_lock(int fd);
 
 int zed_file_unlock(int fd);

--- a/cmd/zed/zed_file.h
+++ b/cmd/zed/zed_file.h
@@ -18,8 +18,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-ssize_t zed_file_read_n(int fd, void *buf, size_t n);
-
 ssize_t zed_file_write_n(int fd, void *buf, size_t n);
 
 int zed_file_lock(int fd);

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -234,9 +234,6 @@ Terminate the daemon.
 .PP
 ZEDLETs are unable to return state/status information to the kernel.
 .PP
-Some zevent nvpair types are not handled.  These are denoted by zevent
-environment variables having a "_NOT_IMPLEMENTED_" value.
-.PP
 Internationalization support via gettext has not been added.
 .PP
 The diagnosis engine is not yet implemented.

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -76,9 +76,6 @@ while the daemon is running.
 .BI \-Z
 Zero the daemon's state, thereby allowing zevents still within the kernel
 to be reprocessed.
-.\" .TP
-.\" .BI \-c\  configfile
-.\" Read the configuration from the specified file.
 .TP
 .BI \-d\  zedletdir
 Read the enabled ZEDLETs from the specified directory.
@@ -203,9 +200,6 @@ the following executables are defined: \fBZDB\fR, \fBZED\fR, \fBZFS\fR,
 rc file if needed.
 
 .SH FILES
-.\" .TP
-.\" @sysconfdir@/zfs/zed.conf
-.\" The default configuration file for the daemon.
 .TP
 .I @sysconfdir@/zfs/zed.d
 The default directory for enabled ZEDLETs.
@@ -249,8 +243,6 @@ Some zevent nvpair types are not handled.  These are denoted by zevent
 environment variables having a "_NOT_IMPLEMENTED_" value.
 .PP
 Internationalization support via gettext has not been added.
-.PP
-The configuration file is not yet implemented.
 .PP
 The diagnosis engine is not yet implemented.
 

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -235,8 +235,6 @@ Terminate the daemon.
 ZEDLETs are unable to return state/status information to the kernel.
 .PP
 Internationalization support via gettext has not been added.
-.PP
-The diagnosis engine is not yet implemented.
 
 .SH LICENSE
 .PP

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -117,9 +117,10 @@ ZEDLETs to be invoked in response to zevents are located in the
 \fIenabled-zedlets\fR directory.  These can be symlinked or copied from the
 \fIinstalled-zedlets\fR directory; symlinks allow for automatic updates
 from the installed ZEDLETs, whereas copies preserve local modifications.
-As a security measure, ZEDLETs must be owned by root.  They must have
-execute permissions for the user, but they must not have write permissions
-for group or other.  Dotfiles are ignored.
+As a security measure, since ownership change is a privileged operation,
+ZEDLETs must be owned by root.  They must have execute permissions for the user,
+but they must not have write permissions for group or other.
+Dotfiles are ignored.
 .PP
 ZEDLETs are named after the zevent class for which they should be invoked.
 In particular, a ZEDLET will be invoked for a given zevent if either its
@@ -230,12 +231,6 @@ Terminate the daemon.
 .\" Do not taunt zed.
 
 .SH BUGS
-.PP
-The ownership and permissions of the \fIenabled-zedlets\fR directory (along
-with all parent directories) are not checked.  If any of these directories
-are improperly owned or permissioned, an unprivileged user could insert a
-ZEDLET to be executed as root.  The requirement that ZEDLETs be owned by
-root mitigates this to some extent.
 .PP
 ZEDLETs are unable to return state/status information to the kernel.
 .PP


### PR DESCRIPTION
### Motivation and Context
See individual commits for analysis where applicable.

### Description
The first patch prints out the sum times from the accounting information we get out of wait().

The second patch makes ZED start-up *and* ZEDLET pre-exec roughly a thousand times faster [lol](https://twitter.com/nabijaczleweli/status/1377975727014969346).

The third patch cleans out all traces of the config file that never was.

The fourth patch removes a long and confusing (also wrong) paragraph from the man-page.

The fifth patch implements the suggested `zfs_zevent_len_max` bump when we drop events.

The sixth and eighth patches dump `zed_file_{read,write}_n()`.

The seventh patch makes `_zed_event_add_nvpair()` slightly more similar to `zpool_do_events_nvprint()` I guess, in a way?

The ninth patch removes the blatant lie that the Diagnosis Engine doesn't exist. It might be prudent to link to `cmd/zed/agents/README.md` from the manpage somewhere under some key words, but I don't understand a damn thing about it (that might be because I missed Illumos by a few years), so I defer to someone who does to determine those.

The tenth patch depessimises the close_from() no-/proc fallback.

### How Has This Been Tested?
Dunno, just ran it a bunch.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
