### PR TITLE
Improvements to the 'compatibility' property.

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -393,6 +393,7 @@ typedef enum {
 	ZPOOL_STATUS_REBUILD_SCRUB,	/* recommend scrubbing the pool */
 	ZPOOL_STATUS_NON_NATIVE_ASHIFT,	/* (e.g. 512e dev with ashift of 9) */
 	ZPOOL_STATUS_COMPATIBILITY_ERR,	/* bad 'compatibility' property */
+	ZPOOL_STATUS_INCOMPATIBLE_FEAT,	/* feature set outside compatibility */
 
 	/*
 	 * Finally, the following indicates a healthy pool.
@@ -922,14 +923,14 @@ extern int zpool_disable_datasets(zpool_handle_t *, boolean_t);
  */
 typedef enum {
 	ZPOOL_COMPATIBILITY_OK,
-	ZPOOL_COMPATIBILITY_READERR,
+	ZPOOL_COMPATIBILITY_WARNTOKEN,
+	ZPOOL_COMPATIBILITY_BADTOKEN,
 	ZPOOL_COMPATIBILITY_BADFILE,
-	ZPOOL_COMPATIBILITY_BADWORD,
 	ZPOOL_COMPATIBILITY_NOFILES
 } zpool_compat_status_t;
 
 extern zpool_compat_status_t zpool_load_compat(const char *,
-    boolean_t *, char *, char *);
+    boolean_t *, char *, size_t);
 
 #ifdef __FreeBSD__
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -421,40 +421,40 @@
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='prop_changelist' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='75' column='1' id='type-id-1'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='prop_changelist' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='75' column='1' id='type-id-1'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cl_prop' type-id='type-id-2' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='76' column='1'/>
+        <var-decl name='cl_prop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cl_realprop' type-id='type-id-2' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='77' column='1'/>
+        <var-decl name='cl_realprop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cl_shareprop' type-id='type-id-2' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='78' column='1'/>
+        <var-decl name='cl_shareprop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cl_pool' type-id='type-id-3' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='79' column='1'/>
+        <var-decl name='cl_pool' type-id='type-id-3' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cl_tree' type-id='type-id-4' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='80' column='1'/>
+        <var-decl name='cl_tree' type-id='type-id-4' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='cl_waslegacy' type-id='type-id-5' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='81' column='1'/>
+        <var-decl name='cl_waslegacy' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='cl_allchildren' type-id='type-id-5' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='82' column='1'/>
+        <var-decl name='cl_allchildren' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='cl_alldependents' type-id='type-id-5' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='83' column='1'/>
+        <var-decl name='cl_alldependents' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='cl_mflags' type-id='type-id-6' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='84' column='1'/>
+        <var-decl name='cl_mflags' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cl_gflags' type-id='type-id-6' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='85' column='1'/>
+        <var-decl name='cl_gflags' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='cl_haszonedchild' type-id='type-id-5' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='86' column='1'/>
+        <var-decl name='cl_haszonedchild' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='86' column='1'/>
       </data-member>
     </class-decl>
     <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-7'/>
@@ -736,67 +736,62 @@
       <data-member access='public' layout-offset-in-bits='1048'>
         <var-decl name='_shortbuf' type-id='type-id-38' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-39' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='81' column='1'/>
-      </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-40' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+        <var-decl name='_offset' type-id='type-id-39' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-41' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+        <var-decl name='_codecvt' type-id='type-id-40' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-42' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+        <var-decl name='_wide_data' type-id='type-id-41' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
         <var-decl name='_freeres_list' type-id='type-id-34' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+        <var-decl name='_freeres_buf' type-id='type-id-42' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-44' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+        <var-decl name='__pad5' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
         <var-decl name='_mode' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-45' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+        <var-decl name='_unused2' type-id='type-id-44' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
       </data-member>
     </class-decl>
-    <type-decl name='char' size-in-bits='8' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-23'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-47'/>
-    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-33'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-23'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-33'/>
     <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-34'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-48'/>
-    <typedef-decl name='__off_t' type-id='type-id-48' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-35'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-47'/>
+    <typedef-decl name='__off_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-35'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='type-id-36'/>
     <type-decl name='signed char' size-in-bits='8' id='type-id-37'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-49'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-48'/>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='8' id='type-id-38'>
-      <subrange length='1' type-id='type-id-49' id='type-id-50'/>
-
-    </array-type-def>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-51' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='43' column='1' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-39'/>
-    <typedef-decl name='__off64_t' type-id='type-id-48' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-40'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-41'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-42'/>
-    <type-decl name='void' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-43'/>
-    <typedef-decl name='size_t' type-id='type-id-49' filepath='/usr/lib/gcc/x86_64-linux-gnu/9/include/stddef.h' line='209' column='1' id='type-id-44'/>
-
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='160' id='type-id-45'>
-      <subrange length='20' type-id='type-id-49' id='type-id-55'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='8' id='type-id-38'>
+      <subrange length='1' type-id='type-id-48' id='type-id-49'/>
 
     </array-type-def>
-    <typedef-decl name='FILE' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-56'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-26'/>
-    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1' id='type-id-57'>
+    <typedef-decl name='__off64_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-39'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-40'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-41'/>
+    <type-decl name='void' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-42'/>
+    <typedef-decl name='size_t' type-id='type-id-48' filepath='/usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h' line='216' column='1' id='type-id-43'/>
+
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='160' id='type-id-44'>
+      <subrange length='20' type-id='type-id-48' id='type-id-53'/>
+
+    </array-type-def>
+    <typedef-decl name='FILE' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-26'/>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1' id='type-id-55'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zpool_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
       </data-member>
@@ -810,7 +805,7 @@
         <var-decl name='zpool_state' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zpool_config_size' type-id='type-id-44' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
+        <var-decl name='zpool_config_size' type-id='type-id-43' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
         <var-decl name='zpool_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
@@ -822,193 +817,193 @@
         <var-decl name='zpool_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='zpool_start_block' type-id='type-id-58' visibility='default' filepath='../../include/libzfs_impl.h' line='107' column='1'/>
+        <var-decl name='zpool_start_block' type-id='type-id-56' visibility='default' filepath='../../include/libzfs_impl.h' line='107' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='libzfs_handle_t' type-id='type-id-25' filepath='../../include/libzfs.h' line='197' column='1' id='type-id-59'/>
-    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-17'/>
-    <typedef-decl name='zpool_handle_t' type-id='type-id-57' filepath='../../include/libzfs.h' line='196' column='1' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-18'/>
+    <typedef-decl name='libzfs_handle_t' type-id='type-id-25' filepath='../../include/libzfs.h' line='197' column='1' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-17'/>
+    <typedef-decl name='zpool_handle_t' type-id='type-id-55' filepath='../../include/libzfs.h' line='196' column='1' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-18'/>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='2048' id='type-id-19'>
-      <subrange length='256' type-id='type-id-49' id='type-id-61'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='2048' id='type-id-19'>
+      <subrange length='256' type-id='type-id-48' id='type-id-59'/>
 
     </array-type-def>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-62'>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-60'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-63' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+        <var-decl name='nvl_version' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-64' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+        <var-decl name='nvl_nvflag' type-id='type-id-62' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='nvl_priv' type-id='type-id-27' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-64' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+        <var-decl name='nvl_flag' type-id='type-id-62' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-63' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+        <var-decl name='nvl_pad' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-65'/>
-    <typedef-decl name='int32_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-63'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-66'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-66' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-67'/>
-    <typedef-decl name='uint32_t' type-id='type-id-67' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-64'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-49' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-68'/>
-    <typedef-decl name='uint64_t' type-id='type-id-68' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-27'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-62' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-22'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-70'/>
-    <typedef-decl name='longlong_t' type-id='type-id-70' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-71'/>
-    <typedef-decl name='diskaddr_t' type-id='type-id-71' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-58'/>
+    <typedef-decl name='__int32_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-63'/>
+    <typedef-decl name='int32_t' type-id='type-id-63' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-61'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-64'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-64' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-65'/>
+    <typedef-decl name='uint32_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-62'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-48' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-66'/>
+    <typedef-decl name='uint64_t' type-id='type-id-66' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-27'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-60' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-22'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-68'/>
+    <typedef-decl name='longlong_t' type-id='type-id-68' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-69'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-69' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-56'/>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='8192' id='type-id-28'>
-      <subrange length='1024' type-id='type-id-49' id='type-id-72'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='8192' id='type-id-28'>
+      <subrange length='1024' type-id='type-id-48' id='type-id-70'/>
 
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-73'>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-71'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__data' type-id='type-id-72' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-75' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
+        <var-decl name='__size' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-48' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+        <var-decl name='__align' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='22' column='1' id='type-id-74'>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-72'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='24' column='1'/>
+        <var-decl name='__lock' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-66' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='25' column='1'/>
+        <var-decl name='__count' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='26' column='1'/>
+        <var-decl name='__owner' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-66' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='28' column='1'/>
+        <var-decl name='__nusers' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='32' column='1'/>
+        <var-decl name='__kind' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-76' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='34' column='1'/>
+        <var-decl name='__spins' type-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-76' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='35' column='1'/>
+        <var-decl name='__elision' type-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/struct_mutex.h' line='36' column='1'/>
+        <var-decl name='__list' type-id='type-id-75' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
       </data-member>
     </class-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-76'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='49' column='1' id='type-id-78'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-74'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-76'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-79' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='51' column='1'/>
+        <var-decl name='__prev' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-79' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='52' column='1'/>
+        <var-decl name='__next' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-79'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-78' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='53' column='1' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-76' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-75'/>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='320' id='type-id-75'>
-      <subrange length='40' type-id='type-id-49' id='type-id-80'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='320' id='type-id-73'>
+      <subrange length='40' type-id='type-id-48' id='type-id-78'/>
 
     </array-type-def>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-73' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-29'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-81'>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-71' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-29'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-79'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-82' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+        <var-decl name='avl_root' type-id='type-id-80' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-83' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+        <var-decl name='avl_compar' type-id='type-id-81' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-44' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+        <var-decl name='avl_offset' type-id='type-id-43' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-84' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+        <var-decl name='avl_numnodes' type-id='type-id-82' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-44' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+        <var-decl name='avl_size' type-id='type-id-43' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-85'>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-83'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-86' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+        <var-decl name='avl_child' type-id='type-id-84' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-87' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+        <var-decl name='avl_pcb' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-80'/>
 
-    <array-type-def dimensions='1' type-id='type-id-82' size-in-bits='128' id='type-id-86'>
-      <subrange length='2' type-id='type-id-49' id='type-id-88'/>
+    <array-type-def dimensions='1' type-id='type-id-80' size-in-bits='128' id='type-id-84'>
+      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
 
     </array-type-def>
-    <typedef-decl name='uintptr_t' type-id='type-id-49' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-87'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-83'/>
-    <typedef-decl name='ulong_t' type-id='type-id-49' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-84'/>
-    <typedef-decl name='avl_tree_t' type-id='type-id-81' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-30'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-90'>
+    <typedef-decl name='uintptr_t' type-id='type-id-48' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-81'/>
+    <typedef-decl name='ulong_t' type-id='type-id-48' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-82'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-79' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-30'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-88'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='type-id-91' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
+        <var-decl name='buffer' type-id='type-id-89' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='type-id-92' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
+        <var-decl name='allocated' type-id='type-id-90' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='type-id-92' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
+        <var-decl name='used' type-id='type-id-90' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='type-id-93' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
+        <var-decl name='syntax' type-id='type-id-91' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='fastmap' type-id='type-id-23' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='type-id-94' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
+        <var-decl name='translate' type-id='type-id-92' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='type-id-44' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
+        <var-decl name='re_nsub' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
+        <var-decl name='can_be_null' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
+        <var-decl name='regs_allocated' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
+        <var-decl name='fastmap_accurate' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
+        <var-decl name='no_sub' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
+        <var-decl name='not_bol' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
+        <var-decl name='not_eol' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='type-id-66' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
+        <var-decl name='newline_anchor' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-95'/>
-    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-91'/>
-    <typedef-decl name='__re_long_size_t' type-id='type-id-49' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-92'/>
-    <typedef-decl name='reg_syntax_t' type-id='type-id-49' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-93'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-96'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-94'/>
-    <typedef-decl name='regex_t' type-id='type-id-90' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-31'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='52' column='1' id='type-id-97'>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-89'/>
+    <typedef-decl name='__re_long_size_t' type-id='type-id-48' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-90'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-48' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-91'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-92'/>
+    <typedef-decl name='regex_t' type-id='type-id-88' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-31'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='52' column='1' id='type-id-95'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
       <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
@@ -1016,8 +1011,8 @@
       <enumerator name='ZFS_TYPE_POOL' value='8'/>
       <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
     </enum-decl>
-    <typedef-decl name='zfs_type_t' type-id='type-id-97' filepath='../../include/sys/fs/zfs.h' line='58' column='1' id='type-id-20'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='931' column='1' id='type-id-98'>
+    <typedef-decl name='zfs_type_t' type-id='type-id-95' filepath='../../include/sys/fs/zfs.h' line='58' column='1' id='type-id-20'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='931' column='1' id='type-id-96'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='dds_num_clones' type-id='type-id-27' visibility='default' filepath='../../include/sys/dmu.h' line='932' column='1'/>
       </data-member>
@@ -1028,22 +1023,22 @@
         <var-decl name='dds_guid' type-id='type-id-27' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='type-id-99' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
+        <var-decl name='dds_type' type-id='type-id-97' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='type-id-100' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
+        <var-decl name='dds_is_snapshot' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='type-id-100' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
+        <var-decl name='dds_inconsistent' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='type-id-100' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
+        <var-decl name='dds_redacted' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='248'>
         <var-decl name='dds_origin' type-id='type-id-19' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-101'>
+    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-99'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='DMU_OST_NONE' value='0'/>
       <enumerator name='DMU_OST_META' value='1'/>
@@ -1053,589 +1048,583 @@
       <enumerator name='DMU_OST_ANY' value='5'/>
       <enumerator name='DMU_OST_NUMTYPES' value='6'/>
     </enum-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='type-id-101' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-99'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-96' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-102'/>
-    <typedef-decl name='uint8_t' type-id='type-id-102' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-100'/>
-    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-98' filepath='../../include/sys/dmu.h' line='940' column='1' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-24'/>
-    <typedef-decl name='zfs_handle_t' type-id='type-id-16' filepath='../../include/libzfs.h' line='195' column='1' id='type-id-103'/>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-104'/>
-    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_gather'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-6' name='gather_flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-6' name='mnt_flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='625' column='1'/>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-99' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-97'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-94' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-100'/>
+    <typedef-decl name='uint8_t' type-id='type-id-100' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-98'/>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-96' filepath='../../include/sys/dmu.h' line='940' column='1' id='type-id-21'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-24'/>
+    <typedef-decl name='zfs_handle_t' type-id='type-id-16' filepath='../../include/libzfs.h' line='195' column='1' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-102'/>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_gather'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-6' name='gather_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-6' name='mnt_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='625' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_free'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_free'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-46' const='yes' id='type-id-105'/>
-    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-106'/>
-    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_remove'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
-      <return type-id='type-id-51'/>
+    <qualified-type-def type-id='type-id-45' const='yes' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-104'/>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_remove'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_haszonedchild'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_haszonedchild'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='110' column='1' id='type-id-107'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='110' column='1' id='type-id-105'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROTO_NFS' value='0'/>
       <enumerator name='PROTO_SMB' value='1'/>
       <enumerator name='PROTO_END' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_proto_t' type-id='type-id-107' filepath='../../include/libzfs_impl.h' line='114' column='1' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-109'/>
-    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
-      <parameter type-id='type-id-109' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+    <typedef-decl name='zfs_share_proto_t' type-id='type-id-105' filepath='../../include/libzfs_impl.h' line='114' column='1' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_rename'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <parameter type-id='type-id-106' name='src' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <parameter type-id='type-id-106' name='dst' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_rename'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-104' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-104' name='dst' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
-      <parameter type-id='type-id-106' name='dataset' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
-      <parameter type-id='type-id-106' name='parent' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+    <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
+      <parameter type-id='type-id-104' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+      <parameter type-id='type-id-104' name='parent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_postfix'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1'/>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_postfix'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_prefix'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_prefix'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='../../include/libuutil.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='../../include/libuutil.h' line='351' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='../../include/libzfs.h' line='493' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='../../include/libzfs.h' line='494' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='../../include/libzfs.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='../../include/libzfs.h' line='615' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='../../include/libzfs.h' line='470' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='../../include/libzfs.h' line='471' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='../../include/libzfs.h' line='466' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='../../include/libzfs.h' line='467' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='../../include/libzfs.h' line='839' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='../../include/libzfs.h' line='840' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='../../include/libzfs.h' line='510' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='../../include/libzfs.h' line='511' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='../../include/libuutil.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='../../include/libuutil.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='free' mangled-name='free' filepath='/usr/include/stdlib.h' line='565' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='free' mangled-name='free' filepath='/usr/include/stdlib.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='../../include/libzfs.h' line='468' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='../../include/libzfs.h' line='469' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='../../include/libzfs.h' line='613' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='../../include/libzfs.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='../../include/libzfs.h' line='622' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='../../include/libzfs.h' line='623' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='../../include/libzfs.h' line='823' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='../../include/libzfs.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='../../include/libuutil.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_error' mangled-name='zfs_error' filepath='../../include/libzfs_impl.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='strcmp' mangled-name='strcmp' filepath='/usr/include/string.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strcmp' mangled-name='strcmp' filepath='/usr/include/string.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='../../include/libzfs.h' line='210' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='getzoneid' mangled-name='getzoneid' filepath='../../include/sys/zfs_context.h' line='732' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='../../include/libuutil.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='../../include/libuutil.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='../../include/libuutil.h' line='367' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='../../include/libuutil.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='../../include/libuutil.h' line='354' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='../../include/libuutil.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='../../include/libzfs_impl.h' line='211' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='../../include/libzfs_impl.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strlcpy' mangled-name='strlcpy' filepath='../../lib/libspl/include/string.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strlen' mangled-name='strlen' filepath='/usr/include/string.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strlen' mangled-name='strlen' filepath='/usr/include/string.h' line='384' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strlcat' mangled-name='strlcat' filepath='../../lib/libspl/include/string.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strncmp' mangled-name='strncmp' filepath='/usr/include/string.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strncmp' mangled-name='strncmp' filepath='/usr/include/string.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='../../include/libzfs.h' line='809' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='../../include/libzfs.h' line='810' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='../../include/libzfs.h' line='848' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='../../include/libzfs.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='../../include/libzfs.h' line='852' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='../../include/libzfs.h' line='853' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='../../include/libzfs.h' line='851' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='../../include/libzfs.h' line='852' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='../../include/libzfs.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='../../include/libzfs.h' line='850' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='../../include/libzfs.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='../../include/libzfs.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='../../include/libuutil.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' filepath='../../include/libzfs.h' line='861' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' filepath='../../include/libzfs.h' line='861' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' filepath='../../include/libzfs.h' line='860' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' filepath='../../include/libzfs.h' line='862' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='../../include/libzfs.h' line='826' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='../../include/libzfs.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-89'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-43'/>
+    <function-type size-in-bits='64' id='type-id-87'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
-    <typedef-decl name='zfs_iter_f' type-id='type-id-111' filepath='../../include/libzfs.h' line='611' column='1' id='type-id-112'/>
-    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-109'/>
+    <typedef-decl name='zfs_iter_f' type-id='type-id-109' filepath='../../include/libzfs.h' line='612' column='1' id='type-id-110'/>
+    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-114'/>
-    <typedef-decl name='zpool_iter_f' type-id='type-id-114' filepath='../../include/libzfs.h' line='246' column='1' id='type-id-115'/>
-    <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
-      <parameter type-id='type-id-115' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-112'/>
+    <typedef-decl name='zpool_iter_f' type-id='type-id-112' filepath='../../include/libzfs.h' line='246' column='1' id='type-id-113'/>
+    <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-113' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
-      <parameter type-id='type-id-106' name='poolname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='340' column='1'/>
+    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
+      <parameter type-id='type-id-104' name='poolname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='340' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-116'/>
-    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
-      <parameter type-id='type-id-116' name='missing' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-114'/>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='232' column='1'/>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='232' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-117'/>
-    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
-      <parameter type-id='type-id-117' name='oldconfig' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-115'/>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+      <parameter type-id='type-id-115' name='oldconfig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='namespace_clear'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_config.c' line='79' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='namespace_clear'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='79' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='../../include/libuutil.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='../../include/libzfs_impl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='../../include/libuutil.h' line='361' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='../../include/libzfs_impl.h' line='200' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strchr' mangled-name='strchr' filepath='/usr/include/string.h' line='226' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strchr' mangled-name='strchr' filepath='/usr/include/string.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='getenv' mangled-name='getenv' filepath='/usr/include/stdlib.h' line='634' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__builtin___strcpy_chk' mangled-name='__strcpy_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='getenv' mangled-name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='strcpy' mangled-name='strcpy' filepath='/usr/include/string.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='../../include/libzfs_impl.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__errno_location' mangled-name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='../../include/libzfs_impl.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='../../include/libzfs.h' line='454' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='../../include/libzfs.h' line='455' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='../../include/libzfs_impl.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='../../include/libzfs_impl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../include/sys/nvpair.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_exists' mangled-name='nvlist_exists' filepath='../../include/sys/nvpair.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='214' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='no_memory' mangled-name='no_memory' filepath='../../include/libzfs_impl.h' line='143' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../include/sys/nvpair.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../include/sys/nvpair.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='../../include/libzfs_impl.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='dcgettext' mangled-name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='../../include/libzfs_impl.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='../../include/libuutil.h' line='376' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' filepath='../../include/sys/nvpair.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-110'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-43'/>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-113'>
+    <function-type size-in-bits='64' id='type-id-111'>
       <parameter type-id='type-id-18'/>
