### PR TITLE
Polish formerly known as Bottom Of #11731, cloexec everywhere

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -638,8 +638,8 @@ extern void delay(clock_t ticks);
 #define	NN_NUMBUF_SZ	(6)
 
 extern uint64_t physmem;
-extern char *random_path;
-extern char *urandom_path;
+extern const char *random_path;
+extern const char *urandom_path;
 
 extern int highbit64(uint64_t i);
 extern int lowbit64(uint64_t i);

--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -66,7 +66,7 @@ static int
 nfs_exports_lock(void)
 {
 	nfs_lock_fd = open(ZFS_EXPORTS_LOCK,
-	    O_RDWR | O_CREAT, 0600);
+	    O_RDWR | O_CREAT | O_CLOEXEC, 0600);
 	if (nfs_lock_fd == -1) {
 		fprintf(stderr, "failed to lock %s: %s\n",
 		    ZFS_EXPORTS_LOCK, strerror(errno));
@@ -228,8 +228,8 @@ nfs_copy_entries(char *filename, const char *mountpoint)
 	int error = SA_OK;
 	char *line;
 
-	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "r");
-	FILE *newfp = fopen(filename, "w+");
+	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "re");
+	FILE *newfp = fopen(filename, "w+e");
 	if (newfp == NULL) {
 		fprintf(stderr, "failed to open %s file: %s", filename,
 		    strerror(errno));
@@ -291,7 +291,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
 		return (error);
 	}
 
