### PR TITLE
Added check for broken alien version

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -15,13 +15,18 @@ deb-local:
 	"*** re-run configure, and try again.\n"; \
 		exit 1; \
 	fi; \
-	if test "${ALIEN_VERSION}" = "8.95.3"; then \
-		echo -e "\n" \
-	"*** Installed version of ${ALIEN} is known to be broken;\n" \
-	"*** attempting to generate debs will fail! See\n" \
-	"*** https://github.com/openzfs/zfs/issues/11650 for details.\n"; \
-		exit 1; \
-	fi)
+        if test "${ALIEN_MAJOR}" = "8" && \
+           test "${ALIEN_MINOR}" = "95"; then \
+        if test "${ALIEN_POINT}" = "1" || \
+           test "${ALIEN_POINT}" = "2" || \
+           test "${ALIEN_POINT}" = "3"; then \
+                /bin/echo -e "\n" \
+        "*** Installed version of ${ALIEN} is known to be broken;\n" \
+        "*** attempting to generate debs will fail! See\n" \
+        "*** https://github.com/openzfs/zfs/issues/11650 for details.\n"; \
+                exit 1; \
+        fi; \
+        fi)
 
 deb-kmod: deb-local rpm-kmod
 	name=${PACKAGE}; \

--- a/config/deb.am
+++ b/config/deb.am
@@ -14,6 +14,13 @@ deb-local:
 	"*** package for your distribution which provides ${ALIEN},\n" \
 	"*** re-run configure, and try again.\n"; \
 		exit 1; \
+	fi; \
+	if test "${ALIEN_VERSION}" = "8.95.3"; then \
+		echo -e "\n" \
+	"*** Installed version of ${ALIEN} is known to be broken;\n" \
+	"*** attempting to generate debs will fail! See\n" \
+	"*** https://github.com/openzfs/zfs/issues/11650 for details.\n"; \
+		exit 1; \
 	fi)
 
 deb-kmod: deb-local rpm-kmod

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -437,6 +437,9 @@ AC_DEFUN([ZFS_AC_ALIEN], [
 	AC_MSG_CHECKING([whether $ALIEN is available])
 	AS_IF([tmp=$($ALIEN --version 2>/dev/null)], [
 		ALIEN_VERSION=$(echo $tmp | $AWK '{ print $[3] }')
+		ALIEN_MAJOR=$(echo ${ALIEN_VERSION} | $AWK -F'.' '{ print $[1] }')
+		ALIEN_MINOR=$(echo ${ALIEN_VERSION} | $AWK -F'.' '{ print $[2] }')
+		ALIEN_POINT=$(echo ${ALIEN_VERSION} | $AWK -F'.' '{ print $[3] }')
 		HAVE_ALIEN=yes
 		AC_MSG_RESULT([$HAVE_ALIEN ($ALIEN_VERSION)])
 	],[
@@ -447,6 +450,9 @@ AC_DEFUN([ZFS_AC_ALIEN], [
 	AC_SUBST(HAVE_ALIEN)
 	AC_SUBST(ALIEN)
 	AC_SUBST(ALIEN_VERSION)
+	AC_SUBST(ALIEN_MAJOR)
+	AC_SUBST(ALIEN_MINOR)
+	AC_SUBST(ALIEN_POINT)
 ])
 
 dnl #


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Implemented the suggested detection of a broken alien version from #11848 

### Motivation and Context
Closes #11848 ; does not fix #11650, merely detects the broken version discovered from that.

### Description
Added a check for alien 8.95.3, which is known to fail to generate debs 100% of the time, and instead print out a message informing the developer that it's known to be broken and linking them to more information.

### How Has This Been Tested?
Tried compiling with alien 8.95 and 8.95.3 installed, verified that it bailed out on the latter and built normally with the former.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