-      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
-      <parameter type-id='type-id-22' name='raw_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
-      <parameter type-id='type-id-5' name='inheritkey' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+      <parameter type-id='type-id-22' name='raw_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+      <parameter type-id='type-id-5' name='inheritkey' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1'/>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
-      <parameter type-id='type-id-5' name='noop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
-      <parameter type-id='type-id-23' name='alt_keylocation' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+      <parameter type-id='type-id-5' name='noop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+      <parameter type-id='type-id-23' name='alt_keylocation' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
-      <parameter type-id='type-id-23' name='fsname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
+      <parameter type-id='type-id-23' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
-      <parameter type-id='type-id-104' name='origin_zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
-      <parameter type-id='type-id-23' name='parent_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
+      <parameter type-id='type-id-102' name='origin_zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
+      <parameter type-id='type-id-23' name='parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-118'/>
-    <typedef-decl name='uint_t' type-id='type-id-66' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-119'/>
-    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-120'/>
-    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-23' name='parent_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-22' name='pool_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-5' name='stdin_available' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-118' name='wkeydata_out' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-120' name='wkeylen_out' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-116'/>
+    <typedef-decl name='uint_t' type-id='type-id-64' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-23' name='parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-22' name='pool_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-5' name='stdin_available' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-116' name='wkeydata_out' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-118' name='wkeylen_out' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
-      <parameter type-id='type-id-116' name='is_encroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_crypto.c' line='780' column='1'/>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
+      <parameter type-id='type-id-114' name='is_encroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='780' column='1'/>
       <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='__builtin___snprintf_chk' mangled-name='__snprintf_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
     </function-decl>
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../include/sys/fs/zfs.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='../../include/libzfs_impl.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../include/sys/nvpair.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='../../include/libzfs.h' line='487' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='../../include/libzfs.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='../../include/libzfs.h' line='813' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='snprintf' mangled-name='snprintf' filepath='/usr/include/stdio.h' line='354' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='../../include/libzfs.h' line='814' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_change_key' mangled-name='lzc_change_key' filepath='../../include/libzfs_core.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../include/libzfs.h' line='490' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../include/libzfs.h' line='491' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='212' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' filepath='../../include/sys/nvpair.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' filepath='../../include/libzfs_core.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_load_key' mangled-name='lzc_load_key' filepath='../../include/libzfs_core.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__printf_chk' mangled-name='__printf_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='../../include/libzfs.h' line='468' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='../../include/libzfs.h' line='467' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='printf' mangled-name='printf' filepath='/usr/include/stdio.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='../../include/libzfs.h' line='615' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='../../include/libzfs.h' line='616' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='calloc' mangled-name='calloc' filepath='/usr/include/stdlib.h' line='541' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='calloc' mangled-name='calloc' filepath='/usr/include/stdlib.h' line='542' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='regexec' mangled-name='regexec' filepath='/usr/include/regex.h' line='643' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='fileno' mangled-name='fileno' filepath='/usr/include/stdio.h' line='786' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fileno' mangled-name='fileno' filepath='/usr/include/stdio.h' line='792' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='isatty' mangled-name='isatty' filepath='/usr/include/unistd.h' line='779' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__getdelim' mangled-name='__getdelim' filepath='/usr/include/stdio.h' line='603' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='__getdelim' mangled-name='__getdelim' filepath='/usr/include/stdio.h' line='609' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sigemptyset' mangled-name='sigemptyset' filepath='/usr/include/signal.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sigaction' mangled-name='sigaction' filepath='/usr/include/signal.h' line='240' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='fputc' mangled-name='fputc' filepath='/usr/include/stdio.h' line='521' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fputc' mangled-name='fputc' filepath='/usr/include/stdio.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fflush' mangled-name='fflush' filepath='/usr/include/stdio.h' line='218' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tcgetattr' mangled-name='tcgetattr' filepath='/usr/include/termios.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tcsetattr' mangled-name='tcsetattr' filepath='/usr/include/termios.h' line='70' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='getpid' mangled-name='getpid' filepath='/usr/include/unistd.h' line='628' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='kill' mangled-name='kill' filepath='/usr/include/signal.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__ctype_b_loc' mangled-name='__ctype_b_loc' filepath='/usr/include/ctype.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='../../include/libzfs.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='../../include/libzfs.h' line='413' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='../../include/libzfs.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__fread_alias' mangled-name='fread' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='271' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='malloc' mangled-name='malloc' filepath='/usr/include/stdlib.h' line='539' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='ferror' mangled-name='ferror' filepath='/usr/include/stdio.h' line='761' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fread' mangled-name='fread' filepath='/usr/include/stdio.h' line='652' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='ferror' mangled-name='ferror' filepath='/usr/include/stdio.h' line='767' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fopen' mangled-name='fopen64' filepath='/usr/include/stdio.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fclose' mangled-name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='sscanf' mangled-name='__isoc99_sscanf' filepath='/usr/include/stdio.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='sscanf' mangled-name='sscanf' filepath='/usr/include/stdio.h' line='399' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' mangled-name='PKCS5_PBKDF2_HMAC_SHA1' filepath='/usr/include/openssl/evp.h' line='1087' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__open_alias' mangled-name='open64' filepath='/usr/include/x86_64-linux-gnu/bits/fcntl2.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='read' mangled-name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__read_alias' mangled-name='read' filepath='/usr/include/x86_64-linux-gnu/bits/unistd.h' line='25' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='close' mangled-name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__builtin_strcpy' mangled-name='strcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1439' column='1' id='type-id-121'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1439' column='1' id='type-id-119'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
       <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
     </enum-decl>
-    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-121' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-122'/>
-    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
-      <parameter type-id='type-id-122' name='activity' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
-      <parameter type-id='type-id-116' name='missing' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
-      <parameter type-id='type-id-116' name='waited' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-119' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-120'/>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
+      <parameter type-id='type-id-120' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
-      <parameter type-id='type-id-18' name='zph' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
-      <parameter type-id='type-id-27' name='volsize' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='type-id-18' name='zph' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
+      <parameter type-id='type-id-27' name='volsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
-      <parameter type-id='type-id-117' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
+      <parameter type-id='type-id-115' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
-      <parameter type-id='type-id-5' name='un' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+      <parameter type-id='type-id-5' name='un' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
-      <parameter type-id='type-id-117' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
+      <parameter type-id='type-id-115' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-106' name='snapname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-106' name='tag' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
+    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-104' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-104' name='tag' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
-      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
-      <parameter type-id='type-id-22' name='holds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+      <parameter type-id='type-id-22' name='holds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-106' name='snapname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-106' name='tag' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
-      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-104' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-104' name='tag' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-123'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-121'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_PROP_USERUSED' value='0'/>
       <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
@@ -1651,229 +1640,229 @@
       <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
       <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
     </enum-decl>
-    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-123' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-124'/>
-    <typedef-decl name='__uid_t' type-id='type-id-66' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='146' column='1' id='type-id-125'/>
-    <typedef-decl name='uid_t' type-id='type-id-125' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-126'/>
-    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
-    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-128' filepath='../../include/libzfs.h' line='737' column='1' id='type-id-129'/>
-    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
-      <parameter type-id='type-id-124' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
-      <parameter type-id='type-id-129' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
-      <parameter type-id='type-id-43' name='arg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-121' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-122'/>
+    <typedef-decl name='__uid_t' type-id='type-id-64' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-123'/>
+    <typedef-decl name='uid_t' type-id='type-id-123' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-126'/>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-126' filepath='../../include/libzfs.h' line='738' column='1' id='type-id-127'/>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
+      <parameter type-id='type-id-122' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
+      <parameter type-id='type-id-127' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+      <parameter type-id='type-id-42' name='arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='oldname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
-      <parameter type-id='type-id-23' name='newname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='oldname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+      <parameter type-id='type-id-23' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
-      <parameter type-id='type-id-23' name='resource' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-23' name='resource' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
-      <parameter type-id='type-id-23' name='resource' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-23' name='resource' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
-      <parameter type-id='type-id-24' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
+      <parameter type-id='type-id-24' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='535' column='1' id='type-id-130'>
+    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='536' column='1' id='type-id-128'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pl_prop' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='536' column='1'/>
+        <var-decl name='pl_prop' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='537' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pl_user_prop' type-id='type-id-23' visibility='default' filepath='../../include/libzfs.h' line='537' column='1'/>
+        <var-decl name='pl_user_prop' type-id='type-id-23' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pl_next' type-id='type-id-131' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
+        <var-decl name='pl_next' type-id='type-id-129' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pl_all' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
+        <var-decl name='pl_all' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pl_width' type-id='type-id-44' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
+        <var-decl name='pl_width' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pl_recvd_width' type-id='type-id-44' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
+        <var-decl name='pl_recvd_width' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pl_fixed' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
+        <var-decl name='pl_fixed' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='543' column='1'/>
       </data-member>
     </class-decl>
+    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-129'/>
+    <typedef-decl name='zprop_list_t' type-id='type-id-128' filepath='../../include/libzfs.h' line='544' column='1' id='type-id-130'/>
     <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-131'/>
-    <typedef-decl name='zprop_list_t' type-id='type-id-130' filepath='../../include/libzfs.h' line='543' column='1' id='type-id-132'/>
-    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-133'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-134'/>
-    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-134' name='plp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-5' name='received' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-132'/>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-5' name='received' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1'/>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='649' column='1' id='type-id-135'>
+    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='650' column='1' id='type-id-133'>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='recursive' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='651' column='1'/>
+        <var-decl name='recursive' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='652' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='30'>
-        <var-decl name='nounmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='654' column='1'/>
+        <var-decl name='nounmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='655' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='forceunmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='657' column='1'/>
+        <var-decl name='forceunmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='658' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='renameflags_t' type-id='type-id-135' filepath='../../include/libzfs.h' line='658' column='1' id='type-id-136'/>
-    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
-      <parameter type-id='type-id-106' name='target' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
-      <parameter type-id='type-id-136' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+    <typedef-decl name='renameflags_t' type-id='type-id-133' filepath='../../include/libzfs.h' line='659' column='1' id='type-id-134'/>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+      <parameter type-id='type-id-104' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+      <parameter type-id='type-id-134' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
-      <parameter type-id='type-id-104' name='snap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+      <parameter type-id='type-id-102' name='snap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
-      <parameter type-id='type-id-22' name='snaps' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+      <parameter type-id='type-id-22' name='snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1'/>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
-      <parameter type-id='type-id-106' name='target' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+      <parameter type-id='type-id-104' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
-      <parameter type-id='type-id-22' name='snaps' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+      <parameter type-id='type-id-22' name='snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
-      <parameter type-id='type-id-23' name='snapname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+      <parameter type-id='type-id-23' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
+    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
-      <parameter type-id='type-id-23' name='target' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
-      <parameter type-id='type-id-6' name='prefixlen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+      <parameter type-id='type-id-23' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+      <parameter type-id='type-id-6' name='prefixlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
-      <parameter type-id='type-id-44' name='buflen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+      <parameter type-id='type-id-43' name='buflen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-103' const='yes' id='type-id-137'/>
-    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-138'/>
-    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
-      <parameter type-id='type-id-138' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1'/>
+    <qualified-type-def type-id='type-id-101' const='yes' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-136'/>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
+      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
-      <parameter type-id='type-id-138' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
+      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
-      <parameter type-id='type-id-138' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
+      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
-      <parameter type-id='type-id-6' name='proplen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-6' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-139'/>
-    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
-      <parameter type-id='type-id-139' name='propvalue' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
+    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-137'/>
+    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
+      <parameter type-id='type-id-137' name='propvalue' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
-      <parameter type-id='type-id-6' name='proplen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-6' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
-      <parameter type-id='type-id-139' name='propvalue' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
+    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
+      <parameter type-id='type-id-137' name='propvalue' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='259' column='1' id='type-id-140'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='259' column='1' id='type-id-138'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPROP_SRC_NONE' value='1'/>
       <enumerator name='ZPROP_SRC_DEFAULT' value='2'/>
@@ -1882,120 +1871,131 @@
       <enumerator name='ZPROP_SRC_INHERITED' value='16'/>
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
-    <typedef-decl name='zprop_source_t' type-id='type-id-140' filepath='../../include/sys/fs/zfs.h' line='266' column='1' id='type-id-141'/>
-    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-142'/>
-    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-139' name='value' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-142' name='src' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
-      <parameter type-id='type-id-23' name='statbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
-      <parameter type-id='type-id-44' name='statlen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+    <typedef-decl name='zprop_source_t' type-id='type-id-138' filepath='../../include/sys/fs/zfs.h' line='266' column='1' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-140'/>
+    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-137' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-23' name='statbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-43' name='statlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1'/>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-43' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-23' name='statbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-43' name='statlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-44' name='proplen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-43' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
-      <parameter type-id='type-id-5' name='received' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+      <parameter type-id='type-id-5' name='received' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
+    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
-      <parameter type-id='type-id-106' name='propval' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+      <parameter type-id='type-id-104' name='propval' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-27' name='zoned' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-18' name='zpool_hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-5' name='key_params_ok' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
-      <parameter type-id='type-id-106' name='errbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-27' name='zoned' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-18' name='zpool_hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-5' name='key_params_ok' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+      <parameter type-id='type-id-104' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-143'/>
-    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
-      <parameter type-id='type-id-143' name='spa_version' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-141'/>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
+      <parameter type-id='type-id-141' name='spa_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
-      <parameter type-id='type-id-106' name='fsname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
+      <parameter type-id='type-id-104' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
-      <parameter type-id='type-id-106' name='special' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
-      <parameter type-id='type-id-106' name='mountp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
-      <parameter type-id='type-id-106' name='mntopts' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
+      <parameter type-id='type-id-104' name='special' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
+      <parameter type-id='type-id-104' name='mountp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <parameter type-id='type-id-104' name='mntopts' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <parameter type-id='type-id-5' name='enable' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
+      <parameter type-id='type-id-5' name='enable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <parameter type-id='type-id-6' name='types' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <parameter type-id='type-id-6' name='types' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_bookmark_handle'>
-      <parameter type-id='type-id-104' name='parent' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
-      <parameter type-id='type-id-22' name='bmark_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_bookmark_handle'>
+      <parameter type-id='type-id-102' name='parent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
+      <parameter type-id='type-id-22' name='bmark_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1'/>
+    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
-      <parameter type-id='type-id-104' name='zhp_orig' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
+      <parameter type-id='type-id-102' name='zhp_orig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-144'>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-142'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_name' type-id='type-id-145' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
+        <var-decl name='zc_name' type-id='type-id-143' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32768'>
         <var-decl name='zc_nvlist_src' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
@@ -2019,7 +2019,7 @@
         <var-decl name='zc_history' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='33152'>
-        <var-decl name='zc_value' type-id='type-id-146' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
+        <var-decl name='zc_value' type-id='type-id-144' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='98688'>
         <var-decl name='zc_string' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
@@ -2055,22 +2055,22 @@
         <var-decl name='zc_iflags' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101376'>
-        <var-decl name='zc_share' type-id='type-id-147' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
+        <var-decl name='zc_share' type-id='type-id-145' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101632'>
         <var-decl name='zc_objset_stats' type-id='type-id-21' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='103936'>
-        <var-decl name='zc_begin_record' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
+        <var-decl name='zc_begin_record' type-id='type-id-146' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='type-id-149' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
+        <var-decl name='zc_inject_record' type-id='type-id-147' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109184'>
-        <var-decl name='zc_defer_destroy' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
+        <var-decl name='zc_defer_destroy' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109216'>
-        <var-decl name='zc_flags' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
+        <var-decl name='zc_flags' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109248'>
         <var-decl name='zc_action_handle' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
@@ -2079,10 +2079,10 @@
         <var-decl name='zc_cleanup_fd' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_simple' type-id='type-id-100' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
+        <var-decl name='zc_simple' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109352'>
-        <var-decl name='zc_pad' type-id='type-id-150' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
+        <var-decl name='zc_pad' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_sendobj' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
@@ -2094,23 +2094,23 @@
         <var-decl name='zc_createtxg' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109568'>
-        <var-decl name='zc_stat' type-id='type-id-151' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
+        <var-decl name='zc_stat' type-id='type-id-149' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109888'>
         <var-decl name='zc_zoneid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='32768' id='type-id-145'>
-      <subrange length='4096' type-id='type-id-49' id='type-id-152'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='32768' id='type-id-143'>
+      <subrange length='4096' type-id='type-id-48' id='type-id-150'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='65536' id='type-id-146'>
-      <subrange length='8192' type-id='type-id-49' id='type-id-153'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='65536' id='type-id-144'>
+      <subrange length='8192' type-id='type-id-48' id='type-id-151'/>
 
     </array-type-def>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-154'>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-152'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='z_exportdata' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
       </data-member>
@@ -2124,8 +2124,8 @@
         <var-decl name='z_sharemax' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='type-id-154' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-147'/>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-148'>
+    <typedef-decl name='zfs_share_t' type-id='type-id-152' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-145'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-146'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='drr_magic' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
       </data-member>
@@ -2136,10 +2136,10 @@
         <var-decl name='drr_creation_time' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='type-id-99' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
+        <var-decl name='drr_type' type-id='type-id-97' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+        <var-decl name='drr_flags' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='drr_toguid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
@@ -2151,7 +2151,7 @@
         <var-decl name='drr_toname' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-155'>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-153'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zi_objset' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
       </data-member>
@@ -2168,28 +2168,28 @@
         <var-decl name='zi_guid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
+        <var-decl name='zi_level' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
+        <var-decl name='zi_error' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='zi_type' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+        <var-decl name='zi_freq' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+        <var-decl name='zi_failfast' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='zi_func' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
+        <var-decl name='zi_iotype' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='type-id-63' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
+        <var-decl name='zi_duration' type-id='type-id-61' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2624'>
         <var-decl name='zi_timer' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
@@ -2198,19 +2198,19 @@
         <var-decl name='zi_nlanes' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
+        <var-decl name='zi_cmd' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='type-id-64' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
+        <var-decl name='zi_dvas' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='type-id-155' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-149'/>
+    <typedef-decl name='zinject_record_t' type-id='type-id-153' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-147'/>
 
-    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='24' id='type-id-150'>
-      <subrange length='3' type-id='type-id-49' id='type-id-156'/>
+    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='24' id='type-id-148'>
+      <subrange length='3' type-id='type-id-48' id='type-id-154'/>
 
     </array-type-def>
-    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-157'>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-155'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zs_gen' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
       </data-member>
@@ -2221,57 +2221,57 @@
         <var-decl name='zs_links' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zs_ctime' type-id='type-id-158' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
+        <var-decl name='zs_ctime' type-id='type-id-156' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='128' id='type-id-158'>
-      <subrange length='2' type-id='type-id-49' id='type-id-88'/>
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='128' id='type-id-156'>
+      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
 
     </array-type-def>
-    <typedef-decl name='zfs_stat_t' type-id='type-id-157' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-151'/>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-144' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-159'/>
-    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-160'/>
-    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_simple_handle_zc'>
-      <parameter type-id='type-id-104' name='pzhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
-      <return type-id='type-id-104'/>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-155' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-149'/>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-142' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_simple_handle_zc'>
+      <parameter type-id='type-id-102' name='pzhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle_zc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle_zc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_validate_name'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-6' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-5' name='modifying' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_validate_name'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-6' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-5' name='modifying' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-161'>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-159'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='type-id-23' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
       </data-member>
@@ -2285,454 +2285,448 @@
         <var-decl name='mnt_mntopts' type-id='type-id-23' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-162'/>
-    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
-      <parameter type-id='type-id-106' name='fsname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
-      <parameter type-id='type-id-162' name='entry' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-160'/>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
+      <parameter type-id='type-id-104' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
+      <parameter type-id='type-id-160' name='entry' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-163'/>
-    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
-      <parameter type-id='type-id-163' name='source' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-161'/>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+      <parameter type-id='type-id-161' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
-      <parameter type-id='type-id-20' name='types' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+      <parameter type-id='type-id-20' name='types' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='../../include/libzfs_core.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../include/sys/nvpair.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='../../include/libzfs.h' line='411' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='../../include/libzfs.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strtol' mangled-name='strtol' filepath='/usr/include/stdlib.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' filepath='../../include/libzfs_core.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_size' mangled-name='nvlist_size' filepath='../../include/sys/nvpair.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_pack' mangled-name='nvlist_pack' filepath='../../include/sys/nvpair.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' filepath='../../include/sys/nvpair.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strerror' mangled-name='strerror' filepath='/usr/include/string.h' line='397' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strerror' mangled-name='strerror' filepath='/usr/include/string.h' line='396' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_empty' mangled-name='nvlist_empty' filepath='../../include/sys/nvpair.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_release' mangled-name='lzc_release' filepath='../../include/libzfs_core.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_free' mangled-name='fnvlist_free' filepath='../../include/sys/nvpair.h' line='277' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' filepath='../../include/sys/nvpair.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_hold' mangled-name='lzc_hold' filepath='../../include/libzfs_core.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='ioctl' mangled-name='ioctl' filepath='/usr/include/x86_64-linux-gnu/sys/ioctl.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../include/sys/nvpair.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='../../include/libzfs_impl.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../include/sys/nvpair.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../include/sys/nvpair.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='../../include/libzfs_impl.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='../../include/libzfs_impl.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='../../include/libzfs_impl.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='../../include/libzfs_impl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='../../include/libzfs_impl.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_free' mangled-name='changelist_free' filepath='../../include/libzfs_impl.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='616' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='../../include/libzfs.h' line='621' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='../../include/libzfs.h' line='622' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='../../include/libzfs_core.h' line='118' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='../../include/libzfs_impl.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strcspn' mangled-name='strcspn' filepath='/usr/include/string.h' line='273' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strcspn' mangled-name='strcspn' filepath='/usr/include/string.h' line='272' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_open' mangled-name='zpool_open' filepath='../../include/libzfs.h' line='234' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_close' mangled-name='zpool_close' filepath='../../include/libzfs.h' line='236' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' filepath='../../include/libzfs_core.h' line='52' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_promote' mangled-name='lzc_promote' filepath='../../include/libzfs_core.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='../../include/libzfs.h' line='528' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='../../include/libzfs.h' line='529' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_clone' mangled-name='lzc_clone' filepath='../../include/libzfs_core.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' filepath='../../include/libzfs_core.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' filepath='../../include/libzfs_core.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_destroy' mangled-name='lzc_destroy' filepath='../../include/libzfs_core.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../include/libzfs.h' line='483' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../include/libzfs.h' line='484' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' filepath='../../include/zfs_namecheck.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='../../include/libzfs.h' line='526' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='../../include/libzfs.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_create' mangled-name='lzc_create' filepath='../../include/libzfs_core.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strdup' mangled-name='strdup' filepath='/usr/include/string.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strdup' mangled-name='strdup' filepath='/usr/include/string.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='../../include/libzfs.h' line='840' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='../../include/libzfs.h' line='841' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' filepath='../../include/libzfs.h' line='862' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' filepath='../../include/libzfs.h' line='863' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__builtin___strncpy_chk' mangled-name='__strncpy_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strncpy' mangled-name='strncpy' filepath='/usr/include/string.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strrchr' mangled-name='strrchr' filepath='/usr/include/string.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strrchr' mangled-name='strrchr' filepath='/usr/include/string.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' filepath='../../include/libzutil.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' filepath='../../include/libzutil.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../include/sys/fs/zfs.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='../../include/libzfs_impl.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='localtime_r' mangled-name='localtime_r' filepath='/usr/include/time.h' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strftime' mangled-name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='../../include/libzfs.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__builtin_snprintf' mangled-name='snprintf' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' filepath='../../include/zfs_prop.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' filepath='../../include/sys/fs/zfs.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' filepath='../../include/sys/fs/zfs.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='abort' mangled-name='abort' filepath='/usr/include/stdlib.h' line='591' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='abort' mangled-name='abort' filepath='/usr/include/stdlib.h' line='588' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' filepath='../../include/sys/nvpair.h' line='211' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fprintf' mangled-name='fprintf' filepath='/usr/include/stdio.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' filepath='../../include/sys/nvpair.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' filepath='../../include/libzfs_core.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strsep' mangled-name='strsep' filepath='/usr/include/string.h' line='440' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strsep' mangled-name='strsep' filepath='/usr/include/string.h' line='439' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='hasmntopt' mangled-name='hasmntopt' filepath='/usr/include/mntent.h' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' filepath='../../include/sys/fs/zfs.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' filepath='../../include/sys/fs/zfs.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../include/sys/fs/zfs.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='../../include/libzfs_impl.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__asprintf_chk' mangled-name='__asprintf_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='161' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='asprintf' mangled-name='asprintf' filepath='/usr/include/stdio.h' line='372' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' filepath='../../include/sys/nvpair.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' filepath='../../include/sys/nvpair.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='../../include/libzfs.h' line='865' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='../../include/libzfs.h' line='866' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='../../include/libzfs.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='../../include/libzfs.h' line='564' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../include/zfs_namecheck.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='../../include/libzfs_impl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' filepath='../../include/sys/fs/zfs.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='../../include/libzfs_impl.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../include/sys/fs/zfs.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' filepath='../../include/sys/fs/zfs.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' filepath='../../include/sys/fs/zfs.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='738' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_find' mangled-name='avl_find' filepath='../../include/sys/avl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../include/sys/avl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='756' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='774' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../include/sys/avl.h' line='281' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_add' mangled-name='avl_add' filepath='../../include/sys/avl.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='freopen' mangled-name='freopen64' filepath='/usr/include/stdio.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='getmntany' mangled-name='getmntany' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../include/sys/avl.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../include/sys/avl.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='730' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='755' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='725' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='750' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_create' mangled-name='avl_create' filepath='../../include/sys/avl.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' filepath='../../include/libzfs_core.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='../../include/libzfs.h' line='237' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='../../include/libzfs.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='../../include/libzfs_impl.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../include/zfs_namecheck.h' line='58' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strtoul' mangled-name='strtoul' filepath='/usr/include/stdlib.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='getgrnam' mangled-name='getgrnam' filepath='/usr/include/grp.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='getpwnam' mangled-name='getpwnam' filepath='/usr/include/pwd.h' line='116' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../include/libzfs.h' line='482' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../include/libzfs.h' line='483' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strstr' mangled-name='strstr' filepath='/usr/include/string.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strstr' mangled-name='strstr' filepath='/usr/include/string.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_exists' mangled-name='lzc_exists' filepath='../../include/libzfs_core.h' line='115' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='168' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='freopen' mangled-name='freopen64' filepath='/usr/include/stdio.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='getmntany' mangled-name='getmntany' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' filepath='../../include/sys/nvpair.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-127'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-106'/>
-      <parameter type-id='type-id-126'/>
+    <function-type size-in-bits='64' id='type-id-125'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-104'/>
+      <parameter type-id='type-id-124'/>
       <parameter type-id='type-id-27'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-106' name='fromsnap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-106' name='tosnap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-104' name='fromsnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='__builtin_strncpy' mangled-name='strncpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
     <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='../../include/libzfs_impl.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='../../include/libzfs_impl.h' line='204' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='pipe2' mangled-name='pipe2' filepath='/usr/include/unistd.h' line='422' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_create' mangled-name='pthread_create' filepath='/usr/include/pthread.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_create' mangled-name='pthread_create' filepath='/usr/include/pthread.h' line='234' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_cancel' mangled-name='pthread_cancel' filepath='/usr/include/pthread.h' line='489' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_join' mangled-name='pthread_join' filepath='/usr/include/pthread.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='pthread_join' mangled-name='pthread_join' filepath='/usr/include/pthread.h' line='215' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pthread_cancel' mangled-name='pthread_cancel' filepath='/usr/include/pthread.h' line='514' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fdopen' mangled-name='fdopen' filepath='/usr/include/stdio.h' line='279' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='../../include/libzfs.h' line='822' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='../../include/libzfs.h' line='823' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-164'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-162'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-165' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+        <var-decl name='pco_refresh_config' type-id='type-id-163' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-166' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