-	FILE *fp = fopen(filename, "a+");
+	FILE *fp = fopen(filename, "a+e");
 	if (fp == NULL) {
 		fprintf(stderr, "failed to open %s file: %s", filename,
 		    strerror(errno));
@@ -368,7 +368,7 @@ nfs_is_shared(sa_share_impl_t impl_share)
 	char *mntpoint = impl_share->sa_mountpoint;
 	size_t mntlen = strlen(mntpoint);
 
-	FILE *fp = fopen(ZFS_EXPORTS_FILE, "r");
+	FILE *fp = fopen(ZFS_EXPORTS_FILE, "re");
 	if (fp == NULL)
 		return (B_FALSE);
 

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -66,7 +66,7 @@ static int
 nfs_exports_lock(void)
 {
 	nfs_lock_fd = open(ZFS_EXPORTS_LOCK,
-	    O_RDWR | O_CREAT, 0600);
+	    O_RDWR | O_CREAT | O_CLOEXEC, 0600);
 	if (nfs_lock_fd == -1) {
 		fprintf(stderr, "failed to lock %s: %s\n",
 		    ZFS_EXPORTS_LOCK, strerror(errno));
@@ -453,7 +453,7 @@ nfs_add_entry(const char *filename, const char *sharepath,
 	if (linux_opts == NULL)
 		linux_opts = "";
 
-	FILE *fp = fopen(filename, "a+");
+	FILE *fp = fopen(filename, "a+e");
 	if (fp == NULL) {
 		fprintf(stderr, "failed to open %s file: %s", filename,
 		    strerror(errno));
@@ -489,8 +489,8 @@ nfs_copy_entries(char *filename, const char *mountpoint)
 	size_t buflen = 0;
 	int error = SA_OK;
 
-	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "r");
-	FILE *newfp = fopen(filename, "w+");
+	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "re");
+	FILE *newfp = fopen(filename, "w+e");
 	if (newfp == NULL) {
 		fprintf(stderr, "failed to open %s file: %s", filename,
 		    strerror(errno));
@@ -632,7 +632,7 @@ nfs_is_shared(sa_share_impl_t impl_share)
 	size_t buflen = 0;
 	char *buf = NULL;
 
-	FILE *fp = fopen(ZFS_EXPORTS_FILE, "r");
+	FILE *fp = fopen(ZFS_EXPORTS_FILE, "re");
 	if (fp == NULL) {
 		return (B_FALSE);
 	}

--- a/lib/libshare/os/linux/smb.c
+++ b/lib/libshare/os/linux/smb.c
@@ -107,7 +107,7 @@ smb_retrieve_shares(void)
 		if (!S_ISREG(eStat.st_mode))
 			continue;
 
-		if ((share_file_fp = fopen(file_path, "r")) == NULL) {
+		if ((share_file_fp = fopen(file_path, "re")) == NULL) {
 			rc = SA_SYSTEM_ERR;
 			goto out;
 		}

--- a/lib/libspl/os/linux/gethostid.c
+++ b/lib/libspl/os/linux/gethostid.c
@@ -45,7 +45,7 @@ get_spl_hostid(void)
 		return (hostid & HOSTID_MASK);
 	}
 
-	f = fopen("/sys/module/spl/parameters/spl_hostid", "r");
+	f = fopen("/sys/module/spl/parameters/spl_hostid", "re");
 	if (!f)
 		return (0);
 
@@ -74,7 +74,7 @@ get_system_hostid(void)
 		unsigned long hostid;
 		int hostid_size = 4;  /* 4 bytes regardless of arch */
 
-		fd = open("/etc/hostid", O_RDONLY);
+		fd = open("/etc/hostid", O_RDONLY | O_CLOEXEC);
 		if (fd >= 0) {
 			rc = read(fd, &hostid, hostid_size);
 			if (rc > 0)

--- a/lib/libspl/os/linux/getmntany.c
+++ b/lib/libspl/os/linux/getmntany.c
@@ -128,9 +128,9 @@ getextmntent(const char *path, struct extmnttab *entry, struct stat64 *statbuf)
 
 
 #ifdef HAVE_SETMNTENT
-	if ((fp = setmntent(MNTTAB, "r")) == NULL) {
+	if ((fp = setmntent(MNTTAB, "re")) == NULL) {
 #else
-	if ((fp = fopen(MNTTAB, "r")) == NULL) {
+	if ((fp = fopen(MNTTAB, "re")) == NULL) {
 #endif
 		(void) fprintf(stderr, "cannot open %s\n", MNTTAB);
 		return (-1);

--- a/lib/libuutil/uu_open.c
+++ b/lib/libuutil/uu_open.c
@@ -36,12 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#ifdef _LP64
-#define	TMPPATHFMT	"%s/uu%ld"
-#else /* _LP64 */
-#define	TMPPATHFMT	"%s/uu%lld"
-#endif /* _LP64 */
-
 /*ARGSUSED*/
 int
 uu_open_tmp(const char *dir, uint_t uflags)
@@ -55,7 +49,7 @@ uu_open_tmp(const char *dir, uint_t uflags)
 	for (;;) {
 		(void) snprintf(fname, PATH_MAX, "%s/uu%lld", dir, gethrtime());
 
-		f = open(fname, O_CREAT | O_EXCL | O_RDWR, 0600);
+		f = open(fname, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
 
 		if (f >= 0 || errno != EEXIST)
 			break;

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -71,7 +71,7 @@ pkcs11_get_urandom(uint8_t *buf, size_t bytes)
 	int rand;
 	ssize_t bytes_read = 0;
 
-	rand = open("/dev/urandom", O_RDONLY);
+	rand = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
 
 	if (rand < 0)
 		return (rand);
@@ -468,7 +468,7 @@ get_key_material_file(libzfs_handle_t *hdl, const char *uri,
 	if (strlen(uri) < 7)
 		return (EINVAL);
 
-	if ((f = fopen(uri + 7, "r")) == NULL) {
+	if ((f = fopen(uri + 7, "re")) == NULL) {
 		ret = errno;
 		errno = 0;
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -954,7 +954,7 @@ zfs_crypto_create(libzfs_handle_t *hdl, char *parent_name, nvlist_t *props,
 		}
 
 		ret = populate_create_encryption_params_nvlists(hdl, NULL,
-		    B_FALSE, keyformat, keylocation, props, &wkeydata,
+		    B_TRUE, keyformat, keylocation, props, &wkeydata,
 		    &wkeylen);
 		if (ret != 0)
 			goto out;

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -51,12 +51,6 @@
  * technically ok if the salt is known to the attacker).
  */
 
-typedef enum key_locator {
-	KEY_LOCATOR_NONE,
-	KEY_LOCATOR_PROMPT,
-	KEY_LOCATOR_URI
-} key_locator_t;
-
 #define	MIN_PASSPHRASE_LEN 8
 #define	MAX_PASSPHRASE_LEN 512
 #define	MAX_KEY_PROMPT_ATTEMPTS 3

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -811,7 +811,7 @@ libzfs_mnttab_update(libzfs_handle_t *hdl)
 	struct mnttab entry;
 
 	/* Reopen MNTTAB to prevent reading stale data from open file */
-	if (freopen(MNTTAB, "r", hdl->libzfs_mnttab) == NULL)
+	if (freopen(MNTTAB, "re", hdl->libzfs_mnttab) == NULL)
 		return (ENOENT);
 
 	while (getmntent(hdl->libzfs_mnttab, &entry) == 0) {
@@ -882,7 +882,7 @@ libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
 			libzfs_mnttab_fini(hdl);
 
 		/* Reopen MNTTAB to prevent reading stale data from open file */
-		if (freopen(MNTTAB, "r", hdl->libzfs_mnttab) == NULL)
+		if (freopen(MNTTAB, "re", hdl->libzfs_mnttab) == NULL)
 			return (ENOENT);
 
 		srch.mnt_special = (char *)fsname;

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -697,7 +697,7 @@ setup_differ_info(zfs_handle_t *zhp, const char *fromsnap,
 {
 	di->zhp = zhp;
 
-	di->cleanupfd = open(ZFS_DEV, O_RDWR);
+	di->cleanupfd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 	VERIFY(di->cleanupfd >= 0);
 
 	if (get_snapshot_names(di, fromsnap, tosnap) != 0)
@@ -731,7 +731,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 		return (-1);
 	}
 
-	if (pipe(pipefd)) {
+	if (pipe2(pipefd, O_CLOEXEC)) {
 		zfs_error_aux(zhp->zfs_hdl, strerror(errno));
 		teardown_differ_info(&di);
 		return (zfs_error(zhp->zfs_hdl, EZFS_PIPEFAILED, errbuf));

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -565,7 +565,7 @@ zfs_iter_mounted(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 	FILE *mnttab;
 	int err = 0;
 
-	if ((mnttab = fopen(MNTTAB, "r")) == NULL)
+	if ((mnttab = fopen(MNTTAB, "re")) == NULL)
 		return (ENOENT);
 
 	while (err == 0 && getmntent(mnttab, &entry) == 0) {

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1517,7 +1517,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	namelen = strlen(zhp->zpool_name);
 
 	/* Reopen MNTTAB to prevent reading stale data from open file */
-	if (freopen(MNTTAB, "r", hdl->libzfs_mnttab) == NULL)
+	if (freopen(MNTTAB, "re", hdl->libzfs_mnttab) == NULL)
 		return (ENOENT);
 
 	used = alloc = 0;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4809,13 +4809,11 @@ zpool_load_compat(const char *compatibility,
 	 * as they're only needed if the filename is relative
 	 * which will be checked during the openat().
 	 */
-#ifdef O_PATH
-	sdirfd = open(ZPOOL_SYSCONF_COMPAT_D, O_DIRECTORY | O_PATH);
-	ddirfd = open(ZPOOL_DATA_COMPAT_D, O_DIRECTORY | O_PATH);
-#else
-	sdirfd = open(ZPOOL_SYSCONF_COMPAT_D, O_DIRECTORY | O_RDONLY);
-	ddirfd = open(ZPOOL_DATA_COMPAT_D, O_DIRECTORY | O_RDONLY);
+#ifndef O_PATH
+#define	O_PATH O_RDONLY
 #endif
+	sdirfd = open(ZPOOL_SYSCONF_COMPAT_D, O_DIRECTORY | O_PATH | O_CLOEXEC);
+	ddirfd = open(ZPOOL_DATA_COMPAT_D, O_DIRECTORY | O_PATH | O_CLOEXEC);
 
 	(void) strlcpy(filenames, compatibility, ZFS_MAXPROPLEN);
 	file = strtok_r(filenames, ",", &ps);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2207,7 +2207,7 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 		++holdseq;
 		(void) snprintf(sdd.holdtag, sizeof (sdd.holdtag),
 		    ".send-%d-%llu", getpid(), (u_longlong_t)holdseq);
-		sdd.cleanup_fd = open(ZFS_DEV, O_RDWR);
+		sdd.cleanup_fd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 		if (sdd.cleanup_fd < 0) {
 			err = errno;
 			goto stderr_out;

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1024,15 +1024,15 @@ libzfs_init(void)
 		return (NULL);
 	}
 
-	if ((hdl->libzfs_fd = open(ZFS_DEV, O_RDWR|O_EXCL)) < 0) {
+	if ((hdl->libzfs_fd = open(ZFS_DEV, O_RDWR|O_EXCL|O_CLOEXEC)) < 0) {
 		free(hdl);
 		return (NULL);
 	}
 
 #ifdef HAVE_SETMNTENT
-	if ((hdl->libzfs_mnttab = setmntent(MNTTAB, "r")) == NULL) {
+	if ((hdl->libzfs_mnttab = setmntent(MNTTAB, "re")) == NULL) {
 #else
-	if ((hdl->libzfs_mnttab = fopen(MNTTAB, "r")) == NULL) {
+	if ((hdl->libzfs_mnttab = fopen(MNTTAB, "re")) == NULL) {
 #endif
 		(void) close(hdl->libzfs_fd);
 		free(hdl);

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -884,13 +884,13 @@ libzfs_run_process_impl(const char *path, char *argv[], char *env[], int flags,
 	 * Setup a pipe between our child and parent process if we're
 	 * reading stdout.
 	 */
-	if ((lines != NULL) && pipe(link) == -1)
+	if ((lines != NULL) && pipe2(link, O_CLOEXEC) == -1)
 		return (-EPIPE);
 
 	pid = vfork();
 	if (pid == 0) {
 		/* Child process */
-		devnull_fd = open("/dev/null", O_WRONLY);
+		devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
 
 		if (devnull_fd < 0)
 			_exit(-1);
@@ -900,14 +900,10 @@ libzfs_run_process_impl(const char *path, char *argv[], char *env[], int flags,
 		else if (lines != NULL) {
 			/* Save the output to lines[] */
 			dup2(link[1], STDOUT_FILENO);
-			close(link[0]);
-			close(link[1]);
 		}
 
 		if (!(flags & STDERR_VERBOSE))
 			(void) dup2(devnull_fd, STDERR_FILENO);
-
-		close(devnull_fd);
 
 		if (flags & NO_DEFAULT_PATH) {
 			if (env == NULL)
@@ -1144,7 +1140,7 @@ zfs_path_to_zhandle(libzfs_handle_t *hdl, const char *path, zfs_type_t argtype)
 	}
 
 	/* Reopen MNTTAB to prevent reading stale data from open file */
-	if (freopen(MNTTAB, "r", hdl->libzfs_mnttab) == NULL)
+	if (freopen(MNTTAB, "re", hdl->libzfs_mnttab) == NULL)
 		return (NULL);
 
 	if (getextmntent(path, &entry, &statbuf) != 0)

--- a/lib/libzfs/os/linux/libzfs_pool_os.c
+++ b/lib/libzfs/os/linux/libzfs_pool_os.c
@@ -62,7 +62,7 @@ zpool_relabel_disk(libzfs_handle_t *hdl, const char *path, const char *msg)
 {
 	int fd, error;
 
-	if ((fd = open(path, O_RDWR|O_DIRECT)) < 0) {
+	if ((fd = open(path, O_RDWR|O_DIRECT|O_CLOEXEC)) < 0) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
 		    "relabel '%s': unable to open device: %d"), path, errno);
 		return (zfs_error(hdl, EZFS_OPENFAILED, msg));
@@ -107,7 +107,7 @@ read_efi_label(nvlist_t *config, diskaddr_t *sb)
 
 	(void) snprintf(diskname, sizeof (diskname), "%s%s", DISK_ROOT,
 	    strrchr(path, '/'));
-	if ((fd = open(diskname, O_RDONLY|O_DIRECT)) >= 0) {
+	if ((fd = open(diskname, O_RDONLY|O_DIRECT|O_CLOEXEC)) >= 0) {
 		struct dk_gpt *vtoc;
 
 		if ((err = efi_alloc_and_read(fd, &vtoc)) >= 0) {
@@ -159,7 +159,7 @@ zpool_label_disk_check(char *path)
 	struct dk_gpt *vtoc;
 	int fd, err;
 
-	if ((fd = open(path, O_RDONLY|O_DIRECT)) < 0)
+	if ((fd = open(path, O_RDONLY|O_DIRECT|O_CLOEXEC)) < 0)
 		return (errno);
 
 	if ((err = efi_alloc_and_read(fd, &vtoc)) != 0) {
@@ -190,7 +190,7 @@ zpool_label_name(char *label_name, int label_size)
 	uint64_t id = 0;
 	int fd;
 
-	fd = open("/dev/urandom", O_RDONLY);
+	fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC);
 	if (fd >= 0) {
 		if (read(fd, &id, sizeof (id)) != sizeof (id))
 			id = 0;
@@ -241,7 +241,7 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 
 	(void) snprintf(path, sizeof (path), "%s/%s", DISK_ROOT, name);
 
-	if ((fd = open(path, O_RDWR|O_DIRECT|O_EXCL)) < 0) {
+	if ((fd = open(path, O_RDWR|O_DIRECT|O_EXCL|O_CLOEXEC)) < 0) {
 		/*
 		 * This shouldn't happen.  We've long since verified that this
 		 * is a valid device.

--- a/lib/libzfs/os/linux/libzfs_sendrecv_os.c
+++ b/lib/libzfs/os/linux/libzfs_sendrecv_os.c
@@ -35,7 +35,7 @@
 void
 libzfs_set_pipe_max(int infd)
 {
-	FILE *procf = fopen("/proc/sys/fs/pipe-max-size", "r");
+	FILE *procf = fopen("/proc/sys/fs/pipe-max-size", "re");
 
 	if (procf != NULL) {
 		unsigned long max_psize;

--- a/lib/libzfs/os/linux/libzfs_util_os.c
+++ b/lib/libzfs/os/linux/libzfs_util_os.c
@@ -143,7 +143,7 @@ libzfs_load_module_impl(const char *module)
 
 	start = gethrtime();
 	do {
-		fd = open(ZFS_DEV, O_RDWR);
+		fd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 		if (fd >= 0) {
 			(void) close(fd);
 			return (0);
@@ -195,7 +195,7 @@ zfs_version_kernel(char *version, int len)
 	int fd;
 	int rlen;
 
-	if ((fd = open(ZFS_SYSFS_DIR "/version", O_RDONLY)) == -1)
+	if ((fd = open(ZFS_SYSFS_DIR "/version", O_RDONLY | O_CLOEXEC)) == -1)
 		return (-1);
 
 	if ((rlen = read(fd, version, len)) == -1) {

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -137,7 +137,7 @@ libzfs_core_init(void)
 {
 	(void) pthread_mutex_lock(&g_lock);
 	if (g_refcount == 0) {
-		g_fd = open(ZFS_DEV, O_RDWR);
+		g_fd = open(ZFS_DEV, O_RDWR|O_CLOEXEC);
 		if (g_fd < 0) {
 			(void) pthread_mutex_unlock(&g_lock);
 			return (errno);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -723,15 +723,15 @@ lowbit64(uint64_t i)
 	return (__builtin_ffsll(i));
 }
 
-char *random_path = "/dev/random";
-char *urandom_path = "/dev/urandom";
+const char *random_path = "/dev/random";
+const char *urandom_path = "/dev/urandom";
 static int random_fd = -1, urandom_fd = -1;
 
 void
 random_init(void)
 {
-	VERIFY((random_fd = open(random_path, O_RDONLY)) != -1);
-	VERIFY((urandom_fd = open(urandom_path, O_RDONLY)) != -1);
+	VERIFY((random_fd = open(random_path, O_RDONLY | O_CLOEXEC)) != -1);
+	VERIFY((urandom_fd = open(urandom_path, O_RDONLY | O_CLOEXEC)) != -1);
 }
 
 void

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -259,7 +259,7 @@ pool_active(void *unused, const char *name, uint64_t guid,
 	 * Use ZFS_IOC_POOL_SYNC to confirm if a pool is active
 	 */
 
-	fd = open(ZFS_DEV, O_RDWR);
+	fd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 	if (fd < 0)
 		return (-1);
 

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -127,7 +127,7 @@ zpool_open_func(void *arg)
 	/*
 	 * O_NONBLOCK so we don't hang trying to open things like serial ports.
 	 */
-	if ((fd = open(rn->rn_name, O_RDONLY|O_NONBLOCK)) < 0)
+	if ((fd = open(rn->rn_name, O_RDONLY|O_NONBLOCK|O_CLOEXEC)) < 0)
 		return;
 
 	/*

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -390,7 +390,7 @@ zfs_dev_is_whole_disk(const char *dev_name)
 	struct dk_gpt *label;
 	int fd;
 
-	if ((fd = open(dev_name, O_RDONLY | O_DIRECT)) < 0)
+	if ((fd = open(dev_name, O_RDONLY | O_DIRECT | O_CLOEXEC)) < 0)
 		return (B_FALSE);
 
 	if (efi_alloc_and_init(fd, EFI_NUMPAR, &label) != 0) {

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -136,9 +136,9 @@ zpool_open_func(void *arg)
 	 * cache which may be stale for multipath devices.  An EINVAL errno
 	 * indicates O_DIRECT is unsupported so fallback to just O_RDONLY.
 	 */
-	fd = open(rn->rn_name, O_RDONLY | O_DIRECT);
+	fd = open(rn->rn_name, O_RDONLY | O_DIRECT | O_CLOEXEC);
 	if ((fd < 0) && (errno == EINVAL))
-		fd = open(rn->rn_name, O_RDONLY);
+		fd = open(rn->rn_name, O_RDONLY | O_CLOEXEC);
 	if ((fd < 0) && (errno == EACCES))
 		hdl->lpc_open_access_error = B_TRUE;
 	if (fd < 0)

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1345,7 +1345,8 @@ zpool_find_import_impl(libpc_handle_t *hdl, importargs_t *iarg,
 				 * would prevent a zdb -e of active pools with
 				 * no cachefile.
 				 */
-				fd = open(slice->rn_name, O_RDONLY | O_EXCL);
+				fd = open(slice->rn_name,
+				    O_RDONLY | O_EXCL | O_CLOEXEC);
 				if (fd >= 0 || iarg->can_be_active) {
 					if (fd >= 0)
 						close(fd);
@@ -1437,7 +1438,7 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 
 	verify(iarg->poolname == NULL || iarg->guid == 0);
 
-	if ((fd = open(iarg->cachefile, O_RDONLY)) < 0) {
+	if ((fd = open(iarg->cachefile, O_RDONLY | O_CLOEXEC)) < 0) {
 		zutil_error_aux(hdl, "%s", strerror(errno));
 		(void) zutil_error(hdl, EZFS_BADCACHE,
 		    dgettext(TEXT_DOMAIN, "failed to open cache file"));

--- a/man/man8/zfs-jail.8
+++ b/man/man8/zfs-jail.8
@@ -45,7 +45,7 @@
 .Nd Attaches and detaches ZFS filesystems from FreeBSD jails.
 .No A Tn ZFS
 dataset can be attached to a jail by using the
-.Qq Nm Cm jail
+.Qq Nm zfs jail
 subcommand. You cannot attach a dataset to one jail and the children of the
 same dataset to another jail. You can also not attach the root file system
 of the jail or any dataset which needs to be mounted before the zfs rc script
@@ -65,7 +65,7 @@ datasets from within a jail.
 .Pp
 .No A Tn ZFS
 dataset can be detached from a jail using the
-.Qq Nm Cm unjail
+.Qq Nm zfs unjail
 subcommand.
 .Pp
 After a dataset is attached to a jail and the jailed property is set, a jailed

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -1817,7 +1817,7 @@ are equivalent to the
 and
 .Sy noxattr
 mount options.
-.It Sy jailed Ns = Ns Cm off | on
+.It Sy jailed Ns = Ns Sy off Ns | Ns Sy on
 Controls whether the dataset is managed from a jail. See the
 .Qq Sx Jails
 section in


### PR DESCRIPTION
### Motivation and Context
See individual commit messages.

### Description
All but the last one came from the bottom of #11731 and should be relatively uncontroversial.

Additionally, this makes all of lib/ cloexec-clean (save for the files from pidfile_open(3), the manpage says nothing about those), I'm pretty sure.

I also found uu_open_tmp() in uu_open.c to be quite a sad sight – there are no users here, nor did I find any in DCS (just openzfs and zfs-fuse), going out to google led me to an [Apple import](https://opensource.apple.com/source/zfs/zfs-59/zfs_lib/libuutil/uu_open.c.auto.html) of the same file from 2007, with the same format string Problem, and a MidnightBSD one from 2008, likewise. Do you have a policy of purging this sort of thing that, as far as I can tell, hasn't been used or touched in the past, like, 10 years at least, if not more?

### How Has This Been Tested?
Ran it, mostly. 99% of the cloexecs are no-brainers, since the fd is closed like 50 lines down anyway. The one in libzfs_run_process_impl() is used by zpool -c, and that still works.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv) – technically this does break the libzfs and libzfs_core ABI, since they no longer leak their persistent fds, but, y'know
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
