### PR TITLE
zpool-features.5: remove "booting not possible with this feature"s

### DIFF
--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -730,8 +730,6 @@ will be compressed with \fBlz4\fR algorithm. Since this feature is not
 read-only compatible, this operation will render the pool unimportable
 on systems without support for the \fBlz4_compress\fR feature.
 
-Booting off of \fBlz4\fR-compressed root pools is supported.
-
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fB.
 .RE
@@ -1058,8 +1056,6 @@ on \fBzstd\fR compression of any dataset by running
 This feature becomes \fBactive\fR once a \fBcompress\fR property has been set to
 \fBzstd\fR, and will return to being \fBenabled\fR once all filesystems that
 have ever had their compress property set to \fBzstd\fR are destroyed.
-
-Booting off of \fBzstd\fR-compressed root pools is not yet supported.
 .RE
 
 .SH "SEE ALSO"


### PR DESCRIPTION
### Motivation and Context
See commit message.

### Description
See title.

### How Has This Been Tested?
I, uh, read it? dunno

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – no need
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