+        <var-decl name='pco_pool_active' type-id='type-id-164' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-167' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-168'/>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-165'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-169' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-170'/>
-    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-166'/>
-    <qualified-type-def type-id='type-id-164' const='yes' id='type-id-171'/>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-171' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-172'/>
-    <var-decl name='libzfs_config_ops' type-id='type-id-172' mangled-name='libzfs_config_ops' visibility='default' filepath='../../include/libzutil.h' line='59' column='1' elf-symbol-id='libzfs_config_ops'/>
-    <enum-decl name='pool_state' filepath='../../include/sys/fs/zfs.h' line='914' column='1' id='type-id-173'>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-165' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-163'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-167' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-164'/>
+    <qualified-type-def type-id='type-id-162' const='yes' id='type-id-169'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-169' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-170'/>
+    <var-decl name='libzfs_config_ops' type-id='type-id-170' mangled-name='libzfs_config_ops' visibility='default' filepath='../../include/libzutil.h' line='59' column='1' elf-symbol-id='libzfs_config_ops'/>
+    <enum-decl name='pool_state' filepath='../../include/sys/fs/zfs.h' line='914' column='1' id='type-id-171'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_STATE_ACTIVE' value='0'/>
       <enumerator name='POOL_STATE_EXPORTED' value='1'/>
@@ -2743,137 +2737,137 @@
       <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
       <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
     </enum-decl>
-    <typedef-decl name='pool_state_t' type-id='type-id-173' filepath='../../include/sys/fs/zfs.h' line='923' column='1' id='type-id-174'/>
-    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
-    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-175' name='state' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-163' name='namestr' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-116' name='inuse' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='301' column='1'/>
+    <typedef-decl name='pool_state_t' type-id='type-id-171' filepath='../../include/sys/fs/zfs.h' line='923' column='1' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
+    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-173' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-161' name='namestr' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-114' name='inuse' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='301' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_import.c' line='144' column='1'/>
+    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='144' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_read_label' mangled-name='zpool_read_label' filepath='../../include/libzutil.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='../../include/libzfs.h' line='247' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__pread64_alias' mangled-name='pread64' filepath='/usr/include/x86_64-linux-gnu/bits/unistd.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='pread64' mangled-name='pread64' filepath='/usr/include/unistd.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='pwrite64' mangled-name='pwrite64' filepath='/usr/include/unistd.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__fxstat64' mangled-name='__fxstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='428' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='../../include/libzfs_impl.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-169'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-106'/>
+    <function-type size-in-bits='64' id='type-id-167'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-104'/>
       <parameter type-id='type-id-27'/>
-      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-114'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-167'>
-      <parameter type-id='type-id-43'/>
+    <function-type size-in-bits='64' id='type-id-165'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-22'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
-      <parameter type-id='type-id-5' name='allowrecursion' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-5' name='allowrecursion' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
-      <parameter type-id='type-id-104' name='fs_zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
-      <parameter type-id='type-id-106' name='spec_orig' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
-      <parameter type-id='type-id-43' name='arg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
+      <parameter type-id='type-id-102' name='fs_zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-104' name='spec_orig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+      <parameter type-id='type-id-42' name='arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-112' name='callback' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-27' name='min_txg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
-      <parameter type-id='type-id-27' name='max_txg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-110' name='callback' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-27' name='min_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+      <parameter type-id='type-id-27' name='max_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-5' name='simple' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
-      <parameter type-id='type-id-27' name='min_txg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
-      <parameter type-id='type-id-27' name='max_txg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-5' name='simple' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-27' name='min_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-27' name='max_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='../../include/libzfs.h' line='517' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='../../include/libzfs.h' line='518' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='../../include/libzfs.h' line='814' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='../../include/libzfs.h' line='815' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_first' mangled-name='avl_first' filepath='../../include/sys/avl.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='../../include/libzfs_impl.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='../../include/libzfs.h' line='469' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='../../include/libzfs.h' line='470' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='../../include/libzfs_impl.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='../../include/libzfs_impl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-176' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1' id='type-id-177'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-174' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1' id='type-id-175'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='p_prop' type-id='type-id-2' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
       </data-member>
@@ -2887,335 +2881,335 @@
         <var-decl name='p_unshare_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='218' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='proto_table_t' type-id='type-id-177' filepath='../../include/libzfs_impl.h' line='219' column='1' id='type-id-176'/>
+    <typedef-decl name='proto_table_t' type-id='type-id-175' filepath='../../include/libzfs_impl.h' line='219' column='1' id='type-id-174'/>
 
-    <array-type-def dimensions='1' type-id='type-id-176' size-in-bits='384' id='type-id-178'>
-      <subrange length='2' type-id='type-id-49' id='type-id-88'/>
-
-    </array-type-def>
-    <var-decl name='proto_table' type-id='type-id-178' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='242' column='1' elf-symbol-id='proto_table'/>
-
-    <array-type-def dimensions='1' type-id='type-id-108' size-in-bits='64' alignment-in-bits='32' id='type-id-179'>
-      <subrange length='2' type-id='type-id-49' id='type-id-88'/>
+    <array-type-def dimensions='1' type-id='type-id-174' size-in-bits='384' id='type-id-176'>
+      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
 
     </array-type-def>
-    <var-decl name='nfs_only' type-id='type-id-179' mangled-name='nfs_only' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='110' column='1' elf-symbol-id='nfs_only'/>
-    <var-decl name='smb_only' type-id='type-id-179' mangled-name='smb_only' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='115' column='1' elf-symbol-id='smb_only'/>
+    <var-decl name='proto_table' type-id='type-id-176' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='242' column='1' elf-symbol-id='proto_table'/>
 
-    <array-type-def dimensions='1' type-id='type-id-108' size-in-bits='96' alignment-in-bits='32' id='type-id-180'>
-      <subrange length='3' type-id='type-id-49' id='type-id-156'/>
+    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='64' alignment-in-bits='32' id='type-id-177'>
+      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
 
     </array-type-def>
-    <var-decl name='share_all_proto' type-id='type-id-180' mangled-name='share_all_proto' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='119' column='1' elf-symbol-id='share_all_proto'/>
-    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
+    <var-decl name='nfs_only' type-id='type-id-177' mangled-name='nfs_only' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='110' column='1' elf-symbol-id='nfs_only'/>
+    <var-decl name='smb_only' type-id='type-id-177' mangled-name='smb_only' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='115' column='1' elf-symbol-id='smb_only'/>
+
+    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='96' alignment-in-bits='32' id='type-id-178'>
+      <subrange length='3' type-id='type-id-48' id='type-id-154'/>
+
+    </array-type-def>
+    <var-decl name='share_all_proto' type-id='type-id-178' mangled-name='share_all_proto' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='119' column='1' elf-symbol-id='share_all_proto'/>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
-      <parameter type-id='type-id-106' name='mntopts' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+      <parameter type-id='type-id-104' name='mntopts' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-181'/>
-    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
-      <parameter type-id='type-id-181' name='handles' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
-      <parameter type-id='type-id-44' name='num_handles' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-112' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-5' name='parallel' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <return type-id='type-id-51'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-179'/>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
+      <parameter type-id='type-id-179' name='handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
+      <parameter type-id='type-id-43' name='num_handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-5' name='parallel' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='624' column='1' id='type-id-182'>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='625' column='1' id='type-id-180'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_handles' type-id='type-id-181' visibility='default' filepath='../../include/libzfs.h' line='625' column='1'/>
+        <var-decl name='cb_handles' type-id='type-id-179' visibility='default' filepath='../../include/libzfs.h' line='626' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cb_alloc' type-id='type-id-44' visibility='default' filepath='../../include/libzfs.h' line='626' column='1'/>
+        <var-decl name='cb_alloc' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cb_used' type-id='type-id-44' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
+        <var-decl name='cb_used' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='628' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='get_all_cb_t' type-id='type-id-182' filepath='../../include/libzfs.h' line='628' column='1' id='type-id-183'/>
-    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-184'/>
-    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
-      <parameter type-id='type-id-184' name='cbp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
-      <return type-id='type-id-51'/>
+    <typedef-decl name='get_all_cb_t' type-id='type-id-180' filepath='../../include/libzfs.h' line='629' column='1' id='type-id-181'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-182'/>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='type-id-182' name='cbp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='1002' column='1'/>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
+      <parameter type-id='type-id-104' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1002' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
-      <parameter type-id='type-id-109' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='909' column='1'/>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
+      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='909' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='893' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='893' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='type-id-104' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
-      <parameter type-id='type-id-109' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
+      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
-      <parameter type-id='type-id-23' name='options' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
-      <parameter type-id='type-id-108' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
+      <parameter type-id='type-id-23' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
+      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
-      <parameter type-id='type-id-163' name='where' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
-      <parameter type-id='type-id-163' name='where' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='120' column='1' id='type-id-185'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='120' column='1' id='type-id-183'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='SHARED_NOT_SHARED' value='0'/>
       <enumerator name='SHARED_NFS' value='2'/>
       <enumerator name='SHARED_SMB' value='4'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_type_t' type-id='type-id-185' filepath='../../include/libzfs_impl.h' line='124' column='1' id='type-id-186'/>
-    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <parameter type-id='type-id-163' name='where' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <parameter type-id='type-id-108' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <return type-id='type-id-186'/>
+    <typedef-decl name='zfs_share_type_t' type-id='type-id-183' filepath='../../include/libzfs_impl.h' line='124' column='1' id='type-id-184'/>
+    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <return type-id='type-id-184'/>
     </function-decl>
-    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
-      <parameter type-id='type-id-109' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
+    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
+      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-108' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='700' column='1'/>
+    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='700' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1'/>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-106' name='options' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
+    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-104' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
-      <parameter type-id='type-id-106' name='options' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-104' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
-      <parameter type-id='type-id-163' name='where' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
-      <parameter type-id='type-id-17' name='zfs_hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
-      <parameter type-id='type-id-106' name='special' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
-      <parameter type-id='type-id-163' name='where' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
+      <parameter type-id='type-id-17' name='zfs_hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-104' name='special' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_is_mountable' mangled-name='zfs_is_mountable' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mountable'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-44' name='buflen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-142' name='source' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+    <function-decl name='zfs_is_mountable' mangled-name='zfs_is_mountable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mountable'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-43' name='buflen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-140' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
-      <parameter type-id='type-id-108' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
-      <return type-id='type-id-186'/>
+    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='qsort' mangled-name='qsort' filepath='/usr/include/stdlib.h' line='830' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='qsort' mangled-name='qsort' filepath='/usr/include/stdlib.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' filepath='../../include/thread_pool.h' line='44' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tpool_create' mangled-name='tpool_create' filepath='../../include/thread_pool.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tpool_wait' mangled-name='tpool_wait' filepath='../../include/thread_pool.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='tpool_destroy' mangled-name='tpool_destroy' filepath='../../include/thread_pool.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='rmdir' mangled-name='rmdir' filepath='/usr/include/unistd.h' line='834' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='../../include/libzfs.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='../../lib/libspl/include/libshare.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='../../lib/libspl/include/libshare.h' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='../../lib/libspl/include/libshare.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='../../lib/libspl/include/libshare.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='../../lib/libspl/include/libshare.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='../../include/libzfs.h' line='229' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='../../include/libzfs.h' line='525' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='../../include/libzfs.h' line='526' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='532' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='533' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='do_unmount' mangled-name='do_unmount' filepath='../../include/libzfs_impl.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='../../include/libzfs.h' line='816' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='../../include/libzfs.h' line='817' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__lxstat' mangled-name='__lxstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__openat_alias' mangled-name='openat64' filepath='/usr/include/x86_64-linux-gnu/bits/fcntl2.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='openat' mangled-name='openat64' filepath='/usr/include/fcntl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fdopendir' mangled-name='fdopendir' filepath='/usr/include/dirent.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='readdir64' mangled-name='readdir64' filepath='/usr/include/dirent.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='closedir' mangled-name='closedir' filepath='/usr/include/dirent.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__xstat' mangled-name='__xstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='409' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='statfs64' mangled-name='statfs64' filepath='/usr/include/x86_64-linux-gnu/sys/statfs.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='do_mount' mangled-name='do_mount' filepath='../../include/libzfs_impl.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='../../include/libzfs.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='mkdirp' mangled-name='mkdirp' filepath='../../lib/libspl/include/libgen.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='../../include/libzfs.h' line='531' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='../../include/libzfs.h' line='532' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='../../include/libzfs.h' line='509' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='../../include/libzfs.h' line='510' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='../../lib/libspl/include/libshare.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4719' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4719' column='1'/>
-      <parameter type-id='type-id-117' name='nvlp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4719' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
+      <parameter type-id='type-id-115' name='nvlp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-69' const='yes' id='type-id-187'/>
-    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-188'/>
-    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4706' column='1'/>
-      <parameter type-id='type-id-188' name='envmap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4706' column='1'/>
+    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-185'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
+      <parameter type-id='type-id-186' name='envmap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-189'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-187'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
       <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
@@ -3227,131 +3221,131 @@
       <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
       <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
     </enum-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-189' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-190'/>
-    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4688' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4688' column='1'/>
-      <parameter type-id='type-id-190' name='activity' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4688' column='1'/>
-      <parameter type-id='type-id-116' name='missing' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4689' column='1'/>
-      <parameter type-id='type-id-116' name='waited' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4689' column='1'/>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-187' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-188'/>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
+      <parameter type-id='type-id-188' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4661' column='1'/>
-      <parameter type-id='type-id-190' name='activity' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4661' column='1'/>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
+      <parameter type-id='type-id-188' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-27' name='dsobj' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-27' name='obj' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-23' name='pathname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4653' column='1'/>
-      <parameter type-id='type-id-44' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4653' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-27' name='dsobj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-27' name='obj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-23' name='pathname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-27' name='dsobj' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-27' name='obj' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4652' column='1'/>
-      <parameter type-id='type-id-23' name='pathname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4653' column='1'/>
-      <parameter type-id='type-id-44' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4653' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-27' name='dsobj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-27' name='obj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-23' name='pathname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4563' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4563' column='1'/>
-      <parameter type-id='type-id-27' name='eid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4563' column='1'/>
-      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4563' column='1'/>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+      <parameter type-id='type-id-27' name='eid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4540' column='1'/>
-      <parameter type-id='type-id-143' name='count' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4540' column='1'/>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
+      <parameter type-id='type-id-141' name='count' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4480' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4480' column='1'/>
-      <parameter type-id='type-id-117' name='nvp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4480' column='1'/>
-      <parameter type-id='type-id-143' name='dropped' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4481' column='1'/>
-      <parameter type-id='type-id-66' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4481' column='1'/>
-      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4481' column='1'/>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-115' name='nvp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-141' name='dropped' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+      <parameter type-id='type-id-64' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4410' column='1'/>
-      <parameter type-id='type-id-117' name='nvhisp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4410' column='1'/>
-      <parameter type-id='type-id-139' name='off' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4410' column='1'/>
-      <parameter type-id='type-id-116' name='eof' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4411' column='1'/>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-115' name='nvhisp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-137' name='off' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-114' name='eof' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4391' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4341' column='1'/>
-      <parameter type-id='type-id-106' name='message' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4341' column='1'/>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
+      <parameter type-id='type-id-104' name='message' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4329' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
-      <parameter type-id='type-id-6' name='argc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4329' column='1'/>
-      <parameter type-id='type-id-163' name='argv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4329' column='1'/>
-      <parameter type-id='type-id-23' name='string' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4329' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4329' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='type-id-6' name='argc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-23' name='string' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4313' column='1'/>
-      <parameter type-id='type-id-27' name='new_version' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4313' column='1'/>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
+      <parameter type-id='type-id-27' name='new_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4214' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4214' column='1'/>
-      <parameter type-id='type-id-117' name='nverrlistp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4214' column='1'/>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
+      <parameter type-id='type-id-115' name='nverrlistp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4089' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4089' column='1'/>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4089' column='1'/>
-      <parameter type-id='type-id-22' name='nv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4089' column='1'/>
-      <parameter type-id='type-id-6' name='name_flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4090' column='1'/>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-22' name='nv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-6' name='name_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4070' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4052' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4052' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4052' column='1'/>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4034' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4034' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4034' column='1'/>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3990' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3990' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3990' column='1'/>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
+      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3914' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3914' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3914' column='1'/>
-      <parameter type-id='type-id-22' name='rewindnvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3914' column='1'/>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+      <parameter type-id='type-id-22' name='rewindnvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3881' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3881' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3881' column='1'/>
-      <parameter type-id='type-id-139' name='sizep' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3882' column='1'/>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
+      <parameter type-id='type-id-137' name='sizep' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3862' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3789' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3789' column='1'/>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='258' column='1' id='type-id-191'>
+    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='258' column='1' id='type-id-189'>
       <data-member access='public' layout-offset-in-bits='31'>
         <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='260' column='1'/>
       </data-member>
@@ -3362,30 +3356,30 @@
         <var-decl name='name_flags' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='splitflags_t' type-id='type-id-191' filepath='../../include/libzfs.h' line='265' column='1' id='type-id-192'/>
-    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3545' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3545' column='1'/>
-      <parameter type-id='type-id-23' name='newname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3545' column='1'/>
-      <parameter type-id='type-id-117' name='newroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3545' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3546' column='1'/>
-      <parameter type-id='type-id-192' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3546' column='1'/>
+    <typedef-decl name='splitflags_t' type-id='type-id-189' filepath='../../include/libzfs.h' line='265' column='1' id='type-id-190'/>
+    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-23' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-115' name='newroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
+      <parameter type-id='type-id-190' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3448' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3448' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3448' column='1'/>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3275' column='1'/>
-      <parameter type-id='type-id-106' name='old_disk' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3275' column='1'/>
-      <parameter type-id='type-id-106' name='new_disk' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3276' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3276' column='1'/>
-      <parameter type-id='type-id-6' name='replacing' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3276' column='1'/>
-      <parameter type-id='type-id-5' name='rebuild' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3276' column='1'/>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-104' name='old_disk' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-104' name='new_disk' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-6' name='replacing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-5' name='rebuild' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='vdev_aux' filepath='../../include/sys/fs/zfs.h' line='884' column='1' id='type-id-193'>
+    <enum-decl name='vdev_aux' filepath='../../include/sys/fs/zfs.h' line='884' column='1' id='type-id-191'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='VDEV_AUX_NONE' value='0'/>
       <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
@@ -3409,26 +3403,26 @@
       <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
       <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
     </enum-decl>
-    <typedef-decl name='vdev_aux_t' type-id='type-id-193' filepath='../../include/sys/fs/zfs.h' line='906' column='1' id='type-id-194'/>
-    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3221' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3221' column='1'/>
-      <parameter type-id='type-id-194' name='aux' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3221' column='1'/>
+    <typedef-decl name='vdev_aux_t' type-id='type-id-191' filepath='../../include/sys/fs/zfs.h' line='906' column='1' id='type-id-192'/>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3186' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3186' column='1'/>
-      <parameter type-id='type-id-194' name='aux' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3186' column='1'/>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3136' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3136' column='1'/>
-      <parameter type-id='type-id-5' name='istmp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3136' column='1'/>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+      <parameter type-id='type-id-5' name='istmp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='vdev_state' filepath='../../include/sys/fs/zfs.h' line='867' column='1' id='type-id-195'>
+    <enum-decl name='vdev_state' filepath='../../include/sys/fs/zfs.h' line='867' column='1' id='type-id-193'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
       <enumerator name='VDEV_STATE_CLOSED' value='1'/>
@@ -3439,72 +3433,72 @@
       <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
       <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
     </enum-decl>
-    <typedef-decl name='vdev_state_t' type-id='type-id-195' filepath='../../include/sys/fs/zfs.h' line='876' column='1' id='type-id-196'/>
-    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
-    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3049' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3049' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3049' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3049' column='1'/>
-      <parameter type-id='type-id-197' name='newstate' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3050' column='1'/>
+    <typedef-decl name='vdev_state_t' type-id='type-id-193' filepath='../../include/sys/fs/zfs.h' line='876' column='1' id='type-id-194'/>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-195' name='newstate' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3030' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3039' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3039' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3039' column='1'/>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3001' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3001' column='1'/>
-      <parameter type-id='type-id-23' name='physpath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3001' column='1'/>
-      <parameter type-id='type-id-44' name='phypath_size' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='3001' column='1'/>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+      <parameter type-id='type-id-23' name='physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+      <parameter type-id='type-id-43' name='phypath_size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2828' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2828' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2828' column='1'/>
-      <parameter type-id='type-id-116' name='avail_spare' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2828' column='1'/>
-      <parameter type-id='type-id-116' name='l2cache' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2829' column='1'/>
-      <parameter type-id='type-id-116' name='log' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2829' column='1'/>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2777' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2777' column='1'/>
-      <parameter type-id='type-id-106' name='ppath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2777' column='1'/>
-      <parameter type-id='type-id-116' name='avail_spare' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2778' column='1'/>
-      <parameter type-id='type-id-116' name='l2cache' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2778' column='1'/>
-      <parameter type-id='type-id-116' name='log' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2778' column='1'/>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-104' name='ppath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='938' column='1' id='type-id-198'>
+    <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='938' column='1' id='type-id-196'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_SCAN_NONE' value='0'/>
       <enumerator name='POOL_SCAN_SCRUB' value='1'/>
       <enumerator name='POOL_SCAN_RESILVER' value='2'/>
       <enumerator name='POOL_SCAN_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_scan_func_t' type-id='type-id-198' filepath='../../include/sys/fs/zfs.h' line='943' column='1' id='type-id-199'/>
-    <enum-decl name='pool_scrub_cmd' filepath='../../include/sys/fs/zfs.h' line='948' column='1' id='type-id-200'>
+    <typedef-decl name='pool_scan_func_t' type-id='type-id-196' filepath='../../include/sys/fs/zfs.h' line='943' column='1' id='type-id-197'/>
+    <enum-decl name='pool_scrub_cmd' filepath='../../include/sys/fs/zfs.h' line='948' column='1' id='type-id-198'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
       <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
       <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
     </enum-decl>
