### PR TITLE
zed: minor clean-up

### DIFF
--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -216,15 +216,15 @@ _finish_daemonize(void)
 int
 main(int argc, char *argv[])
 {
-	struct zed_conf *zcp;
+	struct zed_conf zcp;
 	uint64_t saved_eid;
 	int64_t saved_etime[2];
 
 	zed_log_init(argv[0]);
 	zed_log_stderr_open(LOG_NOTICE);
-	zcp = zed_conf_create();
-	zed_conf_parse_opts(zcp, argc, argv);
-	if (zcp->do_verbose)
+	zed_conf_init(&zcp);
+	zed_conf_parse_opts(&zcp, argc, argv);
+	if (zcp.do_verbose)
 		zed_log_stderr_open(LOG_INFO);
 
 	if (geteuid() != 0)
@@ -237,32 +237,32 @@ main(int argc, char *argv[])
 	if (chdir("/") < 0)
 		zed_log_die("Failed to change to root directory");
 
-	if (zed_conf_scan_dir(zcp) < 0)
+	if (zed_conf_scan_dir(&zcp) < 0)
 		exit(EXIT_FAILURE);
 
-	if (!zcp->do_foreground) {
+	if (!zcp.do_foreground) {
 		_start_daemonize();
 		zed_log_syslog_open(LOG_DAEMON);
 	}
 	_setup_sig_handlers();
 
-	if (zcp->do_memlock)
+	if (zcp.do_memlock)
 		_lock_memory();
 
-	if ((zed_conf_write_pid(zcp) < 0) && (!zcp->do_force))
+	if ((zed_conf_write_pid(&zcp) < 0) && (!zcp.do_force))
 		exit(EXIT_FAILURE);
 
-	if (!zcp->do_foreground)
+	if (!zcp.do_foreground)
 		_finish_daemonize();
 
 	zed_log_msg(LOG_NOTICE,
 	    "ZFS Event Daemon %s-%s (PID %d)",
 	    ZFS_META_VERSION, ZFS_META_RELEASE, (int)getpid());
 
-	if (zed_conf_open_state(zcp) < 0)
+	if (zed_conf_open_state(&zcp) < 0)
 		exit(EXIT_FAILURE);
 
-	if (zed_conf_read_state(zcp, &saved_eid, saved_etime) < 0)
+	if (zed_conf_read_state(&zcp, &saved_eid, saved_etime) < 0)
 		exit(EXIT_FAILURE);
 
 idle:
@@ -271,24 +271,24 @@ idle:
 	 * successful.
 	 */
 	do {
-		if (!zed_event_init(zcp))
+		if (!zed_event_init(&zcp))
 			break;
 		/* Wait for some time and try again. tunable? */
 		sleep(30);
-	} while (!_got_exit && zcp->do_idle);
+	} while (!_got_exit && zcp.do_idle);
 
 	if (_got_exit)
 		goto out;
 
-	zed_event_seek(zcp, saved_eid, saved_etime);
+	zed_event_seek(&zcp, saved_eid, saved_etime);
 
 	while (!_got_exit) {
 		int rv;
 		if (_got_hup) {
 			_got_hup = 0;
-			(void) zed_conf_scan_dir(zcp);
+			(void) zed_conf_scan_dir(&zcp);
 		}
-		rv = zed_event_service(zcp);
+		rv = zed_event_service(&zcp);
 
 		/* ENODEV: When kernel module is unloaded (osx) */
 		if (rv == ENODEV)
@@ -296,13 +296,13 @@ idle:
 	}
 
 	zed_log_msg(LOG_NOTICE, "Exiting");
-	zed_event_fini(zcp);
+	zed_event_fini(&zcp);
 
-	if (zcp->do_idle && !_got_exit)
+	if (zcp.do_idle && !_got_exit)
 		goto idle;
 
 out:
-	zed_conf_destroy(zcp);
+	zed_conf_destroy(&zcp);
 	zed_log_fini();
 	exit(EXIT_SUCCESS);
 }

--- a/cmd/zed/zed.h
+++ b/cmd/zed/zed.h
@@ -31,16 +31,6 @@
 #define	ZED_ZEDLET_DIR		SYSCONFDIR "/zfs/zed.d"
 
 /*
- * Reserved for future use.
- */
-#define	ZED_MAX_EVENTS		0
-
-/*
- * Reserved for future use.
- */
-#define	ZED_MIN_EVENTS		0
-
-/*
  * String prefix for ZED variables passed via environment variables.
  */
 #define	ZED_VAR_PREFIX		"ZED_"

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -43,8 +43,6 @@ zed_conf_create(void)
 	if (!zcp)
 		goto nomem;
 
