### PR TITLE
man: fix wrong .Xr macros usages

### DIFF
--- a/man/man8/zfs-wait.8
+++ b/man/man8/zfs-wait.8
@@ -68,4 +68,4 @@ handles to unlinked files are closed.
 .El
 .El
 .Sh SEE ALSO
-.Xr lsof  8
+.Xr lsof 8

--- a/man/man8/zpool-create.8
+++ b/man/man8/zpool-create.8
@@ -92,7 +92,7 @@ The
 specification is described in the
 .Em Virtual Devices
 section of
-.Xr zpoolconcepts.
+.Xr zpoolconcepts 8 .
 .Pp
 The command attempts to verify that each device specified is accessible and not
 currently in use by another subsystem.  However this check is not robust enough
@@ -185,7 +185,7 @@ device sharing.
 .It Fl o Ar property Ns = Ns Ar value
 Sets the given pool properties.
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for a list of valid properties that can be set.
 .It Fl o Ar compatibility Ns = Ns Ar off | legacy | file Bq , Ns Ar file Ns ...
 Specifies compatibility feature sets. See

--- a/man/man8/zpool-get.8
+++ b/man/man8/zpool-get.8
@@ -70,7 +70,7 @@ These properties are displayed with the following fields:
 .Ed
 .Pp
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for more information on the available pool properties.
 .Bl -tag -width Ds
 .It Fl H
@@ -92,7 +92,7 @@ Display numbers in parsable (exact) values.
 .Xc
 Sets the given property on the specified pool.
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for more information on what properties can be set and acceptable
 values.
 .El

--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -198,7 +198,7 @@ for a description of dataset properties and mount options.
 .It Fl o Ar property Ns = Ns Ar value
 Sets the specified property on the imported pool.
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for more information on the available pool properties.
 .It Fl R Ar root
 Sets the
@@ -337,7 +337,7 @@ for a description of dataset properties and mount options.
 .It Fl o Ar property Ns = Ns Ar value
 Sets the specified property on the imported pool.
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for more information on the available pool properties.
 .It Fl R Ar root
 Sets the

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -78,7 +78,7 @@ space.
 .It Fl o Ar property
 Comma-separated list of properties to display.
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for a list of valid properties.
 The default list is
 .Cm name , size , allocated , free , checkpoint, expandsize , fragmentation ,

--- a/man/man8/zpool-replace.8
+++ b/man/man8/zpool-replace.8
@@ -83,7 +83,7 @@ even if it appears to be in use.
 Not all devices can be overridden in this manner.
 .It Fl o Ar property Ns = Ns Ar value
 Sets the given pool properties. See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for a list of valid properties that can be set.
 The only property supported at the moment is
 .Sy ashift .

--- a/man/man8/zpool-split.8
+++ b/man/man8/zpool-split.8
@@ -106,7 +106,7 @@ flag.
 Sets the specified property for
 .Ar newpool .
 See the
-.Xr zpoolprops
+.Xr zpoolprops 8
 manual page for more information on the available pool properties.
 .It Fl R Ar root
 Set


### PR DESCRIPTION
In addition, html doc will have working hyperlinks.

Signed-off-by: George Melikov <mail@gmelikov.ru>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wrong .Xr usage leads to not working links in html doc, for ex. look at `zpoolprops` in https://openzfs.github.io/openzfs-docs/man/8/zpool-import.8.html?highlight=zpoolprops

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
`mandoc -W all` doesn't have warnings about .Xr macros.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)