-    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-200' filepath='../../include/sys/fs/zfs.h' line='952' column='1' id='type-id-201'/>
-    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2502' column='1'/>
-      <parameter type-id='type-id-199' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2502' column='1'/>
-      <parameter type-id='type-id-201' name='cmd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2502' column='1'/>
+    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-198' filepath='../../include/sys/fs/zfs.h' line='952' column='1' id='type-id-199'/>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+      <parameter type-id='type-id-197' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+      <parameter type-id='type-id-199' name='cmd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-202'>
+    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-200'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_TRIM_START' value='0'/>
       <enumerator name='POOL_TRIM_CANCEL' value='1'/>
       <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
       <enumerator name='POOL_TRIM_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='type-id-202' filepath='../../include/sys/fs/zfs.h' line='1182' column='1' id='type-id-203'/>
-    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='267' column='1' id='type-id-204'>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-200' filepath='../../include/sys/fs/zfs.h' line='1182' column='1' id='type-id-201'/>
+    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='267' column='1' id='type-id-202'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='fullpool' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='269' column='1'/>
       </data-member>
@@ -3518,166 +3512,157 @@
         <var-decl name='rate' type-id='type-id-27' visibility='default' filepath='../../include/libzfs.h' line='278' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='trimflags_t' type-id='type-id-204' filepath='../../include/libzfs.h' line='279' column='1' id='type-id-205'/>
-    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-206'/>
-    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2446' column='1'/>
-      <parameter type-id='type-id-203' name='cmd_type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2446' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2446' column='1'/>
-      <parameter type-id='type-id-206' name='trim_flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2447' column='1'/>
+    <typedef-decl name='trimflags_t' type-id='type-id-202' filepath='../../include/libzfs.h' line='279' column='1' id='type-id-203'/>
+    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-204'/>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-201' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-204' name='trim_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2427' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-207'>
+    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-205'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_INITIALIZE_START' value='0'/>
       <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
       <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
       <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='type-id-207' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-208'/>
-    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2337' column='1'/>
-      <parameter type-id='type-id-208' name='cmd_type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2337' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2338' column='1'/>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-205' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-206'/>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-206' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2337' column='1'/>
-      <parameter type-id='type-id-208' name='cmd_type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2337' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='2338' column='1'/>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-206' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1941' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1941' column='1'/>
-      <parameter type-id='type-id-106' name='newname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1941' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1942' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1942' column='1'/>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-104' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1910' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
-      <parameter type-id='type-id-22' name='config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1910' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1852' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1852' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1852' column='1'/>
-      <parameter type-id='type-id-106' name='newname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1852' column='1'/>
-      <parameter type-id='type-id-23' name='altroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1853' column='1'/>
+    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-104' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-23' name='altroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1833' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1765' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1765' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1765' column='1'/>
-      <parameter type-id='type-id-6' name='reason' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1765' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1766' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-6' name='reason' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1746' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1707' column='1'/>
-      <parameter type-id='type-id-106' name='log_str' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1707' column='1'/>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
+      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1701' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1701' column='1'/>
-      <parameter type-id='type-id-106' name='log_str' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1701' column='1'/>
+    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1557' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1557' column='1'/>
+    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1535' column='1'/>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1535' column='1'/>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1471' column='1'/>
-      <parameter type-id='type-id-106' name='log_str' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1471' column='1'/>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
+      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1292' column='1'/>
-      <parameter type-id='type-id-106' name='pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1292' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1292' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1293' column='1'/>
-      <parameter type-id='type-id-22' name='fsprops' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1293' column='1'/>
+    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+      <parameter type-id='type-id-22' name='fsprops' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1202' column='1'/>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1192' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1180' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1159' column='1'/>
-      <parameter type-id='type-id-106' name='pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1159' column='1'/>
+    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-209'/>
-    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1128' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1128' column='1'/>
-      <parameter type-id='type-id-106' name='pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1128' column='1'/>
-      <parameter type-id='type-id-209' name='ret' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1128' column='1'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-207'/>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+      <parameter type-id='type-id-207' name='ret' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1086' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1086' column='1'/>
-      <parameter type-id='type-id-106' name='pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='1086' column='1'/>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='987' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='987' column='1'/>
-      <parameter type-id='type-id-5' name='isopen' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='987' column='1'/>
-      <parameter type-id='type-id-106' name='pool' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='987' column='1'/>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+      <parameter type-id='type-id-5' name='isopen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='925' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='925' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='925' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='925' column='1'/>
-      <parameter type-id='type-id-44' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='926' column='1'/>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='827' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='827' column='1'/>
-      <parameter type-id='type-id-134' name='plp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='827' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='828' column='1'/>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
+      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='771' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='771' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='771' column='1'/>
-      <parameter type-id='type-id-106' name='propval' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='771' column='1'/>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+      <parameter type-id='type-id-104' name='propval' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
-      <parameter type-id='type-id-174' name='state' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1'/>
-      <return type-id='type-id-106'/>
-    </function-decl>
-    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
-      <parameter type-id='type-id-196' name='state' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
-      <parameter type-id='type-id-194' name='aux' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
-      <return type-id='type-id-106'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='215' column='1' id='type-id-210'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='215' column='1' id='type-id-208'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
       <enumerator name='ZPOOL_PROP_NAME' value='0'/>
@@ -3715,463 +3700,481 @@
       <enumerator name='ZPOOL_PROP_COMPATIBILITY' value='32'/>
       <enumerator name='ZPOOL_NUM_PROPS' value='33'/>
     </enum-decl>
-    <typedef-decl name='zpool_prop_t' type-id='type-id-210' filepath='../../include/sys/fs/zfs.h' line='251' column='1' id='type-id-211'/>
-    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
-      <parameter type-id='type-id-211' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
-      <parameter type-id='type-id-142' name='src' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+    <typedef-decl name='zpool_prop_t' type-id='type-id-208' filepath='../../include/sys/fs/zfs.h' line='251' column='1' id='type-id-209'/>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+      <parameter type-id='type-id-140' name='srctype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
+      <parameter type-id='type-id-172' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
+      <parameter type-id='type-id-194' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
+      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1'/>
+    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='923' column='1' id='type-id-212'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='924' column='1' id='type-id-210'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_READERR' value='1'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='2'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_BADWORD' value='3'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_BADTOKEN' value='2'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
       <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_compat_status_t' type-id='type-id-212' filepath='../../include/libzfs.h' line='929' column='1' id='type-id-213'/>
-    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4771' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
-      <parameter type-id='type-id-106' name='compatibility' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4771' column='1'/>
-      <parameter type-id='type-id-116' name='features' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4772' column='1'/>
-      <parameter type-id='type-id-23' name='badtoken' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4772' column='1'/>
-      <parameter type-id='type-id-23' name='badfile' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_pool.c' line='4772' column='1'/>
-      <return type-id='type-id-213'/>
+    <typedef-decl name='zpool_compat_status_t' type-id='type-id-210' filepath='../../include/libzfs.h' line='930' column='1' id='type-id-211'/>
+    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
+      <parameter type-id='type-id-104' name='compat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-114' name='features' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-23' name='report' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-43' name='rlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4752' column='1'/>
+      <return type-id='type-id-211'/>
     </function-decl>
     <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='../../include/libzfs_core.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='../../include/libzfs_core.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_wait' mangled-name='lzc_wait' filepath='../../include/libzfs_core.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' filepath='../../include/libzutil.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' filepath='../../include/sys/nvpair.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__xpg_basename' mangled-name='__xpg_basename' filepath='/usr/include/libgen.h' line='34' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='memcmp' mangled-name='memcmp' filepath='/usr/include/string.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='memcmp' mangled-name='memcmp' filepath='/usr/include/string.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__realpath_alias' mangled-name='realpath' filepath='/usr/include/x86_64-linux-gnu/bits/stdlib.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='realpath' mangled-name='realpath' filepath='/usr/include/stdlib.h' line='797' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strncasecmp' mangled-name='strncasecmp' filepath='/usr/include/strings.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' filepath='../../include/libzutil.h' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' filepath='../../include/libzutil.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='../../include/libzfs.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' filepath='../../include/sys/nvpair.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_sync' mangled-name='lzc_sync' filepath='../../include/libzfs_core.h' line='128' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='../../include/libzfs_core.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../include/zfs_comutil.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' filepath='../../include/libzfs.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' filepath='../../include/zfeature_common.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='../../include/libzutil.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strtoull' mangled-name='strtoull' filepath='/usr/include/stdlib.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' filepath='../../include/libzutil.h' line='102' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' filepath='../../include/libzfs_core.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_trim' mangled-name='lzc_trim' filepath='../../include/libzfs_core.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' filepath='../../include/sys/nvpair.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_initialize' mangled-name='lzc_initialize' filepath='../../include/libzfs_core.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' filepath='../../include/zfeature_common.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' filepath='../../include/libzfs_core.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' filepath='../../include/libzfs_core.h' line='131' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' filepath='../../include/sys/nvpair.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='../../include/libzfs.h' line='413' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='../../include/libzfs.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='pool_namecheck' mangled-name='pool_namecheck' filepath='../../include/zfs_namecheck.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' filepath='../../include/sys/fs/zfs.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' filepath='../../include/zfeature_common.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='../../include/libzfs.h' line='810' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='../../include/libzfs.h' line='811' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' filepath='../../include/sys/fs/zfs.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' filepath='../../include/sys/fs/zfs.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' filepath='../../include/sys/fs/zfs.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='../../lib/libspl/include/sys/systeminfo.h' line='36' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' filepath='../../include/zfs_prop.h' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' filepath='../../include/sys/fs/zfs.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../include/libzfs.h' line='566' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../include/libzfs.h' line='567' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../include/libzfs.h' line='565' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../include/libzfs.h' line='566' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='mmap' mangled-name='mmap64' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='strtok_r' mangled-name='strtok_r' filepath='/usr/include/string.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='strchrnul' mangled-name='strchrnul' filepath='/usr/include/string.h' line='266' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='munmap' mangled-name='munmap' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='../../include/libzfs.h' line='403' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strtok_r' mangled-name='strtok_r' filepath='/usr/include/string.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='strchrnul' mangled-name='strchrnul' filepath='/usr/include/string.h' line='265' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='../../include/libzfs.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' filepath='../../include/sys/nvpair.h' line='295' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='746' column='1' id='type-id-214'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='747' column='1' id='type-id-212'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbose' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='748' column='1'/>
+        <var-decl name='verbose' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='749' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='isprefix' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='751' column='1'/>
+        <var-decl name='isprefix' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='752' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='istail' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='757' column='1'/>
+        <var-decl name='istail' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='758' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='dryrun' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='760' column='1'/>
+        <var-decl name='dryrun' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='761' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='force' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='763' column='1'/>
+        <var-decl name='force' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='764' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='canmountoff' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='766' column='1'/>
+        <var-decl name='canmountoff' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='767' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='resumable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='772' column='1'/>
+        <var-decl name='resumable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='773' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='byteswap' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='775' column='1'/>
+        <var-decl name='byteswap' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='776' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nomount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='778' column='1'/>
+        <var-decl name='nomount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='779' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='holds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='781' column='1'/>
+        <var-decl name='holds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='782' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='skipholds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='784' column='1'/>
+        <var-decl name='skipholds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='785' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='domount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='787' column='1'/>
+        <var-decl name='domount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='788' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='forceunmount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='790' column='1'/>
+        <var-decl name='forceunmount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='791' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='recvflags_t' type-id='type-id-214' filepath='../../include/libzfs.h' line='791' column='1' id='type-id-215'/>
-    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-216'/>
-    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-217'/>
-    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-106' name='tosnap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-216' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
-      <parameter type-id='type-id-6' name='infd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
-      <parameter type-id='type-id-217' name='stream_avl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+    <typedef-decl name='recvflags_t' type-id='type-id-212' filepath='../../include/libzfs.h' line='792' column='1' id='type-id-213'/>
+    <pointer-type-def type-id='type-id-213' size-in-bits='64' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-215'/>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-214' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+      <parameter type-id='type-id-6' name='infd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+      <parameter type-id='type-id-215' name='stream_avl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='662' column='1' id='type-id-218'>
+    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='663' column='1' id='type-id-216'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbosity' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='664' column='1'/>
+        <var-decl name='verbosity' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='665' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='replicate' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='667' column='1'/>
+        <var-decl name='replicate' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='668' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='skipmissing' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='670' column='1'/>
+        <var-decl name='skipmissing' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='671' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='doall' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='673' column='1'/>
+        <var-decl name='doall' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='674' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fromorigin' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='676' column='1'/>
+        <var-decl name='fromorigin' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='677' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pad' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='679' column='1'/>
+        <var-decl name='pad' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='680' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='props' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='682' column='1'/>
+        <var-decl name='props' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='683' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dryrun' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='685' column='1'/>
+        <var-decl name='dryrun' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='686' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='parsable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='688' column='1'/>
+        <var-decl name='parsable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='689' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='progress' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='691' column='1'/>
+        <var-decl name='progress' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='692' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='largeblock' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='694' column='1'/>
+        <var-decl name='largeblock' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='695' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='embed_data' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='697' column='1'/>
+        <var-decl name='embed_data' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='698' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='compress' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='700' column='1'/>
+        <var-decl name='compress' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='701' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='raw' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='703' column='1'/>
+        <var-decl name='raw' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='704' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='backup' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='706' column='1'/>
+        <var-decl name='backup' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='707' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='holds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='709' column='1'/>
+        <var-decl name='holds' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='710' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='saved' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='712' column='1'/>
+        <var-decl name='saved' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='713' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='sendflags_t' type-id='type-id-218' filepath='../../include/libzfs.h' line='713' column='1' id='type-id-219'/>
-    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-220'/>
-    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-106' name='from' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-220' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-106' name='redactbook' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2396' column='1'/>
+    <typedef-decl name='sendflags_t' type-id='type-id-216' filepath='../../include/libzfs.h' line='714' column='1' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-218'/>
+    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-104' name='from' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-104' name='redactbook' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2396' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <typedef-decl name='snapfilter_cb_t' type-id='type-id-221' filepath='../../include/libzfs.h' line='715' column='1' id='type-id-222'/>
-    <pointer-type-def type-id='type-id-222' size-in-bits='64' id='type-id-223'/>
-    <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-106' name='fromsnap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-106' name='tosnap' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-220' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-223' name='filter_func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-43' name='cb_arg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
-      <parameter type-id='type-id-117' name='debugnvp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
+    <typedef-decl name='snapfilter_cb_t' type-id='type-id-219' filepath='../../include/libzfs.h' line='716' column='1' id='type-id-220'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-221'/>
+    <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-104' name='fromsnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-221' name='filter_func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-42' name='cb_arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
+      <parameter type-id='type-id-115' name='debugnvp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-220' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-106' name='resume_token' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1869' column='1'/>
+    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-104' name='resume_token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1869' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-220' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-106' name='resume_token' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1843' column='1'/>
+    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-104' name='resume_token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1843' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
-      <parameter type-id='type-id-106' name='token' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
+    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
+      <parameter type-id='type-id-104' name='token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-139' name='bytes_written' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-139' name='blocks_visited' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_sendrecv.c' line='884' column='1'/>
+    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-137' name='bytes_written' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-137' name='blocks_visited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='884' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='perror' mangled-name='perror' filepath='/usr/include/stdio.h' line='775' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='perror' mangled-name='perror' filepath='/usr/include/stdio.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='../../include/libzfs.h' line='491' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='../../include/libzfs.h' line='492' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' filepath='../../include/sys/nvpair.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' filepath='../../include/zfs_fletcher.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__builtin___strcat_chk' mangled-name='__strcat_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strcat' mangled-name='strcat' filepath='/usr/include/string.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../include/sys/nvpair.h' line='283' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='create_parents' mangled-name='create_parents' filepath='../../include/libzfs_impl.h' line='193' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../include/sys/nvpair.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='time' mangled-name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' filepath='../../include/sys/nvpair.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' filepath='../../include/sys/nvpair.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' filepath='../../include/libzfs_core.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__builtin___sprintf_chk' mangled-name='__sprintf_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='sprintf' mangled-name='sprintf' filepath='/usr/include/stdio.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../include/zfs_fletcher.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' filepath='../../include/libzfs_core.h' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='../../include/libzfs.h' line='731' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='../../include/libzfs.h' line='732' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='../../include/libzfs.h' line='471' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='../../include/libzfs.h' line='472' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_size' mangled-name='fnvlist_size' filepath='../../include/sys/nvpair.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../include/zfs_fletcher.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='write' mangled-name='write' filepath='/usr/include/unistd.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' filepath='../../include/sys/nvpair.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strndup' mangled-name='strndup' filepath='/usr/include/string.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strndup' mangled-name='strndup' filepath='/usr/include/string.h' line='174' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' filepath='../../include/libzfs_core.h' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='nvlist_print' mangled-name='nvlist_print' filepath='../../include/libnvpair.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' filepath='../../include/libzfs_core.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' filepath='../../include/zfs_fletcher.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='uncompress' mangled-name='uncompress' filepath='/usr/include/zlib.h' line='1266' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='uncompress' mangled-name='uncompress' filepath='/usr/include/zlib.h' line='1265' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='../../include/libzfs.h' line='618' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='../../include/libzfs.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_send_space' mangled-name='lzc_send_space' filepath='../../include/libzfs_core.h' line='109' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sleep' mangled-name='sleep' filepath='/usr/include/unistd.h' line='444' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='localtime' mangled-name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='../../include/libzfs.h' line='516' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='../../include/libzfs.h' line='517' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='lzc_rename' mangled-name='lzc_rename' filepath='../../include/libzfs_core.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-221'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-43'/>
+    <function-type size-in-bits='64' id='type-id-219'>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='339' column='1' id='type-id-224'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='339' column='1' id='type-id-222'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_STATUS_CORRUPT_CACHE' value='0'/>
       <enumerator name='ZPOOL_STATUS_MISSING_DEV_R' value='1'/>
@@ -4204,10 +4207,11 @@
       <enumerator name='ZPOOL_STATUS_REBUILD_SCRUB' value='28'/>
       <enumerator name='ZPOOL_STATUS_NON_NATIVE_ASHIFT' value='29'/>
       <enumerator name='ZPOOL_STATUS_COMPATIBILITY_ERR' value='30'/>
-      <enumerator name='ZPOOL_STATUS_OK' value='31'/>
+      <enumerator name='ZPOOL_STATUS_INCOMPATIBLE_FEAT' value='31'/>
+      <enumerator name='ZPOOL_STATUS_OK' value='32'/>
     </enum-decl>
-    <typedef-decl name='zpool_status_t' type-id='type-id-224' filepath='../../include/libzfs.h' line='401' column='1' id='type-id-225'/>
-    <enum-decl name='zpool_errata' filepath='../../include/sys/fs/zfs.h' line='1050' column='1' id='type-id-226'>
+    <typedef-decl name='zpool_status_t' type-id='type-id-222' filepath='../../include/libzfs.h' line='402' column='1' id='type-id-223'/>
+    <enum-decl name='zpool_errata' filepath='../../include/sys/fs/zfs.h' line='1050' column='1' id='type-id-224'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_ERRATA_NONE' value='0'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_2094_SCRUB' value='1'/>
@@ -4215,99 +4219,171 @@
       <enumerator name='ZPOOL_ERRATA_ZOL_6845_ENCRYPTION' value='3'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_errata_t' type-id='type-id-226' filepath='../../include/sys/fs/zfs.h' line='1056' column='1' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-228'/>
-    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
-      <parameter type-id='type-id-22' name='config' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='521' column='1'/>
-      <parameter type-id='type-id-163' name='msgid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='521' column='1'/>
-      <parameter type-id='type-id-228' name='errata' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='521' column='1'/>
-      <return type-id='type-id-225'/>
+    <typedef-decl name='zpool_errata_t' type-id='type-id-224' filepath='../../include/sys/fs/zfs.h' line='1056' column='1' id='type-id-225'/>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-226'/>
+    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
+      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <parameter type-id='type-id-161' name='msgid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <parameter type-id='type-id-226' name='errata' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <return type-id='type-id-223'/>
     </function-decl>
-    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='497' column='1'/>
-      <parameter type-id='type-id-163' name='msgid' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='497' column='1'/>
-      <parameter type-id='type-id-228' name='errata' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_status.c' line='497' column='1'/>
-      <return type-id='type-id-225'/>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <parameter type-id='type-id-161' name='msgid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <parameter type-id='type-id-226' name='errata' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <return type-id='type-id-223'/>
     </function-decl>
-    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='../../include/libzfs.h' line='931' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='../../include/libzfs.h' line='932' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='printf_color' mangled-name='printf_color' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
-      <parameter type-id='type-id-23' name='color' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
-      <parameter type-id='type-id-23' name='format' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='printf_color' mangled-name='printf_color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
+      <parameter type-id='type-id-23' name='color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
+      <parameter type-id='type-id-23' name='format' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1990' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
+    <function-decl name='color_end' mangled-name='color_end' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='color_start' mangled-name='color_start' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
+      <parameter type-id='type-id-23' name='color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1990' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
-      <parameter type-id='type-id-23' name='version' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
+      <parameter type-id='type-id-23' name='version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-229' size-in-bits='64' id='type-id-230'/>
-    <typedef-decl name='zprop_func' type-id='type-id-230' filepath='../../include/sys/fs/zfs.h' line='287' column='1' id='type-id-231'/>
-    <function-decl name='zprop_iter' mangled-name='zprop_iter' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
-      <parameter type-id='type-id-231' name='func' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-43' name='cb' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-5' name='show_all' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-5' name='ordered' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1971' column='1'/>
+    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-228'/>
+    <typedef-decl name='zprop_func' type-id='type-id-228' filepath='../../include/sys/fs/zfs.h' line='287' column='1' id='type-id-229'/>
+    <function-decl name='zprop_iter' mangled-name='zprop_iter' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
+      <parameter type-id='type-id-229' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
+      <parameter type-id='type-id-42' name='cb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
+      <parameter type-id='type-id-5' name='show_all' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
+      <parameter type-id='type-id-5' name='ordered' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1971' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_expand_list'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
-      <parameter type-id='type-id-134' name='plp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_expand_list'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
+      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
-      <parameter type-id='type-id-133' name='pl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
+      <parameter type-id='type-id-131' name='pl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-23' name='props' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-134' name='listp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1811' column='1'/>
+    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
+      <parameter type-id='type-id-23' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
+      <parameter type-id='type-id-132' name='listp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1811' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
-      <parameter type-id='type-id-106' name='value' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
-      <parameter type-id='type-id-139' name='num' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='593' column='1' id='type-id-232'>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-230'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_sources' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='594' column='1'/>
+        <var-decl name='nvp_size' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cb_columns' type-id='type-id-233' visibility='default' filepath='../../include/libzfs.h' line='595' column='1'/>
+        <var-decl name='nvp_name_sz' type-id='type-id-231' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cb_colwidths' type-id='type-id-234' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='type-id-231' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cb_scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvp_value_elem' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='cb_literal' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='cb_first' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='599' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='cb_proplist' type-id='type-id-133' visibility='default' filepath='../../include/libzfs.h' line='600' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='cb_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='type-id-232' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='581' column='1' id='type-id-235'>
+    <typedef-decl name='__int16_t' type-id='type-id-74' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-233'/>
+    <typedef-decl name='int16_t' type-id='type-id-233' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-231'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-234'>
+      <underlying-type type-id='type-id-7'/>
+      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
+      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
+      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
+      <enumerator name='DATA_TYPE_BYTE' value='2'/>
+      <enumerator name='DATA_TYPE_INT16' value='3'/>
+      <enumerator name='DATA_TYPE_UINT16' value='4'/>
+      <enumerator name='DATA_TYPE_INT32' value='5'/>
+      <enumerator name='DATA_TYPE_UINT32' value='6'/>
+      <enumerator name='DATA_TYPE_INT64' value='7'/>
+      <enumerator name='DATA_TYPE_UINT64' value='8'/>
+      <enumerator name='DATA_TYPE_STRING' value='9'/>
+      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
+      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
+      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
+      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
+      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
+      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
+      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
+      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
+      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
+      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
+      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
+      <enumerator name='DATA_TYPE_INT8' value='22'/>
+      <enumerator name='DATA_TYPE_UINT8' value='23'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
+      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
+      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
+      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
+    </enum-decl>
+    <typedef-decl name='data_type_t' type-id='type-id-234' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-232'/>
+    <typedef-decl name='nvpair_t' type-id='type-id-230' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-235'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_parse_value'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
+      <parameter type-id='type-id-236' name='elem' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
+      <parameter type-id='type-id-6' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
+      <parameter type-id='type-id-22' name='ret' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
+      <parameter type-id='type-id-161' name='svalp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
+      <parameter type-id='type-id-137' name='ivalp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
+      <parameter type-id='type-id-104' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1604' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
+      <parameter type-id='type-id-104' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
+      <parameter type-id='type-id-137' name='num' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='594' column='1' id='type-id-237'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_sources' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='595' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='cb_columns' type-id='type-id-238' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='cb_colwidths' type-id='type-id-239' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='cb_scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cb_literal' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='599' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='cb_first' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='600' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='cb_proplist' type-id='type-id-131' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='cb_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs.h' line='602' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='582' column='1' id='type-id-240'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='GET_COL_NONE' value='0'/>
       <enumerator name='GET_COL_NAME' value='1'/>