-	zcp->min_events = ZED_MIN_EVENTS;
-	zcp->max_events = ZED_MAX_EVENTS;
 	zcp->pid_fd = -1;
 	zcp->zedlets = NULL;		/* created via zed_conf_scan_dir() */
 	zcp->state_fd = -1;		/* opened via zed_conf_open_state() */

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -206,16 +206,19 @@ _zed_conf_parse_path(char **resultp, const char *path)
 
 	if (path[0] == '/') {
 		*resultp = strdup(path);
-	} else if (!getcwd(buf, sizeof (buf))) {
-		zed_log_die("Failed to get current working dir: %s",
-		    strerror(errno));
-	} else if (strlcat(buf, "/", sizeof (buf)) >= sizeof (buf)) {
-		zed_log_die("Failed to copy path: %s", strerror(ENAMETOOLONG));
-	} else if (strlcat(buf, path, sizeof (buf)) >= sizeof (buf)) {
-		zed_log_die("Failed to copy path: %s", strerror(ENAMETOOLONG));
 	} else {
+		if (!getcwd(buf, sizeof (buf)))
+			zed_log_die("Failed to get current working dir: %s",
+			    strerror(errno));
+
+		if (strlcat(buf, "/", sizeof (buf)) >= sizeof (buf) ||
+		    strlcat(buf, path, sizeof (buf)) >= sizeof (buf))
+			zed_log_die("Failed to copy path: %s",
+			    strerror(ENAMETOOLONG));
+
 		*resultp = strdup(buf);
 	}
+
 	if (!*resultp)
 		zed_log_die("Failed to copy path: %s", strerror(ENOMEM));
 }

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -128,42 +128,50 @@ zed_conf_destroy(struct zed_conf *zcp)
 static void
 _zed_conf_display_help(const char *prog, int got_err)
 {
+	struct opt { const char *o, *d, *v; };
+
 	FILE *fp = got_err ? stderr : stdout;
-	int w1 = 4;			/* width of leading whitespace */
-	int w2 = 8;			/* width of L-justified option field */
+
+	struct opt *oo;
+	struct opt iopts[] = {
+		{ .o = "-h", .d = "Display help" },
+		{ .o = "-L", .d = "Display license information" },
+		{ .o = "-V", .d = "Display version information" },
+		{},
+	};
+	struct opt nopts[] = {
+		{ .o = "-v", .d = "Be verbose" },
+		{ .o = "-f", .d = "Force daemon to run" },
+		{ .o = "-F", .d = "Run daemon in the foreground" },
+		{ .o = "-I",
+		    .d = "Idle daemon until kernel module is (re)loaded" },
+		{ .o = "-M", .d = "Lock all pages in memory" },
+		{ .o = "-P", .d = "$PATH for ZED to use (only used by ZTS)" },
+		{ .o = "-Z", .d = "Zero state file" },
+		{},
+	};
+	struct opt vopts[] = {
+		{ .o = "-d DIR", .d = "Read enabled ZEDLETs from DIR.",
+		    .v = ZED_ZEDLET_DIR },
+		{ .o = "-p FILE", .d = "Write daemon's PID to FILE.",
+		    .v = ZED_PID_FILE },
+		{ .o = "-s FILE", .d = "Write daemon's state to FILE.",
+		    .v = ZED_STATE_FILE },
+		{ .o = "-j JOBS", .d = "Start at most JOBS at once.",
+		    .v = "16" },
+		{},
+	};
 
 	fprintf(fp, "Usage: %s [OPTION]...\n", (prog ? prog : "zed"));
 	fprintf(fp, "\n");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-h",
-	    "Display help.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-L",
-	    "Display license information.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-V",
-	    "Display version information.");
+	for (oo = iopts; oo->o; ++oo)
+		fprintf(fp, "    %*s %s\n", -8, oo->o, oo->d);
 	fprintf(fp, "\n");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-v",
