### PR TITLE
Minor all-round touch-ups

### DIFF
--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -161,21 +161,11 @@ elif sys.platform.startswith('linux'):
         # The original arc_summary called /sbin/modinfo/{spl,zfs} to get
         # the version information. We switch to /sys/module/{spl,zfs}/version
         # to make sure we get what is really loaded in the kernel
-        command = ["cat", "/sys/module/{0}/version".format(request)]
-        req = request.upper()
-
-        # The recommended way to do this is with subprocess.run(). However,
-        # some installed versions of Python are < 3.5, so we offer them
-        # the option of doing it the old way (for now)
-        if 'run' in dir(subprocess):
-            info = subprocess.run(command, stdout=subprocess.PIPE,
-                                  universal_newlines=True)
-            version = info.stdout.strip()
-        else:
-            info = subprocess.check_output(command, universal_newlines=True)
-            version = info.strip()
-
-        return version
+        try:
+            with open("/sys/module/{}/version".format(request)) as f:
+                return f.read().strip()
+        except:
+            return "(unknown)"
 
     def get_descriptions(request):
         """Get the descriptions of the Solaris Porting Layer (SPL) or the

--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -63,11 +63,11 @@ main(int argc, char **argv)
 
 	uint64_t objset, object;
 	if (sscanf(argv[1], "%llu", (u_longlong_t *)&objset) != 1) {
-		(void) fprintf(stderr, "Invalid objset id: %s\n", argv[2]);
+		(void) fprintf(stderr, "Invalid objset id: %s\n", argv[1]);
 		usage(2);
 	}
 	if (sscanf(argv[2], "%llu", (u_longlong_t *)&object) != 1) {
-		(void) fprintf(stderr, "Invalid object id: %s\n", argv[3]);
+		(void) fprintf(stderr, "Invalid object id: %s\n", argv[2]);
 		usage(3);
 	}
 	if ((g_zfs = libzfs_init()) == NULL) {
@@ -76,7 +76,7 @@ main(int argc, char **argv)
 	}
 	zpool_handle_t *pool = zpool_open(g_zfs, argv[0]);
 	if (pool == NULL) {
-		fprintf(stderr, "Could not open pool %s\n", argv[1]);
+		fprintf(stderr, "Could not open pool %s\n", argv[0]);
 		libzfs_fini(g_zfs);
 		return (5);
 	}

--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -35,7 +35,7 @@ libzfs_handle_t *g_zfs;
 static void
 usage(int err)
 {
-	fprintf(stderr, "Usage: [-v] zfs_ids_to_path <pool> <objset id> "
+	fprintf(stderr, "Usage: zfs_ids_to_path [-v] <pool> <objset id> "
 	    "<object id>\n");
 	exit(err);
 }

--- a/cmd/zstreamdump/zstreamdump
+++ b/cmd/zstreamdump/zstreamdump
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-zstream dump "$@"
+exec zstream dump "$@"

--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -9,29 +9,25 @@ count_zvols() {
 }
 
 filter_out_zvols_with_links() {
-	while read -r zvol; do
-		if [ ! -L "/dev/zvol/$zvol" ]; then
+	echo "$zvols" | tr ' ' '+' | while read -r zvol; do
+		if ! [ -L "/dev/zvol/$zvol" ]; then
 			echo "$zvol"
 		fi
-	done
+	done | tr '+' ' '
 }
 
 filter_out_deleted_zvols() {
-	while read -r zvol; do
-		if zfs list "$zvol" >/dev/null 2>&1; then
-			echo "$zvol"
-		fi
-	done
+	OIFS="$IFS"
+	IFS="
+"
+	zfs list -H -o name $zvols 2>/dev/null
+	IFS="$OIFS"
 }
 
 list_zvols() {
 	zfs list -t volume -H -o \
-		name,volmode,receive_resume_token,redact_snaps |
-		while read -r zvol_line; do
-		name=$(echo "$zvol_line" | awk '{print $1}')
-		volmode=$(echo "$zvol_line" | awk '{print $2}')
-		token=$(echo "$zvol_line" | awk '{print $3}')
-		redacted=$(echo "$zvol_line" | awk '{print $4}')
+	    name,volmode,receive_resume_token,redact_snaps |
+	    while IFS="	" read -r name volmode token redacted; do # IFS=\t here!
 		#
 		# /dev links are not created for zvols with volmode = "none"
 		# or for redacted zvols.
@@ -75,7 +71,7 @@ while [ "$outer_loop" -lt 20 ]; do
 	while [ "$inner_loop" -lt 30 ]; do
 		inner_loop=$((inner_loop + 1))
 
-		zvols="$(echo "$zvols" | filter_out_zvols_with_links)"
+		zvols="$(filter_out_zvols_with_links)"
 
 		zvols_count=$(count_zvols)
 		if [ "$zvols_count" -eq 0 ]; then
@@ -95,7 +91,7 @@ while [ "$outer_loop" -lt 20 ]; do
 		echo "No progress since last loop."
 		echo "Checking if any zvols were deleted."
 
-		zvols=$(echo "$zvols" | filter_out_deleted_zvols)
+		zvols=$(filter_out_deleted_zvols)
 		zvols_count=$(count_zvols)
 
 		if [ "$old_zvols_count" -ne "$zvols_count" ]; then

--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -25,25 +25,25 @@ filter_out_deleted_zvols() {
 }
 
 list_zvols() {
+	read -r default_volmode < /sys/module/zfs/parameters/zvol_volmode
 	zfs list -t volume -H -o \
 	    name,volmode,receive_resume_token,redact_snaps |
 	    while IFS="	" read -r name volmode token redacted; do # IFS=\t here!
-		#
+
 		# /dev links are not created for zvols with volmode = "none"
 		# or for redacted zvols.
-		#
 		[ "$volmode" = "none" ] && continue
+		[ "$volmode" = "default" ] && [ "$default_volmode" = "3" ] &&
+		    continue
 		[ "$redacted" = "-" ] || continue
-		#
+
 		# We also ignore partially received zvols if it is
 		# not an incremental receive, as those won't even have a block
 		# device minor node created yet.
-		#
 		if [ "$token" != "-" ]; then
-			#
+
 			# Incremental receives create an invisible clone that
 			# is not automatically displayed by zfs list.
-			#
 			if ! zfs list "$name/%recv" >/dev/null 2>&1; then
 				continue
 			fi

--- a/contrib/bpftrace/zfs-trace.sh
+++ b/contrib/bpftrace/zfs-trace.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-ZVER=$(cat /sys/module/zfs/version | cut -f 1 -d '-')
+ZVER=$(cut -f 1 -d '-' /sys/module/zfs/version)
 KVER=$(uname -r)
 
-bpftrace \
+exec bpftrace \
 	--include "/usr/src/zfs-$ZVER/$KVER/zfs_config.h" \
 	-I "/usr/src/zfs-$ZVER/include" \
 	-I "/usr/src/zfs-$ZVER/include/spl" \


### PR DESCRIPTION
### Motivation and Context
See individual commit messages.

### Description
The first patch execs zstream dump from the zstreamdump wrapper instead of spawning it normally.

The second patch fixes zvol_wait when zvols with spaces in their names exist.

The third patch replaces a subprocess.run("cat", "known file").stdio.strip() in arc_summary3 with an open().read().strip()(!)

The fourth patch removes a useless cat in the bpftrace wrapper (and execs bpftrace).

The fifth and sixth patches fix zfs_ids_to_path usage and error messages.

### How Has This Been Tested?
Ran it, mostly, I guess?

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