@@ -4316,468 +4392,461 @@
       <enumerator name='GET_COL_RECVD' value='4'/>
       <enumerator name='GET_COL_SOURCE' value='5'/>
     </enum-decl>
-    <typedef-decl name='zfs_get_column_t' type-id='type-id-235' filepath='../../include/libzfs.h' line='588' column='1' id='type-id-236'/>
+    <typedef-decl name='zfs_get_column_t' type-id='type-id-240' filepath='../../include/libzfs.h' line='589' column='1' id='type-id-241'/>
 
-    <array-type-def dimensions='1' type-id='type-id-236' size-in-bits='160' alignment-in-bits='32' id='type-id-233'>
-      <subrange length='5' type-id='type-id-49' id='type-id-237'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='192' id='type-id-234'>
-      <subrange length='6' type-id='type-id-49' id='type-id-238'/>
+    <array-type-def dimensions='1' type-id='type-id-241' size-in-bits='160' alignment-in-bits='32' id='type-id-238'>
+      <subrange length='5' type-id='type-id-48' id='type-id-242'/>
 
     </array-type-def>
-    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-232' filepath='../../include/libzfs.h' line='602' column='1' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-239' size-in-bits='64' id='type-id-240'/>
-    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
-      <parameter type-id='type-id-240' name='cbp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
-      <parameter type-id='type-id-106' name='propname' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-106' name='value' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-141' name='sourcetype' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-106' name='source' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
-      <parameter type-id='type-id-106' name='recvd_value' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
-      <return type-id='type-id-51'/>
+
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='192' id='type-id-239'>
+      <subrange length='6' type-id='type-id-48' id='type-id-243'/>
+
+    </array-type-def>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-237' filepath='../../include/libzfs.h' line='603' column='1' id='type-id-244'/>
+    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-245'/>
+    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
+      <parameter type-id='type-id-245' name='cbp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
+      <parameter type-id='type-id-104' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
+      <parameter type-id='type-id-139' name='sourcetype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
+      <parameter type-id='type-id-104' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
+      <parameter type-id='type-id-104' name='recvd_value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_read_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
-      <parameter type-id='type-id-117' name='nvlp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_read_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
+      <parameter type-id='type-id-115' name='nvlp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_src_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_src_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_conf_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_conf_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_free_nvlists'>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_free_nvlists'>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_expand_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_expand_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_alloc_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
-      <parameter type-id='type-id-44' name='len' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_alloc_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
+      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <parameter type-id='type-id-20' name='argtype' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
+      <parameter type-id='type-id-20' name='argtype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
+      <return type-id='type-id-102'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
-      <parameter type-id='type-id-138' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1'/>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
+      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
-      <parameter type-id='type-id-104' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
+      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1'/>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
-      <parameter type-id='type-id-23' name='envvar' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='991' column='1'/>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
+      <parameter type-id='type-id-23' name='envvar' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='991' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
-      <parameter type-id='type-id-163' name='strs' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
-      <parameter type-id='type-id-6' name='count' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
+      <parameter type-id='type-id-161' name='strs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
+      <parameter type-id='type-id-6' name='count' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-241'/>
-    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-163' name='argv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-163' name='env' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-241' name='lines' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-143' name='lines_cnt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-246'/>
+    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-161' name='env' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-246' name='lines' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-141' name='lines_cnt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-163' name='argv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-163' name='env' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-241' name='lines' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-143' name='lines_cnt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-161' name='env' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-246' name='lines' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-141' name='lines_cnt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
-      <parameter type-id='type-id-106' name='path' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
-      <parameter type-id='type-id-163' name='argv' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
+      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <parameter type-id='type-id-5' name='enable' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
+      <parameter type-id='type-id-5' name='enable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strdup'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
-      <parameter type-id='type-id-106' name='str' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strdup'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+      <parameter type-id='type-id-104' name='str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_realloc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-43' name='ptr' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-44' name='oldsize' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-44' name='newsize' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <return type-id='type-id-43'/>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_realloc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-42' name='ptr' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-43' name='oldsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-43' name='newsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <return type-id='type-id-42'/>
     </function-decl>
-    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_asprintf'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
-      <parameter type-id='type-id-106' name='fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_asprintf'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_alloc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
-      <parameter type-id='type-id-44' name='size' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
-      <return type-id='type-id-43'/>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_alloc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <parameter type-id='type-id-43' name='size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <return type-id='type-id-42'/>
     </function-decl>
-    <function-decl name='no_memory' mangled-name='no_memory' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='no_memory'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='749' column='1'/>
+    <function-decl name='no_memory' mangled-name='no_memory' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='no_memory'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='749' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
-      <parameter type-id='type-id-106' name='fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-106' name='msg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_setprop_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-6' name='err' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-23' name='errbuf' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='497' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_setprop_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-6' name='err' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-23' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='497' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
-      <parameter type-id='type-id-106' name='fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-106' name='msg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
-      <parameter type-id='type-id-106' name='fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-106' name='msg' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_aux'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
-      <parameter type-id='type-id-106' name='fmt' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_aux'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='76' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='76' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='70' column='1'/>
+    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='70' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='82' column='1'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='82' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
-    <function-decl name='color_start' mangled-name='color_start' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
-      <parameter type-id='type-id-23' name='color' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='vfprintf' mangled-name='vfprintf' filepath='/usr/include/stdio.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='color_end' mangled-name='color_end' filepath='/home/behlendo/src/git/zfs/lib/libzfs/libzfs_util.c' line='2076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='__vfprintf_chk' mangled-name='__vfprintf_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='../../include/libzfs.h' line='888' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='../../include/libzfs.h' line='889' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' filepath='../../include/zfs_prop.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_width' mangled-name='zprop_width' filepath='../../include/zfs_prop.h' line='126' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' filepath='../../include/zfs_prop.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' filepath='../../include/zfs_prop.h' line='127' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' filepath='../../include/sys/fs/zfs.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' filepath='../../include/zfs_prop.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_values' mangled-name='zprop_values' filepath='../../include/zfs_prop.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='strtod' mangled-name='strtod' filepath='/usr/include/stdlib.h' line='117' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='pow' mangled-name='pow' filepath='/usr/include/x86_64-linux-gnu/bits/mathcalls.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__ctype_toupper_loc' mangled-name='__ctype_toupper_loc' filepath='/usr/include/ctype.h' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='getextmntent' mangled-name='getextmntent' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='../../include/libzfs.h' line='241' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='../../include/libzfs_impl.h' line='207' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='../../include/libzfs.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' filepath='../../include/libzfs_core.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='regfree' mangled-name='regfree' filepath='/usr/include/regex.h' line='651' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' filepath='../../include/zfs_fletcher.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' filepath='../../include/zfs_prop.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../include/zfs_prop.h' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='regcomp' mangled-name='regcomp' filepath='/usr/include/regex.h' line='639' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' filepath='../../include/libzfs_core.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' filepath='../../include/zfs_prop.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' filepath='../../include/zfs_prop.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' filepath='../../include/zfeature_common.h' line='128' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='../../include/libzfs.h' line='222' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' filepath='../../include/zfs_fletcher.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='strnlen' mangled-name='strnlen' filepath='/usr/include/string.h' line='391' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='strnlen' mangled-name='strnlen' filepath='/usr/include/string.h' line='390' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='realloc' mangled-name='realloc' filepath='/usr/include/stdlib.h' line='550' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='realloc' mangled-name='realloc' filepath='/usr/include/stdlib.h' line='549' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='waitpid' mangled-name='waitpid' filepath='/usr/include/x86_64-linux-gnu/sys/wait.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='vfork' mangled-name='vfork' filepath='/usr/include/unistd.h' line='764' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='execve' mangled-name='execve' filepath='/usr/include/unistd.h' line='551' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='_exit' mangled-name='_exit' filepath='/usr/include/unistd.h' line='603' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='dup2' mangled-name='dup2' filepath='/usr/include/unistd.h' line='534' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='execvpe' mangled-name='execvpe' filepath='/usr/include/unistd.h' line='590' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='execv' mangled-name='execv' filepath='/usr/include/unistd.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='execvp' mangled-name='execvp' filepath='/usr/include/unistd.h' line='578' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__vasprintf_chk' mangled-name='__vasprintf_chk' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='vasprintf' mangled-name='vasprintf' filepath='/usr/include/stdio.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='__builtin___vsnprintf_chk' mangled-name='__vsnprintf_chk' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='vsnprintf' mangled-name='vsnprintf' filepath='/usr/include/stdio.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='exit' mangled-name='exit' filepath='/usr/include/stdlib.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='exit' mangled-name='exit' filepath='/usr/include/stdlib.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-229'>
+    <function-type size-in-bits='64' id='type-id-227'>
       <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' filepath='os/linux/libzfs_mount_os.c' line='410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='do_unmount' mangled-name='do_unmount' filepath='os/linux/libzfs_mount_os.c' line='377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_unmount'>
-      <parameter type-id='type-id-106' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
+      <parameter type-id='type-id-104' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
       <parameter type-id='type-id-6' name='flags' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='do_mount' mangled-name='do_mount' filepath='os/linux/libzfs_mount_os.c' line='323' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_mount'>
-      <parameter type-id='type-id-104' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
-      <parameter type-id='type-id-106' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-102' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-104' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <parameter type-id='type-id-23' name='opts' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <parameter type-id='type-id-6' name='flags' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' filepath='os/linux/libzfs_mount_os.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
-      <parameter type-id='type-id-104' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
-      <parameter type-id='type-id-106' name='mntpoint' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-102' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-104' name='mntpoint' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
       <parameter type-id='type-id-23' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
       <parameter type-id='type-id-23' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-242'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-247'/>
     <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' filepath='os/linux/libzfs_mount_os.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
       <parameter type-id='type-id-23' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
-      <parameter type-id='type-id-242' name='mntflags' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
-      <parameter type-id='type-id-242' name='zfsflags' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <parameter type-id='type-id-247' name='mntflags' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
+      <parameter type-id='type-id-247' name='zfsflags' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-6' name='sloppy' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-23' name='badopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-23' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='geteuid' mangled-name='geteuid' filepath='/usr/include/unistd.h' line='678' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='umount2' mangled-name='umount2' filepath='/usr/include/x86_64-linux-gnu/sys/mount.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='../../include/libzfs.h' line='882' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='../../include/libzfs.h' line='883' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='../../include/libzfs.h' line='874' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='../../include/libzfs.h' line='875' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='mount' mangled-name='mount' filepath='/usr/include/x86_64-linux-gnu/sys/mount.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' filepath='os/linux/libzfs_pool_os.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
       <parameter type-id='type-id-18' name='zhp' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='os/linux/libzfs_pool_os.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_relabel_disk'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
-      <parameter type-id='type-id-106' name='path' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
-      <parameter type-id='type-id-106' name='msg' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-104' name='msg' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='rand' mangled-name='rand' filepath='/usr/include/stdlib.h' line='453' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' filepath='../../include/sys/efi_partition.h' line='367' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_free' mangled-name='efi_free' filepath='../../include/sys/efi_partition.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' filepath='../../include/sys/efi_partition.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_write' mangled-name='efi_write' filepath='../../include/sys/efi_partition.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fsync' mangled-name='fsync' filepath='/usr/include/unistd.h' line='954' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_rescan' mangled-name='efi_rescan' filepath='../../include/sys/efi_partition.h' line='369' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' filepath='../../include/libzutil.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' filepath='../../include/libzutil.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' filepath='../../include/sys/efi_partition.h' line='374' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_set_pipe_max'>
       <parameter type-id='type-id-6' name='infd' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1'/>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='fscanf' mangled-name='__isoc99_fscanf' filepath='/usr/include/stdio.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fscanf' mangled-name='fscanf' filepath='/usr/include/stdio.h' line='391' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fcntl' mangled-name='fcntl64' filepath='/usr/include/fcntl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='os/linux/libzfs_util_os.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
       <parameter type-id='type-id-23' name='version' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
       <parameter type-id='type-id-6' name='len' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1' id='type-id-243'>
+    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1' id='type-id-248'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zhp' type-id='type-id-104' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
+        <var-decl name='zhp' type-id='type-id-102' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='fromsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
@@ -4831,10 +4900,10 @@
         <var-decl name='datafd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='239' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='differ_info_t' type-id='type-id-243' filepath='../../include/libzfs_impl.h' line='240' column='1' id='type-id-244'/>
-    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-245'/>
+    <typedef-decl name='differ_info_t' type-id='type-id-248' filepath='../../include/libzfs_impl.h' line='240' column='1' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
     <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='os/linux/libzfs_util_os.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='find_shares_object'>
-      <parameter type-id='type-id-245' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>
+      <parameter type-id='type-id-250' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='os/linux/libzfs_util_os.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_load_module'>
@@ -4842,140 +4911,140 @@
     </function-decl>
     <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' filepath='os/linux/libzfs_util_os.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
       <parameter type-id='type-id-6' name='error' filepath='os/linux/libzfs_util_os.c' line='55' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='os/linux/libzfs_util_os.c' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
       <parameter type-id='type-id-6' name='request' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
-      <parameter type-id='type-id-160' name='zc' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
+      <parameter type-id='type-id-158' name='zc' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='clock_gettime' mangled-name='clock_gettime' filepath='/usr/include/time.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='clock_gettime' mangled-name='clock_gettime' filepath='/usr/include/time.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='sched_yield' mangled-name='sched_yield' filepath='/usr/include/sched.h' line='68' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='usleep' mangled-name='usleep' filepath='/usr/include/unistd.h' line='460' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='access' mangled-name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='__anonymous_struct__' size-in-bits='1728' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-246' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='69' column='1' id='type-id-247'>
+  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='__anonymous_struct__' size-in-bits='1728' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='69' column='1' id='type-id-252'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='algotype' type-id='type-id-64' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='70' column='1'/>
+        <var-decl name='algotype' type-id='type-id-62' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='state' type-id='type-id-248' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='76' column='1'/>
+        <var-decl name='state' type-id='type-id-253' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='count' type-id='type-id-249' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='81' column='1'/>
+        <var-decl name='count' type-id='type-id-254' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='buf_un' type-id='type-id-250' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='86' column='1'/>
+        <var-decl name='buf_un' type-id='type-id-255' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='86' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='512' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='73' column='1' id='type-id-248'>
+    <union-decl name='__anonymous_union__' size-in-bits='512' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='73' column='1' id='type-id-253'>
       <data-member access='private'>
-        <var-decl name='s32' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='74' column='1'/>
+        <var-decl name='s32' type-id='type-id-256' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='74' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='s64' type-id='type-id-252' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='256' id='type-id-251'>
-      <subrange length='8' type-id='type-id-49' id='type-id-253'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='512' id='type-id-252'>
-      <subrange length='8' type-id='type-id-49' id='type-id-253'/>
-
-    </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='78' column='1' id='type-id-249'>
-      <data-member access='private'>
-        <var-decl name='c32' type-id='type-id-254' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='c64' type-id='type-id-158' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='80' column='1'/>
+        <var-decl name='s64' type-id='type-id-257' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='75' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='64' id='type-id-254'>
-      <subrange length='2' type-id='type-id-49' id='type-id-88'/>
+    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='256' id='type-id-256'>
+      <subrange length='8' type-id='type-id-48' id='type-id-258'/>
 
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='1024' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='82' column='1' id='type-id-250'>
+
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='512' id='type-id-257'>
+      <subrange length='8' type-id='type-id-48' id='type-id-258'/>
+
+    </array-type-def>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='78' column='1' id='type-id-254'>
       <data-member access='private'>
-        <var-decl name='buf8' type-id='type-id-255' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='83' column='1'/>
+        <var-decl name='c32' type-id='type-id-259' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='79' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='buf32' type-id='type-id-256' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='84' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='buf64' type-id='type-id-257' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='85' column='1'/>
+        <var-decl name='c64' type-id='type-id-156' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='80' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='1024' id='type-id-255'>
-      <subrange length='128' type-id='type-id-49' id='type-id-258'/>
+    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='64' id='type-id-259'>
+      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
+
+    </array-type-def>
+    <union-decl name='__anonymous_union__' size-in-bits='1024' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='82' column='1' id='type-id-255'>
+      <data-member access='private'>
+        <var-decl name='buf8' type-id='type-id-260' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf32' type-id='type-id-261' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf64' type-id='type-id-262' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='85' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='1024' id='type-id-260'>
+      <subrange length='128' type-id='type-id-48' id='type-id-263'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='1024' id='type-id-256'>
-      <subrange length='32' type-id='type-id-49' id='type-id-259'/>
+    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='1024' id='type-id-261'>
+      <subrange length='32' type-id='type-id-48' id='type-id-264'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='1024' id='type-id-257'>
-      <subrange length='16' type-id='type-id-49' id='type-id-260'/>
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='1024' id='type-id-262'>
+      <subrange length='16' type-id='type-id-48' id='type-id-265'/>
 
     </array-type-def>
-    <typedef-decl name='SHA2_CTX' type-id='type-id-247' filepath='../../lib/libspl/include/sys/sha2.h' line='87' column='1' id='type-id-246'/>
-    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-261'/>
+    <typedef-decl name='SHA2_CTX' type-id='type-id-252' filepath='../../lib/libspl/include/sys/sha2.h' line='87' column='1' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-266'/>
     <function-decl name='SHA2Final' mangled-name='SHA2Final' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Final'>
-      <parameter type-id='type-id-43' name='digest' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
-      <parameter type-id='type-id-261' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-42' name='digest' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='SHA2Update' mangled-name='SHA2Update' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Update'>
-      <parameter type-id='type-id-261' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <parameter type-id='type-id-43' name='inptr' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <parameter type-id='type-id-44' name='input_len' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-42' name='inptr' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-43' name='input_len' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <typedef-decl name='SHA512_CTX' type-id='type-id-246' filepath='../../lib/libspl/include/sys/sha2.h' line='91' column='1' id='type-id-262'/>
-    <pointer-type-def type-id='type-id-262' size-in-bits='64' id='type-id-263'/>
+    <typedef-decl name='SHA512_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='91' column='1' id='type-id-267'/>
+    <pointer-type-def type-id='type-id-267' size-in-bits='64' id='type-id-268'/>
     <function-decl name='SHA512Init' mangled-name='SHA512Init' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA512Init'>
-      <parameter type-id='type-id-263' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-268' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <typedef-decl name='SHA384_CTX' type-id='type-id-246' filepath='../../lib/libspl/include/sys/sha2.h' line='90' column='1' id='type-id-264'/>
-    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-265'/>
+    <typedef-decl name='SHA384_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='90' column='1' id='type-id-269'/>
+    <pointer-type-def type-id='type-id-269' size-in-bits='64' id='type-id-270'/>
     <function-decl name='SHA384Init' mangled-name='SHA384Init' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA384Init'>
-      <parameter type-id='type-id-265' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-270' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <typedef-decl name='SHA256_CTX' type-id='type-id-246' filepath='../../lib/libspl/include/sys/sha2.h' line='89' column='1' id='type-id-266'/>
-    <pointer-type-def type-id='type-id-266' size-in-bits='64' id='type-id-267'/>
+    <typedef-decl name='SHA256_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='89' column='1' id='type-id-271'/>
+    <pointer-type-def type-id='type-id-271' size-in-bits='64' id='type-id-272'/>
     <function-decl name='SHA256Init' mangled-name='SHA256Init' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA256Init'>
-      <parameter type-id='type-id-267' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-272' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='SHA2Init' mangled-name='SHA2Init' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Init'>
       <parameter type-id='type-id-27' name='mech' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
-      <parameter type-id='type-id-261' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='htonl' mangled-name='htonl' filepath='../../lib/libspl/include/os/linux/sys/byteorder.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='cityhash4' mangled-name='cityhash4' filepath='../../module/zcommon/cityhash.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
       <parameter type-id='type-id-27' name='w1' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
       <parameter type-id='type-id-27' name='w2' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
@@ -4984,35 +5053,35 @@
       <return type-id='type-id-27'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <var-decl name='zfeature_checks_disable' type-id='type-id-5' mangled-name='zfeature_checks_disable' visibility='default' filepath='../../module/zcommon/zfeature_common.c' line='49' column='1' elf-symbol-id='zfeature_checks_disable'/>
-    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/zfeature_common.h' line='103' column='1' id='type-id-268'>
+    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/zfeature_common.h' line='103' column='1' id='type-id-273'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fi_feature' type-id='type-id-269' visibility='default' filepath='../../include/zfeature_common.h' line='104' column='1'/>
+        <var-decl name='fi_feature' type-id='type-id-274' visibility='default' filepath='../../include/zfeature_common.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fi_uname' type-id='type-id-106' visibility='default' filepath='../../include/zfeature_common.h' line='105' column='1'/>
+        <var-decl name='fi_uname' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='105' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fi_guid' type-id='type-id-106' visibility='default' filepath='../../include/zfeature_common.h' line='106' column='1'/>
+        <var-decl name='fi_guid' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fi_desc' type-id='type-id-106' visibility='default' filepath='../../include/zfeature_common.h' line='107' column='1'/>
+        <var-decl name='fi_desc' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fi_flags' type-id='type-id-270' visibility='default' filepath='../../include/zfeature_common.h' line='108' column='1'/>
+        <var-decl name='fi_flags' type-id='type-id-275' visibility='default' filepath='../../include/zfeature_common.h' line='108' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='fi_zfs_mod_supported' type-id='type-id-5' visibility='default' filepath='../../include/zfeature_common.h' line='109' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='fi_type' type-id='type-id-271' visibility='default' filepath='../../include/zfeature_common.h' line='110' column='1'/>
+        <var-decl name='fi_type' type-id='type-id-276' visibility='default' filepath='../../include/zfeature_common.h' line='110' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='fi_depends' type-id='type-id-272' visibility='default' filepath='../../include/zfeature_common.h' line='112' column='1'/>
+        <var-decl name='fi_depends' type-id='type-id-277' visibility='default' filepath='../../include/zfeature_common.h' line='112' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='spa_feature' filepath='../../include/zfeature_common.h' line='42' column='1' id='type-id-273'>
+    <enum-decl name='spa_feature' filepath='../../include/zfeature_common.h' line='42' column='1' id='type-id-278'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='SPA_FEATURE_NONE' value='-1'/>
       <enumerator name='SPA_FEATURE_ASYNC_DESTROY' value='0'/>
@@ -5051,70 +5120,70 @@
       <enumerator name='SPA_FEATURE_DRAID' value='33'/>
       <enumerator name='SPA_FEATURES' value='34'/>
     </enum-decl>