-	    "Be verbose.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-f",
-	    "Force daemon to run.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-F",
-	    "Run daemon in the foreground.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-I",
-	    "Idle daemon until kernel module is (re)loaded.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-M",
-	    "Lock all pages in memory.");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-P",
-	    "$PATH for ZED to use (only used by ZTS).");
-	fprintf(fp, "%*c%*s %s\n", w1, 0x20, -w2, "-Z",
-	    "Zero state file.");
+	for (oo = nopts; oo->o; ++oo)
+		fprintf(fp, "    %*s %s\n", -8, oo->o, oo->d);
 	fprintf(fp, "\n");
-	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-d DIR",
-	    "Read enabled ZEDLETs from DIR.", ZED_ZEDLET_DIR);
-	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-p FILE",
-	    "Write daemon's PID to FILE.", ZED_PID_FILE);
-	fprintf(fp, "%*c%*s %s [%s]\n", w1, 0x20, -w2, "-s FILE",
-	    "Write daemon's state to FILE.", ZED_STATE_FILE);
-	fprintf(fp, "%*c%*s %s [%d]\n", w1, 0x20, -w2, "-j JOBS",
-	    "Start at most JOBS at once.", 16);
+	for (oo = vopts; oo->o; ++oo)
+		fprintf(fp, "    %*s %s [%s]\n", -8, oo->o, oo->d, oo->v);
 	fprintf(fp, "\n");
 
 	exit(got_err ? EXIT_FAILURE : EXIT_SUCCESS);
@@ -303,8 +311,8 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 			if (optopt == '?')
 				_zed_conf_display_help(argv[0], EXIT_SUCCESS);
 
-			fprintf(stderr, "%s: %s '-%c'\n\n", argv[0],
-			    "Invalid option", optopt);
+			fprintf(stderr, "%s: Invalid option '-%c'\n\n",
+			    argv[0], optopt);
 			_zed_conf_display_help(argv[0], EXIT_FAILURE);
 			break;
 		}

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -126,7 +126,7 @@ zed_conf_destroy(struct zed_conf *zcp)
  * otherwise, output to stderr and exit with a failure status.
  */
 static void
-_zed_conf_display_help(const char *prog, int got_err)
+_zed_conf_display_help(const char *prog, boolean_t got_err)
 {
 	struct opt { const char *o, *d, *v; };
 
@@ -257,7 +257,7 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 	while ((opt = getopt(argc, argv, opts)) != -1) {
 		switch (opt) {
 		case 'h':
-			_zed_conf_display_help(argv[0], EXIT_SUCCESS);
+			_zed_conf_display_help(argv[0], B_FALSE);
 			break;
 		case 'L':
 			_zed_conf_display_license();
@@ -309,11 +309,11 @@ zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv)
 		case '?':
 		default:
 			if (optopt == '?')
-				_zed_conf_display_help(argv[0], EXIT_SUCCESS);
+				_zed_conf_display_help(argv[0], B_FALSE);
 
 			fprintf(stderr, "%s: Invalid option '-%c'\n\n",
 			    argv[0], optopt);
-			_zed_conf_display_help(argv[0], EXIT_FAILURE);
+			_zed_conf_display_help(argv[0], B_TRUE);
 			break;
 		}
 	}

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -43,7 +43,6 @@ zed_conf_create(void)
 	if (!zcp)
 		goto nomem;
 