-    <typedef-decl name='spa_feature_t' type-id='type-id-273' filepath='../../include/zfeature_common.h' line='79' column='1' id='type-id-269'/>
-    <enum-decl name='zfeature_flags' filepath='../../include/zfeature_common.h' line='83' column='1' id='type-id-274'>
+    <typedef-decl name='spa_feature_t' type-id='type-id-278' filepath='../../include/zfeature_common.h' line='79' column='1' id='type-id-274'/>
+    <enum-decl name='zfeature_flags' filepath='../../include/zfeature_common.h' line='83' column='1' id='type-id-279'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFEATURE_FLAG_READONLY_COMPAT' value='1'/>
       <enumerator name='ZFEATURE_FLAG_MOS' value='2'/>
       <enumerator name='ZFEATURE_FLAG_ACTIVATE_ON_ENABLE' value='4'/>
       <enumerator name='ZFEATURE_FLAG_PER_DATASET' value='8'/>
     </enum-decl>
-    <typedef-decl name='zfeature_flags_t' type-id='type-id-274' filepath='../../include/zfeature_common.h' line='95' column='1' id='type-id-270'/>
-    <enum-decl name='zfeature_type' filepath='../../include/zfeature_common.h' line='97' column='1' id='type-id-275'>
+    <typedef-decl name='zfeature_flags_t' type-id='type-id-279' filepath='../../include/zfeature_common.h' line='95' column='1' id='type-id-275'/>
+    <enum-decl name='zfeature_type' filepath='../../include/zfeature_common.h' line='97' column='1' id='type-id-280'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFEATURE_TYPE_BOOLEAN' value='0'/>
       <enumerator name='ZFEATURE_TYPE_UINT64_ARRAY' value='1'/>
       <enumerator name='ZFEATURE_NUM_TYPES' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfeature_type_t' type-id='type-id-275' filepath='../../include/zfeature_common.h' line='101' column='1' id='type-id-271'/>
-    <qualified-type-def type-id='type-id-269' const='yes' id='type-id-276'/>
-    <pointer-type-def type-id='type-id-276' size-in-bits='64' id='type-id-272'/>
-    <typedef-decl name='zfeature_info_t' type-id='type-id-268' filepath='../../include/zfeature_common.h' line='113' column='1' id='type-id-277'/>
+    <typedef-decl name='zfeature_type_t' type-id='type-id-280' filepath='../../include/zfeature_common.h' line='101' column='1' id='type-id-276'/>
+    <qualified-type-def type-id='type-id-274' const='yes' id='type-id-281'/>
+    <pointer-type-def type-id='type-id-281' size-in-bits='64' id='type-id-277'/>
+    <typedef-decl name='zfeature_info_t' type-id='type-id-273' filepath='../../include/zfeature_common.h' line='113' column='1' id='type-id-282'/>
 
-    <array-type-def dimensions='1' type-id='type-id-277' size-in-bits='15232' id='type-id-278'>
-      <subrange length='34' type-id='type-id-49' id='type-id-279'/>
+    <array-type-def dimensions='1' type-id='type-id-282' size-in-bits='15232' id='type-id-283'>
+      <subrange length='34' type-id='type-id-48' id='type-id-284'/>
 
     </array-type-def>
-    <var-decl name='spa_feature_table' type-id='type-id-278' mangled-name='spa_feature_table' visibility='default' filepath='../../include/zfeature_common.h' line='119' column='1' elf-symbol-id='spa_feature_table'/>
+    <var-decl name='spa_feature_table' type-id='type-id-283' mangled-name='spa_feature_table' visibility='default' filepath='../../include/zfeature_common.h' line='119' column='1' elf-symbol-id='spa_feature_table'/>
     <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
-      <parameter type-id='type-id-269' name='fid' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
-      <parameter type-id='type-id-269' name='check' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
+      <parameter type-id='type-id-274' name='fid' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
+      <parameter type-id='type-id-274' name='check' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-269' size-in-bits='64' id='type-id-280'/>
+    <pointer-type-def type-id='type-id-274' size-in-bits='64' id='type-id-285'/>
     <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
-      <parameter type-id='type-id-280' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' filepath='../../module/zcommon/zfeature_common.c' line='112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
-      <parameter type-id='type-id-280' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
-      <parameter type-id='type-id-106' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1'/>
+      <parameter type-id='type-id-104' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mod_supported'>
-      <parameter type-id='type-id-106' name='scope' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
+      <parameter type-id='type-id-104' name='scope' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='2624' id='type-id-281'>
-      <subrange length='41' type-id='type-id-49' id='type-id-282'/>
+    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='2624' id='type-id-286'>
+      <subrange length='41' type-id='type-id-48' id='type-id-287'/>
 
     </array-type-def>
-    <var-decl name='zfs_history_event_names' type-id='type-id-281' mangled-name='zfs_history_event_names' visibility='default' filepath='../../include/zfs_comutil.h' line='46' column='1' elf-symbol-id='zfs_history_event_names'/>
+    <var-decl name='zfs_history_event_names' type-id='type-id-286' mangled-name='zfs_history_event_names' visibility='default' filepath='../../include/zfs_comutil.h' line='46' column='1' elf-symbol-id='zfs_history_event_names'/>
     <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
@@ -5125,9 +5194,9 @@
       <parameter type-id='type-id-6' name='zpl_version' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1' id='type-id-283'>
+    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1' id='type-id-288'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zlp_rewind' type-id='type-id-64' visibility='default' filepath='../../include/sys/fs/zfs.h' line='592' column='1'/>
+        <var-decl name='zlp_rewind' type-id='type-id-62' visibility='default' filepath='../../include/sys/fs/zfs.h' line='592' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='zlp_maxmeta' type-id='type-id-27' visibility='default' filepath='../../include/sys/fs/zfs.h' line='593' column='1'/>
@@ -5139,12 +5208,12 @@
         <var-decl name='zlp_txg' type-id='type-id-27' visibility='default' filepath='../../include/sys/fs/zfs.h' line='595' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zpool_load_policy_t' type-id='type-id-283' filepath='../../include/sys/fs/zfs.h' line='596' column='1' id='type-id-284'/>
-    <pointer-type-def type-id='type-id-284' size-in-bits='64' id='type-id-285'/>
+    <typedef-decl name='zpool_load_policy_t' type-id='type-id-288' filepath='../../include/sys/fs/zfs.h' line='596' column='1' id='type-id-289'/>
+    <pointer-type-def type-id='type-id-289' size-in-bits='64' id='type-id-290'/>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
       <parameter type-id='type-id-22' name='nvl' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
-      <parameter type-id='type-id-285' name='zlpp' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-290' name='zlpp' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
       <parameter type-id='type-id-22' name='nv' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1'/>
@@ -5156,19 +5225,19 @@
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' filepath='../../include/sys/nvpair.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_deleg.h' line='83' column='1' id='type-id-286'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_deleg.h' line='83' column='1' id='type-id-291'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='z_perm' type-id='type-id-23' visibility='default' filepath='../../include/zfs_deleg.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_note' type-id='type-id-287' visibility='default' filepath='../../include/zfs_deleg.h' line='85' column='1'/>
+        <var-decl name='z_note' type-id='type-id-292' visibility='default' filepath='../../include/zfs_deleg.h' line='85' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_deleg.h' line='48' column='1' id='type-id-288'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_deleg.h' line='48' column='1' id='type-id-293'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_DELEG_NOTE_CREATE' value='0'/>
       <enumerator name='ZFS_DELEG_NOTE_DESTROY' value='1'/>
@@ -5203,15 +5272,15 @@
       <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
       <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-288' filepath='../../include/zfs_deleg.h' line='81' column='1' id='type-id-287'/>
-    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-286' filepath='../../include/zfs_deleg.h' line='86' column='1' id='type-id-289'/>
+    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-293' filepath='../../include/zfs_deleg.h' line='81' column='1' id='type-id-292'/>
+    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-291' filepath='../../include/zfs_deleg.h' line='86' column='1' id='type-id-294'/>
 
-    <array-type-def dimensions='1' type-id='type-id-289' size-in-bits='infinite' id='type-id-290'>
-      <subrange length='infinite' id='type-id-291'/>
+    <array-type-def dimensions='1' type-id='type-id-294' size-in-bits='infinite' id='type-id-295'>
+      <subrange length='infinite' id='type-id-296'/>
 
     </array-type-def>
-    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-290' mangled-name='zfs_deleg_perm_tab' visibility='default' filepath='../../include/zfs_deleg.h' line='88' column='1' elf-symbol-id='zfs_deleg_perm_tab'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='340' column='1' id='type-id-292'>
+    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-295' mangled-name='zfs_deleg_perm_tab' visibility='default' filepath='../../include/zfs_deleg.h' line='88' column='1' elf-symbol-id='zfs_deleg_perm_tab'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='340' column='1' id='type-id-297'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
       <enumerator name='ZFS_DELEG_USER' value='117'/>
@@ -5225,303 +5294,303 @@
       <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
       <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-292' filepath='../../include/sys/fs/zfs.h' line='352' column='1' id='type-id-293'/>
+    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-297' filepath='../../include/sys/fs/zfs.h' line='352' column='1' id='type-id-298'/>
     <function-decl name='zfs_deleg_whokey' mangled-name='zfs_deleg_whokey' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_whokey'>
       <parameter type-id='type-id-23' name='attr' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
-      <parameter type-id='type-id-293' name='type' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
-      <parameter type-id='type-id-46' name='inheritchr' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-298' name='type' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
+      <parameter type-id='type-id-45' name='inheritchr' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
       <parameter type-id='type-id-22' name='nvp' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
-      <parameter type-id='type-id-106' name='perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1'/>
-      <return type-id='type-id-106'/>
+      <parameter type-id='type-id-104' name='perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='permset_namecheck' mangled-name='permset_namecheck' filepath='../../include/zfs_namecheck.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' filepath='../../include/zfs_prop.h' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='77' column='1' id='type-id-294'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='77' column='1' id='type-id-299'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acf_init' type-id='type-id-295' visibility='default' filepath='../../include/sys/zio_checksum.h' line='78' column='1'/>
+        <var-decl name='acf_init' type-id='type-id-300' visibility='default' filepath='../../include/sys/zio_checksum.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acf_fini' type-id='type-id-296' visibility='default' filepath='../../include/sys/zio_checksum.h' line='79' column='1'/>
+        <var-decl name='acf_fini' type-id='type-id-301' visibility='default' filepath='../../include/sys/zio_checksum.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acf_iter' type-id='type-id-297' visibility='default' filepath='../../include/sys/zio_checksum.h' line='80' column='1'/>
+        <var-decl name='acf_iter' type-id='type-id-302' visibility='default' filepath='../../include/sys/zio_checksum.h' line='80' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='66' column='1' id='type-id-298'>
+    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='66' column='1' id='type-id-303'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acd_byteorder' type-id='type-id-299' visibility='default' filepath='../../include/sys/zio_checksum.h' line='67' column='1'/>
+        <var-decl name='acd_byteorder' type-id='type-id-304' visibility='default' filepath='../../include/sys/zio_checksum.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acd_ctx' type-id='type-id-300' visibility='default' filepath='../../include/sys/zio_checksum.h' line='68' column='1'/>
+        <var-decl name='acd_ctx' type-id='type-id-305' visibility='default' filepath='../../include/sys/zio_checksum.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acd_zcp' type-id='type-id-301' visibility='default' filepath='../../include/sys/zio_checksum.h' line='69' column='1'/>
+        <var-decl name='acd_zcp' type-id='type-id-306' visibility='default' filepath='../../include/sys/zio_checksum.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='acd_private' type-id='type-id-43' visibility='default' filepath='../../include/sys/zio_checksum.h' line='70' column='1'/>
+        <var-decl name='acd_private' type-id='type-id-42' visibility='default' filepath='../../include/sys/zio_checksum.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zio_checksum.h' line='61' column='1' id='type-id-302'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zio_checksum.h' line='61' column='1' id='type-id-307'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
       <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
     </enum-decl>
-    <typedef-decl name='zio_byteorder_t' type-id='type-id-302' filepath='../../include/sys/zio_checksum.h' line='64' column='1' id='type-id-299'/>
-    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' filepath='../../include/zfs_fletcher.h' line='90' column='1' id='type-id-303'>
+    <typedef-decl name='zio_byteorder_t' type-id='type-id-307' filepath='../../include/sys/zio_checksum.h' line='64' column='1' id='type-id-304'/>
+    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' filepath='../../include/zfs_fletcher.h' line='90' column='1' id='type-id-308'>
       <data-member access='private'>
-        <var-decl name='scalar' type-id='type-id-304' visibility='default' filepath='../../include/zfs_fletcher.h' line='91' column='1'/>
+        <var-decl name='scalar' type-id='type-id-309' visibility='default' filepath='../../include/zfs_fletcher.h' line='91' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='superscalar' type-id='type-id-305' visibility='default' filepath='../../include/zfs_fletcher.h' line='92' column='1'/>
+        <var-decl name='superscalar' type-id='type-id-310' visibility='default' filepath='../../include/zfs_fletcher.h' line='92' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sse' type-id='type-id-306' visibility='default' filepath='../../include/zfs_fletcher.h' line='95' column='1'/>
+        <var-decl name='sse' type-id='type-id-311' visibility='default' filepath='../../include/zfs_fletcher.h' line='95' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx' type-id='type-id-307' visibility='default' filepath='../../include/zfs_fletcher.h' line='98' column='1'/>
+        <var-decl name='avx' type-id='type-id-312' visibility='default' filepath='../../include/zfs_fletcher.h' line='98' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx512' type-id='type-id-308' visibility='default' filepath='../../include/zfs_fletcher.h' line='101' column='1'/>
+        <var-decl name='avx512' type-id='type-id-313' visibility='default' filepath='../../include/zfs_fletcher.h' line='101' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-309'>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-314'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='type-id-310' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
+        <var-decl name='zc_word' type-id='type-id-315' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='256' id='type-id-310'>
-      <subrange length='4' type-id='type-id-49' id='type-id-311'/>
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='256' id='type-id-315'>
+      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
 
     </array-type-def>
-    <typedef-decl name='zio_cksum_t' type-id='type-id-309' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-304'/>
-    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='69' column='1' id='type-id-312'>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-314' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-309'/>
+    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='69' column='1' id='type-id-317'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-310' visibility='default' filepath='../../include/zfs_fletcher.h' line='70' column='1'/>
+        <var-decl name='v' type-id='type-id-315' visibility='default' filepath='../../include/zfs_fletcher.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-312' filepath='../../include/zfs_fletcher.h' line='71' column='1' id='type-id-313'/>
+    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-317' filepath='../../include/zfs_fletcher.h' line='71' column='1' id='type-id-318'/>
 
-    <array-type-def dimensions='1' type-id='type-id-313' size-in-bits='1024' id='type-id-305'>
-      <subrange length='4' type-id='type-id-49' id='type-id-311'/>
+    <array-type-def dimensions='1' type-id='type-id-318' size-in-bits='1024' id='type-id-310'>
+      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='73' column='1' id='type-id-314'>
+    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='73' column='1' id='type-id-319'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-158' visibility='default' filepath='../../include/zfs_fletcher.h' line='74' column='1'/>
+        <var-decl name='v' type-id='type-id-156' visibility='default' filepath='../../include/zfs_fletcher.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-314' filepath='../../include/zfs_fletcher.h' line='75' column='1' id='type-id-315'/>
+    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-319' filepath='../../include/zfs_fletcher.h' line='75' column='1' id='type-id-320'/>
 
-    <array-type-def dimensions='1' type-id='type-id-315' size-in-bits='512' id='type-id-306'>
-      <subrange length='4' type-id='type-id-49' id='type-id-311'/>
+    <array-type-def dimensions='1' type-id='type-id-320' size-in-bits='512' id='type-id-311'>
+      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='77' column='1' id='type-id-316'>
+    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='77' column='1' id='type-id-321'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-310' visibility='default' filepath='../../include/zfs_fletcher.h' line='78' column='1'/>
+        <var-decl name='v' type-id='type-id-315' visibility='default' filepath='../../include/zfs_fletcher.h' line='78' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-316' filepath='../../include/zfs_fletcher.h' line='79' column='1' id='type-id-317'/>
+    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-321' filepath='../../include/zfs_fletcher.h' line='79' column='1' id='type-id-322'/>
 
-    <array-type-def dimensions='1' type-id='type-id-317' size-in-bits='1024' id='type-id-307'>
-      <subrange length='4' type-id='type-id-49' id='type-id-311'/>
+    <array-type-def dimensions='1' type-id='type-id-322' size-in-bits='1024' id='type-id-312'>
+      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='81' column='1' id='type-id-318'>
+    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='81' column='1' id='type-id-323'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-252' visibility='default' filepath='../../include/zfs_fletcher.h' line='82' column='1'/>
+        <var-decl name='v' type-id='type-id-257' visibility='default' filepath='../../include/zfs_fletcher.h' line='82' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-318' filepath='../../include/zfs_fletcher.h' line='83' column='1' id='type-id-319'/>
+    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-323' filepath='../../include/zfs_fletcher.h' line='83' column='1' id='type-id-324'/>
 
-    <array-type-def dimensions='1' type-id='type-id-319' size-in-bits='2048' id='type-id-308'>
-      <subrange length='4' type-id='type-id-49' id='type-id-311'/>
+    <array-type-def dimensions='1' type-id='type-id-324' size-in-bits='2048' id='type-id-313'>
+      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
 
     </array-type-def>
-    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-303' filepath='../../include/zfs_fletcher.h' line='106' column='1' id='type-id-320'/>
-    <pointer-type-def type-id='type-id-320' size-in-bits='64' id='type-id-300'/>
-    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-301'/>
-    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-298' filepath='../../include/sys/zio_checksum.h' line='71' column='1' id='type-id-321'/>
-    <pointer-type-def type-id='type-id-321' size-in-bits='64' id='type-id-322'/>
-    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-323' filepath='../../include/sys/zio_checksum.h' line='73' column='1' id='type-id-324'/>
-    <pointer-type-def type-id='type-id-324' size-in-bits='64' id='type-id-295'/>
-    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-323' filepath='../../include/sys/zio_checksum.h' line='74' column='1' id='type-id-325'/>
-    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-296'/>
-    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-326' filepath='../../include/sys/zio_checksum.h' line='75' column='1' id='type-id-327'/>
-    <pointer-type-def type-id='type-id-327' size-in-bits='64' id='type-id-297'/>
-    <qualified-type-def type-id='type-id-294' const='yes' id='type-id-328'/>
-    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-328' filepath='../../include/sys/zio_checksum.h' line='81' column='1' id='type-id-329'/>
-    <var-decl name='fletcher_4_abd_ops' type-id='type-id-329' mangled-name='fletcher_4_abd_ops' visibility='default' filepath='../../include/sys/zio_checksum.h' line='125' column='1' elf-symbol-id='fletcher_4_abd_ops'/>
+    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-308' filepath='../../include/zfs_fletcher.h' line='106' column='1' id='type-id-325'/>
+    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-305'/>
+    <pointer-type-def type-id='type-id-309' size-in-bits='64' id='type-id-306'/>
+    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-303' filepath='../../include/sys/zio_checksum.h' line='71' column='1' id='type-id-326'/>
+    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-327'/>
+    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-328' filepath='../../include/sys/zio_checksum.h' line='73' column='1' id='type-id-329'/>
+    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-300'/>
+    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-328' filepath='../../include/sys/zio_checksum.h' line='74' column='1' id='type-id-330'/>
+    <pointer-type-def type-id='type-id-330' size-in-bits='64' id='type-id-301'/>
+    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-331' filepath='../../include/sys/zio_checksum.h' line='75' column='1' id='type-id-332'/>
+    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-302'/>
+    <qualified-type-def type-id='type-id-299' const='yes' id='type-id-333'/>
+    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-333' filepath='../../include/sys/zio_checksum.h' line='81' column='1' id='type-id-334'/>
+    <var-decl name='fletcher_4_abd_ops' type-id='type-id-334' mangled-name='fletcher_4_abd_ops' visibility='default' filepath='../../include/sys/zio_checksum.h' line='125' column='1' elf-symbol-id='fletcher_4_abd_ops'/>
     <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
-      <parameter type-id='type-id-44' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
       <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
-      <parameter type-id='type-id-106' name='val' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1'/>
+      <parameter type-id='type-id-104' name='val' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
       <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-43' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-44' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_2_native' mangled-name='fletcher_2_native' filepath='../../module/zcommon/zfs_fletcher.c' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_native'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
       <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-43' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-44' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_init' mangled-name='fletcher_init' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_native' mangled-name='fletcher_4_native' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
       <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
-      <parameter type-id='type-id-43' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_byteswap' mangled-name='fletcher_4_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_byteswap'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
       <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
-      <parameter type-id='type-id-43' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
-      <parameter type-id='type-id-301' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_native'>
-      <parameter type-id='type-id-43' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
-      <parameter type-id='type-id-44' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
-      <parameter type-id='type-id-43' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='membar_producer' mangled-name='membar_producer' filepath='../../lib/libspl/include/atomic.h' line='280' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' filepath='../../lib/libspl/include/atomic.h' line='240' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-326'>
+    <function-type size-in-bits='64' id='type-id-331'>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-42'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-323'>
-      <parameter type-id='type-id-322'/>
-      <return type-id='type-id-51'/>
+    <function-type size-in-bits='64' id='type-id-328'>
+      <parameter type-id='type-id-327'/>
+      <return type-id='type-id-52'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='116' column='1' id='type-id-330'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='116' column='1' id='type-id-335'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='init_native' type-id='type-id-331' visibility='default' filepath='../../include/zfs_fletcher.h' line='117' column='1'/>
+        <var-decl name='init_native' type-id='type-id-336' visibility='default' filepath='../../include/zfs_fletcher.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fini_native' type-id='type-id-332' visibility='default' filepath='../../include/zfs_fletcher.h' line='118' column='1'/>
+        <var-decl name='fini_native' type-id='type-id-337' visibility='default' filepath='../../include/zfs_fletcher.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='compute_native' type-id='type-id-333' visibility='default' filepath='../../include/zfs_fletcher.h' line='119' column='1'/>
+        <var-decl name='compute_native' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='init_byteswap' type-id='type-id-331' visibility='default' filepath='../../include/zfs_fletcher.h' line='120' column='1'/>
+        <var-decl name='init_byteswap' type-id='type-id-336' visibility='default' filepath='../../include/zfs_fletcher.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fini_byteswap' type-id='type-id-332' visibility='default' filepath='../../include/zfs_fletcher.h' line='121' column='1'/>
+        <var-decl name='fini_byteswap' type-id='type-id-337' visibility='default' filepath='../../include/zfs_fletcher.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='compute_byteswap' type-id='type-id-333' visibility='default' filepath='../../include/zfs_fletcher.h' line='122' column='1'/>
+        <var-decl name='compute_byteswap' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='valid' type-id='type-id-334' visibility='default' filepath='../../include/zfs_fletcher.h' line='123' column='1'/>
+        <var-decl name='valid' type-id='type-id-339' visibility='default' filepath='../../include/zfs_fletcher.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='name' type-id='type-id-106' visibility='default' filepath='../../include/zfs_fletcher.h' line='124' column='1'/>
+        <var-decl name='name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_fletcher.h' line='124' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-335' size-in-bits='64' id='type-id-336'/>
-    <typedef-decl name='fletcher_4_init_f' type-id='type-id-336' filepath='../../include/zfs_fletcher.h' line='111' column='1' id='type-id-331'/>
-    <pointer-type-def type-id='type-id-337' size-in-bits='64' id='type-id-338'/>
-    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-338' filepath='../../include/zfs_fletcher.h' line='112' column='1' id='type-id-332'/>
-    <pointer-type-def type-id='type-id-339' size-in-bits='64' id='type-id-340'/>
-    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-340' filepath='../../include/zfs_fletcher.h' line='113' column='1' id='type-id-333'/>
-    <pointer-type-def type-id='type-id-341' size-in-bits='64' id='type-id-334'/>
-    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-330' filepath='../../include/zfs_fletcher.h' line='125' column='1' id='type-id-342'/>
-    <qualified-type-def type-id='type-id-342' const='yes' id='type-id-343'/>
-    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-343' mangled-name='fletcher_4_avx512f_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='143' column='1' elf-symbol-id='fletcher_4_avx512f_ops'/>
-    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-343' mangled-name='fletcher_4_avx512bw_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='147' column='1' elf-symbol-id='fletcher_4_avx512bw_ops'/>
-    <function-type size-in-bits='64' id='type-id-341'>
+    <pointer-type-def type-id='type-id-340' size-in-bits='64' id='type-id-341'/>
+    <typedef-decl name='fletcher_4_init_f' type-id='type-id-341' filepath='../../include/zfs_fletcher.h' line='111' column='1' id='type-id-336'/>
+    <pointer-type-def type-id='type-id-342' size-in-bits='64' id='type-id-343'/>
+    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-343' filepath='../../include/zfs_fletcher.h' line='112' column='1' id='type-id-337'/>
+    <pointer-type-def type-id='type-id-344' size-in-bits='64' id='type-id-345'/>
+    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-345' filepath='../../include/zfs_fletcher.h' line='113' column='1' id='type-id-338'/>
+    <pointer-type-def type-id='type-id-346' size-in-bits='64' id='type-id-339'/>
+    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-335' filepath='../../include/zfs_fletcher.h' line='125' column='1' id='type-id-347'/>
+    <qualified-type-def type-id='type-id-347' const='yes' id='type-id-348'/>
+    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-348' mangled-name='fletcher_4_avx512f_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='143' column='1' elf-symbol-id='fletcher_4_avx512f_ops'/>
+    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-348' mangled-name='fletcher_4_avx512bw_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='147' column='1' elf-symbol-id='fletcher_4_avx512bw_ops'/>
+    <function-type size-in-bits='64' id='type-id-346'>
       <return type-id='type-id-5'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-335'>
-      <parameter type-id='type-id-300'/>
-      <return type-id='type-id-51'/>
+    <function-type size-in-bits='64' id='type-id-340'>
+      <parameter type-id='type-id-305'/>
+      <return type-id='type-id-52'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-339'>
-      <parameter type-id='type-id-300'/>
-      <parameter type-id='type-id-43'/>
+    <function-type size-in-bits='64' id='type-id-344'>
+      <parameter type-id='type-id-305'/>
+      <parameter type-id='type-id-42'/>
       <parameter type-id='type-id-27'/>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-337'>
-      <parameter type-id='type-id-300'/>
-      <parameter type-id='type-id-301'/>
-      <return type-id='type-id-51'/>
+    <function-type size-in-bits='64' id='type-id-342'>
+      <parameter type-id='type-id-305'/>
+      <parameter type-id='type-id-306'/>
+      <return type-id='type-id-52'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-343' mangled-name='fletcher_4_avx2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='139' column='1' elf-symbol-id='fletcher_4_avx2_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-348' mangled-name='fletcher_4_avx2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='139' column='1' elf-symbol-id='fletcher_4_avx2_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-343' mangled-name='fletcher_4_sse2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='131' column='1' elf-symbol-id='fletcher_4_sse2_ops'/>
-    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-343' mangled-name='fletcher_4_ssse3_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='135' column='1' elf-symbol-id='fletcher_4_ssse3_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-348' mangled-name='fletcher_4_sse2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='131' column='1' elf-symbol-id='fletcher_4_sse2_ops'/>
+    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-348' mangled-name='fletcher_4_ssse3_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='135' column='1' elf-symbol-id='fletcher_4_ssse3_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-343' mangled-name='fletcher_4_superscalar_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='127' column='1' elf-symbol-id='fletcher_4_superscalar_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-348' mangled-name='fletcher_4_superscalar_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='127' column='1' elf-symbol-id='fletcher_4_superscalar_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-343' mangled-name='fletcher_4_superscalar4_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='128' column='1' elf-symbol-id='fletcher_4_superscalar4_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-348' mangled-name='fletcher_4_superscalar4_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='128' column='1' elf-symbol-id='fletcher_4_superscalar4_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <var-decl name='zfs_max_dataset_nesting' type-id='type-id-6' mangled-name='zfs_max_dataset_nesting' visibility='default' filepath='../../include/zfs_namecheck.h' line='54' column='1' elf-symbol-id='zfs_max_dataset_nesting'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_namecheck.h' line='36' column='1' id='type-id-344'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_namecheck.h' line='36' column='1' id='type-id-349'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
       <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
@@ -5537,78 +5606,78 @@
       <enumerator name='NAME_ERR_NO_AT' value='11'/>
       <enumerator name='NAME_ERR_NO_POUND' value='12'/>
     </enum-decl>
-    <typedef-decl name='namecheck_err_t' type-id='type-id-344' filepath='../../include/zfs_namecheck.h' line='50' column='1' id='type-id-345'/>
-    <pointer-type-def type-id='type-id-345' size-in-bits='64' id='type-id-346'/>
+    <typedef-decl name='namecheck_err_t' type-id='type-id-349' filepath='../../include/zfs_namecheck.h' line='50' column='1' id='type-id-350'/>
+    <pointer-type-def type-id='type-id-350' size-in-bits='64' id='type-id-351'/>
     <function-decl name='pool_namecheck' mangled-name='pool_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
-      <parameter type-id='type-id-106' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
-      <parameter type-id='type-id-106' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
-      <parameter type-id='type-id-106' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='dataset_namecheck' mangled-name='dataset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_namecheck'>
-      <parameter type-id='type-id-106' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='permset_namecheck' mangled-name='permset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
-      <parameter type-id='type-id-106' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
-      <parameter type-id='type-id-346' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='768' id='type-id-347'>
-      <subrange length='12' type-id='type-id-49' id='type-id-348'/>
+    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='768' id='type-id-352'>
+      <subrange length='12' type-id='type-id-48' id='type-id-353'/>
 
     </array-type-def>
-    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-347' mangled-name='zfs_userquota_prop_prefixes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='208' column='1' elf-symbol-id='zfs_userquota_prop_prefixes'/>
+    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-352' mangled-name='zfs_userquota_prop_prefixes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='208' column='1' elf-symbol-id='zfs_userquota_prop_prefixes'/>
     <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1'/>
@@ -5616,10 +5685,10 @@
     </function-decl>
     <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' filepath='../../module/zcommon/zfs_prop.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
-      <parameter type-id='type-id-106' name='str' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
+      <parameter type-id='type-id-104' name='str' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
       <parameter type-id='type-id-5' name='encrypted' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
@@ -5633,7 +5702,7 @@
     </function-decl>
     <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../module/zcommon/zfs_prop.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1'/>
@@ -5641,7 +5710,7 @@
     </function-decl>
     <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' filepath='../../module/zcommon/zfs_prop.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
@@ -5655,16 +5724,16 @@
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='40' column='1' id='type-id-349'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='40' column='1' id='type-id-354'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROP_TYPE_NUMBER' value='0'/>
       <enumerator name='PROP_TYPE_STRING' value='1'/>
       <enumerator name='PROP_TYPE_INDEX' value='2'/>
     </enum-decl>
-    <typedef-decl name='zprop_type_t' type-id='type-id-349' filepath='../../include/zfs_prop.h' line='44' column='1' id='type-id-350'/>
+    <typedef-decl name='zprop_type_t' type-id='type-id-354' filepath='../../include/zfs_prop.h' line='44' column='1' id='type-id-355'/>
     <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1'/>
-      <return type-id='type-id-350'/>
+      <return type-id='type-id-355'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1'/>
@@ -5677,66 +5746,66 @@
       <parameter type-id='type-id-27' name='seed' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-351'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-356'/>
     <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
       <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
-      <parameter type-id='type-id-351' name='string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
-      <parameter type-id='type-id-106' name='string' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
-      <parameter type-id='type-id-139' name='index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
-      <parameter type-id='type-id-106' name='propname' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-352' visibility='default' filepath='../../include/zfs_prop.h' line='67' column='1' id='type-id-353'>
+    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-357' visibility='default' filepath='../../include/zfs_prop.h' line='67' column='1' id='type-id-358'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pd_name' type-id='type-id-106' visibility='default' filepath='../../include/zfs_prop.h' line='68' column='1'/>
+        <var-decl name='pd_name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='pd_propnum' type-id='type-id-6' visibility='default' filepath='../../include/zfs_prop.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pd_proptype' type-id='type-id-350' visibility='default' filepath='../../include/zfs_prop.h' line='70' column='1'/>
+        <var-decl name='pd_proptype' type-id='type-id-355' visibility='default' filepath='../../include/zfs_prop.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pd_strdefault' type-id='type-id-106' visibility='default' filepath='../../include/zfs_prop.h' line='71' column='1'/>
+        <var-decl name='pd_strdefault' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='pd_numdefault' type-id='type-id-27' visibility='default' filepath='../../include/zfs_prop.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pd_attr' type-id='type-id-354' visibility='default' filepath='../../include/zfs_prop.h' line='73' column='1'/>
+        <var-decl name='pd_attr' type-id='type-id-359' visibility='default' filepath='../../include/zfs_prop.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='pd_types' type-id='type-id-6' visibility='default' filepath='../../include/zfs_prop.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pd_values' type-id='type-id-106' visibility='default' filepath='../../include/zfs_prop.h' line='76' column='1'/>
+        <var-decl name='pd_values' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pd_colname' type-id='type-id-106' visibility='default' filepath='../../include/zfs_prop.h' line='77' column='1'/>
+        <var-decl name='pd_colname' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='pd_rightalign' type-id='type-id-5' visibility='default' filepath='../../include/zfs_prop.h' line='78' column='1'/>
@@ -5748,13 +5817,13 @@
         <var-decl name='pd_zfs_mod_supported' type-id='type-id-5' visibility='default' filepath='../../include/zfs_prop.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='pd_table' type-id='type-id-355' visibility='default' filepath='../../include/zfs_prop.h' line='82' column='1'/>
+        <var-decl name='pd_table' type-id='type-id-360' visibility='default' filepath='../../include/zfs_prop.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='pd_table_size' type-id='type-id-44' visibility='default' filepath='../../include/zfs_prop.h' line='84' column='1'/>
+        <var-decl name='pd_table_size' type-id='type-id-43' visibility='default' filepath='../../include/zfs_prop.h' line='84' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='46' column='1' id='type-id-356'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='46' column='1' id='type-id-361'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROP_DEFAULT' value='0'/>
       <enumerator name='PROP_READONLY' value='1'/>
@@ -5762,121 +5831,121 @@
       <enumerator name='PROP_ONETIME' value='3'/>
       <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
     </enum-decl>
-    <typedef-decl name='zprop_attr_t' type-id='type-id-356' filepath='../../include/zfs_prop.h' line='60' column='1' id='type-id-354'/>
-    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_prop.h' line='62' column='1' id='type-id-357'>
+    <typedef-decl name='zprop_attr_t' type-id='type-id-361' filepath='../../include/zfs_prop.h' line='60' column='1' id='type-id-359'/>
+    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_prop.h' line='62' column='1' id='type-id-362'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pi_name' type-id='type-id-106' visibility='default' filepath='../../include/zfs_prop.h' line='63' column='1'/>
+        <var-decl name='pi_name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='63' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='pi_value' type-id='type-id-27' visibility='default' filepath='../../include/zfs_prop.h' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zprop_index_t' type-id='type-id-357' filepath='../../include/zfs_prop.h' line='65' column='1' id='type-id-358'/>
-    <qualified-type-def type-id='type-id-358' const='yes' id='type-id-359'/>
-    <pointer-type-def type-id='type-id-359' size-in-bits='64' id='type-id-355'/>
-    <typedef-decl name='zprop_desc_t' type-id='type-id-353' filepath='../../include/zfs_prop.h' line='85' column='1' id='type-id-352'/>
-    <pointer-type-def type-id='type-id-352' size-in-bits='64' id='type-id-360'/>
+    <typedef-decl name='zprop_index_t' type-id='type-id-362' filepath='../../include/zfs_prop.h' line='65' column='1' id='type-id-363'/>
+    <qualified-type-def type-id='type-id-363' const='yes' id='type-id-364'/>
+    <pointer-type-def type-id='type-id-364' size-in-bits='64' id='type-id-360'/>
+    <typedef-decl name='zprop_desc_t' type-id='type-id-358' filepath='../../include/zfs_prop.h' line='85' column='1' id='type-id-357'/>
+    <pointer-type-def type-id='type-id-357' size-in-bits='64' id='type-id-365'/>
     <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../module/zcommon/zfs_prop.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
-      <return type-id='type-id-360'/>
+      <return type-id='type-id-365'/>
     </function-decl>
     <function-decl name='zprop_random_value' mangled-name='zprop_random_value' filepath='../../include/zfs_prop.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' filepath='../../include/zfs_prop.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_index' mangled-name='zprop_register_index' filepath='../../include/zfs_prop.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_string' mangled-name='zprop_register_string' filepath='../../include/zfs_prop.h' line='108' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_number' mangled-name='zprop_register_number' filepath='../../include/zfs_prop.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' filepath='../../include/zfs_prop.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' filepath='../../include/zfs_prop.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-106'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' filepath='../../module/zcommon/zpool_prop.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-106'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
       <parameter type-id='type-id-27' name='seed' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
       <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
-      <parameter type-id='type-id-351' name='string' filepath='../../module/zcommon/zpool_prop.c' line='230' column='1'/>
+      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zpool_prop.c' line='230' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
-      <parameter type-id='type-id-106' name='string' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
-      <parameter type-id='type-id-139' name='index' filepath='../../module/zcommon/zpool_prop.c' line='223' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
+      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
+      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zpool_prop.c' line='223' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' filepath='../../module/zcommon/zpool_prop.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1'/>
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../module/zcommon/zpool_prop.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-106'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' filepath='../../module/zcommon/zpool_prop.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' filepath='../../module/zcommon/zpool_prop.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1'/>
-      <return type-id='type-id-350'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1'/>
+      <return type-id='type-id-355'/>
     </function-decl>
     <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' filepath='../../module/zcommon/zpool_prop.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
-      <parameter type-id='type-id-211' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-106'/>
+      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
-      <parameter type-id='type-id-106' name='propname' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1'/>
-      <return type-id='type-id-211'/>
+      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1'/>
+      <return type-id='type-id-209'/>
     </function-decl>
     <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' filepath='../../module/zcommon/zpool_prop.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
-      <return type-id='type-id-360'/>
+      <return type-id='type-id-365'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zprop_width' mangled-name='zprop_width' filepath='../../module/zcommon/zprop_common.c' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
-      <parameter type-id='type-id-116' name='fixed' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
+      <parameter type-id='type-id-114' name='fixed' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
-      <return type-id='type-id-44'/>
+      <return type-id='type-id-43'/>
     </function-decl>
     <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' filepath='../../module/zcommon/zprop_common.c' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='380' column='1'/>
@@ -5887,7 +5956,7 @@
     <function-decl name='zprop_values' mangled-name='zprop_values' filepath='../../module/zcommon/zprop_common.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
-      <return type-id='type-id-106'/>
+      <return type-id='type-id-104'/>
     </function-decl>
     <function-decl name='zprop_random_value' mangled-name='zprop_random_value' filepath='../../module/zcommon/zprop_common.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
@@ -5898,25 +5967,25 @@
     <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
       <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
-      <parameter type-id='type-id-351' name='string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='316' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
-      <parameter type-id='type-id-106' name='string' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
-      <parameter type-id='type-id-139' name='index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='290' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' filepath='../../module/zcommon/zprop_common.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
-      <parameter type-id='type-id-106' name='propname' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
+      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' filepath='../../module/zcommon/zprop_common.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
-      <parameter type-id='type-id-231' name='func' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
-      <parameter type-id='type-id-43' name='cb' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-229' name='func' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-42' name='cb' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
       <parameter type-id='type-id-5' name='show_all' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
       <parameter type-id='type-id-5' name='ordered' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
@@ -5924,260 +5993,260 @@
     </function-decl>
     <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' filepath='../../module/zcommon/zprop_common.c' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-350' name='type' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-354' name='attr' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-355' name='type' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
-      <parameter type-id='type-id-106' name='colname' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_index' mangled-name='zprop_register_index' filepath='../../module/zcommon/zprop_common.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
       <parameter type-id='type-id-27' name='def' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
-      <parameter type-id='type-id-354' name='attr' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
-      <parameter type-id='type-id-106' name='values' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
-      <parameter type-id='type-id-106' name='colname' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
-      <parameter type-id='type-id-355' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_number' mangled-name='zprop_register_number' filepath='../../module/zcommon/zprop_common.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
       <parameter type-id='type-id-27' name='def' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
-      <parameter type-id='type-id-354' name='attr' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
-      <parameter type-id='type-id-106' name='values' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
-      <parameter type-id='type-id-106' name='colname' filepath='../../module/zcommon/zprop_common.c' line='134' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='134' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_string' mangled-name='zprop_register_string' filepath='../../module/zcommon/zprop_common.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-106' name='def' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-354' name='attr' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-104' name='def' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
-      <parameter type-id='type-id-106' name='values' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
-      <parameter type-id='type-id-106' name='colname' filepath='../../module/zcommon/zprop_common.c' line='124' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='124' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' filepath='../../module/zcommon/zprop_common.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
-      <parameter type-id='type-id-106' name='name' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
-      <parameter type-id='type-id-350' name='type' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-355' name='type' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
       <parameter type-id='type-id-27' name='numdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
-      <parameter type-id='type-id-106' name='strdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
-      <parameter type-id='type-id-354' name='attr' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-104' name='strdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
-      <parameter type-id='type-id-106' name='values' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
-      <parameter type-id='type-id-106' name='colname' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
       <parameter type-id='type-id-5' name='rightalign' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
       <parameter type-id='type-id-5' name='visible' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
-      <parameter type-id='type-id-355' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
-      <return type-id='type-id-51'/>
+      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__ctype_tolower_loc' mangled-name='__ctype_tolower_loc' filepath='/usr/include/ctype.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' filepath='../../include/sys/zfs_sysfs.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
-      <parameter type-id='type-id-23' name='options' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='299' column='1'/>
-      <parameter type-id='type-id-23' name='proto' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
+      <parameter type-id='type-id-23' name='options' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+      <parameter type-id='type-id-23' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
-      <parameter type-id='type-id-6' name='err' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='182' column='1'/>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
+      <parameter type-id='type-id-6' name='err' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='182' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
-      <parameter type-id='type-id-106' name='protocol' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='166' column='1'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
+      <parameter type-id='type-id-104' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='166' column='1'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='144' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='115' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
-      <parameter type-id='type-id-106' name='zfsname' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='80' column='1'/>
-      <parameter type-id='type-id-106' name='mountpoint' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='80' column='1'/>
-      <parameter type-id='type-id-106' name='shareopts' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='81' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
+      <parameter type-id='type-id-104' name='zfsname' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-104' name='shareopts' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='81' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='53' column='1' id='type-id-361'>
+    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='53' column='1' id='type-id-366'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-362' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='54' column='1'/>
+        <var-decl name='next' type-id='type-id-367' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='name' type-id='type-id-106' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='56' column='1'/>
+        <var-decl name='name' type-id='type-id-104' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ops' type-id='type-id-363' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='57' column='1'/>
+        <var-decl name='ops' type-id='type-id-368' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fsinfo_index' type-id='type-id-6' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='58' column='1'/>
+        <var-decl name='fsinfo_index' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-361' size-in-bits='64' id='type-id-362'/>
-    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='42' column='1' id='type-id-364'>
+    <pointer-type-def type-id='type-id-366' size-in-bits='64' id='type-id-367'/>
+    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='42' column='1' id='type-id-369'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='enable_share' type-id='type-id-365' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='43' column='1'/>
+        <var-decl name='enable_share' type-id='type-id-370' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='disable_share' type-id='type-id-365' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='44' column='1'/>
+        <var-decl name='disable_share' type-id='type-id-370' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='is_shared' type-id='type-id-366' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='45' column='1'/>
+        <var-decl name='is_shared' type-id='type-id-371' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='validate_shareopts' type-id='type-id-367' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='46' column='1'/>
+        <var-decl name='validate_shareopts' type-id='type-id-372' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='46' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='update_shareopts' type-id='type-id-368' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='47' column='1'/>
+        <var-decl name='update_shareopts' type-id='type-id-373' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='47' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='clear_shareopts' type-id='type-id-369' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='49' column='1'/>
+        <var-decl name='clear_shareopts' type-id='type-id-374' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='49' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='commit_shares' type-id='type-id-370' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='50' column='1'/>
+        <var-decl name='commit_shares' type-id='type-id-375' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='50' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='32' column='1' id='type-id-371'>
+    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='32' column='1' id='type-id-376'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sa_mountpoint' type-id='type-id-23' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='33' column='1'/>
+        <var-decl name='sa_mountpoint' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='33' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sa_zfsname' type-id='type-id-23' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='34' column='1'/>
+        <var-decl name='sa_zfsname' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sa_fsinfo' type-id='type-id-372' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='36' column='1'/>
+        <var-decl name='sa_fsinfo' type-id='type-id-377' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='28' column='1' id='type-id-373'>
+    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='28' column='1' id='type-id-378'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='shareopts' type-id='type-id-23' visibility='default' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='29' column='1'/>
+        <var-decl name='shareopts' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='29' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-373' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='30' column='1' id='type-id-374'/>
-    <pointer-type-def type-id='type-id-374' size-in-bits='64' id='type-id-372'/>
-    <pointer-type-def type-id='type-id-371' size-in-bits='64' id='type-id-375'/>
-    <typedef-decl name='sa_share_impl_t' type-id='type-id-375' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='37' column='1' id='type-id-376'/>
-    <pointer-type-def type-id='type-id-377' size-in-bits='64' id='type-id-365'/>
-    <pointer-type-def type-id='type-id-378' size-in-bits='64' id='type-id-366'/>
-    <pointer-type-def type-id='type-id-379' size-in-bits='64' id='type-id-367'/>
-    <pointer-type-def type-id='type-id-380' size-in-bits='64' id='type-id-368'/>
-    <pointer-type-def type-id='type-id-381' size-in-bits='64' id='type-id-369'/>
+    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-378' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='30' column='1' id='type-id-379'/>
+    <pointer-type-def type-id='type-id-379' size-in-bits='64' id='type-id-377'/>
+    <pointer-type-def type-id='type-id-376' size-in-bits='64' id='type-id-380'/>
+    <typedef-decl name='sa_share_impl_t' type-id='type-id-380' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='37' column='1' id='type-id-381'/>
     <pointer-type-def type-id='type-id-382' size-in-bits='64' id='type-id-370'/>
-    <typedef-decl name='sa_share_ops_t' type-id='type-id-364' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='51' column='1' id='type-id-383'/>
-    <qualified-type-def type-id='type-id-383' const='yes' id='type-id-384'/>
-    <pointer-type-def type-id='type-id-384' size-in-bits='64' id='type-id-363'/>
-    <typedef-decl name='sa_fstype_t' type-id='type-id-361' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare_impl.h' line='59' column='1' id='type-id-385'/>
-    <pointer-type-def type-id='type-id-385' size-in-bits='64' id='type-id-386'/>
-    <function-decl name='register_fstype' mangled-name='register_fstype' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='register_fstype'>
-      <parameter type-id='type-id-106' name='name' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='51' column='1'/>
-      <parameter type-id='type-id-363' name='ops' filepath='/home/behlendo/src/git/zfs/lib/libshare/libshare.c' line='51' column='1'/>
-      <return type-id='type-id-386'/>
+    <pointer-type-def type-id='type-id-383' size-in-bits='64' id='type-id-371'/>
+    <pointer-type-def type-id='type-id-384' size-in-bits='64' id='type-id-372'/>
+    <pointer-type-def type-id='type-id-385' size-in-bits='64' id='type-id-373'/>
+    <pointer-type-def type-id='type-id-386' size-in-bits='64' id='type-id-374'/>
+    <pointer-type-def type-id='type-id-387' size-in-bits='64' id='type-id-375'/>
+    <typedef-decl name='sa_share_ops_t' type-id='type-id-369' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='51' column='1' id='type-id-388'/>
+    <qualified-type-def type-id='type-id-388' const='yes' id='type-id-389'/>
+    <pointer-type-def type-id='type-id-389' size-in-bits='64' id='type-id-368'/>
+    <typedef-decl name='sa_fstype_t' type-id='type-id-366' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='59' column='1' id='type-id-390'/>
+    <pointer-type-def type-id='type-id-390' size-in-bits='64' id='type-id-391'/>
+    <function-decl name='register_fstype' mangled-name='register_fstype' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='register_fstype'>
+      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <parameter type-id='type-id-368' name='ops' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <return type-id='type-id-391'/>
     </function-decl>