-	zcp->syslog_facility = LOG_DAEMON;
 	zcp->min_events = ZED_MIN_EVENTS;
 	zcp->max_events = ZED_MAX_EVENTS;
 	zcp->pid_fd = -1;

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -175,20 +175,14 @@ _zed_conf_display_help(const char *prog, int got_err)
 static void
 _zed_conf_display_license(void)
 {
-	const char **pp;
-	const char *text[] = {
-	    "The ZFS Event Daemon (ZED) is distributed under the terms of the",
-	    "  Common Development and Distribution License (CDDL-1.0)",
-	    "  <http://opensource.org/licenses/CDDL-1.0>.",
-	    "",
+	printf(
+	    "The ZFS Event Daemon (ZED) is distributed under the terms of the\n"
+	    "  Common Development and Distribution License (CDDL-1.0)\n"
+	    "  <http://opensource.org/licenses/CDDL-1.0>.\n"
+	    "\n"
 	    "Developed at Lawrence Livermore National Laboratory"
-	    " (LLNL-CODE-403049).",
-	    "",
-	    NULL
-	};
-
-	for (pp = text; *pp; pp++)
-		printf("%s\n", *pp);
+	    " (LLNL-CODE-403049).\n"
+	    "\n");
 
 	exit(EXIT_SUCCESS);
 }

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -26,8 +26,6 @@ struct zed_conf {
 	unsigned	do_verbose:1;		/* true if verbosity enabled */
 	unsigned	do_zero:1;		/* true if zeroing state */
 	unsigned	do_idle:1;		/* true if idle enabled */
-	int		min_events;		/* RESERVED FOR FUTURE USE */
-	int		max_events;		/* RESERVED FOR FUTURE USE */
 	char		*pid_file;		/* abs path to pid file */
 	int		pid_fd;			/* fd to pid file for lock */
 	char		*zedlet_dir;		/* abs path to zedlet dir */

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -26,7 +26,6 @@ struct zed_conf {
 	unsigned	do_verbose:1;		/* true if verbosity enabled */
 	unsigned	do_zero:1;		/* true if zeroing state */
 	unsigned	do_idle:1;		/* true if idle enabled */
-	int		syslog_facility;	/* syslog facility value */
 	int		min_events;		/* RESERVED FOR FUTURE USE */
 	int		max_events;		/* RESERVED FOR FUTURE USE */
 	char		*pid_file;		/* abs path to pid file */

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -20,26 +20,29 @@
 #include "zed_strings.h"
 
 struct zed_conf {
-	unsigned	do_force:1;		/* true if force enabled */
-	unsigned	do_foreground:1;	/* true if run in foreground */
-	unsigned	do_memlock:1;		/* true if locking memory */
-	unsigned	do_verbose:1;		/* true if verbosity enabled */
-	unsigned	do_zero:1;		/* true if zeroing state */
-	unsigned	do_idle:1;		/* true if idle enabled */
 	char		*pid_file;		/* abs path to pid file */
-	int		pid_fd;			/* fd to pid file for lock */
 	char		*zedlet_dir;		/* abs path to zedlet dir */
-	zed_strings_t	*zedlets;		/* names of enabled zedlets */
 	char		*state_file;		/* abs path to state file */
-	int		state_fd;		/* fd to state file */
+
 	libzfs_handle_t	*zfs_hdl;		/* handle to libzfs */
-	int		zevent_fd;		/* fd for access to zevents */
+	zed_strings_t	*zedlets;		/* names of enabled zedlets */
 	char		*path;		/* custom $PATH for zedlets to use */
+
+	int		pid_fd;			/* fd to pid file for lock */
+	int		state_fd;		/* fd to state file */
+	int		zevent_fd;		/* fd for access to zevents */
+
 	int16_t max_jobs;		/* max zedlets to run at one time */
+
+	boolean_t	do_force:1;		/* true if force enabled */
+	boolean_t	do_foreground:1;	/* true if run in foreground */
+	boolean_t	do_memlock:1;		/* true if locking memory */
+	boolean_t	do_verbose:1;		/* true if verbosity enabled */
+	boolean_t	do_zero:1;		/* true if zeroing state */
+	boolean_t	do_idle:1;		/* true if idle enabled */
 };
 
-struct zed_conf *zed_conf_create(void);
-
+void zed_conf_init(struct zed_conf *zcp);
 void zed_conf_destroy(struct zed_conf *zcp);
 
 void zed_conf_parse_opts(struct zed_conf *zcp, int argc, char **argv);
@@ -49,9 +52,7 @@ int zed_conf_scan_dir(struct zed_conf *zcp);
 int zed_conf_write_pid(struct zed_conf *zcp);
 
 int zed_conf_open_state(struct zed_conf *zcp);
-
 int zed_conf_read_state(struct zed_conf *zcp, uint64_t *eidp, int64_t etime[]);
-
 int zed_conf_write_state(struct zed_conf *zcp, uint64_t eid, int64_t etime[]);
 
 #endif	/* !ZED_CONF_H */


### PR DESCRIPTION
### Motivation and Context
See individual commit messages.

### Description
The first patch replaces a loop to print a constant string with a print of that constant string.

The second patch replaces the mess that was _zed_conf_display_help() with a few arrays.

The third patch makes _zed_conf_display_help() be passed actual booleans and take boolean_t for its is-this-an-error argument.

The fourth and fifth patches remove zed_conf::{syslog_facility,{min,max}_events} and the accompanying macros – all unused.

The sixth patch moves the global zed_conf instance from being malloc()ed to main()'s stack and simplifies the constructor.

The seventh patch replaces the if-else chain that's not actually an if-else chain in _zed_conf_parse_path() with a more obvious spelling.

### How Has This Been Tested?
Ran it a bit, dunno.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