-    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' filepath='/home/behlendo/src/git/zfs/lib/libshare/nfs.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' filepath='/home/colm/src/zfs/zfs/lib/libshare/nfs.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' filepath='/home/behlendo/src/git/zfs/lib/libshare/smb.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' filepath='/home/colm/src/zfs/zfs/lib/libshare/smb.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
+    <function-type size-in-bits='64' id='type-id-387'>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-384'>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-6'/>
+    </function-type>
     <function-type size-in-bits='64' id='type-id-382'>
+      <parameter type-id='type-id-381'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-379'>
-      <parameter type-id='type-id-106'/>
+    <function-type size-in-bits='64' id='type-id-385'>
+      <parameter type-id='type-id-381'/>
+      <parameter type-id='type-id-104'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-377'>
-      <parameter type-id='type-id-376'/>
-      <return type-id='type-id-6'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-380'>
-      <parameter type-id='type-id-376'/>
-      <parameter type-id='type-id-106'/>
-      <return type-id='type-id-6'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-378'>
-      <parameter type-id='type-id-376'/>
+    <function-type size-in-bits='64' id='type-id-383'>
+      <parameter type-id='type-id-381'/>
       <return type-id='type-id-5'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-381'>
-      <parameter type-id='type-id-376'/>
-      <return type-id='type-id-51'/>
+    <function-type size-in-bits='64' id='type-id-386'>
+      <parameter type-id='type-id-381'/>
+      <return type-id='type-id-52'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libshare' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
     <function-decl name='register_fstype' mangled-name='register_fstype' filepath='./libshare_impl.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='unlink' mangled-name='unlink' filepath='/usr/include/unistd.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='fputs' mangled-name='fputs' filepath='/usr/include/stdio.h' line='626' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='fputs' mangled-name='fputs' filepath='/usr/include/stdio.h' line='632' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='mkstemp' mangled-name='mkstemp64' filepath='/usr/include/stdlib.h' line='691' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='mkstemp' mangled-name='mkstemp64' filepath='/usr/include/stdlib.h' line='688' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='mkdir' mangled-name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='__builtin_stpcpy' mangled-name='stpcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
-    <function-decl name='flock' mangled-name='flock' filepath='/usr/include/x86_64-linux-gnu/sys/file.h' line='50' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+    <function-decl name='flock' mangled-name='flock' filepath='/usr/include/x86_64-linux-gnu/sys/file.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='rename' mangled-name='rename' filepath='/usr/include/stdio.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/behlendo/src/git/zfs/lib/libshare' language='LANG_C99'>
-    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' filepath='./smb.h' line='38' column='1' id='type-id-387'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
+    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' filepath='./smb.h' line='38' column='1' id='type-id-392'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-388' visibility='default' filepath='./smb.h' line='39' column='1'/>
+        <var-decl name='name' type-id='type-id-393' visibility='default' filepath='./smb.h' line='39' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2040'>
-        <var-decl name='path' type-id='type-id-145' visibility='default' filepath='./smb.h' line='40' column='1'/>
+        <var-decl name='path' type-id='type-id-143' visibility='default' filepath='./smb.h' line='40' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='34808'>
-        <var-decl name='comment' type-id='type-id-388' visibility='default' filepath='./smb.h' line='41' column='1'/>
+        <var-decl name='comment' type-id='type-id-393' visibility='default' filepath='./smb.h' line='41' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='36864'>
         <var-decl name='guest_ok' type-id='type-id-5' visibility='default' filepath='./smb.h' line='42' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='36928'>
-        <var-decl name='next' type-id='type-id-389' visibility='default' filepath='./smb.h' line='44' column='1'/>
+        <var-decl name='next' type-id='type-id-394' visibility='default' filepath='./smb.h' line='44' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='2040' id='type-id-388'>
-      <subrange length='255' type-id='type-id-49' id='type-id-390'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='2040' id='type-id-393'>
+      <subrange length='255' type-id='type-id-48' id='type-id-395'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-387' size-in-bits='64' id='type-id-389'/>
-    <typedef-decl name='smb_share_t' type-id='type-id-387' filepath='./smb.h' line='45' column='1' id='type-id-391'/>
-    <pointer-type-def type-id='type-id-391' size-in-bits='64' id='type-id-392'/>
-    <var-decl name='smb_shares' type-id='type-id-392' mangled-name='smb_shares' visibility='default' filepath='./smb.h' line='47' column='1' elf-symbol-id='smb_shares'/>
-    <function-decl name='__fgets_alias' mangled-name='fgets' filepath='/usr/include/x86_64-linux-gnu/bits/stdio2.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
-    </function-decl>
+    <pointer-type-def type-id='type-id-392' size-in-bits='64' id='type-id-394'/>
+    <typedef-decl name='smb_share_t' type-id='type-id-392' filepath='./smb.h' line='45' column='1' id='type-id-396'/>
+    <pointer-type-def type-id='type-id-396' size-in-bits='64' id='type-id-397'/>
+    <var-decl name='smb_shares' type-id='type-id-397' mangled-name='smb_shares' visibility='default' filepath='./smb.h' line='47' column='1' elf-symbol-id='smb_shares'/>
     <function-decl name='opendir' mangled-name='opendir' filepath='/usr/include/dirent.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-51'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='fgets' mangled-name='fgets' filepath='/usr/include/stdio.h' line='570' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-52'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -467,8 +467,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 	char *slash, *check;
 	struct stat64 statbuf;
 	zpool_handle_t *zhp;
-	char badword[ZFS_MAXPROPLEN];
-	char badfile[MAXPATHLEN];
+	char report[1024];
 
 	if (nvlist_alloc(&retprops, NV_UNIQUE_NAME, 0) != 0) {
 		(void) no_memory(hdl);
@@ -679,33 +678,14 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			break;
 
 		case ZPOOL_PROP_COMPATIBILITY:
-			switch (zpool_load_compat(strval, NULL,
-			    badword, badfile)) {
+			switch (zpool_load_compat(strval, NULL, report, 1024)) {
 			case ZPOOL_COMPATIBILITY_OK:
+			case ZPOOL_COMPATIBILITY_WARNTOKEN:
 				break;
-			case ZPOOL_COMPATIBILITY_READERR:
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "error reading feature file '%s'"),
-				    badfile);
-				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
-				goto error;
 			case ZPOOL_COMPATIBILITY_BADFILE:
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "feature file '%s' too large or not "
-				    "newline-terminated"),
-				    badfile);
-				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
-				goto error;
-			case ZPOOL_COMPATIBILITY_BADWORD:
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "unknown feature '%s' in feature "
-				    "file '%s'"),
-				    badword, badfile);
-				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
-				goto error;
+			case ZPOOL_COMPATIBILITY_BADTOKEN:
 			case ZPOOL_COMPATIBILITY_NOFILES:
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "no feature files specified"));
+				zfs_error_aux(hdl, report);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -4742,8 +4722,8 @@ zpool_get_bootenv(zpool_handle_t *zhp, nvlist_t **nvlp)
  * Arguments:
  *  compatibility : string containing feature filenames
  *  features : either NULL or pointer to array of boolean
- *  badtoken : either NULL or pointer to char[ZFS_MAXPROPLEN]
- *  badfile : either NULL or pointer to char[MAXPATHLEN]
+ *  report : either NULL or pointer to string buffer
+ *  rlen : length of "report" buffer
  *
  * compatibility is NULL (unset), "", "off", "legacy", or list of
  * comma-separated filenames. filenames should either be absolute,
@@ -4752,48 +4732,56 @@ zpool_get_bootenv(zpool_handle_t *zhp, nvlist_t **nvlp)
  *   2) ZPOOL_DATA_COMPAT_D (eg: /usr/share/zfs/compatibility.d).
  * (Unset), "" or "off" => enable all features
  * "legacy" => disable all features
+ *
  * Any feature names read from files which match unames in spa_feature_table
  * will have the corresponding boolean set in the features array (if non-NULL).
  * If more than one feature set specified, only features present in *all* of
  * them will be set.
  *
- * An unreadable filename will be strlcpy'd to badfile (if non-NULL).
- * An unrecognized feature will be strlcpy'd to badtoken (if non-NULL).
+ * "report" if not NULL will be populated with a suitable status message.
  *
  * Return values:
  *   ZPOOL_COMPATIBILITY_OK : files read and parsed ok
- *   ZPOOL_COMPATIBILITY_READERR : file could not be opened / mmap'd
  *   ZPOOL_COMPATIBILITY_BADFILE : file too big or not a text file
- *   ZPOOL_COMPATIBILITY_BADWORD : file contains invalid feature name
- *   ZPOOL_COMPATIBILITY_NOFILES  : no file names found
+ *   ZPOOL_COMPATIBILITY_BADTOKEN : SYSCONF file contains invalid feature name
+ *   ZPOOL_COMPATIBILITY_WARNTOKEN : DATA file contains invalid feature name
+ *   ZPOOL_COMPATIBILITY_NOFILES : no feature files found
  */
 zpool_compat_status_t
-zpool_load_compat(const char *compatibility,
-    boolean_t *features, char *badtoken, char *badfile)
+zpool_load_compat(const char *compat, boolean_t *features, char *report,
+    size_t rlen)
 {
 	int sdirfd, ddirfd, featfd;
-	int i;
 	struct stat fs;
-	char *fc;			/* mmap of file */
-	char *ps, *ls, *ws;		/* strtok state */
+	char *fc;
+	char *ps, *ls, *ws;
 	char *file, *line, *word;
-	char filenames[ZFS_MAXPROPLEN];
-	int filecount = 0;
+
+	char l_compat[ZFS_MAXPROPLEN];
+
+	boolean_t ret_nofiles = B_TRUE;
+	boolean_t ret_badfile = B_FALSE;
+	boolean_t ret_badtoken = B_FALSE;
+	boolean_t ret_warntoken = B_FALSE;
 
 	/* special cases (unset), "" and "off" => enable all features */
-	if (compatibility == NULL || compatibility[0] == '\0' ||
-	    strcmp(compatibility, ZPOOL_COMPAT_OFF) == 0) {
+	if (compat == NULL || compat[0] == '\0' ||
+	    strcmp(compat, ZPOOL_COMPAT_OFF) == 0) {
 		if (features != NULL)
-			for (i = 0; i < SPA_FEATURES; i++)
+			for (uint_t i = 0; i < SPA_FEATURES; i++)
 				features[i] = B_TRUE;
+		if (report != NULL)
+			strlcpy(report, gettext("all features enabled"), rlen);
 		return (ZPOOL_COMPATIBILITY_OK);
 	}
 
 	/* Final special case "legacy" => disable all features */
-	if (strcmp(compatibility, ZPOOL_COMPAT_LEGACY) == 0) {
+	if (strcmp(compat, ZPOOL_COMPAT_LEGACY) == 0) {
 		if (features != NULL)
-			for (i = 0; i < SPA_FEATURES; i++)
+			for (uint_t i = 0; i < SPA_FEATURES; i++)
 				features[i] = B_FALSE;
+		if (report != NULL)
+			strlcpy(report, gettext("all features disabled"), rlen);
 		return (ZPOOL_COMPATIBILITY_OK);
 	}
 
@@ -4801,8 +4789,11 @@ zpool_load_compat(const char *compatibility,
 	 * Start with all true; will be ANDed with results from each file
 	 */
 	if (features != NULL)
-		for (i = 0; i < SPA_FEATURES; i++)
+		for (uint_t i = 0; i < SPA_FEATURES; i++)
 			features[i] = B_TRUE;
+
+	char err_badfile[1024] = "";
+	char err_badtoken[1024] = "";
 
 	/*
 	 * We ignore errors from the directory open()
@@ -4815,32 +4806,33 @@ zpool_load_compat(const char *compatibility,
 	sdirfd = open(ZPOOL_SYSCONF_COMPAT_D, O_DIRECTORY | O_PATH | O_CLOEXEC);
 	ddirfd = open(ZPOOL_DATA_COMPAT_D, O_DIRECTORY | O_PATH | O_CLOEXEC);
 
-	(void) strlcpy(filenames, compatibility, ZFS_MAXPROPLEN);
-	file = strtok_r(filenames, ",", &ps);
-	while (file != NULL) {
-		boolean_t features_local[SPA_FEATURES];
+	(void) strlcpy(l_compat, compat, ZFS_MAXPROPLEN);
+
+	for (file = strtok_r(l_compat, ",", &ps);
+	    file != NULL;
+	    file = strtok_r(NULL, ",", &ps)) {
+
+		boolean_t l_features[SPA_FEATURES];
+
+		enum { Z_SYSCONF, Z_DATA } source;
 
 		/* try sysconfdir first, then datadir */
-		if ((featfd = openat(sdirfd, file, 0, O_RDONLY)) < 0)
+		source = Z_SYSCONF;
+		if ((featfd = openat(sdirfd, file, 0, O_RDONLY)) < 0) {
 			featfd = openat(ddirfd, file, 0, O_RDONLY);
-
-		if (featfd < 0 || fstat(featfd, &fs) < 0) {
-			(void) close(featfd);
-			(void) close(sdirfd);
-			(void) close(ddirfd);
-			if (badfile != NULL)
-				(void) strlcpy(badfile, file, MAXPATHLEN);
-			return (ZPOOL_COMPATIBILITY_READERR);
+			source = Z_DATA;
 		}
 
-		/* Too big or too small */
-		if (fs.st_size < 1 || fs.st_size > ZPOOL_COMPAT_MAXSIZE) {
+		/* File readable and correct size? */
+		if (featfd < 0 ||
+		    fstat(featfd, &fs) < 0 ||
+		    fs.st_size < 1 ||
+		    fs.st_size > ZPOOL_COMPAT_MAXSIZE) {
 			(void) close(featfd);
-			(void) close(sdirfd);
-			(void) close(ddirfd);
-			if (badfile != NULL)
-				(void) strlcpy(badfile, file, MAXPATHLEN);
-			return (ZPOOL_COMPATIBILITY_BADFILE);
+			strlcat(err_badfile, file, ZFS_MAXPROPLEN);
+			strlcat(err_badfile, " ", ZFS_MAXPROPLEN);
+			ret_badfile = B_TRUE;
+			continue;
 		}
 
 		/* private mmap() so we can strtok safely */
@@ -4848,73 +4840,99 @@ zpool_load_compat(const char *compatibility,
 		    PROT_READ|PROT_WRITE, MAP_PRIVATE, featfd, 0);
 		(void) close(featfd);
 
-		if (fc < 0) {
-			(void) close(sdirfd);
-			(void) close(ddirfd);
-			if (badfile != NULL)
-				(void) strlcpy(badfile, file, MAXPATHLEN);
-			return (ZPOOL_COMPATIBILITY_READERR);
-		}
-
-		/* Text file sanity check - last char should be newline */
-		if (fc[fs.st_size - 1] != '\n') {
+		/* map ok, and last character == newline? */
+		if (fc < 0 || fc[fs.st_size - 1] != '\n') {
 			(void) munmap((void *) fc, fs.st_size);
-			(void) close(sdirfd);
-			(void) close(ddirfd);
-			if (badfile != NULL)
-				(void) strlcpy(badfile, file, MAXPATHLEN);
-			return (ZPOOL_COMPATIBILITY_BADFILE);
+			strlcat(err_badfile, file, ZFS_MAXPROPLEN);
+			strlcat(err_badfile, " ", ZFS_MAXPROPLEN);
+			ret_badfile = B_TRUE;
+			continue;
 		}
 
-		/* replace with NUL to ensure we have a delimiter */
+		ret_nofiles = B_FALSE;
+
+		for (uint_t i = 0; i < SPA_FEATURES; i++)
+			l_features[i] = B_FALSE;
+
+		/* replace last char with NUL to ensure we have a delimiter */
 		fc[fs.st_size - 1] = '\0';
 
-		for (i = 0; i < SPA_FEATURES; i++)
-			features_local[i] = B_FALSE;
-
-		line = strtok_r(fc, "\n", &ls);
-		while (line != NULL) {
+		for (line = strtok_r(fc, "\n", &ls);
+		    line != NULL;
+		    line = strtok_r(NULL, "\n", &ls)) {
 			/* discard comments */
 			*(strchrnul(line, '#')) = '\0';
 
-			word = strtok_r(line, ", \t", &ws);
-			while (word != NULL) {
+			for (word = strtok_r(line, ", \t", &ws);
+			    word != NULL;
+			    word = strtok_r(NULL, ", \t", &ws)) {
 				/* Find matching feature name */
-				for (i = 0; i < SPA_FEATURES; i++) {
+				uint_t f;
+				for (f = 0; f < SPA_FEATURES; f++) {
 					zfeature_info_t *fi =
-					    &spa_feature_table[i];
+					    &spa_feature_table[f];
 					if (strcmp(word, fi->fi_uname) == 0) {
-						features_local[i] = B_TRUE;
+						l_features[f] = B_TRUE;
 						break;
 					}
 				}
-				if (i == SPA_FEATURES) {
-					if (badtoken != NULL)
-						(void) strlcpy(badtoken, word,
-						    ZFS_MAXPROPLEN);
-					if (badfile != NULL)
-						(void) strlcpy(badfile, file,
-						    MAXPATHLEN);
-					(void) munmap((void *) fc, fs.st_size);
-					(void) close(sdirfd);
-					(void) close(ddirfd);
-					return (ZPOOL_COMPATIBILITY_BADWORD);
-				}
-				word = strtok_r(NULL, ", \t", &ws);
+				if (f < SPA_FEATURES)
+					continue;
+
+				/* found an unrecognized word */
+				/* lightly sanitize it */
+				if (strlen(word) > 32)
+					word[32] = '\0';
+				for (char *c = word; *c != '\0'; c++)
+					if (!isprint(*c))
+						*c = '?';
+
+				strlcat(err_badtoken, word, ZFS_MAXPROPLEN);
+				strlcat(err_badtoken, " ", ZFS_MAXPROPLEN);
+				if (source == Z_SYSCONF)
+					ret_badtoken = B_TRUE;
+				else
+					ret_warntoken = B_TRUE;
 			}
-			line = strtok_r(NULL, "\n", &ls);
 		}
 		(void) munmap((void *) fc, fs.st_size);
-		if (features != NULL) {
-			for (i = 0; i < SPA_FEATURES; i++)
-				features[i] &= features_local[i];
-		}
-		filecount++;
-		file = strtok_r(NULL, ",", &ps);
+
+		if (features != NULL)
+			for (uint_t i = 0; i < SPA_FEATURES; i++)
+				features[i] &= l_features[i];
 	}
 	(void) close(sdirfd);
 	(void) close(ddirfd);
-	if (filecount == 0)
+
+	/* Return the most serious error */
+	if (ret_badfile) {
+		if (report != NULL)
+			snprintf(report, rlen, gettext("could not read/"
+			    "parse feature file(s): %s"), err_badfile);
+		return (ZPOOL_COMPATIBILITY_BADFILE);
+	}
+	if (ret_nofiles) {
+		if (report != NULL)
+			strlcpy(report,
+			    gettext("no valid compatibility files specified"),
+			    rlen);
 		return (ZPOOL_COMPATIBILITY_NOFILES);
+	}
+	if (ret_badtoken) {
+		if (report != NULL)
+			snprintf(report, rlen, gettext("invalid feature "
+			    "name(s) in local compatibility files: %s"),
+			    err_badtoken);
+		return (ZPOOL_COMPATIBILITY_BADTOKEN);
+	}
+	if (ret_warntoken) {
+		if (report != NULL)
+			snprintf(report, rlen, gettext("unrecognized feature "
+			    "name(s) in distribution compatibility files: %s"),
+			    err_badtoken);
+		return (ZPOOL_COMPATIBILITY_WARNTOKEN);
+	}
+	if (report != NULL)
+		strlcpy(report, gettext("compatibility set ok"), rlen);
 	return (ZPOOL_COMPATIBILITY_OK);
 }

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -166,12 +166,27 @@ enabled when using \fBzpool upgrade\fR. \fBzpool status\fR
 will not show a warning about disabled features which are not part
 of the requested feature set.
 .LP
+The special value \fBlegacy\fR prevents any features from being enabled,
+either via \fBzpool upgrade\fR or via \fBzpool set feature@XX=enabled\fR.
+This setting also prevents pools from being upgraded to newer on-disk
+versions. This is a safety measure to prevent new features from being
+accidentally enabled, breaking compatibility.
+.LP
 By convention, compatibility files in \fB/usr/share/zfs/compatibility.d\fR
 are provided by the distribution package, and include feature sets
 supported by important versions of popular distributions, and feature
 sets commonly supported at the start of each year.  Compatibility files
 in \fB/etc/zfs/compatibility.d\fR, if present, will take precedence over
 files with the same name in \fB/usr/share/zfs/compatibility.d\fR.
+.LP
+If an unrecognized feature is found in these files, an error message will
+be shown. If the unrecognized feature is in a file in
+\fB/etc/zfs/compatibility.d\fR, this is treated as an error and processing
+will stop. If the unrecognized feature is under
+\fB/usr/share/zfs/compatibility.d\fR, this is treated as a warning and
+processing will continue. This difference is to allow distributions to
+include features which might not be recognized by the currently-installed
+binaries.
 .LP
 Compatibility files may include comments; any text from \fB#\fR to the end
 of the line is ignored.

--- a/man/man8/zpool-upgrade.8
+++ b/man/man8/zpool-upgrade.8
@@ -55,11 +55,9 @@ formatted using a legacy ZFS version number.
 These pools can continue to be used, but some features may not be available.
 Use
 .Nm zpool Cm upgrade Fl a
-to enable all features on all pools. (If a pool has specified compatibility
-feature sets using the
+to enable all features on all pools (subject to the
 .Fl o Ar compatibility
-property, only the features present in all requested compatibility sets will
-be enabled on that pool.)
+property).
 .It Xo
 .Nm zpool
 .Cm upgrade
@@ -75,11 +73,15 @@ for a description of feature flags features supported by the current software.
 .Op Fl V Ar version
 .Fl a Ns | Ns Ar pool Ns ...
 .Xc
-Enables all supported features on the given pool. (If the pool has specified
-compatibility feature sets using the
+Enables all supported features on the given pool.
+.Pp
+If the pool has specified compatibility feature sets using the
 .Fl o Ar compatibility
 property, only the features present in all requested compatibility sets will be
-enabled.)
+enabled. If this property is set to 
+.Ar legacy
+then no upgrade will take place.
+.Pp
 Once this is done, the pool will no longer be accessible on systems that do not
 support feature flags.
 See


### PR DESCRIPTION
Several improvements to the operation of the 'compatibility' property:

1) Improved handling of unrecognized features:
Change the way unrecognized features in compatibility files are handled.

 * invalid features in files under /usr/share/zfs/compatibility.d
   only get a warning (as these may refer to future features not yet in
   the library),
 * invalid features in files under /etc/zfs/compatibility.d
   get an error (as these are presumed to refer to the current system).

2) Improved error reporting from zpool_load_compat.
Note: slight ABI change to zpool_load_compat for better error reporting.

3) compatibility=legacy inhibits all 'zpool upgrade' operations.

4) Detect when features are enabled outside current compatibility set
   * zpool set compatibility=foo <-- print a warning
   * zpool set feature@xxx=enabled <-- error
   * zpool status <-- indicate this state

Signed-off-by: Colm Buckley <colm@tuatha.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
