### PR TITLE
libspl's getextmntent() fd leak on Linux, libzfs's obsession with the mtab

### DIFF
--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -56,7 +56,6 @@ struct libzfs_handle {
 	char libzfs_action[1024];
 	char libzfs_desc[1024];
 	int libzfs_printerr;
-	int libzfs_storeerr; /* stuff error messages into buffer */
 	boolean_t libzfs_mnttab_enable;
 	/*
 	 * We need a lock to handle the case where parallel mount
@@ -67,7 +66,6 @@ struct libzfs_handle {
 	pthread_mutex_t libzfs_mnttab_cache_lock;
 	avl_tree_t libzfs_mnttab_cache;
 	int libzfs_pool_iter;
-	char libzfs_chassis_id[256];
 	boolean_t libzfs_prop_debug;
 	regex_t libzfs_urire;
 	uint64_t libzfs_max_nvlist;

--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -48,7 +48,6 @@ extern "C" {
 struct libzfs_handle {
 	int libzfs_error;
 	int libzfs_fd;
-	FILE *libzfs_mnttab;
 	zpool_handle_t *libzfs_pool_handles;
 	uu_avl_pool_t *libzfs_ns_avlpool;
 	uu_avl_t *libzfs_ns_avl;

--- a/lib/libspl/os/linux/getmntany.c
+++ b/lib/libspl/os/linux/getmntany.c
@@ -127,11 +127,7 @@ getextmntent(const char *path, struct extmnttab *entry, struct stat64 *statbuf)
 	}
 
 
-#ifdef HAVE_SETMNTENT
-	if ((fp = setmntent(MNTTAB, "re")) == NULL) {
-#else
 	if ((fp = fopen(MNTTAB, "re")) == NULL) {
-#endif
 		(void) fprintf(stderr, "cannot open %s\n", MNTTAB);
 		return (-1);
 	}

--- a/lib/libspl/os/linux/getmntany.c
+++ b/lib/libspl/os/linux/getmntany.c
@@ -148,6 +148,7 @@ getextmntent(const char *path, struct extmnttab *entry, struct stat64 *statbuf)
 			break;
 		}
 	}
+	(void) fclose(fp);
 
 	if (!match) {
 		(void) fprintf(stderr, "cannot find mountpoint for '%s'\n",

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -573,47 +573,47 @@
     </enum-decl>
     <typedef-decl name='boolean_t' type-id='type-id-13' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-5'/>
     <type-decl name='int' size-in-bits='32' id='type-id-6'/>
-    <typedef-decl name='prop_changelist_t' type-id='type-id-1' filepath='../../include/libzfs_impl.h' line='173' column='1' id='type-id-14'/>
+    <typedef-decl name='prop_changelist_t' type-id='type-id-1' filepath='../../include/libzfs_impl.h' line='171' column='1' id='type-id-14'/>
     <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
-    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='76' column='1' id='type-id-16'>
+    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='74' column='1' id='type-id-16'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zfs_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='77' column='1'/>
+        <var-decl name='zfs_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='75' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_hdl' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='78' column='1'/>
+        <var-decl name='zpool_hdl' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zfs_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='79' column='1'/>
+        <var-decl name='zfs_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zfs_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='80' column='1'/>
+        <var-decl name='zfs_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2208'>
-        <var-decl name='zfs_head_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='81' column='1'/>
+        <var-decl name='zfs_head_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zfs_dmustats' type-id='type-id-21' visibility='default' filepath='../../include/libzfs_impl.h' line='82' column='1'/>
+        <var-decl name='zfs_dmustats' type-id='type-id-21' visibility='default' filepath='../../include/libzfs_impl.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4544'>
-        <var-decl name='zfs_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='83' column='1'/>
+        <var-decl name='zfs_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4608'>
-        <var-decl name='zfs_user_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='84' column='1'/>
+        <var-decl name='zfs_user_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4672'>
-        <var-decl name='zfs_recvd_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='85' column='1'/>
+        <var-decl name='zfs_recvd_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4736'>
-        <var-decl name='zfs_mntcheck' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='86' column='1'/>
+        <var-decl name='zfs_mntcheck' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4800'>
-        <var-decl name='zfs_mntopts' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='87' column='1'/>
+        <var-decl name='zfs_mntopts' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4864'>
-        <var-decl name='zfs_props_table' type-id='type-id-24' visibility='default' filepath='../../include/libzfs_impl.h' line='88' column='1'/>
+        <var-decl name='zfs_props_table' type-id='type-id-24' visibility='default' filepath='../../include/libzfs_impl.h' line='86' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='libzfs_handle' size-in-bits='20160' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='48' column='1' id='type-id-25'>
+    <class-decl name='libzfs_handle' size-in-bits='18112' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='48' column='1' id='type-id-25'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='libzfs_error' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='49' column='1'/>
       </data-member>
@@ -645,60 +645,54 @@
         <var-decl name='libzfs_printerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='58' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16768'>
-        <var-decl name='libzfs_storeerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='59' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16800'>
-        <var-decl name='libzfs_mnttab_enable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='60' column='1'/>
+        <var-decl name='libzfs_mnttab_enable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='59' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16832'>
-        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='67' column='1'/>
+        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17152'>
-        <var-decl name='libzfs_mnttab_cache' type-id='type-id-29' visibility='default' filepath='../../include/libzfs_impl.h' line='68' column='1'/>
+        <var-decl name='libzfs_mnttab_cache' type-id='type-id-29' visibility='default' filepath='../../include/libzfs_impl.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17472'>
-        <var-decl name='libzfs_pool_iter' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='69' column='1'/>
+        <var-decl name='libzfs_pool_iter' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17504'>
-        <var-decl name='libzfs_chassis_id' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='70' column='1'/>
+        <var-decl name='libzfs_prop_debug' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='69' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='19552'>
-        <var-decl name='libzfs_prop_debug' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='71' column='1'/>
+      <data-member access='public' layout-offset-in-bits='17536'>
+        <var-decl name='libzfs_urire' type-id='type-id-30' visibility='default' filepath='../../include/libzfs_impl.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='19584'>
-        <var-decl name='libzfs_urire' type-id='type-id-30' visibility='default' filepath='../../include/libzfs_impl.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20096'>
-        <var-decl name='libzfs_max_nvlist' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='73' column='1'/>
+      <data-member access='public' layout-offset-in-bits='18048'>
+        <var-decl name='libzfs_max_nvlist' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='71' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='97' column='1' id='type-id-31'>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='95' column='1' id='type-id-31'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zpool_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1'/>
+        <var-decl name='zpool_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_next' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
+        <var-decl name='zpool_next' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zpool_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='100' column='1'/>
+        <var-decl name='zpool_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zpool_state' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='101' column='1'/>
+        <var-decl name='zpool_state' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zpool_config_size' type-id='type-id-32' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
+        <var-decl name='zpool_config_size' type-id='type-id-32' visibility='default' filepath='../../include/libzfs_impl.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='zpool_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
+        <var-decl name='zpool_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='zpool_old_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
+        <var-decl name='zpool_old_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='zpool_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='105' column='1'/>
+        <var-decl name='zpool_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='zpool_start_block' type-id='type-id-33' visibility='default' filepath='../../include/libzfs_impl.h' line='106' column='1'/>
+        <var-decl name='zpool_start_block' type-id='type-id-33' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='libzfs_handle_t' type-id='type-id-25' filepath='../../include/libzfs.h' line='197' column='1' id='type-id-34'/>
@@ -965,13 +959,13 @@
       <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='109' column='1' id='type-id-87'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='107' column='1' id='type-id-87'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROTO_NFS' value='0'/>
       <enumerator name='PROTO_SMB' value='1'/>
       <enumerator name='PROTO_END' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_proto_t' type-id='type-id-87' filepath='../../include/libzfs_impl.h' line='113' column='1' id='type-id-88'/>
+    <typedef-decl name='zfs_share_proto_t' type-id='type-id-87' filepath='../../include/libzfs_impl.h' line='111' column='1' id='type-id-88'/>
     <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-89'/>
     <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
       <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
@@ -997,7 +991,7 @@
       <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='../../include/libzfs_impl.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='../../include/libzfs_impl.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='../../include/libuutil.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1048,7 +1042,7 @@
     <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='../../include/libuutil.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='../../include/libzfs_impl.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='../../include/libzfs_impl.h' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcmp' mangled-name='strcmp' filepath='/usr/include/string.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1078,13 +1072,13 @@
     <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='../../include/libuutil.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='../../include/libzfs_impl.h' line='210' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='../../include/libzfs_impl.h' line='208' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='../../include/libzfs_impl.h' line='191' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='../../include/libzfs_impl.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strlcpy' mangled-name='strlcpy' filepath='../../lib/libspl/include/string.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1179,13 +1173,13 @@
     <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='../../include/libuutil.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='../../include/libzfs_impl.h' line='195' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='../../include/libzfs_impl.h' line='193' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='../../include/libuutil.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='../../include/libzfs_impl.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='../../include/libzfs_impl.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strchr' mangled-name='strchr' filepath='/usr/include/string.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1200,22 +1194,22 @@
     <function-decl name='strcpy' mangled-name='strcpy' filepath='/usr/include/string.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='../../include/libzfs_impl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='../../include/libzfs_impl.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__errno_location' mangled-name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='../../include/libzfs_impl.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='../../include/libzfs_impl.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='../../include/libzfs.h' line='455' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='../../include/libzfs_impl.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='../../include/libzfs_impl.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='../../include/libzfs_impl.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='../../include/libzfs_impl.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../include/sys/nvpair.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1230,7 +1224,7 @@
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='no_memory' mangled-name='no_memory' filepath='../../include/libzfs_impl.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='no_memory' mangled-name='no_memory' filepath='../../include/libzfs_impl.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../include/sys/nvpair.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1239,7 +1233,7 @@
     <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../include/sys/nvpair.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='../../include/libzfs_impl.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1248,7 +1242,7 @@
     <function-decl name='dcgettext' mangled-name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='../../include/libzfs_impl.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='../../include/libzfs_impl.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='../../include/libuutil.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1319,7 +1313,7 @@
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../include/sys/fs/zfs.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='../../include/libzfs_impl.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='../../include/libzfs_impl.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../include/sys/nvpair.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2196,7 +2190,7 @@
     <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='../../include/libzfs_core.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='143' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../include/sys/nvpair.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2250,7 +2244,7 @@
     <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../include/sys/nvpair.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='../../include/libzfs_impl.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='../../include/libzfs_impl.h' line='174' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../include/sys/nvpair.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2259,25 +2253,25 @@
     <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../include/sys/nvpair.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='../../include/libzfs_impl.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='../../include/libzfs_impl.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='../../include/libzfs_impl.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='../../include/libzfs_impl.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='../../include/libzfs_impl.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='../../include/libzfs_impl.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='../../include/libzfs_impl.h' line='182' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='../../include/libzfs_impl.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='../../include/libzfs_impl.h' line='182' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='../../include/libzfs_impl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='../../include/libzfs_impl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='../../include/libzfs_impl.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2289,7 +2283,7 @@
     <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='../../include/libzfs_core.h' line='118' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='../../include/libzfs_impl.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='../../include/libzfs_impl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcspn' mangled-name='strcspn' filepath='/usr/include/string.h' line='272' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2358,7 +2352,7 @@
     <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../include/sys/fs/zfs.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='../../include/libzfs_impl.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='../../include/libzfs_impl.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='localtime_r' mangled-name='localtime_r' filepath='/usr/include/time.h' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2418,7 +2412,7 @@
     <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../include/sys/fs/zfs.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='../../include/libzfs_impl.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='../../include/libzfs_impl.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2448,13 +2442,13 @@
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../include/zfs_namecheck.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='../../include/libzfs_impl.h' line='208' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='../../include/libzfs_impl.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' filepath='../../include/sys/fs/zfs.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='../../include/libzfs_impl.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='../../include/libzfs_impl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../include/sys/fs/zfs.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2508,7 +2502,7 @@
     <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='../../include/libzfs.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='../../include/libzfs_impl.h' line='201' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='../../include/libzfs_impl.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../include/zfs_namecheck.h' line='58' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2564,13 +2558,13 @@
       <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='../../include/libzfs_impl.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='../../include/libzfs_impl.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='../../include/libzfs_impl.h' line='203' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='../../include/libzfs_impl.h' line='201' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='../../include/libzfs_impl.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pipe2' mangled-name='pipe2' filepath='/usr/include/unistd.h' line='422' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2651,7 +2645,7 @@
     <function-decl name='__fxstat64' mangled-name='__fxstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='428' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='../../include/libzfs_impl.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='../../include/libzfs_impl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-149'>
@@ -2735,7 +2729,7 @@
     <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='../../include/libzfs_impl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='../../include/libzfs_impl.h' line='194' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2744,35 +2738,35 @@
     <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='../../include/libzfs.h' line='470' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='../../include/libzfs_impl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='../../include/libzfs_impl.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='../../include/libzfs_impl.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-156' visibility='default' filepath='../../include/libzfs_impl.h' line='213' column='1' id='type-id-157'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-156' visibility='default' filepath='../../include/libzfs_impl.h' line='211' column='1' id='type-id-157'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_prop' type-id='type-id-2' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1'/>
+        <var-decl name='p_prop' type-id='type-id-2' visibility='default' filepath='../../include/libzfs_impl.h' line='212' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_name' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
+        <var-decl name='p_name' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='213' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_share_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='216' column='1'/>
+        <var-decl name='p_share_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='p_unshare_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='217' column='1'/>
+        <var-decl name='p_unshare_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='proto_table_t' type-id='type-id-157' filepath='../../include/libzfs_impl.h' line='218' column='1' id='type-id-156'/>
+    <typedef-decl name='proto_table_t' type-id='type-id-157' filepath='../../include/libzfs_impl.h' line='216' column='1' id='type-id-156'/>
 
     <array-type-def dimensions='1' type-id='type-id-156' size-in-bits='384' id='type-id-158'>
       <subrange length='2' type-id='type-id-37' id='type-id-66'/>
 
     </array-type-def>
-    <var-decl name='proto_table' type-id='type-id-158' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='241' column='1' elf-symbol-id='proto_table'/>
+    <var-decl name='proto_table' type-id='type-id-158' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='239' column='1' elf-symbol-id='proto_table'/>
 
     <array-type-def dimensions='1' type-id='type-id-88' size-in-bits='64' alignment-in-bits='32' id='type-id-159'>
       <subrange length='2' type-id='type-id-37' id='type-id-66'/>
@@ -2899,13 +2893,13 @@
       <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='119' column='1' id='type-id-165'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='117' column='1' id='type-id-165'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='SHARED_NOT_SHARED' value='0'/>
       <enumerator name='SHARED_NFS' value='2'/>
       <enumerator name='SHARED_SMB' value='4'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_type_t' type-id='type-id-165' filepath='../../include/libzfs_impl.h' line='123' column='1' id='type-id-166'/>
+    <typedef-decl name='zfs_share_type_t' type-id='type-id-165' filepath='../../include/libzfs_impl.h' line='121' column='1' id='type-id-166'/>
     <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
       <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
       <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
@@ -2984,7 +2978,7 @@
       <parameter type-id='type-id-88' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
       <return type-id='type-id-166'/>
     </function-decl>
-    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='qsort' mangled-name='qsort' filepath='/usr/include/stdlib.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3005,7 +2999,7 @@
     <function-decl name='rmdir' mangled-name='rmdir' filepath='/usr/include/unistd.h' line='834' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='../../include/libzfs.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3035,7 +3029,7 @@
     <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='533' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='do_unmount' mangled-name='do_unmount' filepath='../../include/libzfs_impl.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='do_unmount' mangled-name='do_unmount' filepath='../../include/libzfs_impl.h' line='243' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='../../include/libzfs.h' line='817' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3062,7 +3056,7 @@
     <function-decl name='statfs64' mangled-name='statfs64' filepath='/usr/include/x86_64-linux-gnu/sys/statfs.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='do_mount' mangled-name='do_mount' filepath='../../include/libzfs_impl.h' line='243' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='do_mount' mangled-name='do_mount' filepath='../../include/libzfs_impl.h' line='241' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='../../include/libzfs.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3637,7 +3631,7 @@
     <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='../../include/libzfs_core.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='../../include/libzfs_core.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3682,7 +3676,7 @@
     <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='../../include/libzfs_core.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../include/zfs_comutil.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3700,7 +3694,7 @@
     <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='../../include/libzutil.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtoull' mangled-name='strtoull' filepath='/usr/include/stdlib.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3947,7 +3941,7 @@
       <parameter type-id='type-id-119' name='blocks_visited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='884' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='perror' mangled-name='perror' filepath='/usr/include/stdio.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3968,7 +3962,7 @@
     <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../include/sys/nvpair.h' line='283' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='create_parents' mangled-name='create_parents' filepath='../../include/libzfs_impl.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='../../include/libzfs_impl.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../include/sys/nvpair.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4528,7 +4522,7 @@
     <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='../../include/libzfs.h' line='241' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='../../include/libzfs_impl.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='../../include/libzfs_impl.h' line='204' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='../../include/libzfs.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4549,7 +4543,7 @@
     <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../include/zfs_prop.h' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='regcomp' mangled-name='regcomp' filepath='/usr/include/regex.h' line='639' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4729,63 +4723,63 @@
       <parameter type-id='type-id-6' name='len' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='220' column='1' id='type-id-230'>
+    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='218' column='1' id='type-id-230'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zhp' type-id='type-id-84' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1'/>
+        <var-decl name='zhp' type-id='type-id-84' visibility='default' filepath='../../include/libzfs_impl.h' line='219' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fromsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
+        <var-decl name='fromsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='frommnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
+        <var-decl name='frommnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tosnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='224' column='1'/>
+        <var-decl name='tosnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tomnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='225' column='1'/>
+        <var-decl name='tomnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ds' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='226' column='1'/>
+        <var-decl name='ds' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='224' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='dsmnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='227' column='1'/>
+        <var-decl name='dsmnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='225' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tmpsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='228' column='1'/>
+        <var-decl name='tmpsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='226' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='errbuf' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='229' column='1'/>
+        <var-decl name='errbuf' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='227' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8704'>
-        <var-decl name='isclone' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='230' column='1'/>
+        <var-decl name='isclone' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='228' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8736'>
-        <var-decl name='scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='231' column='1'/>
+        <var-decl name='scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='229' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8768'>
-        <var-decl name='classify' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='232' column='1'/>
+        <var-decl name='classify' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='230' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8800'>
-        <var-decl name='timestamped' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='233' column='1'/>
+        <var-decl name='timestamped' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='231' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8832'>
-        <var-decl name='shares' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='234' column='1'/>
+        <var-decl name='shares' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='232' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8896'>
-        <var-decl name='zerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='235' column='1'/>
+        <var-decl name='zerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='233' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8928'>
-        <var-decl name='cleanupfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='236' column='1'/>
+        <var-decl name='cleanupfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='234' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8960'>
-        <var-decl name='outputfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='237' column='1'/>
+        <var-decl name='outputfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='235' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8992'>
-        <var-decl name='datafd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='238' column='1'/>
+        <var-decl name='datafd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='236' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='differ_info_t' type-id='type-id-230' filepath='../../include/libzfs_impl.h' line='239' column='1' id='type-id-231'/>
+    <typedef-decl name='differ_info_t' type-id='type-id-230' filepath='../../include/libzfs_impl.h' line='237' column='1' id='type-id-231'/>
     <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-232'/>
     <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='os/linux/libzfs_util_os.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='find_shares_object'>
       <parameter type-id='type-id-232' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -421,40 +421,40 @@
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='prop_changelist' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='75' column='1' id='type-id-1'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='prop_changelist' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='75' column='1' id='type-id-1'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cl_prop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='76' column='1'/>
+        <var-decl name='cl_prop' type-id='type-id-2' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cl_realprop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='77' column='1'/>
+        <var-decl name='cl_realprop' type-id='type-id-2' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cl_shareprop' type-id='type-id-2' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='78' column='1'/>
+        <var-decl name='cl_shareprop' type-id='type-id-2' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cl_pool' type-id='type-id-3' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='79' column='1'/>
+        <var-decl name='cl_pool' type-id='type-id-3' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cl_tree' type-id='type-id-4' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='80' column='1'/>
+        <var-decl name='cl_tree' type-id='type-id-4' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='cl_waslegacy' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='81' column='1'/>
+        <var-decl name='cl_waslegacy' type-id='type-id-5' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='cl_allchildren' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='82' column='1'/>
+        <var-decl name='cl_allchildren' type-id='type-id-5' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='cl_alldependents' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='83' column='1'/>
+        <var-decl name='cl_alldependents' type-id='type-id-5' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='cl_mflags' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='84' column='1'/>
+        <var-decl name='cl_mflags' type-id='type-id-6' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cl_gflags' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='85' column='1'/>
+        <var-decl name='cl_gflags' type-id='type-id-6' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='cl_haszonedchild' type-id='type-id-5' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='86' column='1'/>
+        <var-decl name='cl_haszonedchild' type-id='type-id-5' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='86' column='1'/>
       </data-member>
     </class-decl>
     <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-7'/>
@@ -561,10 +561,10 @@
     </enum-decl>
     <typedef-decl name='zfs_prop_t' type-id='type-id-8' filepath='../../include/sys/fs/zfs.h' line='190' column='1' id='type-id-2'/>
     <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-9'/>
-    <typedef-decl name='uu_avl_pool_t' type-id='type-id-9' filepath='../../include/libuutil.h' line='287' column='1' id='type-id-10'/>
+    <typedef-decl name='uu_avl_pool_t' type-id='type-id-9' filepath='../../include/libuutil.h' line='259' column='1' id='type-id-10'/>
     <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-3'/>
     <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-11'/>
-    <typedef-decl name='uu_avl_t' type-id='type-id-11' filepath='../../include/libuutil.h' line='288' column='1' id='type-id-12'/>
+    <typedef-decl name='uu_avl_t' type-id='type-id-11' filepath='../../include/libuutil.h' line='260' column='1' id='type-id-12'/>
     <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-4'/>
     <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-13'>
       <underlying-type type-id='type-id-7'/>
@@ -573,47 +573,47 @@
     </enum-decl>
     <typedef-decl name='boolean_t' type-id='type-id-13' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-5'/>
     <type-decl name='int' size-in-bits='32' id='type-id-6'/>
-    <typedef-decl name='prop_changelist_t' type-id='type-id-1' filepath='../../include/libzfs_impl.h' line='174' column='1' id='type-id-14'/>
+    <typedef-decl name='prop_changelist_t' type-id='type-id-1' filepath='../../include/libzfs_impl.h' line='173' column='1' id='type-id-14'/>
     <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
-    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='77' column='1' id='type-id-16'>
+    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='76' column='1' id='type-id-16'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zfs_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='78' column='1'/>
+        <var-decl name='zfs_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_hdl' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='79' column='1'/>
+        <var-decl name='zpool_hdl' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zfs_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='80' column='1'/>
+        <var-decl name='zfs_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zfs_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='81' column='1'/>
+        <var-decl name='zfs_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2208'>
-        <var-decl name='zfs_head_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='82' column='1'/>
+        <var-decl name='zfs_head_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs_impl.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zfs_dmustats' type-id='type-id-21' visibility='default' filepath='../../include/libzfs_impl.h' line='83' column='1'/>
+        <var-decl name='zfs_dmustats' type-id='type-id-21' visibility='default' filepath='../../include/libzfs_impl.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4544'>
-        <var-decl name='zfs_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='84' column='1'/>
+        <var-decl name='zfs_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='83' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4608'>
-        <var-decl name='zfs_user_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='85' column='1'/>
+        <var-decl name='zfs_user_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4672'>
-        <var-decl name='zfs_recvd_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='86' column='1'/>
+        <var-decl name='zfs_recvd_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='85' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4736'>
-        <var-decl name='zfs_mntcheck' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='87' column='1'/>
+        <var-decl name='zfs_mntcheck' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4800'>
-        <var-decl name='zfs_mntopts' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='88' column='1'/>
+        <var-decl name='zfs_mntopts' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='4864'>
-        <var-decl name='zfs_props_table' type-id='type-id-24' visibility='default' filepath='../../include/libzfs_impl.h' line='89' column='1'/>
+        <var-decl name='zfs_props_table' type-id='type-id-24' visibility='default' filepath='../../include/libzfs_impl.h' line='88' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='libzfs_handle' size-in-bits='20224' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='48' column='1' id='type-id-25'>
+    <class-decl name='libzfs_handle' size-in-bits='20160' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='48' column='1' id='type-id-25'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='libzfs_error' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='49' column='1'/>
       </data-member>
@@ -621,389 +621,277 @@
         <var-decl name='libzfs_fd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='50' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='libzfs_mnttab' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='51' column='1'/>
+        <var-decl name='libzfs_pool_handles' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='libzfs_pool_handles' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='52' column='1'/>
+        <var-decl name='libzfs_ns_avlpool' type-id='type-id-3' visibility='default' filepath='../../include/libzfs_impl.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='libzfs_ns_avlpool' type-id='type-id-3' visibility='default' filepath='../../include/libzfs_impl.h' line='53' column='1'/>
+        <var-decl name='libzfs_ns_avl' type-id='type-id-4' visibility='default' filepath='../../include/libzfs_impl.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='libzfs_ns_avl' type-id='type-id-4' visibility='default' filepath='../../include/libzfs_impl.h' line='54' column='1'/>
+        <var-decl name='libzfs_ns_gen' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='libzfs_ns_gen' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='55' column='1'/>
+        <var-decl name='libzfs_desc_active' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='55' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='libzfs_desc_active' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='56' column='1'/>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='libzfs_action' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='56' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='libzfs_action' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='57' column='1'/>
+      <data-member access='public' layout-offset-in-bits='8544'>
+        <var-decl name='libzfs_desc' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='57' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='8608'>
-        <var-decl name='libzfs_desc' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='58' column='1'/>
+      <data-member access='public' layout-offset-in-bits='16736'>
+        <var-decl name='libzfs_printerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16768'>
+        <var-decl name='libzfs_storeerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='59' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16800'>
-        <var-decl name='libzfs_printerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='59' column='1'/>
+        <var-decl name='libzfs_mnttab_enable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='60' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16832'>
-        <var-decl name='libzfs_storeerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='60' column='1'/>
+        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='67' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='16864'>
-        <var-decl name='libzfs_mnttab_enable' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='61' column='1'/>
+      <data-member access='public' layout-offset-in-bits='17152'>
+        <var-decl name='libzfs_mnttab_cache' type-id='type-id-29' visibility='default' filepath='../../include/libzfs_impl.h' line='68' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='16896'>
-        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-29' visibility='default' filepath='../../include/libzfs_impl.h' line='68' column='1'/>
+      <data-member access='public' layout-offset-in-bits='17472'>
+        <var-decl name='libzfs_pool_iter' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='69' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='17216'>
-        <var-decl name='libzfs_mnttab_cache' type-id='type-id-30' visibility='default' filepath='../../include/libzfs_impl.h' line='69' column='1'/>
+      <data-member access='public' layout-offset-in-bits='17504'>
+        <var-decl name='libzfs_chassis_id' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='17536'>
-        <var-decl name='libzfs_pool_iter' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='70' column='1'/>
+      <data-member access='public' layout-offset-in-bits='19552'>
+        <var-decl name='libzfs_prop_debug' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='71' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='17568'>
-        <var-decl name='libzfs_chassis_id' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='71' column='1'/>
+      <data-member access='public' layout-offset-in-bits='19584'>
+        <var-decl name='libzfs_urire' type-id='type-id-30' visibility='default' filepath='../../include/libzfs_impl.h' line='72' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='19616'>
-        <var-decl name='libzfs_prop_debug' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='19648'>
-        <var-decl name='libzfs_urire' type-id='type-id-31' visibility='default' filepath='../../include/libzfs_impl.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20160'>
-        <var-decl name='libzfs_max_nvlist' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='74' column='1'/>
+      <data-member access='public' layout-offset-in-bits='20096'>
+        <var-decl name='libzfs_max_nvlist' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='73' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-32'>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='97' column='1' id='type-id-31'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+        <var-decl name='zpool_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+        <var-decl name='zpool_next' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-23' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-33' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-34' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-35' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-36' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-38' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-39' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-40' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-41' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-34' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-42' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-44' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='char' size-in-bits='8' id='type-id-45'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-23'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-33'/>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-34'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-47'/>
-    <typedef-decl name='__off_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-35'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-36'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-37'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-48'/>
-
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='8' id='type-id-38'>
-      <subrange length='1' type-id='type-id-48' id='type-id-49'/>
-
-    </array-type-def>
-    <typedef-decl name='__off64_t' type-id='type-id-47' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-39'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-50'/>
-    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-40'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-41'/>
-    <type-decl name='void' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-42'/>
-    <typedef-decl name='size_t' type-id='type-id-48' filepath='/usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h' line='216' column='1' id='type-id-43'/>
-
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='160' id='type-id-44'>
-      <subrange length='20' type-id='type-id-48' id='type-id-53'/>
-
-    </array-type-def>
-    <typedef-decl name='FILE' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-26'/>
-    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='98' column='1' id='type-id-55'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zpool_hdl' type-id='type-id-17' visibility='default' filepath='../../include/libzfs_impl.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_next' type-id='type-id-18' visibility='default' filepath='../../include/libzfs_impl.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zpool_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='101' column='1'/>
+        <var-decl name='zpool_name' type-id='type-id-19' visibility='default' filepath='../../include/libzfs_impl.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zpool_state' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
+        <var-decl name='zpool_state' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zpool_config_size' type-id='type-id-43' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
+        <var-decl name='zpool_config_size' type-id='type-id-32' visibility='default' filepath='../../include/libzfs_impl.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='zpool_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
+        <var-decl name='zpool_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='103' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='zpool_old_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='105' column='1'/>
+        <var-decl name='zpool_old_config' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='zpool_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='106' column='1'/>
+        <var-decl name='zpool_props' type-id='type-id-22' visibility='default' filepath='../../include/libzfs_impl.h' line='105' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='zpool_start_block' type-id='type-id-56' visibility='default' filepath='../../include/libzfs_impl.h' line='107' column='1'/>
+        <var-decl name='zpool_start_block' type-id='type-id-33' visibility='default' filepath='../../include/libzfs_impl.h' line='106' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='libzfs_handle_t' type-id='type-id-25' filepath='../../include/libzfs.h' line='197' column='1' id='type-id-57'/>
-    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-17'/>
-    <typedef-decl name='zpool_handle_t' type-id='type-id-55' filepath='../../include/libzfs.h' line='196' column='1' id='type-id-58'/>
-    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-18'/>
+    <typedef-decl name='libzfs_handle_t' type-id='type-id-25' filepath='../../include/libzfs.h' line='197' column='1' id='type-id-34'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-17'/>
+    <typedef-decl name='zpool_handle_t' type-id='type-id-31' filepath='../../include/libzfs.h' line='196' column='1' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-18'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-36'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-37'/>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='2048' id='type-id-19'>
-      <subrange length='256' type-id='type-id-48' id='type-id-59'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='2048' id='type-id-19'>
+      <subrange length='256' type-id='type-id-37' id='type-id-38'/>
 
     </array-type-def>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-60'>
+    <typedef-decl name='size_t' type-id='type-id-37' filepath='/usr/lib/gcc/x86_64-linux-gnu/8/include/stddef.h' line='216' column='1' id='type-id-32'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-39'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+        <var-decl name='nvl_version' type-id='type-id-40' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-62' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+        <var-decl name='nvl_nvflag' type-id='type-id-41' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-27' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+        <var-decl name='nvl_priv' type-id='type-id-26' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-62' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+        <var-decl name='nvl_flag' type-id='type-id-41' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+        <var-decl name='nvl_pad' type-id='type-id-40' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-63'/>
-    <typedef-decl name='int32_t' type-id='type-id-63' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-61'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-64'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-64' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-65'/>
-    <typedef-decl name='uint32_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-62'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-48' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-66'/>
-    <typedef-decl name='uint64_t' type-id='type-id-66' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-27'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-60' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-22'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-68'/>
-    <typedef-decl name='longlong_t' type-id='type-id-68' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-69'/>
-    <typedef-decl name='diskaddr_t' type-id='type-id-69' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-56'/>
+    <typedef-decl name='__int32_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-42'/>
+    <typedef-decl name='int32_t' type-id='type-id-42' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-40'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-43'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-43' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-44'/>
+    <typedef-decl name='uint32_t' type-id='type-id-44' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-41'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-37' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-45'/>
+    <typedef-decl name='uint64_t' type-id='type-id-45' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-26'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-39' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-22'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-47'/>
+    <typedef-decl name='longlong_t' type-id='type-id-47' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-48'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-48' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-33'/>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='8192' id='type-id-28'>
-      <subrange length='1024' type-id='type-id-48' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='8192' id='type-id-27'>
+      <subrange length='1024' type-id='type-id-37' id='type-id-49'/>
 
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-71'>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-50'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-72' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__data' type-id='type-id-51' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
+        <var-decl name='__size' type-id='type-id-52' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-47' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+        <var-decl name='__align' type-id='type-id-53' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-72'>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-51'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
+        <var-decl name='__count' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='__owner' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
+        <var-decl name='__nusers' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='__kind' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__spins' type-id='type-id-54' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-74' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__elision' type-id='type-id-54' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-75' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
+        <var-decl name='__list' type-id='type-id-55' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
       </data-member>
     </class-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-74'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-76'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-54'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-56'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
+        <var-decl name='__prev' type-id='type-id-57' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-77' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
+        <var-decl name='__next' type-id='type-id-57' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-76' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-57'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-56' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-55'/>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='320' id='type-id-73'>
-      <subrange length='40' type-id='type-id-48' id='type-id-78'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='320' id='type-id-52'>
+      <subrange length='40' type-id='type-id-37' id='type-id-58'/>
 
     </array-type-def>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-71' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-29'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-79'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-53'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-50' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-28'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-59'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-80' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+        <var-decl name='avl_root' type-id='type-id-60' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-81' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+        <var-decl name='avl_compar' type-id='type-id-61' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-43' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+        <var-decl name='avl_offset' type-id='type-id-32' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-82' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+        <var-decl name='avl_numnodes' type-id='type-id-62' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-43' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+        <var-decl name='avl_size' type-id='type-id-32' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-83'>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-63'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-84' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+        <var-decl name='avl_child' type-id='type-id-64' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+        <var-decl name='avl_pcb' type-id='type-id-65' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-60'/>
 
-    <array-type-def dimensions='1' type-id='type-id-80' size-in-bits='128' id='type-id-84'>
-      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='128' id='type-id-64'>
+      <subrange length='2' type-id='type-id-37' id='type-id-66'/>
 
     </array-type-def>
-    <typedef-decl name='uintptr_t' type-id='type-id-48' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-81'/>
-    <typedef-decl name='ulong_t' type-id='type-id-48' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-82'/>
-    <typedef-decl name='avl_tree_t' type-id='type-id-79' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-30'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-88'>
+    <typedef-decl name='uintptr_t' type-id='type-id-37' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-65'/>
+    <type-decl name='void' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-68'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-61'/>
+    <typedef-decl name='ulong_t' type-id='type-id-37' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-62'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-59' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-29'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-70'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='type-id-89' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
+        <var-decl name='buffer' type-id='type-id-71' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='type-id-90' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
+        <var-decl name='allocated' type-id='type-id-72' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='type-id-90' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
+        <var-decl name='used' type-id='type-id-72' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='type-id-91' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
+        <var-decl name='syntax' type-id='type-id-73' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='fastmap' type-id='type-id-23' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='type-id-92' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
+        <var-decl name='translate' type-id='type-id-74' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
+        <var-decl name='re_nsub' type-id='type-id-32' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
+        <var-decl name='can_be_null' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
+        <var-decl name='regs_allocated' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
+        <var-decl name='fastmap_accurate' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
+        <var-decl name='no_sub' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
+        <var-decl name='not_bol' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
+        <var-decl name='not_eol' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='type-id-64' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
+        <var-decl name='newline_anchor' type-id='type-id-43' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-93'/>
-    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-89'/>
-    <typedef-decl name='__re_long_size_t' type-id='type-id-48' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-90'/>
-    <typedef-decl name='reg_syntax_t' type-id='type-id-48' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-91'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-94'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-92'/>
-    <typedef-decl name='regex_t' type-id='type-id-88' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-31'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='52' column='1' id='type-id-95'>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-71'/>
+    <typedef-decl name='__re_long_size_t' type-id='type-id-37' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-72'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-37' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-23'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-74'/>
+    <typedef-decl name='regex_t' type-id='type-id-70' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-30'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='52' column='1' id='type-id-77'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
       <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
@@ -1011,34 +899,34 @@
       <enumerator name='ZFS_TYPE_POOL' value='8'/>
       <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
     </enum-decl>
-    <typedef-decl name='zfs_type_t' type-id='type-id-95' filepath='../../include/sys/fs/zfs.h' line='58' column='1' id='type-id-20'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='931' column='1' id='type-id-96'>
+    <typedef-decl name='zfs_type_t' type-id='type-id-77' filepath='../../include/sys/fs/zfs.h' line='58' column='1' id='type-id-20'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='931' column='1' id='type-id-78'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='type-id-27' visibility='default' filepath='../../include/sys/dmu.h' line='932' column='1'/>
+        <var-decl name='dds_num_clones' type-id='type-id-26' visibility='default' filepath='../../include/sys/dmu.h' line='932' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='type-id-27' visibility='default' filepath='../../include/sys/dmu.h' line='933' column='1'/>
+        <var-decl name='dds_creation_txg' type-id='type-id-26' visibility='default' filepath='../../include/sys/dmu.h' line='933' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='type-id-27' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1'/>
+        <var-decl name='dds_guid' type-id='type-id-26' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='type-id-97' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
+        <var-decl name='dds_type' type-id='type-id-79' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
+        <var-decl name='dds_is_snapshot' type-id='type-id-80' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
+        <var-decl name='dds_inconsistent' type-id='type-id-80' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='type-id-98' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
+        <var-decl name='dds_redacted' type-id='type-id-80' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='248'>
         <var-decl name='dds_origin' type-id='type-id-19' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-99'>
+    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-81'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='DMU_OST_NONE' value='0'/>
       <enumerator name='DMU_OST_META' value='1'/>
@@ -1048,583 +936,583 @@
       <enumerator name='DMU_OST_ANY' value='5'/>
       <enumerator name='DMU_OST_NUMTYPES' value='6'/>
     </enum-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='type-id-99' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-97'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-94' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-100'/>
-    <typedef-decl name='uint8_t' type-id='type-id-100' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-98'/>
-    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-96' filepath='../../include/sys/dmu.h' line='940' column='1' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-24'/>
-    <typedef-decl name='zfs_handle_t' type-id='type-id-16' filepath='../../include/libzfs.h' line='195' column='1' id='type-id-101'/>
-    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-102'/>
-    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_gather'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-6' name='gather_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
-      <parameter type-id='type-id-6' name='mnt_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='625' column='1'/>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-81' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-79'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-76' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-82'/>
+    <typedef-decl name='uint8_t' type-id='type-id-82' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-80'/>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-78' filepath='../../include/sys/dmu.h' line='940' column='1' id='type-id-21'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-24'/>
+    <typedef-decl name='zfs_handle_t' type-id='type-id-16' filepath='../../include/libzfs.h' line='195' column='1' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_gather'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-6' name='gather_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='624' column='1'/>
+      <parameter type-id='type-id-6' name='mnt_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='625' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_free'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_free'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='412' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-45' const='yes' id='type-id-103'/>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-104'/>
-    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_remove'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
-      <return type-id='type-id-52'/>
+    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-86'/>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_remove'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='387' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_haszonedchild'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_haszonedchild'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='378' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='110' column='1' id='type-id-105'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='109' column='1' id='type-id-87'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROTO_NFS' value='0'/>
       <enumerator name='PROTO_SMB' value='1'/>
       <enumerator name='PROTO_END' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_proto_t' type-id='type-id-105' filepath='../../include/libzfs_impl.h' line='114' column='1' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
-    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
-      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+    <typedef-decl name='zfs_share_proto_t' type-id='type-id-87' filepath='../../include/libzfs_impl.h' line='113' column='1' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-89'/>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_unshare'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='348' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_rename'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <parameter type-id='type-id-104' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <parameter type-id='type-id-104' name='dst' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_rename'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-86' name='src' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <parameter type-id='type-id-86' name='dst' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='311' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
-      <parameter type-id='type-id-104' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
-      <parameter type-id='type-id-104' name='parent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+    <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
+      <parameter type-id='type-id-86' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
+      <parameter type-id='type-id-86' name='parent' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_postfix'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1'/>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_postfix'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='170' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_prefix'>
-      <parameter type-id='type-id-15' name='clp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='changelist_prefix'>
+      <parameter type-id='type-id-15' name='clp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='96' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='../../include/libzfs_impl.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='../../include/libuutil.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='../../include/libuutil.h' line='304' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='../../include/libuutil.h' line='351' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='../../include/libuutil.h' line='323' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='../../include/libzfs.h' line='494' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='../../include/libzfs.h' line='615' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='../../include/libzfs.h' line='471' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_open' mangled-name='zfs_open' filepath='../../include/libzfs.h' line='467' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='../../include/libzfs.h' line='840' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='../../include/libzfs.h' line='511' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='../../include/libuutil.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='../../include/libuutil.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='../../include/libuutil.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='../../include/libuutil.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='free' mangled-name='free' filepath='/usr/include/stdlib.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_close' mangled-name='zfs_close' filepath='../../include/libzfs.h' line='469' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='../../include/libzfs.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='../../include/libzfs.h' line='623' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='../../include/libzfs.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='../../include/libuutil.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='../../include/libuutil.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='../../include/libzfs_impl.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='../../include/libzfs_impl.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcmp' mangled-name='strcmp' filepath='/usr/include/string.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='../../include/libzfs.h' line='210' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getzoneid' mangled-name='getzoneid' filepath='../../include/sys/zfs_context.h' line='732' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='../../include/libuutil.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='../../include/libuutil.h' line='338' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='../../include/libuutil.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='../../include/libuutil.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='../../include/libuutil.h' line='367' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='../../include/libuutil.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='../../include/libuutil.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='../../include/libuutil.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='../../include/libuutil.h' line='354' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='../../include/libuutil.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='../../include/libuutil.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='../../include/libuutil.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='../../include/libzfs_impl.h' line='211' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='../../include/libzfs_impl.h' line='210' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='../../include/libzfs_impl.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='../../include/libzfs_impl.h' line='191' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strlcpy' mangled-name='strlcpy' filepath='../../lib/libspl/include/string.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strlen' mangled-name='strlen' filepath='/usr/include/string.h' line='384' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strlcat' mangled-name='strlcat' filepath='../../lib/libspl/include/string.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strncmp' mangled-name='strncmp' filepath='/usr/include/string.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='../../include/libzfs.h' line='810' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='../../include/libzfs.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='../../include/libzfs.h' line='853' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='../../include/libzfs.h' line='852' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='../../include/libzfs.h' line='850' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='../../include/libzfs.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='../../include/libuutil.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='../../include/libuutil.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' filepath='../../include/libzfs.h' line='861' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' filepath='../../include/libzfs.h' line='862' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='../../include/libzfs.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-87'>
-      <parameter type-id='type-id-42'/>
-      <parameter type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-69'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-109'/>
-    <typedef-decl name='zfs_iter_f' type-id='type-id-109' filepath='../../include/libzfs.h' line='612' column='1' id='type-id-110'/>
-    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-91'/>
+    <typedef-decl name='zfs_iter_f' type-id='type-id-91' filepath='../../include/libzfs.h' line='612' column='1' id='type-id-92'/>
+    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-112'/>
-    <typedef-decl name='zpool_iter_f' type-id='type-id-112' filepath='../../include/libzfs.h' line='246' column='1' id='type-id-113'/>
-    <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
-      <parameter type-id='type-id-113' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='zpool_iter_f' type-id='type-id-94' filepath='../../include/libzfs.h' line='246' column='1' id='type-id-95'/>
+    <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-95' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='389' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
-      <parameter type-id='type-id-104' name='poolname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='340' column='1'/>
+    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
+      <parameter type-id='type-id-86' name='poolname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='340' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-114'/>
-    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
-      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-96'/>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
+      <parameter type-id='type-id-96' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='265' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='232' column='1'/>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='232' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-115'/>
-    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
-      <parameter type-id='type-id-115' name='oldconfig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-97'/>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
+      <parameter type-id='type-id-97' name='oldconfig' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='220' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='namespace_clear'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_config.c' line='79' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='namespace_clear'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='79' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='../../include/libuutil.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='../../include/libuutil.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='../../include/libzfs_impl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='../../include/libzfs_impl.h' line='195' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='../../include/libuutil.h' line='361' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='../../include/libuutil.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='../../include/libzfs_impl.h' line='200' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='../../include/libzfs_impl.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strchr' mangled-name='strchr' filepath='/usr/include/string.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getenv' mangled-name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcpy' mangled-name='strcpy' filepath='/usr/include/string.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='../../include/libzfs_impl.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='../../include/libzfs_impl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__errno_location' mangled-name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='../../include/libzfs_impl.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='../../include/libzfs_impl.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='../../include/libzfs.h' line='455' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='../../include/libzfs_impl.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='../../include/libzfs_impl.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='../../include/libzfs_impl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='../../include/libzfs_impl.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../include/sys/nvpair.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_exists' mangled-name='nvlist_exists' filepath='../../include/sys/nvpair.h' line='238' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='214' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='no_memory' mangled-name='no_memory' filepath='../../include/libzfs_impl.h' line='143' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='no_memory' mangled-name='no_memory' filepath='../../include/libzfs_impl.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../include/sys/nvpair.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../include/sys/nvpair.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='../../include/libzfs_impl.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='../../include/libzfs_impl.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='dcgettext' mangled-name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='../../include/libzfs_impl.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='../../include/libzfs_impl.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='../../include/libuutil.h' line='376' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='../../include/libuutil.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' filepath='../../include/sys/nvpair.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-108'>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-90'>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-111'>
+    <function-type size-in-bits='64' id='type-id-93'>
       <parameter type-id='type-id-18'/>
-      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
-      <parameter type-id='type-id-22' name='raw_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
-      <parameter type-id='type-id-5' name='inheritkey' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+      <parameter type-id='type-id-22' name='raw_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
+      <parameter type-id='type-id-5' name='inheritkey' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1387' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1'/>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1251' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
-      <parameter type-id='type-id-5' name='noop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
-      <parameter type-id='type-id-23' name='alt_keylocation' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+      <parameter type-id='type-id-5' name='noop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
+      <parameter type-id='type-id-23' name='alt_keylocation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1083' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
-      <parameter type-id='type-id-23' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
+      <parameter type-id='type-id-23' name='fsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1048' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
-      <parameter type-id='type-id-102' name='origin_zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
-      <parameter type-id='type-id-23' name='parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
+      <parameter type-id='type-id-84' name='origin_zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='982' column='1'/>
+      <parameter type-id='type-id-23' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='983' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-116'/>
-    <typedef-decl name='uint_t' type-id='type-id-64' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
-    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-23' name='parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
-      <parameter type-id='type-id-22' name='pool_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-5' name='stdin_available' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-116' name='wkeydata_out' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
-      <parameter type-id='type-id-118' name='wkeylen_out' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-98'/>
+    <typedef-decl name='uint_t' type-id='type-id-43' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-23' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='810' column='1'/>
+      <parameter type-id='type-id-22' name='pool_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-5' name='stdin_available' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-98' name='wkeydata_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='811' column='1'/>
+      <parameter type-id='type-id-100' name='wkeylen_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='812' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
-      <parameter type-id='type-id-114' name='is_encroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_crypto.c' line='780' column='1'/>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
+      <parameter type-id='type-id-96' name='is_encroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='779' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='780' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../include/sys/fs/zfs.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='../../include/libzfs_impl.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='../../include/libzfs_impl.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../include/sys/nvpair.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='../../include/libzfs.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='snprintf' mangled-name='snprintf' filepath='/usr/include/stdio.h' line='354' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='../../include/libzfs.h' line='814' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_change_key' mangled-name='lzc_change_key' filepath='../../include/libzfs_core.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../include/libzfs.h' line='491' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='212' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' filepath='../../include/sys/nvpair.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' filepath='../../include/libzfs_core.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_load_key' mangled-name='lzc_load_key' filepath='../../include/libzfs_core.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='../../include/libzfs.h' line='468' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='printf' mangled-name='printf' filepath='/usr/include/stdio.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='../../include/libzfs.h' line='616' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='calloc' mangled-name='calloc' filepath='/usr/include/stdlib.h' line='541' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='regexec' mangled-name='regexec' filepath='/usr/include/regex.h' line='643' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fileno' mangled-name='fileno' filepath='/usr/include/stdio.h' line='792' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='isatty' mangled-name='isatty' filepath='/usr/include/unistd.h' line='779' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__getdelim' mangled-name='__getdelim' filepath='/usr/include/stdio.h' line='609' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sigemptyset' mangled-name='sigemptyset' filepath='/usr/include/signal.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sigaction' mangled-name='sigaction' filepath='/usr/include/signal.h' line='240' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fputc' mangled-name='fputc' filepath='/usr/include/stdio.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fflush' mangled-name='fflush' filepath='/usr/include/stdio.h' line='218' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tcgetattr' mangled-name='tcgetattr' filepath='/usr/include/termios.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tcsetattr' mangled-name='tcsetattr' filepath='/usr/include/termios.h' line='70' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getpid' mangled-name='getpid' filepath='/usr/include/unistd.h' line='628' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='kill' mangled-name='kill' filepath='/usr/include/signal.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__ctype_b_loc' mangled-name='__ctype_b_loc' filepath='/usr/include/ctype.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_features' mangled-name='zpool_get_features' filepath='../../include/libzfs.h' line='413' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='../../include/libzfs.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='malloc' mangled-name='malloc' filepath='/usr/include/stdlib.h' line='539' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fread' mangled-name='fread' filepath='/usr/include/stdio.h' line='652' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='ferror' mangled-name='ferror' filepath='/usr/include/stdio.h' line='767' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fopen' mangled-name='fopen64' filepath='/usr/include/stdio.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fclose' mangled-name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sscanf' mangled-name='sscanf' filepath='/usr/include/stdio.h' line='399' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' mangled-name='PKCS5_PBKDF2_HMAC_SHA1' filepath='/usr/include/openssl/evp.h' line='1087' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='read' mangled-name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='close' mangled-name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1439' column='1' id='type-id-119'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1439' column='1' id='type-id-101'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
       <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
     </enum-decl>
-    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-119' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-120'/>
-    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
-      <parameter type-id='type-id-120' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
-      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
-      <parameter type-id='type-id-114' name='waited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-101' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-102'/>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
+      <parameter type-id='type-id-102' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5546' column='1'/>
+      <parameter type-id='type-id-96' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
+      <parameter type-id='type-id-96' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
-      <parameter type-id='type-id-18' name='zph' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
-      <parameter type-id='type-id-27' name='volsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='type-id-18' name='zph' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
+      <parameter type-id='type-id-26' name='volsize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5490' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
-      <parameter type-id='type-id-115' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
+      <parameter type-id='type-id-97' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5232' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
-      <parameter type-id='type-id-5' name='un' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+      <parameter type-id='type-id-5' name='un' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5178' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
-      <parameter type-id='type-id-115' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
+      <parameter type-id='type-id-97' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5111' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-104' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-104' name='tag' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
+    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-86' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-86' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5030' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
-      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
-      <parameter type-id='type-id-22' name='holds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
+      <parameter type-id='type-id-22' name='holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4931' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-104' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-104' name='tag' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
-      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-86' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-86' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4899' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
+      <parameter type-id='type-id-6' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-121'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-103'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_PROP_USERUSED' value='0'/>
       <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
@@ -1640,52 +1528,52 @@
       <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
       <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
     </enum-decl>
-    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-121' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-122'/>
-    <typedef-decl name='__uid_t' type-id='type-id-64' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-123'/>
-    <typedef-decl name='uid_t' type-id='type-id-123' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-124'/>
-    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-126'/>
-    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-126' filepath='../../include/libzfs.h' line='738' column='1' id='type-id-127'/>
-    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
-      <parameter type-id='type-id-122' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
-      <parameter type-id='type-id-127' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
-      <parameter type-id='type-id-42' name='arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-103' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-104'/>
+    <typedef-decl name='__uid_t' type-id='type-id-43' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-105'/>
+    <typedef-decl name='uid_t' type-id='type-id-105' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-108'/>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-108' filepath='../../include/libzfs.h' line='738' column='1' id='type-id-109'/>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
+      <parameter type-id='type-id-104' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4819' column='1'/>
+      <parameter type-id='type-id-109' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
+      <parameter type-id='type-id-68' name='arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
-      <parameter type-id='type-id-23' name='oldname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
-      <parameter type-id='type-id-23' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4811' column='1'/>
+      <parameter type-id='type-id-23' name='oldname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
+      <parameter type-id='type-id-23' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4804' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
-      <parameter type-id='type-id-23' name='resource' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-23' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='dataset' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
-      <parameter type-id='type-id-23' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
-      <parameter type-id='type-id-23' name='resource' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4796' column='1'/>
+      <parameter type-id='type-id-23' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
+      <parameter type-id='type-id-23' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
-      <parameter type-id='type-id-24' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
+      <parameter type-id='type-id-24' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4706' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='536' column='1' id='type-id-128'>
+    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='536' column='1' id='type-id-110'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pl_prop' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='537' column='1'/>
       </data-member>
@@ -1693,45 +1581,45 @@
         <var-decl name='pl_user_prop' type-id='type-id-23' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pl_next' type-id='type-id-129' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
+        <var-decl name='pl_next' type-id='type-id-111' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='pl_all' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pl_width' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
+        <var-decl name='pl_width' type-id='type-id-32' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pl_recvd_width' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
+        <var-decl name='pl_recvd_width' type-id='type-id-32' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='pl_fixed' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='543' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-129'/>
-    <typedef-decl name='zprop_list_t' type-id='type-id-128' filepath='../../include/libzfs.h' line='544' column='1' id='type-id-130'/>
-    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-131'/>
-    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-132'/>
-    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-5' name='received' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
+    <typedef-decl name='zprop_list_t' type-id='type-id-110' filepath='../../include/libzfs.h' line='544' column='1' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-114'/>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-114' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-5' name='received' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4609' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1'/>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4581' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4590' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='650' column='1' id='type-id-133'>
+    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='650' column='1' id='type-id-115'>
       <data-member access='public' layout-offset-in-bits='31'>
         <var-decl name='recursive' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='652' column='1'/>
       </data-member>
@@ -1742,127 +1630,127 @@
         <var-decl name='forceunmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='658' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='renameflags_t' type-id='type-id-133' filepath='../../include/libzfs.h' line='659' column='1' id='type-id-134'/>
-    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
-      <parameter type-id='type-id-104' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
-      <parameter type-id='type-id-134' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+    <typedef-decl name='renameflags_t' type-id='type-id-115' filepath='../../include/libzfs.h' line='659' column='1' id='type-id-116'/>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+      <parameter type-id='type-id-86' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
+      <parameter type-id='type-id-116' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4373' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
-      <parameter type-id='type-id-102' name='snap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+      <parameter type-id='type-id-84' name='snap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4273' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-5' name='recursive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-5' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4172' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
-      <parameter type-id='type-id-22' name='snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+      <parameter type-id='type-id-22' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4092' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1'/>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4008' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
-      <parameter type-id='type-id-104' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+      <parameter type-id='type-id-86' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3922' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
-      <parameter type-id='type-id-22' name='snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+      <parameter type-id='type-id-22' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3875' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
-      <parameter type-id='type-id-23' name='snapname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+      <parameter type-id='type-id-23' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3851' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
-      <parameter type-id='type-id-5' name='defer' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
+      <parameter type-id='type-id-5' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3783' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
+    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3608' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3571' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
-      <parameter type-id='type-id-23' name='target' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
-      <parameter type-id='type-id-6' name='prefixlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+      <parameter type-id='type-id-23' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
+      <parameter type-id='type-id-6' name='prefixlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3497' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
-      <parameter type-id='type-id-43' name='buflen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
+      <parameter type-id='type-id-32' name='buflen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3376' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-101' const='yes' id='type-id-135'/>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-136'/>
-    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
-      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1'/>
+    <qualified-type-def type-id='type-id-83' const='yes' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
+      <parameter type-id='type-id-118' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3330' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
-      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
+      <parameter type-id='type-id-118' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
-      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
+      <parameter type-id='type-id-118' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3321' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
-      <parameter type-id='type-id-6' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3287' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-6' name='proplen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3288' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-137'/>
-    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
-      <parameter type-id='type-id-137' name='propvalue' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-119'/>
+    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3252' column='1'/>
+      <parameter type-id='type-id-119' name='propvalue' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3253' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
-      <parameter type-id='type-id-6' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3216' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-6' name='proplen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3217' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
-      <parameter type-id='type-id-137' name='propvalue' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
+    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3206' column='1'/>
+      <parameter type-id='type-id-119' name='propvalue' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3207' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='259' column='1' id='type-id-138'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='259' column='1' id='type-id-120'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPROP_SRC_NONE' value='1'/>
       <enumerator name='ZPROP_SRC_DEFAULT' value='2'/>
@@ -1871,143 +1759,143 @@
       <enumerator name='ZPROP_SRC_INHERITED' value='16'/>
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
-    <typedef-decl name='zprop_source_t' type-id='type-id-138' filepath='../../include/sys/fs/zfs.h' line='266' column='1' id='type-id-139'/>
-    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-140'/>
-    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-137' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
-      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
-      <parameter type-id='type-id-23' name='statbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
-      <parameter type-id='type-id-43' name='statlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+    <typedef-decl name='zprop_source_t' type-id='type-id-120' filepath='../../include/sys/fs/zfs.h' line='266' column='1' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
+    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-119' name='value' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3002' column='1'/>
+      <parameter type-id='type-id-122' name='src' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-23' name='statbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
+      <parameter type-id='type-id-32' name='statlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3003' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2979' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
-      <parameter type-id='type-id-43' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
-      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
-      <parameter type-id='type-id-23' name='statbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
-      <parameter type-id='type-id-43' name='statlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-32' name='proplen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2604' column='1'/>
+      <parameter type-id='type-id-122' name='src' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-23' name='statbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-32' name='statlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2605' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1'/>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2435' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-23' name='propbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
-      <parameter type-id='type-id-43' name='proplen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-23' name='propbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2348' column='1'/>
+      <parameter type-id='type-id-32' name='proplen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2349' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
-      <parameter type-id='type-id-5' name='received' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
+      <parameter type-id='type-id-5' name='received' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1926' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
+    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1744' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
-      <parameter type-id='type-id-104' name='propval' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
+      <parameter type-id='type-id-86' name='propval' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1713' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
-      <parameter type-id='type-id-27' name='zoned' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-18' name='zpool_hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
-      <parameter type-id='type-id-5' name='key_params_ok' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
-      <parameter type-id='type-id-104' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1004' column='1'/>
+      <parameter type-id='type-id-26' name='zoned' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-18' name='zpool_hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1005' column='1'/>
+      <parameter type-id='type-id-5' name='key_params_ok' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
+      <parameter type-id='type-id-86' name='errbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='1006' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-141'/>
-    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
-      <parameter type-id='type-id-141' name='spa_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-123'/>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
+      <parameter type-id='type-id-123' name='spa_version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='967' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
-      <parameter type-id='type-id-104' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
+      <parameter type-id='type-id-86' name='fsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='947' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
-      <parameter type-id='type-id-104' name='special' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
-      <parameter type-id='type-id-104' name='mountp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
-      <parameter type-id='type-id-104' name='mntopts' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
+      <parameter type-id='type-id-86' name='special' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='917' column='1'/>
+      <parameter type-id='type-id-86' name='mountp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <parameter type-id='type-id-86' name='mntopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='918' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <parameter type-id='type-id-5' name='enable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <parameter type-id='type-id-5' name='enable' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='847' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='848' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='848' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='800' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_close' mangled-name='zfs_close' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='772' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <parameter type-id='type-id-6' name='types' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='zfs_open' mangled-name='zfs_open' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <parameter type-id='type-id-6' name='types' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_bookmark_handle'>
-      <parameter type-id='type-id-102' name='parent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
-      <parameter type-id='type-id-22' name='bmark_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_bookmark_handle'>
+      <parameter type-id='type-id-84' name='parent' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='618' column='1'/>
+      <parameter type-id='type-id-22' name='bmark_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='619' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1'/>
+    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='587' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
-      <parameter type-id='type-id-102' name='zhp_orig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
+      <parameter type-id='type-id-84' name='zhp_orig' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='540' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-142'>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-124'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_name' type-id='type-id-143' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
+        <var-decl name='zc_name' type-id='type-id-125' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32768'>
-        <var-decl name='zc_nvlist_src' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
+        <var-decl name='zc_nvlist_src' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32832'>
-        <var-decl name='zc_nvlist_src_size' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32896'>
-        <var-decl name='zc_nvlist_dst' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32960'>
-        <var-decl name='zc_nvlist_dst_size' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='33024'>
         <var-decl name='zc_nvlist_dst_filled' type-id='type-id-5' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='483' column='1'/>
@@ -2016,262 +1904,262 @@
         <var-decl name='zc_pad2' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='484' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='33088'>
-        <var-decl name='zc_history' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
+        <var-decl name='zc_history' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='33152'>
-        <var-decl name='zc_value' type-id='type-id-144' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
+        <var-decl name='zc_value' type-id='type-id-126' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='98688'>
         <var-decl name='zc_string' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='100736'>
-        <var-decl name='zc_guid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
+        <var-decl name='zc_guid' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='100800'>
-        <var-decl name='zc_nvlist_conf' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='100864'>
-        <var-decl name='zc_nvlist_conf_size' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='100928'>
-        <var-decl name='zc_cookie' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
+        <var-decl name='zc_cookie' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='100992'>
-        <var-decl name='zc_objset_type' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
+        <var-decl name='zc_objset_type' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101056'>
-        <var-decl name='zc_perm_action' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
+        <var-decl name='zc_perm_action' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101120'>
-        <var-decl name='zc_history_len' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
+        <var-decl name='zc_history_len' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101184'>
-        <var-decl name='zc_history_offset' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
+        <var-decl name='zc_history_offset' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101248'>
-        <var-decl name='zc_obj' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
+        <var-decl name='zc_obj' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101312'>
-        <var-decl name='zc_iflags' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
+        <var-decl name='zc_iflags' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101376'>
-        <var-decl name='zc_share' type-id='type-id-145' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
+        <var-decl name='zc_share' type-id='type-id-127' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='101632'>
         <var-decl name='zc_objset_stats' type-id='type-id-21' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='103936'>
-        <var-decl name='zc_begin_record' type-id='type-id-146' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
+        <var-decl name='zc_begin_record' type-id='type-id-128' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='type-id-147' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
+        <var-decl name='zc_inject_record' type-id='type-id-129' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109184'>
-        <var-decl name='zc_defer_destroy' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
+        <var-decl name='zc_defer_destroy' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109216'>
-        <var-decl name='zc_flags' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
+        <var-decl name='zc_flags' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109248'>
-        <var-decl name='zc_action_handle' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
+        <var-decl name='zc_action_handle' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109312'>
         <var-decl name='zc_cleanup_fd' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_simple' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
+        <var-decl name='zc_simple' type-id='type-id-80' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109352'>
-        <var-decl name='zc_pad' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
+        <var-decl name='zc_pad' type-id='type-id-130' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_sendobj' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
+        <var-decl name='zc_sendobj' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109440'>
-        <var-decl name='zc_fromobj' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
+        <var-decl name='zc_fromobj' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109504'>
-        <var-decl name='zc_createtxg' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
+        <var-decl name='zc_createtxg' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109568'>
-        <var-decl name='zc_stat' type-id='type-id-149' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
+        <var-decl name='zc_stat' type-id='type-id-131' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109888'>
-        <var-decl name='zc_zoneid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
+        <var-decl name='zc_zoneid' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='32768' id='type-id-143'>
-      <subrange length='4096' type-id='type-id-48' id='type-id-150'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='32768' id='type-id-125'>
+      <subrange length='4096' type-id='type-id-37' id='type-id-132'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='65536' id='type-id-144'>
-      <subrange length='8192' type-id='type-id-48' id='type-id-151'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='65536' id='type-id-126'>
+      <subrange length='8192' type-id='type-id-37' id='type-id-133'/>
 
     </array-type-def>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-152'>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-134'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
+        <var-decl name='z_exportdata' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
+        <var-decl name='z_sharedata' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
+        <var-decl name='z_sharetype' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
+        <var-decl name='z_sharemax' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='type-id-152' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-145'/>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-146'>
+    <typedef-decl name='zfs_share_t' type-id='type-id-134' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-127'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-128'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
+        <var-decl name='drr_magic' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
+        <var-decl name='drr_versioninfo' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
+        <var-decl name='drr_creation_time' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='type-id-97' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
+        <var-decl name='drr_type' type-id='type-id-79' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+        <var-decl name='drr_flags' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
+        <var-decl name='drr_toguid' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
+        <var-decl name='drr_fromguid' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='drr_toname' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-153'>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-135'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
+        <var-decl name='zi_objset' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
+        <var-decl name='zi_object' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
+        <var-decl name='zi_start' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
+        <var-decl name='zi_end' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
+        <var-decl name='zi_guid' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
+        <var-decl name='zi_level' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
+        <var-decl name='zi_error' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
+        <var-decl name='zi_type' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+        <var-decl name='zi_freq' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+        <var-decl name='zi_failfast' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='zi_func' type-id='type-id-19' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
+        <var-decl name='zi_iotype' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='type-id-61' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
+        <var-decl name='zi_duration' type-id='type-id-40' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
+        <var-decl name='zi_timer' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
+        <var-decl name='zi_nlanes' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
+        <var-decl name='zi_cmd' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
+        <var-decl name='zi_dvas' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='type-id-153' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-147'/>
+    <typedef-decl name='zinject_record_t' type-id='type-id-135' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-129'/>
 
-    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='24' id='type-id-148'>
-      <subrange length='3' type-id='type-id-48' id='type-id-154'/>
+    <array-type-def dimensions='1' type-id='type-id-80' size-in-bits='24' id='type-id-130'>
+      <subrange length='3' type-id='type-id-37' id='type-id-136'/>
 
     </array-type-def>
-    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-155'>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-137'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zs_gen' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
+        <var-decl name='zs_gen' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zs_mode' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
+        <var-decl name='zs_mode' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zs_links' type-id='type-id-27' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
+        <var-decl name='zs_links' type-id='type-id-26' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zs_ctime' type-id='type-id-156' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
+        <var-decl name='zs_ctime' type-id='type-id-138' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='128' id='type-id-156'>
-      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='128' id='type-id-138'>
+      <subrange length='2' type-id='type-id-37' id='type-id-66'/>
 
     </array-type-def>
-    <typedef-decl name='zfs_stat_t' type-id='type-id-155' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-149'/>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-142' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-157'/>
-    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-158'/>
-    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_simple_handle_zc'>
-      <parameter type-id='type-id-102' name='pzhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
-      <return type-id='type-id-102'/>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-137' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-131'/>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-124' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-140'/>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_simple_handle_zc'>
+      <parameter type-id='type-id-84' name='pzhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='523' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle_zc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle_zc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='506' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='make_dataset_handle'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='477' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='433' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='312' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='221' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_validate_name'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-6' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
-      <parameter type-id='type-id-5' name='modifying' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_validate_name'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-6' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='105' column='1'/>
+      <parameter type-id='type-id-5' name='modifying' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='106' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='79' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-159'>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-141'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='type-id-23' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
       </data-member>
@@ -2285,448 +2173,445 @@
         <var-decl name='mnt_mntopts' type-id='type-id-23' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-160'/>
-    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
-      <parameter type-id='type-id-104' name='fsname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='871' column='1'/>
-      <parameter type-id='type-id-160' name='entry' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-142'/>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+      <parameter type-id='type-id-86' name='fsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='872' column='1'/>
+      <parameter type-id='type-id-142' name='entry' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='873' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-161'/>
-    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
-      <parameter type-id='type-id-161' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
-      <return type-id='type-id-27'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-143'/>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+      <parameter type-id='type-id-143' name='source' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2037' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
-      <parameter type-id='type-id-20' name='types' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
+      <parameter type-id='type-id-20' name='types' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3471' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='../../include/libzfs_core.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='145' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../include/sys/nvpair.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_config' mangled-name='zpool_get_config' filepath='../../include/libzfs.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtol' mangled-name='strtol' filepath='/usr/include/stdlib.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' filepath='../../include/libzfs_core.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_size' mangled-name='nvlist_size' filepath='../../include/sys/nvpair.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_pack' mangled-name='nvlist_pack' filepath='../../include/sys/nvpair.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' filepath='../../include/sys/nvpair.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strerror' mangled-name='strerror' filepath='/usr/include/string.h' line='396' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_empty' mangled-name='nvlist_empty' filepath='../../include/sys/nvpair.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_release' mangled-name='lzc_release' filepath='../../include/libzfs_core.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_free' mangled-name='fnvlist_free' filepath='../../include/sys/nvpair.h' line='277' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' filepath='../../include/sys/nvpair.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_hold' mangled-name='lzc_hold' filepath='../../include/libzfs_core.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='ioctl' mangled-name='ioctl' filepath='/usr/include/x86_64-linux-gnu/sys/ioctl.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../include/sys/nvpair.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='../../include/libzfs_impl.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='../../include/libzfs_impl.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../include/sys/nvpair.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../include/sys/nvpair.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='../../include/libzfs_impl.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='../../include/libzfs_impl.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='../../include/libzfs_impl.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' filepath='../../include/libzfs_impl.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='../../include/libzfs_impl.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' filepath='../../include/libzfs_impl.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='../../include/libzfs_impl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' filepath='../../include/libzfs_impl.h' line='182' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='../../include/libzfs_impl.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' filepath='../../include/libzfs_impl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='../../include/libzfs_impl.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_free' mangled-name='changelist_free' filepath='../../include/libzfs_impl.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='../../include/libzfs.h' line='622' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='../../include/libzfs_core.h' line='118' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='../../include/libzfs_impl.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' filepath='../../include/libzfs_impl.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcspn' mangled-name='strcspn' filepath='/usr/include/string.h' line='272' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_open' mangled-name='zpool_open' filepath='../../include/libzfs.h' line='234' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_close' mangled-name='zpool_close' filepath='../../include/libzfs.h' line='236' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' filepath='../../include/libzfs_core.h' line='52' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_promote' mangled-name='lzc_promote' filepath='../../include/libzfs_core.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='../../include/libzfs.h' line='529' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_clone' mangled-name='lzc_clone' filepath='../../include/libzfs_core.h' line='55' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' filepath='../../include/libzfs_core.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' filepath='../../include/libzfs_core.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_destroy' mangled-name='lzc_destroy' filepath='../../include/libzfs_core.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../include/libzfs.h' line='484' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' filepath='../../include/zfs_namecheck.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='../../include/libzfs.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_create' mangled-name='lzc_create' filepath='../../include/libzfs_core.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strdup' mangled-name='strdup' filepath='/usr/include/string.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_share' mangled-name='zfs_share' filepath='../../include/libzfs.h' line='841' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' filepath='../../include/libzfs.h' line='863' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strncpy' mangled-name='strncpy' filepath='/usr/include/string.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strrchr' mangled-name='strrchr' filepath='/usr/include/string.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' filepath='../../include/libzutil.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' filepath='../../include/libzutil.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../include/sys/fs/zfs.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='../../include/libzfs_impl.h' line='137' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='../../include/libzfs_impl.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='localtime_r' mangled-name='localtime_r' filepath='/usr/include/time.h' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strftime' mangled-name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='../../include/libzfs.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' filepath='../../include/zfs_prop.h' line='91' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' filepath='../../include/sys/fs/zfs.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' filepath='../../include/sys/fs/zfs.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='abort' mangled-name='abort' filepath='/usr/include/stdlib.h' line='588' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' filepath='../../include/sys/nvpair.h' line='211' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fprintf' mangled-name='fprintf' filepath='/usr/include/stdio.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' filepath='../../include/sys/nvpair.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' filepath='../../include/libzfs_core.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strsep' mangled-name='strsep' filepath='/usr/include/string.h' line='439' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='hasmntopt' mangled-name='hasmntopt' filepath='/usr/include/mntent.h' line='89' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' filepath='../../include/sys/fs/zfs.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' filepath='../../include/sys/fs/zfs.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../include/sys/fs/zfs.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='../../include/libzfs_impl.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='../../include/libzfs_impl.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='asprintf' mangled-name='asprintf' filepath='/usr/include/stdio.h' line='372' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' filepath='../../include/sys/nvpair.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' filepath='../../include/sys/nvpair.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='../../include/libzfs.h' line='866' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='../../include/libzfs.h' line='564' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../include/zfs_namecheck.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='../../include/libzfs_impl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='../../include/libzfs_impl.h' line='208' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' filepath='../../include/sys/fs/zfs.h' line='310' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='../../include/libzfs_impl.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='../../include/libzfs_impl.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../include/sys/fs/zfs.h' line='315' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' filepath='../../include/sys/fs/zfs.h' line='316' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' filepath='../../include/sys/fs/zfs.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_find' mangled-name='avl_find' filepath='../../include/sys/avl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../include/sys/avl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='774' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../include/sys/avl.h' line='281' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_add' mangled-name='avl_add' filepath='../../include/sys/avl.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../include/sys/avl.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../include/sys/avl.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='755' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='750' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_create' mangled-name='avl_create' filepath='../../include/sys/avl.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' filepath='../../include/libzfs_core.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='../../include/libzfs.h' line='237' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='../../include/libzfs.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='../../include/libzfs_impl.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='../../include/libzfs_impl.h' line='201' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../include/zfs_namecheck.h' line='58' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtoul' mangled-name='strtoul' filepath='/usr/include/stdlib.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getgrnam' mangled-name='getgrnam' filepath='/usr/include/grp.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getpwnam' mangled-name='getpwnam' filepath='/usr/include/pwd.h' line='116' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../include/libzfs.h' line='483' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strstr' mangled-name='strstr' filepath='/usr/include/string.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_exists' mangled-name='lzc_exists' filepath='../../include/libzfs_core.h' line='115' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='168' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='freopen' mangled-name='freopen64' filepath='/usr/include/stdio.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getmntany' mangled-name='getmntany' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' filepath='../../include/sys/nvpair.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-125'>
-      <parameter type-id='type-id-42'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-124'/>
-      <parameter type-id='type-id-27'/>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-106'/>
+      <parameter type-id='type-id-26'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-104' name='fromsnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
-      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-86' name='fromsnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='716' column='1'/>
+      <parameter type-id='type-id-86' name='tosnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_diff.c' line='717' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='../../include/libzfs_impl.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='../../include/libzfs_impl.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='../../include/libzfs_impl.h' line='204' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' filepath='../../include/libzfs_impl.h' line='203' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='../../include/libzfs_impl.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pipe2' mangled-name='pipe2' filepath='/usr/include/unistd.h' line='422' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_create' mangled-name='pthread_create' filepath='/usr/include/pthread.h' line='234' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_join' mangled-name='pthread_join' filepath='/usr/include/pthread.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pthread_cancel' mangled-name='pthread_cancel' filepath='/usr/include/pthread.h' line='514' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fdopen' mangled-name='fdopen' filepath='/usr/include/stdio.h' line='279' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='is_mounted' mangled-name='is_mounted' filepath='../../include/libzfs.h' line='823' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-162'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-144'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-163' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+        <var-decl name='pco_refresh_config' type-id='type-id-145' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-164' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
+        <var-decl name='pco_pool_active' type-id='type-id-146' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-165' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-166'/>
-    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-163'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-167' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-168'/>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-164'/>
-    <qualified-type-def type-id='type-id-162' const='yes' id='type-id-169'/>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-169' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-170'/>
-    <var-decl name='libzfs_config_ops' type-id='type-id-170' mangled-name='libzfs_config_ops' visibility='default' filepath='../../include/libzutil.h' line='59' column='1' elf-symbol-id='libzfs_config_ops'/>
-    <enum-decl name='pool_state' filepath='../../include/sys/fs/zfs.h' line='914' column='1' id='type-id-171'>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-147' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-145'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-149' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-146'/>
+    <qualified-type-def type-id='type-id-144' const='yes' id='type-id-151'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-151' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-152'/>
+    <var-decl name='libzfs_config_ops' type-id='type-id-152' mangled-name='libzfs_config_ops' visibility='default' filepath='../../include/libzutil.h' line='59' column='1' elf-symbol-id='libzfs_config_ops'/>
+    <enum-decl name='pool_state' filepath='../../include/sys/fs/zfs.h' line='914' column='1' id='type-id-153'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_STATE_ACTIVE' value='0'/>
       <enumerator name='POOL_STATE_EXPORTED' value='1'/>
@@ -2737,479 +2622,479 @@
       <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
       <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
     </enum-decl>
-    <typedef-decl name='pool_state_t' type-id='type-id-171' filepath='../../include/sys/fs/zfs.h' line='923' column='1' id='type-id-172'/>
-    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
-    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-173' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-161' name='namestr' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
-      <parameter type-id='type-id-114' name='inuse' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='301' column='1'/>
+    <typedef-decl name='pool_state_t' type-id='type-id-153' filepath='../../include/sys/fs/zfs.h' line='923' column='1' id='type-id-154'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-155'/>
+    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-155' name='state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-143' name='namestr' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='300' column='1'/>
+      <parameter type-id='type-id-96' name='inuse' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='301' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_import.c' line='144' column='1'/>
+    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_import.c' line='144' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_read_label' mangled-name='zpool_read_label' filepath='../../include/libzutil.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_iter' mangled-name='zpool_iter' filepath='../../include/libzfs.h' line='247' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pread64' mangled-name='pread64' filepath='/usr/include/unistd.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pwrite64' mangled-name='pwrite64' filepath='/usr/include/unistd.h' line='408' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__fxstat64' mangled-name='__fxstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='428' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='../../include/libzfs_impl.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='../../include/libzfs_impl.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-167'>
-      <parameter type-id='type-id-42'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-27'/>
-      <parameter type-id='type-id-114'/>
+    <function-type size-in-bits='64' id='type-id-149'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-96'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-165'>
-      <parameter type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-68'/>
       <parameter type-id='type-id-22'/>
       <return type-id='type-id-22'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='559' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
-      <parameter type-id='type-id-5' name='allowrecursion' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-5' name='allowrecursion' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='543' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='460' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
-      <parameter type-id='type-id-102' name='fs_zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
-      <parameter type-id='type-id-104' name='spec_orig' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
-      <parameter type-id='type-id-42' name='arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
+      <parameter type-id='type-id-84' name='fs_zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-86' name='spec_orig' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='383' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
+      <parameter type-id='type-id-68' name='arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-110' name='callback' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
-      <parameter type-id='type-id-27' name='min_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
-      <parameter type-id='type-id-27' name='max_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-92' name='callback' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='309' column='1'/>
+      <parameter type-id='type-id-26' name='min_txg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
+      <parameter type-id='type-id-26' name='max_txg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='310' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='202' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-5' name='simple' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
-      <parameter type-id='type-id-27' name='min_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
-      <parameter type-id='type-id-27' name='max_txg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-5' name='simple' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='143' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-26' name='min_txg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
+      <parameter type-id='type-id-26' name='max_txg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='144' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='107' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' filepath='../../include/libzfs.h' line='518' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='../../include/libzfs.h' line='815' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_first' mangled-name='avl_first' filepath='../../include/sys/avl.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='../../include/libzfs_impl.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' filepath='../../include/libzfs_impl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_get_type' mangled-name='zfs_get_type' filepath='../../include/libzfs.h' line='470' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='../../include/libzfs_impl.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' filepath='../../include/libzfs_impl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='../../include/libzfs_impl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' filepath='../../include/libzfs_impl.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-174' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1' id='type-id-175'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-156' visibility='default' filepath='../../include/libzfs_impl.h' line='213' column='1' id='type-id-157'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_prop' type-id='type-id-2' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
+        <var-decl name='p_prop' type-id='type-id-2' visibility='default' filepath='../../include/libzfs_impl.h' line='214' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_name' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='216' column='1'/>
+        <var-decl name='p_name' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='215' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_share_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='217' column='1'/>
+        <var-decl name='p_share_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='216' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='p_unshare_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='218' column='1'/>
+        <var-decl name='p_unshare_err' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='217' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='proto_table_t' type-id='type-id-175' filepath='../../include/libzfs_impl.h' line='219' column='1' id='type-id-174'/>
+    <typedef-decl name='proto_table_t' type-id='type-id-157' filepath='../../include/libzfs_impl.h' line='218' column='1' id='type-id-156'/>
 
-    <array-type-def dimensions='1' type-id='type-id-174' size-in-bits='384' id='type-id-176'>
-      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
-
-    </array-type-def>
-    <var-decl name='proto_table' type-id='type-id-176' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='242' column='1' elf-symbol-id='proto_table'/>
-
-    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='64' alignment-in-bits='32' id='type-id-177'>
-      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
+    <array-type-def dimensions='1' type-id='type-id-156' size-in-bits='384' id='type-id-158'>
+      <subrange length='2' type-id='type-id-37' id='type-id-66'/>
 
     </array-type-def>
-    <var-decl name='nfs_only' type-id='type-id-177' mangled-name='nfs_only' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='110' column='1' elf-symbol-id='nfs_only'/>
-    <var-decl name='smb_only' type-id='type-id-177' mangled-name='smb_only' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='115' column='1' elf-symbol-id='smb_only'/>
+    <var-decl name='proto_table' type-id='type-id-158' mangled-name='proto_table' visibility='default' filepath='../../include/libzfs_impl.h' line='241' column='1' elf-symbol-id='proto_table'/>
 
-    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='96' alignment-in-bits='32' id='type-id-178'>
-      <subrange length='3' type-id='type-id-48' id='type-id-154'/>
+    <array-type-def dimensions='1' type-id='type-id-88' size-in-bits='64' alignment-in-bits='32' id='type-id-159'>
+      <subrange length='2' type-id='type-id-37' id='type-id-66'/>
 
     </array-type-def>
-    <var-decl name='share_all_proto' type-id='type-id-178' mangled-name='share_all_proto' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='119' column='1' elf-symbol-id='share_all_proto'/>
-    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
+    <var-decl name='nfs_only' type-id='type-id-159' mangled-name='nfs_only' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='110' column='1' elf-symbol-id='nfs_only'/>
+    <var-decl name='smb_only' type-id='type-id-159' mangled-name='smb_only' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='115' column='1' elf-symbol-id='smb_only'/>
+
+    <array-type-def dimensions='1' type-id='type-id-88' size-in-bits='96' alignment-in-bits='32' id='type-id-160'>
+      <subrange length='3' type-id='type-id-37' id='type-id-136'/>
+
+    </array-type-def>
+    <var-decl name='share_all_proto' type-id='type-id-160' mangled-name='share_all_proto' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='119' column='1' elf-symbol-id='share_all_proto'/>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1505' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
-      <parameter type-id='type-id-104' name='mntopts' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+      <parameter type-id='type-id-86' name='mntopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1435' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-179'/>
-    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
-      <parameter type-id='type-id-179' name='handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
-      <parameter type-id='type-id-43' name='num_handles' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-110' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <parameter type-id='type-id-5' name='parallel' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
-      <return type-id='type-id-52'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-161'/>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
+      <parameter type-id='type-id-161' name='handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1374' column='1'/>
+      <parameter type-id='type-id-32' name='num_handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-92' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <parameter type-id='type-id-5' name='parallel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1375' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='625' column='1' id='type-id-180'>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='625' column='1' id='type-id-162'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_handles' type-id='type-id-179' visibility='default' filepath='../../include/libzfs.h' line='626' column='1'/>
+        <var-decl name='cb_handles' type-id='type-id-161' visibility='default' filepath='../../include/libzfs.h' line='626' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cb_alloc' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
+        <var-decl name='cb_alloc' type-id='type-id-32' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cb_used' type-id='type-id-43' visibility='default' filepath='../../include/libzfs.h' line='628' column='1'/>
+        <var-decl name='cb_used' type-id='type-id-32' visibility='default' filepath='../../include/libzfs.h' line='628' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='get_all_cb_t' type-id='type-id-180' filepath='../../include/libzfs.h' line='629' column='1' id='type-id-181'/>
-    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-182'/>
-    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
-      <parameter type-id='type-id-182' name='cbp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
-      <return type-id='type-id-52'/>
+    <typedef-decl name='get_all_cb_t' type-id='type-id-162' filepath='../../include/libzfs.h' line='629' column='1' id='type-id-163'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-164'/>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='type-id-164' name='cbp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1052' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1026' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
-      <parameter type-id='type-id-104' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='1002' column='1'/>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1001' column='1'/>
+      <parameter type-id='type-id-86' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1002' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='983' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='977' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='946' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='995' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
-      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='909' column='1'/>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1'/>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='909' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='893' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='893' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
-      <parameter type-id='type-id-104' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='type-id-86' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='876' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
-      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='849' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
-      <parameter type-id='type-id-23' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
+      <parameter type-id='type-id-23' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
+      <parameter type-id='type-id-88' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='843' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
-      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+      <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
-      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
+      <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='830' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='120' column='1' id='type-id-183'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='119' column='1' id='type-id-165'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='SHARED_NOT_SHARED' value='0'/>
       <enumerator name='SHARED_NFS' value='2'/>
       <enumerator name='SHARED_SMB' value='4'/>
     </enum-decl>
-    <typedef-decl name='zfs_share_type_t' type-id='type-id-183' filepath='../../include/libzfs_impl.h' line='124' column='1' id='type-id-184'/>
-    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
-      <return type-id='type-id-184'/>
+    <typedef-decl name='zfs_share_type_t' type-id='type-id-165' filepath='../../include/libzfs_impl.h' line='123' column='1' id='type-id-166'/>
+    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <parameter type-id='type-id-88' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='801' column='1'/>
+      <return type-id='type-id-166'/>
     </function-decl>
-    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='791' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
+    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='989' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
-      <parameter type-id='type-id-107' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
+    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='700' column='1'/>
+    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='699' column='1'/>
+      <parameter type-id='type-id-88' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='700' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1'/>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='680' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='663' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='589' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-104' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
+    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-86' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='382' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
-      <parameter type-id='type-id-104' name='options' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-86' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='367' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
-      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
+      <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='238' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
-      <parameter type-id='type-id-17' name='zfs_hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
-      <parameter type-id='type-id-104' name='special' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
-      <parameter type-id='type-id-161' name='where' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+    <function-decl name='is_mounted' mangled-name='is_mounted' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
+      <parameter type-id='type-id-17' name='zfs_hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-86' name='special' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
+      <parameter type-id='type-id-143' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='224' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zfs_is_mountable' mangled-name='zfs_is_mountable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mountable'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-43' name='buflen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
-      <parameter type-id='type-id-140' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+    <function-decl name='zfs_is_mountable' mangled-name='zfs_is_mountable' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mountable'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-32' name='buflen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='265' column='1'/>
+      <parameter type-id='type-id-122' name='source' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='266' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
-      <parameter type-id='type-id-106' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
-      <return type-id='type-id-184'/>
+    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <parameter type-id='type-id-88' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='718' column='1'/>
+      <return type-id='type-id-166'/>
     </function-decl>
-    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='qsort' mangled-name='qsort' filepath='/usr/include/stdlib.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' filepath='../../include/thread_pool.h' line='44' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tpool_create' mangled-name='tpool_create' filepath='../../include/thread_pool.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tpool_wait' mangled-name='tpool_wait' filepath='../../include/thread_pool.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='tpool_destroy' mangled-name='tpool_destroy' filepath='../../include/thread_pool.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='rmdir' mangled-name='rmdir' filepath='/usr/include/unistd.h' line='834' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' filepath='../../include/libzfs.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='../../lib/libspl/include/libshare.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='../../lib/libspl/include/libshare.h' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='../../lib/libspl/include/libshare.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='../../lib/libspl/include/libshare.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='../../lib/libspl/include/libshare.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' filepath='../../include/libzfs.h' line='229' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='../../include/libzfs.h' line='526' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='533' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='do_unmount' mangled-name='do_unmount' filepath='../../include/libzfs_impl.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='do_unmount' mangled-name='do_unmount' filepath='../../include/libzfs_impl.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' filepath='../../include/libzfs.h' line='817' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__lxstat' mangled-name='__lxstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='openat' mangled-name='openat64' filepath='/usr/include/fcntl.h' line='196' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fdopendir' mangled-name='fdopendir' filepath='/usr/include/dirent.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='readdir64' mangled-name='readdir64' filepath='/usr/include/dirent.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='closedir' mangled-name='closedir' filepath='/usr/include/dirent.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__xstat' mangled-name='__xstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='409' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='statfs64' mangled-name='statfs64' filepath='/usr/include/x86_64-linux-gnu/sys/statfs.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='do_mount' mangled-name='do_mount' filepath='../../include/libzfs_impl.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='do_mount' mangled-name='do_mount' filepath='../../include/libzfs_impl.h' line='243' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' filepath='../../include/libzfs.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mkdirp' mangled-name='mkdirp' filepath='../../lib/libspl/include/libgen.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='../../include/libzfs.h' line='532' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getprop_uint64' mangled-name='getprop_uint64' filepath='../../include/libzfs.h' line='510' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='../../lib/libspl/include/libshare.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
-      <parameter type-id='type-id-115' name='nvlp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
+      <parameter type-id='type-id-97' name='nvlp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-185'/>
-    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
-    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
-      <parameter type-id='type-id-186' name='envmap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
+    <qualified-type-def type-id='type-id-46' const='yes' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-168'/>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
+      <parameter type-id='type-id-168' name='envmap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-187'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-169'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
       <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
@@ -3221,131 +3106,131 @@
       <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
       <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
     </enum-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-187' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-188'/>
-    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
-      <parameter type-id='type-id-188' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
-      <parameter type-id='type-id-114' name='missing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
-      <parameter type-id='type-id-114' name='waited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-169' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-170'/>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
+      <parameter type-id='type-id-170' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
+      <parameter type-id='type-id-96' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
+      <parameter type-id='type-id-96' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
-      <parameter type-id='type-id-188' name='activity' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
+      <parameter type-id='type-id-170' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-27' name='dsobj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-27' name='obj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-23' name='pathname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
-      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-26' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-26' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-23' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <parameter type-id='type-id-32' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-27' name='dsobj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-27' name='obj' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
-      <parameter type-id='type-id-23' name='pathname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
-      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-26' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-26' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1'/>
+      <parameter type-id='type-id-23' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <parameter type-id='type-id-32' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4633' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
-      <parameter type-id='type-id-27' name='eid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
-      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+      <parameter type-id='type-id-26' name='eid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
-      <parameter type-id='type-id-141' name='count' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
+      <parameter type-id='type-id-123' name='count' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
-      <parameter type-id='type-id-115' name='nvp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
-      <parameter type-id='type-id-141' name='dropped' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
-      <parameter type-id='type-id-64' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
-      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-97' name='nvp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-123' name='dropped' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+      <parameter type-id='type-id-43' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+      <parameter type-id='type-id-6' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-115' name='nvhisp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-137' name='off' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-114' name='eof' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4391' column='1'/>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-97' name='nvhisp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-119' name='off' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
+      <parameter type-id='type-id-96' name='eof' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4391' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
-      <parameter type-id='type-id-104' name='message' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
+      <parameter type-id='type-id-86' name='message' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
-      <parameter type-id='type-id-6' name='argc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-23' name='string' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='type-id-6' name='argc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-143' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-23' name='string' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
-      <parameter type-id='type-id-27' name='new_version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
+      <parameter type-id='type-id-26' name='new_version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
-      <parameter type-id='type-id-115' name='nverrlistp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
+      <parameter type-id='type-id-97' name='nverrlistp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-22' name='nv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-6' name='name_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4070' column='1'/>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-22' name='nv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
+      <parameter type-id='type-id-6' name='name_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4070' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
+      <parameter type-id='type-id-26' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
-      <parameter type-id='type-id-22' name='rewindnvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+      <parameter type-id='type-id-22' name='rewindnvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
-      <parameter type-id='type-id-137' name='sizep' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3862' column='1'/>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
+      <parameter type-id='type-id-119' name='sizep' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3862' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='258' column='1' id='type-id-189'>
+    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='258' column='1' id='type-id-171'>
       <data-member access='public' layout-offset-in-bits='31'>
         <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='260' column='1'/>
       </data-member>
@@ -3356,30 +3241,30 @@
         <var-decl name='name_flags' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='splitflags_t' type-id='type-id-189' filepath='../../include/libzfs.h' line='265' column='1' id='type-id-190'/>
-    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-23' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-115' name='newroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
-      <parameter type-id='type-id-190' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
+    <typedef-decl name='splitflags_t' type-id='type-id-171' filepath='../../include/libzfs.h' line='265' column='1' id='type-id-172'/>
+    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-23' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-97' name='newroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
+      <parameter type-id='type-id-172' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
-      <parameter type-id='type-id-104' name='old_disk' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
-      <parameter type-id='type-id-104' name='new_disk' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-6' name='replacing' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-5' name='rebuild' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-86' name='old_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-86' name='new_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-6' name='replacing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+      <parameter type-id='type-id-5' name='rebuild' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='vdev_aux' filepath='../../include/sys/fs/zfs.h' line='884' column='1' id='type-id-191'>
+    <enum-decl name='vdev_aux' filepath='../../include/sys/fs/zfs.h' line='884' column='1' id='type-id-173'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='VDEV_AUX_NONE' value='0'/>
       <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
@@ -3403,26 +3288,26 @@
       <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
       <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
     </enum-decl>
-    <typedef-decl name='vdev_aux_t' type-id='type-id-191' filepath='../../include/sys/fs/zfs.h' line='906' column='1' id='type-id-192'/>
-    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
-      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+    <typedef-decl name='vdev_aux_t' type-id='type-id-173' filepath='../../include/sys/fs/zfs.h' line='906' column='1' id='type-id-174'/>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+      <parameter type-id='type-id-26' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+      <parameter type-id='type-id-174' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
-      <parameter type-id='type-id-27' name='guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
-      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+      <parameter type-id='type-id-26' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+      <parameter type-id='type-id-174' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
-      <parameter type-id='type-id-5' name='istmp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+      <parameter type-id='type-id-5' name='istmp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='vdev_state' filepath='../../include/sys/fs/zfs.h' line='867' column='1' id='type-id-193'>
+    <enum-decl name='vdev_state' filepath='../../include/sys/fs/zfs.h' line='867' column='1' id='type-id-175'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
       <enumerator name='VDEV_STATE_CLOSED' value='1'/>
@@ -3433,72 +3318,72 @@
       <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
       <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
     </enum-decl>
-    <typedef-decl name='vdev_state_t' type-id='type-id-193' filepath='../../include/sys/fs/zfs.h' line='876' column='1' id='type-id-194'/>
-    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
-    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-195' name='newstate' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3030' column='1'/>
+    <typedef-decl name='vdev_state_t' type-id='type-id-175' filepath='../../include/sys/fs/zfs.h' line='876' column='1' id='type-id-176'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
+      <parameter type-id='type-id-177' name='newstate' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3030' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
-      <parameter type-id='type-id-23' name='physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
-      <parameter type-id='type-id-43' name='phypath_size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+      <parameter type-id='type-id-23' name='physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+      <parameter type-id='type-id-32' name='phypath_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-114' name='l2cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
-      <parameter type-id='type-id-114' name='log' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-96' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-96' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
+      <parameter type-id='type-id-96' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
-      <parameter type-id='type-id-104' name='ppath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
-      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
-      <parameter type-id='type-id-114' name='l2cache' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
-      <parameter type-id='type-id-114' name='log' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-86' name='ppath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-96' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+      <parameter type-id='type-id-96' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+      <parameter type-id='type-id-96' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='938' column='1' id='type-id-196'>
+    <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='938' column='1' id='type-id-178'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_SCAN_NONE' value='0'/>
       <enumerator name='POOL_SCAN_SCRUB' value='1'/>
       <enumerator name='POOL_SCAN_RESILVER' value='2'/>
       <enumerator name='POOL_SCAN_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_scan_func_t' type-id='type-id-196' filepath='../../include/sys/fs/zfs.h' line='943' column='1' id='type-id-197'/>
-    <enum-decl name='pool_scrub_cmd' filepath='../../include/sys/fs/zfs.h' line='948' column='1' id='type-id-198'>
+    <typedef-decl name='pool_scan_func_t' type-id='type-id-178' filepath='../../include/sys/fs/zfs.h' line='943' column='1' id='type-id-179'/>
+    <enum-decl name='pool_scrub_cmd' filepath='../../include/sys/fs/zfs.h' line='948' column='1' id='type-id-180'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
       <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
       <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
     </enum-decl>
-    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-198' filepath='../../include/sys/fs/zfs.h' line='952' column='1' id='type-id-199'/>
-    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
-      <parameter type-id='type-id-197' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
-      <parameter type-id='type-id-199' name='cmd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-180' filepath='../../include/sys/fs/zfs.h' line='952' column='1' id='type-id-181'/>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+      <parameter type-id='type-id-179' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+      <parameter type-id='type-id-181' name='cmd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-200'>
+    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-182'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_TRIM_START' value='0'/>
       <enumerator name='POOL_TRIM_CANCEL' value='1'/>
       <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
       <enumerator name='POOL_TRIM_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='type-id-200' filepath='../../include/sys/fs/zfs.h' line='1182' column='1' id='type-id-201'/>
-    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='267' column='1' id='type-id-202'>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-182' filepath='../../include/sys/fs/zfs.h' line='1182' column='1' id='type-id-183'/>
+    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='267' column='1' id='type-id-184'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='fullpool' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='269' column='1'/>
       </data-member>
@@ -3509,160 +3394,160 @@
         <var-decl name='wait' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='275' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='rate' type-id='type-id-27' visibility='default' filepath='../../include/libzfs.h' line='278' column='1'/>
+        <var-decl name='rate' type-id='type-id-26' visibility='default' filepath='../../include/libzfs.h' line='278' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='trimflags_t' type-id='type-id-202' filepath='../../include/libzfs.h' line='279' column='1' id='type-id-203'/>
-    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-204'/>
-    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-201' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-204' name='trim_flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2427' column='1'/>
+    <typedef-decl name='trimflags_t' type-id='type-id-184' filepath='../../include/libzfs.h' line='279' column='1' id='type-id-185'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-183' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
+      <parameter type-id='type-id-186' name='trim_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2427' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-205'>
+    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-187'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='POOL_INITIALIZE_START' value='0'/>
       <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
       <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
       <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='type-id-205' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-206'/>
-    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
-      <parameter type-id='type-id-206' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-187' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-188'/>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-188' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
-      <parameter type-id='type-id-206' name='cmd_type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
-      <parameter type-id='type-id-22' name='vds' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-188' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1'/>
+      <parameter type-id='type-id-22' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2318' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-104' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-86' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
-      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='type-id-22' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-104' name='newname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-23' name='altroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1833' column='1'/>
+    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-86' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
+      <parameter type-id='type-id-23' name='altroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1833' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-6' name='reason' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1746' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-6' name='reason' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
+      <parameter type-id='type-id-22' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1746' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
-      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
+      <parameter type-id='type-id-86' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
-      <parameter type-id='type-id-5' name='force' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
-      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+      <parameter type-id='type-id-5' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+      <parameter type-id='type-id-86' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
+    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
-      <parameter type-id='type-id-104' name='log_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
+      <parameter type-id='type-id-86' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-22' name='nvroot' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
-      <parameter type-id='type-id-22' name='fsprops' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-22' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+      <parameter type-id='type-id-22' name='fsprops' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1'/>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1'/>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
-      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
+    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-207'/>
-    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
-      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
-      <parameter type-id='type-id-207' name='ret' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+      <parameter type-id='type-id-189' name='ret' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
-      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
-      <parameter type-id='type-id-5' name='isopen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
-      <parameter type-id='type-id-104' name='pool' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+      <parameter type-id='type-id-5' name='isopen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
+      <parameter type-id='type-id-32' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
-      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
+      <parameter type-id='type-id-114' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
-      <parameter type-id='type-id-104' name='propval' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+      <parameter type-id='type-id-86' name='propval' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='215' column='1' id='type-id-208'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='215' column='1' id='type-id-190'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
       <enumerator name='ZPOOL_PROP_NAME' value='0'/>
@@ -3700,40 +3585,40 @@
       <enumerator name='ZPOOL_PROP_COMPATIBILITY' value='32'/>
       <enumerator name='ZPOOL_NUM_PROPS' value='33'/>
     </enum-decl>
-    <typedef-decl name='zpool_prop_t' type-id='type-id-208' filepath='../../include/sys/fs/zfs.h' line='251' column='1' id='type-id-209'/>
-    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
-      <parameter type-id='type-id-209' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
-      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
-      <parameter type-id='type-id-140' name='srctype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
-      <parameter type-id='type-id-5' name='literal' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+    <typedef-decl name='zpool_prop_t' type-id='type-id-190' filepath='../../include/sys/fs/zfs.h' line='251' column='1' id='type-id-191'/>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1'/>
+      <parameter type-id='type-id-32' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+      <parameter type-id='type-id-122' name='srctype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
+      <parameter type-id='type-id-5' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='285' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
-      <parameter type-id='type-id-172' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
+      <parameter type-id='type-id-154' name='state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='221' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
-      <parameter type-id='type-id-194' name='state' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
-      <parameter type-id='type-id-192' name='aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
+      <parameter type-id='type-id-176' name='state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
+      <parameter type-id='type-id-174' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='188' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
-      <parameter type-id='type-id-209' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
-      <parameter type-id='type-id-140' name='src' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+      <parameter type-id='type-id-122' name='src' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='146' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1'/>
+    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='252' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='924' column='1' id='type-id-210'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='924' column='1' id='type-id-192'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
       <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
@@ -3741,173 +3626,173 @@
       <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
       <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_compat_status_t' type-id='type-id-210' filepath='../../include/libzfs.h' line='930' column='1' id='type-id-211'/>
-    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
-      <parameter type-id='type-id-104' name='compat' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-114' name='features' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-23' name='report' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-43' name='rlen' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_pool.c' line='4752' column='1'/>
-      <return type-id='type-id-211'/>
+    <typedef-decl name='zpool_compat_status_t' type-id='type-id-192' filepath='../../include/libzfs.h' line='930' column='1' id='type-id-193'/>
+    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
+      <parameter type-id='type-id-86' name='compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-96' name='features' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-23' name='report' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
+      <parameter type-id='type-id-32' name='rlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4752' column='1'/>
+      <return type-id='type-id-193'/>
     </function-decl>
     <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='../../include/libzfs_core.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='../../include/libzfs_core.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_wait' mangled-name='lzc_wait' filepath='../../include/libzfs_core.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' filepath='../../include/libzutil.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' filepath='../../include/sys/nvpair.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__xpg_basename' mangled-name='__xpg_basename' filepath='/usr/include/libgen.h' line='34' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='memcmp' mangled-name='memcmp' filepath='/usr/include/string.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='realpath' mangled-name='realpath' filepath='/usr/include/stdlib.h' line='797' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strncasecmp' mangled-name='strncasecmp' filepath='/usr/include/strings.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' filepath='../../include/libzutil.h' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' filepath='../../include/libzutil.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='../../include/libzfs.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' filepath='../../include/sys/nvpair.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_sync' mangled-name='lzc_sync' filepath='../../include/libzfs_core.h' line='128' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='../../include/libzfs_core.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../include/zfs_comutil.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' filepath='../../include/libzfs.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' filepath='../../include/zfeature_common.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='../../include/libzutil.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtoull' mangled-name='strtoull' filepath='/usr/include/stdlib.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' filepath='../../include/libzutil.h' line='102' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' filepath='../../include/libzfs_core.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_trim' mangled-name='lzc_trim' filepath='../../include/libzfs_core.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' filepath='../../include/sys/nvpair.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_initialize' mangled-name='lzc_initialize' filepath='../../include/libzfs_core.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' filepath='../../include/zfeature_common.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' filepath='../../include/libzfs_core.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' filepath='../../include/libzfs_core.h' line='131' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' filepath='../../include/sys/nvpair.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' filepath='../../include/libzfs.h' line='414' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pool_namecheck' mangled-name='pool_namecheck' filepath='../../include/zfs_namecheck.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' filepath='../../include/sys/fs/zfs.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' filepath='../../include/zfeature_common.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' filepath='../../include/libzfs.h' line='811' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' filepath='../../include/sys/fs/zfs.h' line='325' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' filepath='../../include/sys/fs/zfs.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' filepath='../../include/sys/fs/zfs.h' line='330' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='../../lib/libspl/include/sys/systeminfo.h' line='36' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' filepath='../../include/zfs_prop.h' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' filepath='../../include/sys/fs/zfs.h' line='333' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../include/libzfs.h' line='567' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../include/libzfs.h' line='566' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mmap' mangled-name='mmap64' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='munmap' mangled-name='munmap' filepath='/usr/include/x86_64-linux-gnu/sys/mman.h' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtok_r' mangled-name='strtok_r' filepath='/usr/include/string.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strchrnul' mangled-name='strchrnul' filepath='/usr/include/string.h' line='265' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='../../include/libzfs.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' filepath='../../include/sys/nvpair.h' line='295' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='747' column='1' id='type-id-212'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='747' column='1' id='type-id-194'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='verbose' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='749' column='1'/>
       </data-member>
@@ -3948,19 +3833,19 @@
         <var-decl name='forceunmount' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='791' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='recvflags_t' type-id='type-id-212' filepath='../../include/libzfs.h' line='792' column='1' id='type-id-213'/>
-    <pointer-type-def type-id='type-id-213' size-in-bits='64' id='type-id-214'/>
-    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-215'/>
-    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-22' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
-      <parameter type-id='type-id-214' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
-      <parameter type-id='type-id-6' name='infd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
-      <parameter type-id='type-id-215' name='stream_avl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+    <typedef-decl name='recvflags_t' type-id='type-id-194' filepath='../../include/libzfs.h' line='792' column='1' id='type-id-195'/>
+    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-196'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-197'/>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-86' name='tosnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-22' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5121' column='1'/>
+      <parameter type-id='type-id-196' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+      <parameter type-id='type-id-6' name='infd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
+      <parameter type-id='type-id-197' name='stream_avl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5122' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='663' column='1' id='type-id-216'>
+    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='663' column='1' id='type-id-198'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='verbosity' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='665' column='1'/>
       </data-member>
@@ -4013,168 +3898,168 @@
         <var-decl name='saved' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='713' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='sendflags_t' type-id='type-id-216' filepath='../../include/libzfs.h' line='714' column='1' id='type-id-217'/>
-    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-218'/>
-    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-104' name='from' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
-      <parameter type-id='type-id-104' name='redactbook' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2396' column='1'/>
+    <typedef-decl name='sendflags_t' type-id='type-id-198' filepath='../../include/libzfs.h' line='714' column='1' id='type-id-199'/>
+    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-200'/>
+    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-86' name='from' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-200' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2395' column='1'/>
+      <parameter type-id='type-id-86' name='redactbook' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2396' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <typedef-decl name='snapfilter_cb_t' type-id='type-id-219' filepath='../../include/libzfs.h' line='716' column='1' id='type-id-220'/>
-    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-221'/>
-    <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-104' name='fromsnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-104' name='tosnap' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
-      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-221' name='filter_func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
-      <parameter type-id='type-id-42' name='cb_arg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
-      <parameter type-id='type-id-115' name='debugnvp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
+    <typedef-decl name='snapfilter_cb_t' type-id='type-id-201' filepath='../../include/libzfs.h' line='716' column='1' id='type-id-202'/>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-203'/>
+    <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-86' name='fromsnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-86' name='tosnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
+      <parameter type-id='type-id-200' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-203' name='filter_func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2121' column='1'/>
+      <parameter type-id='type-id-68' name='cb_arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
+      <parameter type-id='type-id-97' name='debugnvp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2122' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
-      <parameter type-id='type-id-104' name='resume_token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1869' column='1'/>
+    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-200' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1868' column='1'/>
+      <parameter type-id='type-id-86' name='resume_token' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1869' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-218' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-6' name='outfd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
-      <parameter type-id='type-id-104' name='resume_token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1843' column='1'/>
+    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-200' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-6' name='outfd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1842' column='1'/>
+      <parameter type-id='type-id-86' name='resume_token' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1843' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
-      <parameter type-id='type-id-104' name='token' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
+    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
+      <parameter type-id='type-id-86' name='token' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1369' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-6' name='fd' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-137' name='bytes_written' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
-      <parameter type-id='type-id-137' name='blocks_visited' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_sendrecv.c' line='884' column='1'/>
+    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-6' name='fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-119' name='bytes_written' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='883' column='1'/>
+      <parameter type-id='type-id-119' name='blocks_visited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='884' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='perror' mangled-name='perror' filepath='/usr/include/stdio.h' line='781' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' filepath='../../include/libzfs.h' line='492' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' filepath='../../include/sys/nvpair.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' filepath='../../include/zfs_fletcher.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strcat' mangled-name='strcat' filepath='/usr/include/string.h' line='129' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../include/sys/nvpair.h' line='283' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='create_parents' mangled-name='create_parents' filepath='../../include/libzfs_impl.h' line='193' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='../../include/libzfs_impl.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../include/sys/nvpair.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='time' mangled-name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' filepath='../../include/sys/nvpair.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' filepath='../../include/sys/nvpair.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' filepath='../../include/libzfs_core.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sprintf' mangled-name='sprintf' filepath='/usr/include/stdio.h' line='334' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='339' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' filepath='../../include/libzfs_core.h' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='../../include/libzfs.h' line='732' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='../../include/libzfs.h' line='472' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_size' mangled-name='fnvlist_size' filepath='../../include/sys/nvpair.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../include/zfs_fletcher.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='write' mangled-name='write' filepath='/usr/include/unistd.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' filepath='../../include/sys/nvpair.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strndup' mangled-name='strndup' filepath='/usr/include/string.h' line='174' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' filepath='../../include/libzfs_core.h' line='94' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='nvlist_print' mangled-name='nvlist_print' filepath='../../include/libnvpair.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' filepath='../../include/libzfs_core.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' filepath='../../include/zfs_fletcher.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='/usr/include/zlib.h' line='1265' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' filepath='../../include/libzfs.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_send_space' mangled-name='lzc_send_space' filepath='../../include/libzfs_core.h' line='109' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sleep' mangled-name='sleep' filepath='/usr/include/unistd.h' line='444' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='localtime' mangled-name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='../../include/libzfs.h' line='517' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='lzc_rename' mangled-name='lzc_rename' filepath='../../include/libzfs_core.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-219'>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-201'>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-5'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='339' column='1' id='type-id-222'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='339' column='1' id='type-id-204'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_STATUS_CORRUPT_CACHE' value='0'/>
       <enumerator name='ZPOOL_STATUS_MISSING_DEV_R' value='1'/>
@@ -4210,8 +4095,8 @@
       <enumerator name='ZPOOL_STATUS_INCOMPATIBLE_FEAT' value='31'/>
       <enumerator name='ZPOOL_STATUS_OK' value='32'/>
     </enum-decl>
-    <typedef-decl name='zpool_status_t' type-id='type-id-222' filepath='../../include/libzfs.h' line='402' column='1' id='type-id-223'/>
-    <enum-decl name='zpool_errata' filepath='../../include/sys/fs/zfs.h' line='1050' column='1' id='type-id-224'>
+    <typedef-decl name='zpool_status_t' type-id='type-id-204' filepath='../../include/libzfs.h' line='402' column='1' id='type-id-205'/>
+    <enum-decl name='zpool_errata' filepath='../../include/sys/fs/zfs.h' line='1050' column='1' id='type-id-206'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_ERRATA_NONE' value='0'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_2094_SCRUB' value='1'/>
@@ -4219,93 +4104,93 @@
       <enumerator name='ZPOOL_ERRATA_ZOL_6845_ENCRYPTION' value='3'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_errata_t' type-id='type-id-224' filepath='../../include/sys/fs/zfs.h' line='1056' column='1' id='type-id-225'/>
-    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-226'/>
-    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
-      <parameter type-id='type-id-22' name='config' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
-      <parameter type-id='type-id-161' name='msgid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
-      <parameter type-id='type-id-226' name='errata' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
-      <return type-id='type-id-223'/>
+    <typedef-decl name='zpool_errata_t' type-id='type-id-206' filepath='../../include/sys/fs/zfs.h' line='1056' column='1' id='type-id-207'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='533' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
+      <parameter type-id='type-id-22' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <parameter type-id='type-id-143' name='msgid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <parameter type-id='type-id-208' name='errata' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='533' column='1'/>
+      <return type-id='type-id-205'/>
     </function-decl>
-    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
-      <parameter type-id='type-id-161' name='msgid' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
-      <parameter type-id='type-id-226' name='errata' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
-      <return type-id='type-id-223'/>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='509' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <parameter type-id='type-id-143' name='msgid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <parameter type-id='type-id-208' name='errata' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
+      <return type-id='type-id-205'/>
     </function-decl>
     <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='../../include/libzfs.h' line='932' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='printf_color' mangled-name='printf_color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
-      <parameter type-id='type-id-23' name='color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
-      <parameter type-id='type-id-23' name='format' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2084' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='printf_color' mangled-name='printf_color' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
+      <parameter type-id='type-id-23' name='color' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2062' column='1'/>
+      <parameter type-id='type-id-23' name='format' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2062' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='color_end' mangled-name='color_end' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
-      <return type-id='type-id-52'/>
+    <function-decl name='color_end' mangled-name='color_end' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2054' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='color_start' mangled-name='color_start' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
-      <parameter type-id='type-id-23' name='color' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='2069' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='color_start' mangled-name='color_start' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2047' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
+      <parameter type-id='type-id-23' name='color' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='2047' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1990' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
+    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
-      <parameter type-id='type-id-23' name='version' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1980' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1958' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
+      <parameter type-id='type-id-23' name='version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1958' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1958' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-228'/>
-    <typedef-decl name='zprop_func' type-id='type-id-228' filepath='../../include/sys/fs/zfs.h' line='287' column='1' id='type-id-229'/>
-    <function-decl name='zprop_iter' mangled-name='zprop_iter' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
-      <parameter type-id='type-id-229' name='func' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-42' name='cb' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-5' name='show_all' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-5' name='ordered' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1970' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1971' column='1'/>
+    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-210'/>
+    <typedef-decl name='zprop_func' type-id='type-id-210' filepath='../../include/sys/fs/zfs.h' line='287' column='1' id='type-id-211'/>
+    <function-decl name='zprop_iter' mangled-name='zprop_iter' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1948' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
+      <parameter type-id='type-id-211' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1948' column='1'/>
+      <parameter type-id='type-id-68' name='cb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1948' column='1'/>
+      <parameter type-id='type-id-5' name='show_all' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1948' column='1'/>
+      <parameter type-id='type-id-5' name='ordered' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1948' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1949' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_expand_list'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
-      <parameter type-id='type-id-132' name='plp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1929' column='1'/>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1907' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_expand_list'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1907' column='1'/>
+      <parameter type-id='type-id-114' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1907' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1907' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
-      <parameter type-id='type-id-131' name='pl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1891' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1869' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
+      <parameter type-id='type-id-113' name='pl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1869' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-23' name='props' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-132' name='listp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1810' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1811' column='1'/>
+    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1788' column='1'/>
+      <parameter type-id='type-id-23' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1788' column='1'/>
+      <parameter type-id='type-id-114' name='listp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1788' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1789' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-230'>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-212'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
+        <var-decl name='nvp_size' type-id='type-id-40' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='type-id-231' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
+        <var-decl name='nvp_name_sz' type-id='type-id-213' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='type-id-231' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+        <var-decl name='nvp_reserve' type-id='type-id-213' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='type-id-61' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+        <var-decl name='nvp_value_elem' type-id='type-id-40' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='type-id-232' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+        <var-decl name='nvp_type' type-id='type-id-214' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int16_t' type-id='type-id-74' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-233'/>
-    <typedef-decl name='int16_t' type-id='type-id-233' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-231'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-234'>
+    <typedef-decl name='__int16_t' type-id='type-id-54' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-215'/>
+    <typedef-decl name='int16_t' type-id='type-id-215' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-213'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-216'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
       <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
@@ -4337,35 +4222,35 @@
       <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
       <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
     </enum-decl>
-    <typedef-decl name='data_type_t' type-id='type-id-234' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-232'/>
-    <typedef-decl name='nvpair_t' type-id='type-id-230' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-235'/>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
-    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_parse_value'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
-      <parameter type-id='type-id-236' name='elem' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
-      <parameter type-id='type-id-6' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1602' column='1'/>
-      <parameter type-id='type-id-20' name='type' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
-      <parameter type-id='type-id-22' name='ret' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
-      <parameter type-id='type-id-161' name='svalp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
-      <parameter type-id='type-id-137' name='ivalp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1603' column='1'/>
-      <parameter type-id='type-id-104' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1604' column='1'/>
+    <typedef-decl name='data_type_t' type-id='type-id-216' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-214'/>
+    <typedef-decl name='nvpair_t' type-id='type-id-212' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-218'/>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_parse_value'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1580' column='1'/>
+      <parameter type-id='type-id-218' name='elem' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1580' column='1'/>
+      <parameter type-id='type-id-6' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1580' column='1'/>
+      <parameter type-id='type-id-20' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1581' column='1'/>
+      <parameter type-id='type-id-22' name='ret' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1581' column='1'/>
+      <parameter type-id='type-id-143' name='svalp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1581' column='1'/>
+      <parameter type-id='type-id-119' name='ivalp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1581' column='1'/>
+      <parameter type-id='type-id-86' name='errbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1582' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
-      <parameter type-id='type-id-104' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
-      <parameter type-id='type-id-137' name='num' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1517' column='1'/>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1495' column='1'/>
+      <parameter type-id='type-id-86' name='value' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1495' column='1'/>
+      <parameter type-id='type-id-119' name='num' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1495' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='594' column='1' id='type-id-237'>
+    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='594' column='1' id='type-id-219'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='cb_sources' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='595' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cb_columns' type-id='type-id-238' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
+        <var-decl name='cb_columns' type-id='type-id-220' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cb_colwidths' type-id='type-id-239' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
+        <var-decl name='cb_colwidths' type-id='type-id-221' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='cb_scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
@@ -4377,13 +4262,13 @@
         <var-decl name='cb_first' type-id='type-id-5' visibility='default' filepath='../../include/libzfs.h' line='600' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='cb_proplist' type-id='type-id-131' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
+        <var-decl name='cb_proplist' type-id='type-id-113' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='cb_type' type-id='type-id-20' visibility='default' filepath='../../include/libzfs.h' line='602' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='582' column='1' id='type-id-240'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='582' column='1' id='type-id-222'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='GET_COL_NONE' value='0'/>
       <enumerator name='GET_COL_NAME' value='1'/>
@@ -4392,518 +4277,518 @@
       <enumerator name='GET_COL_RECVD' value='4'/>
       <enumerator name='GET_COL_SOURCE' value='5'/>
     </enum-decl>
-    <typedef-decl name='zfs_get_column_t' type-id='type-id-240' filepath='../../include/libzfs.h' line='589' column='1' id='type-id-241'/>
+    <typedef-decl name='zfs_get_column_t' type-id='type-id-222' filepath='../../include/libzfs.h' line='589' column='1' id='type-id-223'/>
 
-    <array-type-def dimensions='1' type-id='type-id-241' size-in-bits='160' alignment-in-bits='32' id='type-id-238'>
-      <subrange length='5' type-id='type-id-48' id='type-id-242'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='192' id='type-id-239'>
-      <subrange length='6' type-id='type-id-48' id='type-id-243'/>
+    <array-type-def dimensions='1' type-id='type-id-223' size-in-bits='160' alignment-in-bits='32' id='type-id-220'>
+      <subrange length='5' type-id='type-id-37' id='type-id-224'/>
 
     </array-type-def>
-    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-237' filepath='../../include/libzfs.h' line='603' column='1' id='type-id-244'/>
-    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-245'/>
-    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
-      <parameter type-id='type-id-245' name='cbp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1385' column='1'/>
-      <parameter type-id='type-id-104' name='propname' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-104' name='value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-139' name='sourcetype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1386' column='1'/>
-      <parameter type-id='type-id-104' name='source' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
-      <parameter type-id='type-id-104' name='recvd_value' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1387' column='1'/>
-      <return type-id='type-id-52'/>
+
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='192' id='type-id-221'>
+      <subrange length='6' type-id='type-id-37' id='type-id-225'/>
+
+    </array-type-def>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-219' filepath='../../include/libzfs.h' line='603' column='1' id='type-id-226'/>
+    <pointer-type-def type-id='type-id-226' size-in-bits='64' id='type-id-227'/>
+    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1363' column='1'/>
+      <parameter type-id='type-id-227' name='cbp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1363' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1364' column='1'/>
+      <parameter type-id='type-id-86' name='value' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1364' column='1'/>
+      <parameter type-id='type-id-121' name='sourcetype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1364' column='1'/>
+      <parameter type-id='type-id-86' name='source' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1365' column='1'/>
+      <parameter type-id='type-id-86' name='recvd_value' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1365' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_read_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
-      <parameter type-id='type-id-115' name='nvlp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1245' column='1'/>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1223' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_read_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1223' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1223' column='1'/>
+      <parameter type-id='type-id-97' name='nvlp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1223' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_src_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_src_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_conf_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
-      <parameter type-id='type-id-22' name='nvl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1235' column='1'/>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_write_conf_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
+      <parameter type-id='type-id-22' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1213' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_free_nvlists'>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1197' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_free_nvlists'>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1175' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_expand_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1182' column='1'/>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_expand_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1160' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1160' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_alloc_dst_nvlist'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
-      <parameter type-id='type-id-43' name='len' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1163' column='1'/>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_alloc_dst_nvlist'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1141' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1141' column='1'/>
+      <parameter type-id='type-id-32' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1141' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <parameter type-id='type-id-20' name='argtype' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1130' column='1'/>
-      <return type-id='type-id-102'/>
+    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
+      <parameter type-id='type-id-20' name='argtype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
-      <parameter type-id='type-id-136' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1118' column='1'/>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1100' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
+      <parameter type-id='type-id-118' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1100' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
-      <parameter type-id='type-id-102' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1112' column='1'/>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1094' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
+      <parameter type-id='type-id-84' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1094' column='1'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
-      <parameter type-id='type-id-18' name='zhp' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1106' column='1'/>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1088' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
+      <parameter type-id='type-id-18' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1088' column='1'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1087' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1075' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1075' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
-      <parameter type-id='type-id-23' name='envvar' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='991' column='1'/>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='991' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
+      <parameter type-id='type-id-23' name='envvar' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='991' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
-      <parameter type-id='type-id-161' name='strs' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
-      <parameter type-id='type-id-6' name='count' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
+      <parameter type-id='type-id-143' name='strs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
+      <parameter type-id='type-id-6' name='count' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='976' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-246'/>
-    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-161' name='env' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-246' name='lines' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-141' name='lines_cnt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-228'/>
+    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='964' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-143' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-143' name='env' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-228' name='lines' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-123' name='lines_cnt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
-      <parameter type-id='type-id-161' name='env' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-246' name='lines' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
-      <parameter type-id='type-id-141' name='lines_cnt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-143' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='964' column='1'/>
+      <parameter type-id='type-id-143' name='env' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-228' name='lines' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
+      <parameter type-id='type-id-123' name='lines_cnt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='965' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
-      <parameter type-id='type-id-104' name='path' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
-      <parameter type-id='type-id-161' name='argv' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
-      <parameter type-id='type-id-6' name='flags' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
+      <parameter type-id='type-id-86' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+      <parameter type-id='type-id-143' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
+      <parameter type-id='type-id-6' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='941' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <parameter type-id='type-id-5' name='enable' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_dataset.c' line='865' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='823' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <parameter type-id='type-id-5' name='enable' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='866' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strdup'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
-      <parameter type-id='type-id-104' name='str' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strdup'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
+      <parameter type-id='type-id-86' name='str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='812' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_realloc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-42' name='ptr' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-43' name='oldsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <parameter type-id='type-id-43' name='newsize' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
-      <return type-id='type-id-42'/>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_realloc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-68' name='ptr' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-32' name='oldsize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <parameter type-id='type-id-32' name='newsize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='795' column='1'/>
+      <return type-id='type-id-68'/>
     </function-decl>
-    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_asprintf'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
-      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='773' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_asprintf'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
+      <parameter type-id='type-id-86' name='fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='773' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_alloc'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
-      <parameter type-id='type-id-43' name='size' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
-      <return type-id='type-id-42'/>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_alloc'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <parameter type-id='type-id-32' name='size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='758' column='1'/>
+      <return type-id='type-id-68'/>
     </function-decl>
-    <function-decl name='no_memory' mangled-name='no_memory' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='no_memory'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='749' column='1'/>
+    <function-decl name='no_memory' mangled-name='no_memory' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='no_memory'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='749' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
-      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
+      <parameter type-id='type-id-86' name='fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='615' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_standard_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-86' name='msg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_setprop_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-2' name='prop' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-6' name='err' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
-      <parameter type-id='type-id-23' name='errbuf' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='497' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_setprop_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-2' name='prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-6' name='err' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='496' column='1'/>
+      <parameter type-id='type-id-23' name='errbuf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='497' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
-      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
+      <parameter type-id='type-id-86' name='fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='405' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-86' name='msg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_fmt'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
-      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_fmt'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
+      <parameter type-id='type-id-86' name='fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='354' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-6' name='error' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
-      <parameter type-id='type-id-104' name='msg' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+    <function-decl name='zfs_error' mangled-name='zfs_error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-6' name='error' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
+      <parameter type-id='type-id-86' name='msg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='608' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_aux'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
-      <parameter type-id='type-id-104' name='fmt' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_error_aux'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
+      <parameter type-id='type-id-86' name='fmt' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='306' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='76' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='76' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='70' column='1'/>
+    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='70' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
-      <parameter type-id='type-id-17' name='hdl' filepath='/home/colm/src/zfs/zfs/lib/libzfs/libzfs_util.c' line='82' column='1'/>
-      <return type-id='type-id-104'/>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
+      <parameter type-id='type-id-17' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='82' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='vfprintf' mangled-name='vfprintf' filepath='/usr/include/stdio.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='../../include/libzfs.h' line='889' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' filepath='../../include/zfs_prop.h' line='120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_width' mangled-name='zprop_width' filepath='../../include/zfs_prop.h' line='126' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' filepath='../../include/zfs_prop.h' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' filepath='../../include/zfs_prop.h' line='127' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' filepath='../../include/sys/fs/zfs.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' filepath='../../include/zfs_prop.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_values' mangled-name='zprop_values' filepath='../../include/zfs_prop.h' line='125' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strtod' mangled-name='strtod' filepath='/usr/include/stdlib.h' line='117' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='pow' mangled-name='pow' filepath='/usr/include/x86_64-linux-gnu/bits/mathcalls.h' line='140' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__ctype_toupper_loc' mangled-name='__ctype_toupper_loc' filepath='/usr/include/ctype.h' line='83' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='getextmntent' mangled-name='getextmntent' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' filepath='../../include/libzfs.h' line='241' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='../../include/libzfs_impl.h' line='207' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' filepath='../../include/libzfs_impl.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' filepath='../../include/libzfs.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' filepath='../../include/libzfs_core.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='regfree' mangled-name='regfree' filepath='/usr/include/regex.h' line='651' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' filepath='../../include/zfs_fletcher.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' filepath='../../include/zfs_prop.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../include/zfs_prop.h' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='regcomp' mangled-name='regcomp' filepath='/usr/include/regex.h' line='639' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' filepath='../../include/libzfs_core.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' filepath='../../include/zfs_prop.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' filepath='../../include/zfs_prop.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' filepath='../../include/zfeature_common.h' line='128' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' filepath='../../include/libzfs.h' line='222' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' filepath='../../include/zfs_fletcher.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='strnlen' mangled-name='strnlen' filepath='/usr/include/string.h' line='390' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='realloc' mangled-name='realloc' filepath='/usr/include/stdlib.h' line='549' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='waitpid' mangled-name='waitpid' filepath='/usr/include/x86_64-linux-gnu/sys/wait.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='vfork' mangled-name='vfork' filepath='/usr/include/unistd.h' line='764' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='execve' mangled-name='execve' filepath='/usr/include/unistd.h' line='551' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='_exit' mangled-name='_exit' filepath='/usr/include/unistd.h' line='603' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='dup2' mangled-name='dup2' filepath='/usr/include/unistd.h' line='534' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='execvpe' mangled-name='execvpe' filepath='/usr/include/unistd.h' line='590' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='execv' mangled-name='execv' filepath='/usr/include/unistd.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='execvp' mangled-name='execvp' filepath='/usr/include/unistd.h' line='578' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='vasprintf' mangled-name='vasprintf' filepath='/usr/include/stdio.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='vsnprintf' mangled-name='vsnprintf' filepath='/usr/include/stdio.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='exit' mangled-name='exit' filepath='/usr/include/stdlib.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-227'>
+    <function-type size-in-bits='64' id='type-id-209'>
       <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-6'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' filepath='os/linux/libzfs_mount_os.c' line='410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='do_unmount' mangled-name='do_unmount' filepath='os/linux/libzfs_mount_os.c' line='377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_unmount'>
-      <parameter type-id='type-id-104' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
+      <parameter type-id='type-id-86' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
       <parameter type-id='type-id-6' name='flags' filepath='os/linux/libzfs_mount_os.c' line='377' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='do_mount' mangled-name='do_mount' filepath='os/linux/libzfs_mount_os.c' line='323' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='do_mount'>
-      <parameter type-id='type-id-102' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
-      <parameter type-id='type-id-104' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-84' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
+      <parameter type-id='type-id-86' name='mntpt' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <parameter type-id='type-id-23' name='opts' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <parameter type-id='type-id-6' name='flags' filepath='os/linux/libzfs_mount_os.c' line='323' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' filepath='os/linux/libzfs_mount_os.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
-      <parameter type-id='type-id-102' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
-      <parameter type-id='type-id-104' name='mntpoint' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-84' name='zhp' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
+      <parameter type-id='type-id-86' name='mntpoint' filepath='os/linux/libzfs_mount_os.c' line='273' column='1'/>
       <parameter type-id='type-id-23' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
       <parameter type-id='type-id-23' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='274' column='1'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-247'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-229'/>
     <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' filepath='os/linux/libzfs_mount_os.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
       <parameter type-id='type-id-23' name='mntopts' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
-      <parameter type-id='type-id-247' name='mntflags' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
-      <parameter type-id='type-id-247' name='zfsflags' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
+      <parameter type-id='type-id-229' name='mntflags' filepath='os/linux/libzfs_mount_os.c' line='183' column='1'/>
+      <parameter type-id='type-id-229' name='zfsflags' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-6' name='sloppy' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-23' name='badopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <parameter type-id='type-id-23' name='mtabopt' filepath='os/linux/libzfs_mount_os.c' line='184' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='geteuid' mangled-name='geteuid' filepath='/usr/include/unistd.h' line='678' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='umount2' mangled-name='umount2' filepath='/usr/include/x86_64-linux-gnu/sys/mount.h' line='146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' filepath='../../include/libzfs.h' line='883' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' filepath='../../include/libzfs.h' line='875' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mount' mangled-name='mount' filepath='/usr/include/x86_64-linux-gnu/sys/mount.h' line='138' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' filepath='os/linux/libzfs_pool_os.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
       <parameter type-id='type-id-18' name='zhp' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='os/linux/libzfs_pool_os.c' line='212' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' filepath='os/linux/libzfs_pool_os.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_relabel_disk'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
-      <parameter type-id='type-id-104' name='path' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
-      <parameter type-id='type-id-104' name='msg' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
+      <parameter type-id='type-id-86' name='msg' filepath='os/linux/libzfs_pool_os.c' line='61' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='rand' mangled-name='rand' filepath='/usr/include/stdlib.h' line='453' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' filepath='../../include/sys/efi_partition.h' line='367' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_free' mangled-name='efi_free' filepath='../../include/sys/efi_partition.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' filepath='../../include/sys/efi_partition.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_write' mangled-name='efi_write' filepath='../../include/sys/efi_partition.h' line='368' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fsync' mangled-name='fsync' filepath='/usr/include/unistd.h' line='954' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_rescan' mangled-name='efi_rescan' filepath='../../include/sys/efi_partition.h' line='369' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' filepath='../../include/libzutil.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' filepath='../../include/libzutil.h' line='80' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' filepath='../../include/sys/efi_partition.h' line='374' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_set_pipe_max'>
       <parameter type-id='type-id-6' name='infd' filepath='os/linux/libzfs_sendrecv_os.c' line='36' column='1'/>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fscanf' mangled-name='fscanf' filepath='/usr/include/stdio.h' line='391' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fcntl' mangled-name='fcntl64' filepath='/usr/include/fcntl.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' filepath='os/linux/libzfs_util_os.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
       <parameter type-id='type-id-23' name='version' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
       <parameter type-id='type-id-6' name='len' filepath='os/linux/libzfs_util_os.c' line='192' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1' id='type-id-248'>
+    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' filepath='../../include/libzfs_impl.h' line='220' column='1' id='type-id-230'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zhp' type-id='type-id-102' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
+        <var-decl name='zhp' type-id='type-id-84' visibility='default' filepath='../../include/libzfs_impl.h' line='221' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fromsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
+        <var-decl name='fromsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='frommnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='224' column='1'/>
+        <var-decl name='frommnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='223' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tosnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='225' column='1'/>
+        <var-decl name='tosnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='224' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tomnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='226' column='1'/>
+        <var-decl name='tomnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='225' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ds' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='227' column='1'/>
+        <var-decl name='ds' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='226' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='dsmnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='228' column='1'/>
+        <var-decl name='dsmnt' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='227' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tmpsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='229' column='1'/>
+        <var-decl name='tmpsnap' type-id='type-id-23' visibility='default' filepath='../../include/libzfs_impl.h' line='228' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='errbuf' type-id='type-id-28' visibility='default' filepath='../../include/libzfs_impl.h' line='230' column='1'/>
+        <var-decl name='errbuf' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='229' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8704'>
-        <var-decl name='isclone' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='231' column='1'/>
+        <var-decl name='isclone' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='230' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8736'>
-        <var-decl name='scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='232' column='1'/>
+        <var-decl name='scripted' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='231' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8768'>
-        <var-decl name='classify' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='233' column='1'/>
+        <var-decl name='classify' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='232' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8800'>
-        <var-decl name='timestamped' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='234' column='1'/>
+        <var-decl name='timestamped' type-id='type-id-5' visibility='default' filepath='../../include/libzfs_impl.h' line='233' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8832'>
-        <var-decl name='shares' type-id='type-id-27' visibility='default' filepath='../../include/libzfs_impl.h' line='235' column='1'/>
+        <var-decl name='shares' type-id='type-id-26' visibility='default' filepath='../../include/libzfs_impl.h' line='234' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8896'>
-        <var-decl name='zerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='236' column='1'/>
+        <var-decl name='zerr' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='235' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8928'>
-        <var-decl name='cleanupfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='237' column='1'/>
+        <var-decl name='cleanupfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='236' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8960'>
-        <var-decl name='outputfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='238' column='1'/>
+        <var-decl name='outputfd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='237' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8992'>
-        <var-decl name='datafd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='239' column='1'/>
+        <var-decl name='datafd' type-id='type-id-6' visibility='default' filepath='../../include/libzfs_impl.h' line='238' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='differ_info_t' type-id='type-id-248' filepath='../../include/libzfs_impl.h' line='240' column='1' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <typedef-decl name='differ_info_t' type-id='type-id-230' filepath='../../include/libzfs_impl.h' line='239' column='1' id='type-id-231'/>
+    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-232'/>
     <function-decl name='find_shares_object' mangled-name='find_shares_object' filepath='os/linux/libzfs_util_os.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='find_shares_object'>
-      <parameter type-id='type-id-250' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>
+      <parameter type-id='type-id-232' name='di' filepath='os/linux/libzfs_util_os.c' line='169' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' filepath='os/linux/libzfs_util_os.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_load_module'>
@@ -4911,177 +4796,177 @@
     </function-decl>
     <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' filepath='os/linux/libzfs_util_os.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
       <parameter type-id='type-id-6' name='error' filepath='os/linux/libzfs_util_os.c' line='55' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' filepath='os/linux/libzfs_util_os.c' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
       <parameter type-id='type-id-17' name='hdl' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
       <parameter type-id='type-id-6' name='request' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
-      <parameter type-id='type-id-158' name='zc' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
+      <parameter type-id='type-id-140' name='zc' filepath='os/linux/libzfs_util_os.c' line='49' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='clock_gettime' mangled-name='clock_gettime' filepath='/usr/include/time.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='sched_yield' mangled-name='sched_yield' filepath='/usr/include/sched.h' line='68' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='usleep' mangled-name='usleep' filepath='/usr/include/unistd.h' line='460' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='access' mangled-name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='__anonymous_struct__' size-in-bits='1728' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='69' column='1' id='type-id-252'>
+  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='__anonymous_struct__' size-in-bits='1728' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-233' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='69' column='1' id='type-id-234'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='algotype' type-id='type-id-62' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='70' column='1'/>
+        <var-decl name='algotype' type-id='type-id-41' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='state' type-id='type-id-253' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='76' column='1'/>
+        <var-decl name='state' type-id='type-id-235' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='count' type-id='type-id-254' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='81' column='1'/>
+        <var-decl name='count' type-id='type-id-236' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='buf_un' type-id='type-id-255' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='86' column='1'/>
+        <var-decl name='buf_un' type-id='type-id-237' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='86' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='512' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='73' column='1' id='type-id-253'>
+    <union-decl name='__anonymous_union__' size-in-bits='512' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='73' column='1' id='type-id-235'>
       <data-member access='private'>
-        <var-decl name='s32' type-id='type-id-256' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='74' column='1'/>
+        <var-decl name='s32' type-id='type-id-238' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='74' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='s64' type-id='type-id-257' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='256' id='type-id-256'>
-      <subrange length='8' type-id='type-id-48' id='type-id-258'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='512' id='type-id-257'>
-      <subrange length='8' type-id='type-id-48' id='type-id-258'/>
-
-    </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='78' column='1' id='type-id-254'>
-      <data-member access='private'>
-        <var-decl name='c32' type-id='type-id-259' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='c64' type-id='type-id-156' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='80' column='1'/>
+        <var-decl name='s64' type-id='type-id-239' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='75' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='64' id='type-id-259'>
-      <subrange length='2' type-id='type-id-48' id='type-id-86'/>
+    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-238'>
+      <subrange length='8' type-id='type-id-37' id='type-id-240'/>
 
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='1024' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='82' column='1' id='type-id-255'>
+
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='512' id='type-id-239'>
+      <subrange length='8' type-id='type-id-37' id='type-id-240'/>
+
+    </array-type-def>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='78' column='1' id='type-id-236'>
       <data-member access='private'>
-        <var-decl name='buf8' type-id='type-id-260' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='83' column='1'/>
+        <var-decl name='c32' type-id='type-id-241' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='79' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='buf32' type-id='type-id-261' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='84' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='buf64' type-id='type-id-262' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='85' column='1'/>
+        <var-decl name='c64' type-id='type-id-138' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='80' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='1024' id='type-id-260'>
-      <subrange length='128' type-id='type-id-48' id='type-id-263'/>
+    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='64' id='type-id-241'>
+      <subrange length='2' type-id='type-id-37' id='type-id-66'/>
+
+    </array-type-def>
+    <union-decl name='__anonymous_union__' size-in-bits='1024' is-anonymous='yes' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='82' column='1' id='type-id-237'>
+      <data-member access='private'>
+        <var-decl name='buf8' type-id='type-id-242' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='83' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf32' type-id='type-id-243' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='buf64' type-id='type-id-244' visibility='default' filepath='../../lib/libspl/include/sys/sha2.h' line='85' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-80' size-in-bits='1024' id='type-id-242'>
+      <subrange length='128' type-id='type-id-37' id='type-id-245'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-62' size-in-bits='1024' id='type-id-261'>
-      <subrange length='32' type-id='type-id-48' id='type-id-264'/>
+    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='1024' id='type-id-243'>
+      <subrange length='32' type-id='type-id-37' id='type-id-246'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='1024' id='type-id-262'>
-      <subrange length='16' type-id='type-id-48' id='type-id-265'/>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='1024' id='type-id-244'>
+      <subrange length='16' type-id='type-id-37' id='type-id-247'/>
 
     </array-type-def>
-    <typedef-decl name='SHA2_CTX' type-id='type-id-252' filepath='../../lib/libspl/include/sys/sha2.h' line='87' column='1' id='type-id-251'/>
-    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-266'/>
+    <typedef-decl name='SHA2_CTX' type-id='type-id-234' filepath='../../lib/libspl/include/sys/sha2.h' line='87' column='1' id='type-id-233'/>
+    <pointer-type-def type-id='type-id-233' size-in-bits='64' id='type-id-248'/>
     <function-decl name='SHA2Final' mangled-name='SHA2Final' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Final'>
-      <parameter type-id='type-id-42' name='digest' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
-      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='digest' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <parameter type-id='type-id-248' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='904' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='SHA2Update' mangled-name='SHA2Update' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Update'>
-      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <parameter type-id='type-id-42' name='inptr' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <parameter type-id='type-id-43' name='input_len' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-248' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-68' name='inptr' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <parameter type-id='type-id-32' name='input_len' filepath='../../module/icp/algs/sha2/sha2.c' line='782' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <typedef-decl name='SHA512_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='91' column='1' id='type-id-267'/>
-    <pointer-type-def type-id='type-id-267' size-in-bits='64' id='type-id-268'/>
+    <typedef-decl name='SHA512_CTX' type-id='type-id-233' filepath='../../lib/libspl/include/sys/sha2.h' line='91' column='1' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
     <function-decl name='SHA512Init' mangled-name='SHA512Init' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA512Init'>
-      <parameter type-id='type-id-268' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-250' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='763' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <typedef-decl name='SHA384_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='90' column='1' id='type-id-269'/>
-    <pointer-type-def type-id='type-id-269' size-in-bits='64' id='type-id-270'/>
+    <typedef-decl name='SHA384_CTX' type-id='type-id-233' filepath='../../lib/libspl/include/sys/sha2.h' line='90' column='1' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
     <function-decl name='SHA384Init' mangled-name='SHA384Init' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA384Init'>
-      <parameter type-id='type-id-270' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-252' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='757' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <typedef-decl name='SHA256_CTX' type-id='type-id-251' filepath='../../lib/libspl/include/sys/sha2.h' line='89' column='1' id='type-id-271'/>
-    <pointer-type-def type-id='type-id-271' size-in-bits='64' id='type-id-272'/>
+    <typedef-decl name='SHA256_CTX' type-id='type-id-233' filepath='../../lib/libspl/include/sys/sha2.h' line='89' column='1' id='type-id-253'/>
+    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-254'/>
     <function-decl name='SHA256Init' mangled-name='SHA256Init' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA256Init'>
-      <parameter type-id='type-id-272' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-254' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='751' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='SHA2Init' mangled-name='SHA2Init' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='SHA2Init'>
-      <parameter type-id='type-id-27' name='mech' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
-      <parameter type-id='type-id-266' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-26' name='mech' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
+      <parameter type-id='type-id-248' name='ctx' filepath='../../module/icp/algs/sha2/sha2.c' line='674' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='htonl' mangled-name='htonl' filepath='../../lib/libspl/include/os/linux/sys/byteorder.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='cityhash4' mangled-name='cityhash4' filepath='../../module/zcommon/cityhash.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
-      <parameter type-id='type-id-27' name='w1' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
-      <parameter type-id='type-id-27' name='w2' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
-      <parameter type-id='type-id-27' name='w3' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
-      <parameter type-id='type-id-27' name='w4' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
-      <return type-id='type-id-27'/>
+      <parameter type-id='type-id-26' name='w1' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-26' name='w2' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-26' name='w3' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <parameter type-id='type-id-26' name='w4' filepath='../../module/zcommon/cityhash.c' line='53' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <var-decl name='zfeature_checks_disable' type-id='type-id-5' mangled-name='zfeature_checks_disable' visibility='default' filepath='../../module/zcommon/zfeature_common.c' line='49' column='1' elf-symbol-id='zfeature_checks_disable'/>
-    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/zfeature_common.h' line='103' column='1' id='type-id-273'>
+    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/zfeature_common.h' line='103' column='1' id='type-id-255'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fi_feature' type-id='type-id-274' visibility='default' filepath='../../include/zfeature_common.h' line='104' column='1'/>
+        <var-decl name='fi_feature' type-id='type-id-256' visibility='default' filepath='../../include/zfeature_common.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fi_uname' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='105' column='1'/>
+        <var-decl name='fi_uname' type-id='type-id-86' visibility='default' filepath='../../include/zfeature_common.h' line='105' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fi_guid' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='106' column='1'/>
+        <var-decl name='fi_guid' type-id='type-id-86' visibility='default' filepath='../../include/zfeature_common.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fi_desc' type-id='type-id-104' visibility='default' filepath='../../include/zfeature_common.h' line='107' column='1'/>
+        <var-decl name='fi_desc' type-id='type-id-86' visibility='default' filepath='../../include/zfeature_common.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fi_flags' type-id='type-id-275' visibility='default' filepath='../../include/zfeature_common.h' line='108' column='1'/>
+        <var-decl name='fi_flags' type-id='type-id-257' visibility='default' filepath='../../include/zfeature_common.h' line='108' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='fi_zfs_mod_supported' type-id='type-id-5' visibility='default' filepath='../../include/zfeature_common.h' line='109' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='fi_type' type-id='type-id-276' visibility='default' filepath='../../include/zfeature_common.h' line='110' column='1'/>
+        <var-decl name='fi_type' type-id='type-id-258' visibility='default' filepath='../../include/zfeature_common.h' line='110' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='fi_depends' type-id='type-id-277' visibility='default' filepath='../../include/zfeature_common.h' line='112' column='1'/>
+        <var-decl name='fi_depends' type-id='type-id-259' visibility='default' filepath='../../include/zfeature_common.h' line='112' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='spa_feature' filepath='../../include/zfeature_common.h' line='42' column='1' id='type-id-278'>
+    <enum-decl name='spa_feature' filepath='../../include/zfeature_common.h' line='42' column='1' id='type-id-260'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='SPA_FEATURE_NONE' value='-1'/>
       <enumerator name='SPA_FEATURE_ASYNC_DESTROY' value='0'/>
@@ -5120,70 +5005,70 @@
       <enumerator name='SPA_FEATURE_DRAID' value='33'/>
       <enumerator name='SPA_FEATURES' value='34'/>
     </enum-decl>
-    <typedef-decl name='spa_feature_t' type-id='type-id-278' filepath='../../include/zfeature_common.h' line='79' column='1' id='type-id-274'/>
-    <enum-decl name='zfeature_flags' filepath='../../include/zfeature_common.h' line='83' column='1' id='type-id-279'>
+    <typedef-decl name='spa_feature_t' type-id='type-id-260' filepath='../../include/zfeature_common.h' line='79' column='1' id='type-id-256'/>
+    <enum-decl name='zfeature_flags' filepath='../../include/zfeature_common.h' line='83' column='1' id='type-id-261'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFEATURE_FLAG_READONLY_COMPAT' value='1'/>
       <enumerator name='ZFEATURE_FLAG_MOS' value='2'/>
       <enumerator name='ZFEATURE_FLAG_ACTIVATE_ON_ENABLE' value='4'/>
       <enumerator name='ZFEATURE_FLAG_PER_DATASET' value='8'/>
     </enum-decl>
-    <typedef-decl name='zfeature_flags_t' type-id='type-id-279' filepath='../../include/zfeature_common.h' line='95' column='1' id='type-id-275'/>
-    <enum-decl name='zfeature_type' filepath='../../include/zfeature_common.h' line='97' column='1' id='type-id-280'>
+    <typedef-decl name='zfeature_flags_t' type-id='type-id-261' filepath='../../include/zfeature_common.h' line='95' column='1' id='type-id-257'/>
+    <enum-decl name='zfeature_type' filepath='../../include/zfeature_common.h' line='97' column='1' id='type-id-262'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFEATURE_TYPE_BOOLEAN' value='0'/>
       <enumerator name='ZFEATURE_TYPE_UINT64_ARRAY' value='1'/>
       <enumerator name='ZFEATURE_NUM_TYPES' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfeature_type_t' type-id='type-id-280' filepath='../../include/zfeature_common.h' line='101' column='1' id='type-id-276'/>
-    <qualified-type-def type-id='type-id-274' const='yes' id='type-id-281'/>
-    <pointer-type-def type-id='type-id-281' size-in-bits='64' id='type-id-277'/>
-    <typedef-decl name='zfeature_info_t' type-id='type-id-273' filepath='../../include/zfeature_common.h' line='113' column='1' id='type-id-282'/>
+    <typedef-decl name='zfeature_type_t' type-id='type-id-262' filepath='../../include/zfeature_common.h' line='101' column='1' id='type-id-258'/>
+    <qualified-type-def type-id='type-id-256' const='yes' id='type-id-263'/>
+    <pointer-type-def type-id='type-id-263' size-in-bits='64' id='type-id-259'/>
+    <typedef-decl name='zfeature_info_t' type-id='type-id-255' filepath='../../include/zfeature_common.h' line='113' column='1' id='type-id-264'/>
 
-    <array-type-def dimensions='1' type-id='type-id-282' size-in-bits='15232' id='type-id-283'>
-      <subrange length='34' type-id='type-id-48' id='type-id-284'/>
+    <array-type-def dimensions='1' type-id='type-id-264' size-in-bits='15232' id='type-id-265'>
+      <subrange length='34' type-id='type-id-37' id='type-id-266'/>
 
     </array-type-def>
-    <var-decl name='spa_feature_table' type-id='type-id-283' mangled-name='spa_feature_table' visibility='default' filepath='../../include/zfeature_common.h' line='119' column='1' elf-symbol-id='spa_feature_table'/>
+    <var-decl name='spa_feature_table' type-id='type-id-265' mangled-name='spa_feature_table' visibility='default' filepath='../../include/zfeature_common.h' line='119' column='1' elf-symbol-id='spa_feature_table'/>
     <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
-      <parameter type-id='type-id-274' name='fid' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
-      <parameter type-id='type-id-274' name='check' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
+      <parameter type-id='type-id-256' name='fid' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
+      <parameter type-id='type-id-256' name='check' filepath='../../module/zcommon/zfeature_common.c' line='146' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-274' size-in-bits='64' id='type-id-285'/>
+    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-267'/>
     <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
-      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-267' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' filepath='../../module/zcommon/zfeature_common.c' line='112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
-      <parameter type-id='type-id-285' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
+      <parameter type-id='type-id-267' name='res' filepath='../../module/zcommon/zfeature_common.c' line='129' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
-      <parameter type-id='type-id-104' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1'/>
+      <parameter type-id='type-id-86' name='guid' filepath='../../module/zcommon/zfeature_common.c' line='96' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfeature_common.c' line='74' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mod_supported'>
-      <parameter type-id='type-id-104' name='scope' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
+      <parameter type-id='type-id-86' name='scope' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfeature_common.c' line='187' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='2624' id='type-id-286'>
-      <subrange length='41' type-id='type-id-48' id='type-id-287'/>
+    <array-type-def dimensions='1' type-id='type-id-86' size-in-bits='2624' id='type-id-268'>
+      <subrange length='41' type-id='type-id-37' id='type-id-269'/>
 
     </array-type-def>
-    <var-decl name='zfs_history_event_names' type-id='type-id-286' mangled-name='zfs_history_event_names' visibility='default' filepath='../../include/zfs_comutil.h' line='46' column='1' elf-symbol-id='zfs_history_event_names'/>
+    <var-decl name='zfs_history_event_names' type-id='type-id-268' mangled-name='zfs_history_event_names' visibility='default' filepath='../../include/zfs_comutil.h' line='46' column='1' elf-symbol-id='zfs_history_event_names'/>
     <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfs_comutil.c' line='239' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
@@ -5194,26 +5079,26 @@
       <parameter type-id='type-id-6' name='zpl_version' filepath='../../module/zcommon/zfs_comutil.c' line='177' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1' id='type-id-288'>
+    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1' id='type-id-270'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zlp_rewind' type-id='type-id-62' visibility='default' filepath='../../include/sys/fs/zfs.h' line='592' column='1'/>
+        <var-decl name='zlp_rewind' type-id='type-id-41' visibility='default' filepath='../../include/sys/fs/zfs.h' line='592' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zlp_maxmeta' type-id='type-id-27' visibility='default' filepath='../../include/sys/fs/zfs.h' line='593' column='1'/>
+        <var-decl name='zlp_maxmeta' type-id='type-id-26' visibility='default' filepath='../../include/sys/fs/zfs.h' line='593' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zlp_maxdata' type-id='type-id-27' visibility='default' filepath='../../include/sys/fs/zfs.h' line='594' column='1'/>
+        <var-decl name='zlp_maxdata' type-id='type-id-26' visibility='default' filepath='../../include/sys/fs/zfs.h' line='594' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zlp_txg' type-id='type-id-27' visibility='default' filepath='../../include/sys/fs/zfs.h' line='595' column='1'/>
+        <var-decl name='zlp_txg' type-id='type-id-26' visibility='default' filepath='../../include/sys/fs/zfs.h' line='595' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zpool_load_policy_t' type-id='type-id-288' filepath='../../include/sys/fs/zfs.h' line='596' column='1' id='type-id-289'/>
-    <pointer-type-def type-id='type-id-289' size-in-bits='64' id='type-id-290'/>
+    <typedef-decl name='zpool_load_policy_t' type-id='type-id-270' filepath='../../include/sys/fs/zfs.h' line='596' column='1' id='type-id-271'/>
+    <pointer-type-def type-id='type-id-271' size-in-bits='64' id='type-id-272'/>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
       <parameter type-id='type-id-22' name='nvl' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
-      <parameter type-id='type-id-290' name='zlpp' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-272' name='zlpp' filepath='../../module/zcommon/zfs_comutil.c' line='99' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
       <parameter type-id='type-id-22' name='nv' filepath='../../module/zcommon/zfs_comutil.c' line='71' column='1'/>
@@ -5225,19 +5110,19 @@
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' filepath='../../include/sys/nvpair.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_deleg.h' line='83' column='1' id='type-id-291'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_deleg.h' line='83' column='1' id='type-id-273'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='z_perm' type-id='type-id-23' visibility='default' filepath='../../include/zfs_deleg.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_note' type-id='type-id-292' visibility='default' filepath='../../include/zfs_deleg.h' line='85' column='1'/>
+        <var-decl name='z_note' type-id='type-id-274' visibility='default' filepath='../../include/zfs_deleg.h' line='85' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_deleg.h' line='48' column='1' id='type-id-293'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_deleg.h' line='48' column='1' id='type-id-275'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_DELEG_NOTE_CREATE' value='0'/>
       <enumerator name='ZFS_DELEG_NOTE_DESTROY' value='1'/>
@@ -5272,15 +5157,15 @@
       <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
       <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-293' filepath='../../include/zfs_deleg.h' line='81' column='1' id='type-id-292'/>
-    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-291' filepath='../../include/zfs_deleg.h' line='86' column='1' id='type-id-294'/>
+    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-275' filepath='../../include/zfs_deleg.h' line='81' column='1' id='type-id-274'/>
+    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-273' filepath='../../include/zfs_deleg.h' line='86' column='1' id='type-id-276'/>
 
-    <array-type-def dimensions='1' type-id='type-id-294' size-in-bits='infinite' id='type-id-295'>
-      <subrange length='infinite' id='type-id-296'/>
+    <array-type-def dimensions='1' type-id='type-id-276' size-in-bits='infinite' id='type-id-277'>
+      <subrange length='infinite' id='type-id-278'/>
 
     </array-type-def>
-    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-295' mangled-name='zfs_deleg_perm_tab' visibility='default' filepath='../../include/zfs_deleg.h' line='88' column='1' elf-symbol-id='zfs_deleg_perm_tab'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='340' column='1' id='type-id-297'>
+    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-277' mangled-name='zfs_deleg_perm_tab' visibility='default' filepath='../../include/zfs_deleg.h' line='88' column='1' elf-symbol-id='zfs_deleg_perm_tab'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='340' column='1' id='type-id-279'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
       <enumerator name='ZFS_DELEG_USER' value='117'/>
@@ -5294,303 +5179,303 @@
       <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
       <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-297' filepath='../../include/sys/fs/zfs.h' line='352' column='1' id='type-id-298'/>
+    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-279' filepath='../../include/sys/fs/zfs.h' line='352' column='1' id='type-id-280'/>
     <function-decl name='zfs_deleg_whokey' mangled-name='zfs_deleg_whokey' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_whokey'>
       <parameter type-id='type-id-23' name='attr' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
-      <parameter type-id='type-id-298' name='type' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
-      <parameter type-id='type-id-45' name='inheritchr' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-280' name='type' filepath='../../module/zcommon/zfs_deleg.c' line='211' column='1'/>
+      <parameter type-id='type-id-36' name='inheritchr' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='../../module/zcommon/zfs_deleg.c' line='212' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
       <parameter type-id='type-id-22' name='nvp' filepath='../../module/zcommon/zfs_deleg.c' line='157' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
-      <parameter type-id='type-id-104' name='perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1'/>
-      <return type-id='type-id-104'/>
+      <parameter type-id='type-id-86' name='perm' filepath='../../module/zcommon/zfs_deleg.c' line='90' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='permset_namecheck' mangled-name='permset_namecheck' filepath='../../include/zfs_namecheck.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' filepath='../../include/zfs_prop.h' line='92' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='77' column='1' id='type-id-299'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='77' column='1' id='type-id-281'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acf_init' type-id='type-id-300' visibility='default' filepath='../../include/sys/zio_checksum.h' line='78' column='1'/>
+        <var-decl name='acf_init' type-id='type-id-282' visibility='default' filepath='../../include/sys/zio_checksum.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acf_fini' type-id='type-id-301' visibility='default' filepath='../../include/sys/zio_checksum.h' line='79' column='1'/>
+        <var-decl name='acf_fini' type-id='type-id-283' visibility='default' filepath='../../include/sys/zio_checksum.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acf_iter' type-id='type-id-302' visibility='default' filepath='../../include/sys/zio_checksum.h' line='80' column='1'/>
+        <var-decl name='acf_iter' type-id='type-id-284' visibility='default' filepath='../../include/sys/zio_checksum.h' line='80' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='66' column='1' id='type-id-303'>
+    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zio_checksum.h' line='66' column='1' id='type-id-285'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acd_byteorder' type-id='type-id-304' visibility='default' filepath='../../include/sys/zio_checksum.h' line='67' column='1'/>
+        <var-decl name='acd_byteorder' type-id='type-id-286' visibility='default' filepath='../../include/sys/zio_checksum.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acd_ctx' type-id='type-id-305' visibility='default' filepath='../../include/sys/zio_checksum.h' line='68' column='1'/>
+        <var-decl name='acd_ctx' type-id='type-id-287' visibility='default' filepath='../../include/sys/zio_checksum.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acd_zcp' type-id='type-id-306' visibility='default' filepath='../../include/sys/zio_checksum.h' line='69' column='1'/>
+        <var-decl name='acd_zcp' type-id='type-id-288' visibility='default' filepath='../../include/sys/zio_checksum.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='acd_private' type-id='type-id-42' visibility='default' filepath='../../include/sys/zio_checksum.h' line='70' column='1'/>
+        <var-decl name='acd_private' type-id='type-id-68' visibility='default' filepath='../../include/sys/zio_checksum.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zio_checksum.h' line='61' column='1' id='type-id-307'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zio_checksum.h' line='61' column='1' id='type-id-289'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
       <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
     </enum-decl>
-    <typedef-decl name='zio_byteorder_t' type-id='type-id-307' filepath='../../include/sys/zio_checksum.h' line='64' column='1' id='type-id-304'/>
-    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' filepath='../../include/zfs_fletcher.h' line='90' column='1' id='type-id-308'>
+    <typedef-decl name='zio_byteorder_t' type-id='type-id-289' filepath='../../include/sys/zio_checksum.h' line='64' column='1' id='type-id-286'/>
+    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' filepath='../../include/zfs_fletcher.h' line='90' column='1' id='type-id-290'>
       <data-member access='private'>
-        <var-decl name='scalar' type-id='type-id-309' visibility='default' filepath='../../include/zfs_fletcher.h' line='91' column='1'/>
+        <var-decl name='scalar' type-id='type-id-291' visibility='default' filepath='../../include/zfs_fletcher.h' line='91' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='superscalar' type-id='type-id-310' visibility='default' filepath='../../include/zfs_fletcher.h' line='92' column='1'/>
+        <var-decl name='superscalar' type-id='type-id-292' visibility='default' filepath='../../include/zfs_fletcher.h' line='92' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sse' type-id='type-id-311' visibility='default' filepath='../../include/zfs_fletcher.h' line='95' column='1'/>
+        <var-decl name='sse' type-id='type-id-293' visibility='default' filepath='../../include/zfs_fletcher.h' line='95' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx' type-id='type-id-312' visibility='default' filepath='../../include/zfs_fletcher.h' line='98' column='1'/>
+        <var-decl name='avx' type-id='type-id-294' visibility='default' filepath='../../include/zfs_fletcher.h' line='98' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx512' type-id='type-id-313' visibility='default' filepath='../../include/zfs_fletcher.h' line='101' column='1'/>
+        <var-decl name='avx512' type-id='type-id-295' visibility='default' filepath='../../include/zfs_fletcher.h' line='101' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-314'>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-296'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='type-id-315' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
+        <var-decl name='zc_word' type-id='type-id-297' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='256' id='type-id-315'>
-      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='256' id='type-id-297'>
+      <subrange length='4' type-id='type-id-37' id='type-id-298'/>
 
     </array-type-def>
-    <typedef-decl name='zio_cksum_t' type-id='type-id-314' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-309'/>
-    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='69' column='1' id='type-id-317'>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-296' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-291'/>
+    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='69' column='1' id='type-id-299'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-315' visibility='default' filepath='../../include/zfs_fletcher.h' line='70' column='1'/>
+        <var-decl name='v' type-id='type-id-297' visibility='default' filepath='../../include/zfs_fletcher.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-317' filepath='../../include/zfs_fletcher.h' line='71' column='1' id='type-id-318'/>
+    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-299' filepath='../../include/zfs_fletcher.h' line='71' column='1' id='type-id-300'/>
 
-    <array-type-def dimensions='1' type-id='type-id-318' size-in-bits='1024' id='type-id-310'>
-      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
+    <array-type-def dimensions='1' type-id='type-id-300' size-in-bits='1024' id='type-id-292'>
+      <subrange length='4' type-id='type-id-37' id='type-id-298'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='73' column='1' id='type-id-319'>
+    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='73' column='1' id='type-id-301'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-156' visibility='default' filepath='../../include/zfs_fletcher.h' line='74' column='1'/>
+        <var-decl name='v' type-id='type-id-138' visibility='default' filepath='../../include/zfs_fletcher.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-319' filepath='../../include/zfs_fletcher.h' line='75' column='1' id='type-id-320'/>
+    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-301' filepath='../../include/zfs_fletcher.h' line='75' column='1' id='type-id-302'/>
 
-    <array-type-def dimensions='1' type-id='type-id-320' size-in-bits='512' id='type-id-311'>
-      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
+    <array-type-def dimensions='1' type-id='type-id-302' size-in-bits='512' id='type-id-293'>
+      <subrange length='4' type-id='type-id-37' id='type-id-298'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='77' column='1' id='type-id-321'>
+    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='77' column='1' id='type-id-303'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-315' visibility='default' filepath='../../include/zfs_fletcher.h' line='78' column='1'/>
+        <var-decl name='v' type-id='type-id-297' visibility='default' filepath='../../include/zfs_fletcher.h' line='78' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-321' filepath='../../include/zfs_fletcher.h' line='79' column='1' id='type-id-322'/>
+    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-303' filepath='../../include/zfs_fletcher.h' line='79' column='1' id='type-id-304'/>
 
-    <array-type-def dimensions='1' type-id='type-id-322' size-in-bits='1024' id='type-id-312'>
-      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
+    <array-type-def dimensions='1' type-id='type-id-304' size-in-bits='1024' id='type-id-294'>
+      <subrange length='4' type-id='type-id-37' id='type-id-298'/>
 
     </array-type-def>
-    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='81' column='1' id='type-id-323'>
+    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='81' column='1' id='type-id-305'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-257' visibility='default' filepath='../../include/zfs_fletcher.h' line='82' column='1'/>
+        <var-decl name='v' type-id='type-id-239' visibility='default' filepath='../../include/zfs_fletcher.h' line='82' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-323' filepath='../../include/zfs_fletcher.h' line='83' column='1' id='type-id-324'/>
+    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-305' filepath='../../include/zfs_fletcher.h' line='83' column='1' id='type-id-306'/>
 
-    <array-type-def dimensions='1' type-id='type-id-324' size-in-bits='2048' id='type-id-313'>
-      <subrange length='4' type-id='type-id-48' id='type-id-316'/>
+    <array-type-def dimensions='1' type-id='type-id-306' size-in-bits='2048' id='type-id-295'>
+      <subrange length='4' type-id='type-id-37' id='type-id-298'/>
 
     </array-type-def>
-    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-308' filepath='../../include/zfs_fletcher.h' line='106' column='1' id='type-id-325'/>
-    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-305'/>
-    <pointer-type-def type-id='type-id-309' size-in-bits='64' id='type-id-306'/>
-    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-303' filepath='../../include/sys/zio_checksum.h' line='71' column='1' id='type-id-326'/>
-    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-327'/>
-    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-328' filepath='../../include/sys/zio_checksum.h' line='73' column='1' id='type-id-329'/>
-    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-300'/>
-    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-328' filepath='../../include/sys/zio_checksum.h' line='74' column='1' id='type-id-330'/>
-    <pointer-type-def type-id='type-id-330' size-in-bits='64' id='type-id-301'/>
-    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-331' filepath='../../include/sys/zio_checksum.h' line='75' column='1' id='type-id-332'/>
-    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-302'/>
-    <qualified-type-def type-id='type-id-299' const='yes' id='type-id-333'/>
-    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-333' filepath='../../include/sys/zio_checksum.h' line='81' column='1' id='type-id-334'/>
-    <var-decl name='fletcher_4_abd_ops' type-id='type-id-334' mangled-name='fletcher_4_abd_ops' visibility='default' filepath='../../include/sys/zio_checksum.h' line='125' column='1' elf-symbol-id='fletcher_4_abd_ops'/>
+    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-290' filepath='../../include/zfs_fletcher.h' line='106' column='1' id='type-id-307'/>
+    <pointer-type-def type-id='type-id-307' size-in-bits='64' id='type-id-287'/>
+    <pointer-type-def type-id='type-id-291' size-in-bits='64' id='type-id-288'/>
+    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-285' filepath='../../include/sys/zio_checksum.h' line='71' column='1' id='type-id-308'/>
+    <pointer-type-def type-id='type-id-308' size-in-bits='64' id='type-id-309'/>
+    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-310' filepath='../../include/sys/zio_checksum.h' line='73' column='1' id='type-id-311'/>
+    <pointer-type-def type-id='type-id-311' size-in-bits='64' id='type-id-282'/>
+    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-310' filepath='../../include/sys/zio_checksum.h' line='74' column='1' id='type-id-312'/>
+    <pointer-type-def type-id='type-id-312' size-in-bits='64' id='type-id-283'/>
+    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-313' filepath='../../include/sys/zio_checksum.h' line='75' column='1' id='type-id-314'/>
+    <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-284'/>
+    <qualified-type-def type-id='type-id-281' const='yes' id='type-id-315'/>
+    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-315' filepath='../../include/sys/zio_checksum.h' line='81' column='1' id='type-id-316'/>
+    <var-decl name='fletcher_4_abd_ops' type-id='type-id-316' mangled-name='fletcher_4_abd_ops' visibility='default' filepath='../../include/sys/zio_checksum.h' line='125' column='1' elf-symbol-id='fletcher_4_abd_ops'/>
     <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
-      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-32' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='589' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
-      <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <parameter type-id='type-id-26' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='488' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
-      <parameter type-id='type-id-104' name='val' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1'/>
+      <parameter type-id='type-id-86' name='val' filepath='../../module/zcommon/zfs_fletcher.c' line='369' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-26' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-68' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-32' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_2_native' mangled-name='fletcher_2_native' filepath='../../module/zcommon/zfs_fletcher.c' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_native'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
-      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-26' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='297' column='1'/>
+      <parameter type-id='type-id-68' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='298' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-32' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='271' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='fletcher_init' mangled-name='fletcher_init' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='231' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_native' mangled-name='fletcher_4_native' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
-      <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
-      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
+      <parameter type-id='type-id-26' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='465' column='1'/>
+      <parameter type-id='type-id-68' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='466' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_byteswap' mangled-name='fletcher_4_byteswap' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_byteswap'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
-      <parameter type-id='type-id-27' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
-      <parameter type-id='type-id-42' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
-      <parameter type-id='type-id-306' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
+      <parameter type-id='type-id-26' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='507' column='1'/>
+      <parameter type-id='type-id-68' name='ctx_template' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <parameter type-id='type-id-288' name='zcp' filepath='../../module/zcommon/zfs_fletcher.c' line='508' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_native'>
-      <parameter type-id='type-id-42' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
-      <parameter type-id='type-id-43' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
-      <parameter type-id='type-id-42' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-68' name='buf' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-32' name='size' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
+      <parameter type-id='type-id-68' name='data' filepath='../../module/zcommon/zfs_fletcher.c' line='577' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='membar_producer' mangled-name='membar_producer' filepath='../../lib/libspl/include/atomic.h' line='280' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' filepath='../../lib/libspl/include/atomic.h' line='240' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-331'>
-      <parameter type-id='type-id-42'/>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-313'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-68'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-328'>
-      <parameter type-id='type-id-327'/>
-      <return type-id='type-id-52'/>
+    <function-type size-in-bits='64' id='type-id-310'>
+      <parameter type-id='type-id-309'/>
+      <return type-id='type-id-67'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='116' column='1' id='type-id-335'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/zfs_fletcher.h' line='116' column='1' id='type-id-317'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='init_native' type-id='type-id-336' visibility='default' filepath='../../include/zfs_fletcher.h' line='117' column='1'/>
+        <var-decl name='init_native' type-id='type-id-318' visibility='default' filepath='../../include/zfs_fletcher.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fini_native' type-id='type-id-337' visibility='default' filepath='../../include/zfs_fletcher.h' line='118' column='1'/>
+        <var-decl name='fini_native' type-id='type-id-319' visibility='default' filepath='../../include/zfs_fletcher.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='compute_native' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='119' column='1'/>
+        <var-decl name='compute_native' type-id='type-id-320' visibility='default' filepath='../../include/zfs_fletcher.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='init_byteswap' type-id='type-id-336' visibility='default' filepath='../../include/zfs_fletcher.h' line='120' column='1'/>
+        <var-decl name='init_byteswap' type-id='type-id-318' visibility='default' filepath='../../include/zfs_fletcher.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fini_byteswap' type-id='type-id-337' visibility='default' filepath='../../include/zfs_fletcher.h' line='121' column='1'/>
+        <var-decl name='fini_byteswap' type-id='type-id-319' visibility='default' filepath='../../include/zfs_fletcher.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='compute_byteswap' type-id='type-id-338' visibility='default' filepath='../../include/zfs_fletcher.h' line='122' column='1'/>
+        <var-decl name='compute_byteswap' type-id='type-id-320' visibility='default' filepath='../../include/zfs_fletcher.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='valid' type-id='type-id-339' visibility='default' filepath='../../include/zfs_fletcher.h' line='123' column='1'/>
+        <var-decl name='valid' type-id='type-id-321' visibility='default' filepath='../../include/zfs_fletcher.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_fletcher.h' line='124' column='1'/>
+        <var-decl name='name' type-id='type-id-86' visibility='default' filepath='../../include/zfs_fletcher.h' line='124' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-340' size-in-bits='64' id='type-id-341'/>
-    <typedef-decl name='fletcher_4_init_f' type-id='type-id-341' filepath='../../include/zfs_fletcher.h' line='111' column='1' id='type-id-336'/>
-    <pointer-type-def type-id='type-id-342' size-in-bits='64' id='type-id-343'/>
-    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-343' filepath='../../include/zfs_fletcher.h' line='112' column='1' id='type-id-337'/>
-    <pointer-type-def type-id='type-id-344' size-in-bits='64' id='type-id-345'/>
-    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-345' filepath='../../include/zfs_fletcher.h' line='113' column='1' id='type-id-338'/>
-    <pointer-type-def type-id='type-id-346' size-in-bits='64' id='type-id-339'/>
-    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-335' filepath='../../include/zfs_fletcher.h' line='125' column='1' id='type-id-347'/>
-    <qualified-type-def type-id='type-id-347' const='yes' id='type-id-348'/>
-    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-348' mangled-name='fletcher_4_avx512f_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='143' column='1' elf-symbol-id='fletcher_4_avx512f_ops'/>
-    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-348' mangled-name='fletcher_4_avx512bw_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='147' column='1' elf-symbol-id='fletcher_4_avx512bw_ops'/>
-    <function-type size-in-bits='64' id='type-id-346'>
+    <pointer-type-def type-id='type-id-322' size-in-bits='64' id='type-id-323'/>
+    <typedef-decl name='fletcher_4_init_f' type-id='type-id-323' filepath='../../include/zfs_fletcher.h' line='111' column='1' id='type-id-318'/>
+    <pointer-type-def type-id='type-id-324' size-in-bits='64' id='type-id-325'/>
+    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-325' filepath='../../include/zfs_fletcher.h' line='112' column='1' id='type-id-319'/>
+    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-327'/>
+    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-327' filepath='../../include/zfs_fletcher.h' line='113' column='1' id='type-id-320'/>
+    <pointer-type-def type-id='type-id-328' size-in-bits='64' id='type-id-321'/>
+    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-317' filepath='../../include/zfs_fletcher.h' line='125' column='1' id='type-id-329'/>
+    <qualified-type-def type-id='type-id-329' const='yes' id='type-id-330'/>
+    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-330' mangled-name='fletcher_4_avx512f_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='143' column='1' elf-symbol-id='fletcher_4_avx512f_ops'/>
+    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-330' mangled-name='fletcher_4_avx512bw_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='147' column='1' elf-symbol-id='fletcher_4_avx512bw_ops'/>
+    <function-type size-in-bits='64' id='type-id-328'>
       <return type-id='type-id-5'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-340'>
-      <parameter type-id='type-id-305'/>
-      <return type-id='type-id-52'/>
+    <function-type size-in-bits='64' id='type-id-322'>
+      <parameter type-id='type-id-287'/>
+      <return type-id='type-id-67'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-344'>
-      <parameter type-id='type-id-305'/>
-      <parameter type-id='type-id-42'/>
-      <parameter type-id='type-id-27'/>
-      <return type-id='type-id-52'/>
+    <function-type size-in-bits='64' id='type-id-326'>
+      <parameter type-id='type-id-287'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-67'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-342'>
-      <parameter type-id='type-id-305'/>
-      <parameter type-id='type-id-306'/>
-      <return type-id='type-id-52'/>
+    <function-type size-in-bits='64' id='type-id-324'>
+      <parameter type-id='type-id-287'/>
+      <parameter type-id='type-id-288'/>
+      <return type-id='type-id-67'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-348' mangled-name='fletcher_4_avx2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='139' column='1' elf-symbol-id='fletcher_4_avx2_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-330' mangled-name='fletcher_4_avx2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='139' column='1' elf-symbol-id='fletcher_4_avx2_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-348' mangled-name='fletcher_4_sse2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='131' column='1' elf-symbol-id='fletcher_4_sse2_ops'/>
-    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-348' mangled-name='fletcher_4_ssse3_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='135' column='1' elf-symbol-id='fletcher_4_ssse3_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-330' mangled-name='fletcher_4_sse2_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='131' column='1' elf-symbol-id='fletcher_4_sse2_ops'/>
+    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-330' mangled-name='fletcher_4_ssse3_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='135' column='1' elf-symbol-id='fletcher_4_ssse3_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-348' mangled-name='fletcher_4_superscalar_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='127' column='1' elf-symbol-id='fletcher_4_superscalar_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-330' mangled-name='fletcher_4_superscalar_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='127' column='1' elf-symbol-id='fletcher_4_superscalar_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-348' mangled-name='fletcher_4_superscalar4_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='128' column='1' elf-symbol-id='fletcher_4_superscalar4_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-330' mangled-name='fletcher_4_superscalar4_ops' visibility='default' filepath='../../include/zfs_fletcher.h' line='128' column='1' elf-symbol-id='fletcher_4_superscalar4_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <var-decl name='zfs_max_dataset_nesting' type-id='type-id-6' mangled-name='zfs_max_dataset_nesting' visibility='default' filepath='../../include/zfs_namecheck.h' line='54' column='1' elf-symbol-id='zfs_max_dataset_nesting'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_namecheck.h' line='36' column='1' id='type-id-349'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_namecheck.h' line='36' column='1' id='type-id-331'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
       <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
@@ -5606,78 +5491,78 @@
       <enumerator name='NAME_ERR_NO_AT' value='11'/>
       <enumerator name='NAME_ERR_NO_POUND' value='12'/>
     </enum-decl>
-    <typedef-decl name='namecheck_err_t' type-id='type-id-349' filepath='../../include/zfs_namecheck.h' line='50' column='1' id='type-id-350'/>
-    <pointer-type-def type-id='type-id-350' size-in-bits='64' id='type-id-351'/>
+    <typedef-decl name='namecheck_err_t' type-id='type-id-331' filepath='../../include/zfs_namecheck.h' line='50' column='1' id='type-id-332'/>
+    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-333'/>
     <function-decl name='pool_namecheck' mangled-name='pool_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
-      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='361' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='338' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
-      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
-      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='dataset_namecheck' mangled-name='dataset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_namecheck'>
-      <parameter type-id='type-id-104' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-86' name='pool' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='407' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='161' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='permset_namecheck' mangled-name='permset_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='135' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='70' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='98' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='entity_namecheck' mangled-name='entity_namecheck' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
-      <parameter type-id='type-id-104' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
-      <parameter type-id='type-id-351' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-86' name='path' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
+      <parameter type-id='type-id-333' name='why' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
       <parameter type-id='type-id-23' name='what' filepath='../../module/zcommon/zfs_namecheck.c' line='182' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='768' id='type-id-352'>
-      <subrange length='12' type-id='type-id-48' id='type-id-353'/>
+    <array-type-def dimensions='1' type-id='type-id-86' size-in-bits='768' id='type-id-334'>
+      <subrange length='12' type-id='type-id-37' id='type-id-335'/>
 
     </array-type-def>
-    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-352' mangled-name='zfs_userquota_prop_prefixes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='208' column='1' elf-symbol-id='zfs_userquota_prop_prefixes'/>
+    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-334' mangled-name='zfs_userquota_prop_prefixes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='208' column='1' elf-symbol-id='zfs_userquota_prop_prefixes'/>
     <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='963' column='1'/>
@@ -5685,10 +5570,10 @@
     </function-decl>
     <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' filepath='../../module/zcommon/zfs_prop.c' line='952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
-      <parameter type-id='type-id-104' name='str' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
+      <parameter type-id='type-id-86' name='str' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
       <parameter type-id='type-id-5' name='encrypted' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
@@ -5702,15 +5587,15 @@
     </function-decl>
     <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' filepath='../../module/zcommon/zfs_prop.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='885' column='1'/>
-      <return type-id='type-id-27'/>
+      <return type-id='type-id-26'/>
     </function-decl>
     <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='974' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' filepath='../../module/zcommon/zfs_prop.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
@@ -5724,16 +5609,16 @@
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='984' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='40' column='1' id='type-id-354'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='40' column='1' id='type-id-336'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROP_TYPE_NUMBER' value='0'/>
       <enumerator name='PROP_TYPE_STRING' value='1'/>
       <enumerator name='PROP_TYPE_INDEX' value='2'/>
     </enum-decl>
-    <typedef-decl name='zprop_type_t' type-id='type-id-354' filepath='../../include/zfs_prop.h' line='44' column='1' id='type-id-355'/>
+    <typedef-decl name='zprop_type_t' type-id='type-id-336' filepath='../../include/zfs_prop.h' line='44' column='1' id='type-id-337'/>
     <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='842' column='1'/>
-      <return type-id='type-id-355'/>
+      <return type-id='type-id-337'/>
     </function-decl>
     <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='836' column='1'/>
@@ -5743,69 +5628,69 @@
     </function-decl>
     <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
-      <parameter type-id='type-id-27' name='seed' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
-      <return type-id='type-id-27'/>
+      <parameter type-id='type-id-26' name='seed' filepath='../../module/zcommon/zfs_prop.c' line='827' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-356'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-338'/>
     <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
-      <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
-      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <parameter type-id='type-id-26' name='index' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
+      <parameter type-id='type-id-338' name='string' filepath='../../module/zcommon/zfs_prop.c' line='821' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
-      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
-      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-86' name='string' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
+      <parameter type-id='type-id-119' name='index' filepath='../../module/zcommon/zfs_prop.c' line='815' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfs_prop.c' line='802' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfs_prop.c' line='782' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zfs_prop.c' line='756' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
-      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='../../module/zcommon/zfs_prop.c' line='735' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
       <parameter type-id='type-id-2' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='720' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-357' visibility='default' filepath='../../include/zfs_prop.h' line='67' column='1' id='type-id-358'>
+    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-339' visibility='default' filepath='../../include/zfs_prop.h' line='67' column='1' id='type-id-340'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pd_name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='68' column='1'/>
+        <var-decl name='pd_name' type-id='type-id-86' visibility='default' filepath='../../include/zfs_prop.h' line='68' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='pd_propnum' type-id='type-id-6' visibility='default' filepath='../../include/zfs_prop.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pd_proptype' type-id='type-id-355' visibility='default' filepath='../../include/zfs_prop.h' line='70' column='1'/>
+        <var-decl name='pd_proptype' type-id='type-id-337' visibility='default' filepath='../../include/zfs_prop.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pd_strdefault' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='71' column='1'/>
+        <var-decl name='pd_strdefault' type-id='type-id-86' visibility='default' filepath='../../include/zfs_prop.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pd_numdefault' type-id='type-id-27' visibility='default' filepath='../../include/zfs_prop.h' line='72' column='1'/>
+        <var-decl name='pd_numdefault' type-id='type-id-26' visibility='default' filepath='../../include/zfs_prop.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pd_attr' type-id='type-id-359' visibility='default' filepath='../../include/zfs_prop.h' line='73' column='1'/>
+        <var-decl name='pd_attr' type-id='type-id-341' visibility='default' filepath='../../include/zfs_prop.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='pd_types' type-id='type-id-6' visibility='default' filepath='../../include/zfs_prop.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pd_values' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='76' column='1'/>
+        <var-decl name='pd_values' type-id='type-id-86' visibility='default' filepath='../../include/zfs_prop.h' line='76' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pd_colname' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='77' column='1'/>
+        <var-decl name='pd_colname' type-id='type-id-86' visibility='default' filepath='../../include/zfs_prop.h' line='77' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='pd_rightalign' type-id='type-id-5' visibility='default' filepath='../../include/zfs_prop.h' line='78' column='1'/>
@@ -5817,13 +5702,13 @@
         <var-decl name='pd_zfs_mod_supported' type-id='type-id-5' visibility='default' filepath='../../include/zfs_prop.h' line='81' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='pd_table' type-id='type-id-360' visibility='default' filepath='../../include/zfs_prop.h' line='82' column='1'/>
+        <var-decl name='pd_table' type-id='type-id-342' visibility='default' filepath='../../include/zfs_prop.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='pd_table_size' type-id='type-id-43' visibility='default' filepath='../../include/zfs_prop.h' line='84' column='1'/>
+        <var-decl name='pd_table_size' type-id='type-id-32' visibility='default' filepath='../../include/zfs_prop.h' line='84' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='46' column='1' id='type-id-361'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/zfs_prop.h' line='46' column='1' id='type-id-343'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='PROP_DEFAULT' value='0'/>
       <enumerator name='PROP_READONLY' value='1'/>
@@ -5831,121 +5716,121 @@
       <enumerator name='PROP_ONETIME' value='3'/>
       <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
     </enum-decl>
-    <typedef-decl name='zprop_attr_t' type-id='type-id-361' filepath='../../include/zfs_prop.h' line='60' column='1' id='type-id-359'/>
-    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_prop.h' line='62' column='1' id='type-id-362'>
+    <typedef-decl name='zprop_attr_t' type-id='type-id-343' filepath='../../include/zfs_prop.h' line='60' column='1' id='type-id-341'/>
+    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/zfs_prop.h' line='62' column='1' id='type-id-344'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pi_name' type-id='type-id-104' visibility='default' filepath='../../include/zfs_prop.h' line='63' column='1'/>
+        <var-decl name='pi_name' type-id='type-id-86' visibility='default' filepath='../../include/zfs_prop.h' line='63' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pi_value' type-id='type-id-27' visibility='default' filepath='../../include/zfs_prop.h' line='64' column='1'/>
+        <var-decl name='pi_value' type-id='type-id-26' visibility='default' filepath='../../include/zfs_prop.h' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zprop_index_t' type-id='type-id-362' filepath='../../include/zfs_prop.h' line='65' column='1' id='type-id-363'/>
-    <qualified-type-def type-id='type-id-363' const='yes' id='type-id-364'/>
-    <pointer-type-def type-id='type-id-364' size-in-bits='64' id='type-id-360'/>
-    <typedef-decl name='zprop_desc_t' type-id='type-id-358' filepath='../../include/zfs_prop.h' line='85' column='1' id='type-id-357'/>
-    <pointer-type-def type-id='type-id-357' size-in-bits='64' id='type-id-365'/>
+    <typedef-decl name='zprop_index_t' type-id='type-id-344' filepath='../../include/zfs_prop.h' line='65' column='1' id='type-id-345'/>
+    <qualified-type-def type-id='type-id-345' const='yes' id='type-id-346'/>
+    <pointer-type-def type-id='type-id-346' size-in-bits='64' id='type-id-342'/>
+    <typedef-decl name='zprop_desc_t' type-id='type-id-340' filepath='../../include/zfs_prop.h' line='85' column='1' id='type-id-339'/>
+    <pointer-type-def type-id='type-id-339' size-in-bits='64' id='type-id-347'/>
     <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' filepath='../../module/zcommon/zfs_prop.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
-      <return type-id='type-id-365'/>
+      <return type-id='type-id-347'/>
     </function-decl>
     <function-decl name='zprop_random_value' mangled-name='zprop_random_value' filepath='../../include/zfs_prop.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' filepath='../../include/zfs_prop.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_index' mangled-name='zprop_register_index' filepath='../../include/zfs_prop.h' line='112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_string' mangled-name='zprop_register_string' filepath='../../include/zfs_prop.h' line='108' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_number' mangled-name='zprop_register_number' filepath='../../include/zfs_prop.h' line='110' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' filepath='../../include/zfs_prop.h' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' filepath='../../include/zfs_prop.h' line='105' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-104'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' filepath='../../module/zcommon/zpool_prop.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-104'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
-      <parameter type-id='type-id-27' name='seed' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
-      <return type-id='type-id-27'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
+      <parameter type-id='type-id-26' name='seed' filepath='../../module/zcommon/zpool_prop.c' line='236' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
     <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
-      <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
-      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zpool_prop.c' line='230' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
+      <parameter type-id='type-id-26' name='index' filepath='../../module/zcommon/zpool_prop.c' line='229' column='1'/>
+      <parameter type-id='type-id-338' name='string' filepath='../../module/zcommon/zpool_prop.c' line='230' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
-      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
-      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zpool_prop.c' line='223' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
+      <parameter type-id='type-id-86' name='string' filepath='../../module/zcommon/zpool_prop.c' line='222' column='1'/>
+      <parameter type-id='type-id-119' name='index' filepath='../../module/zcommon/zpool_prop.c' line='223' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' filepath='../../module/zcommon/zpool_prop.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zpool_prop.c' line='215' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1'/>
-      <return type-id='type-id-27'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='196' column='1'/>
+      <return type-id='type-id-26'/>
     </function-decl>
     <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' filepath='../../module/zcommon/zpool_prop.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-104'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' filepath='../../module/zcommon/zpool_prop.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' filepath='../../module/zcommon/zpool_prop.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='257' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1'/>
-      <return type-id='type-id-355'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='172' column='1'/>
+      <return type-id='type-id-337'/>
     </function-decl>
     <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' filepath='../../module/zcommon/zpool_prop.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
-      <parameter type-id='type-id-209' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
-      <return type-id='type-id-104'/>
+      <parameter type-id='type-id-191' name='prop' filepath='../../module/zcommon/zpool_prop.c' line='251' column='1'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
-      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1'/>
-      <return type-id='type-id-209'/>
+      <parameter type-id='type-id-86' name='propname' filepath='../../module/zcommon/zpool_prop.c' line='156' column='1'/>
+      <return type-id='type-id-191'/>
     </function-decl>
     <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' filepath='../../module/zcommon/zpool_prop.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
-      <return type-id='type-id-365'/>
+      <return type-id='type-id-347'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
     <function-decl name='zprop_width' mangled-name='zprop_width' filepath='../../module/zcommon/zprop_common.c' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
-      <parameter type-id='type-id-114' name='fixed' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
+      <parameter type-id='type-id-96' name='fixed' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='401' column='1'/>
-      <return type-id='type-id-43'/>
+      <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' filepath='../../module/zcommon/zprop_common.c' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='380' column='1'/>
@@ -5956,36 +5841,36 @@
     <function-decl name='zprop_values' mangled-name='zprop_values' filepath='../../module/zcommon/zprop_common.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='360' column='1'/>
-      <return type-id='type-id-104'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='zprop_random_value' mangled-name='zprop_random_value' filepath='../../module/zcommon/zprop_common.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
-      <parameter type-id='type-id-27' name='seed' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
+      <parameter type-id='type-id-26' name='seed' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='344' column='1'/>
-      <return type-id='type-id-27'/>
+      <return type-id='type-id-26'/>
     </function-decl>
     <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
-      <parameter type-id='type-id-27' name='index' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
-      <parameter type-id='type-id-356' name='string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-26' name='index' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
+      <parameter type-id='type-id-338' name='string' filepath='../../module/zcommon/zprop_common.c' line='315' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='316' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
-      <parameter type-id='type-id-104' name='string' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
-      <parameter type-id='type-id-137' name='index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-86' name='string' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
+      <parameter type-id='type-id-119' name='index' filepath='../../module/zcommon/zprop_common.c' line='289' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='290' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' filepath='../../module/zcommon/zprop_common.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
-      <parameter type-id='type-id-104' name='propname' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
+      <parameter type-id='type-id-86' name='propname' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='274' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' filepath='../../module/zcommon/zprop_common.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
-      <parameter type-id='type-id-229' name='func' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
-      <parameter type-id='type-id-42' name='cb' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-211' name='func' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
+      <parameter type-id='type-id-68' name='cb' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
       <parameter type-id='type-id-5' name='show_all' filepath='../../module/zcommon/zprop_common.c' line='185' column='1'/>
       <parameter type-id='type-id-5' name='ordered' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
       <parameter type-id='type-id-20' name='type' filepath='../../module/zcommon/zprop_common.c' line='186' column='1'/>
@@ -5993,260 +5878,260 @@
     </function-decl>
     <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' filepath='../../module/zcommon/zprop_common.c' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-355' name='type' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
-      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-337' name='type' filepath='../../module/zcommon/zprop_common.c' line='150' column='1'/>
+      <parameter type-id='type-id-341' name='attr' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
-      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-86' name='colname' filepath='../../module/zcommon/zprop_common.c' line='151' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_index' mangled-name='zprop_register_index' filepath='../../module/zcommon/zprop_common.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
-      <parameter type-id='type-id-27' name='def' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
-      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-26' name='def' filepath='../../module/zcommon/zprop_common.c' line='141' column='1'/>
+      <parameter type-id='type-id-341' name='attr' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
-      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
-      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
-      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-86' name='values' filepath='../../module/zcommon/zprop_common.c' line='142' column='1'/>
+      <parameter type-id='type-id-86' name='colname' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <parameter type-id='type-id-342' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='143' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_number' mangled-name='zprop_register_number' filepath='../../module/zcommon/zprop_common.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
-      <parameter type-id='type-id-27' name='def' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
-      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-26' name='def' filepath='../../module/zcommon/zprop_common.c' line='132' column='1'/>
+      <parameter type-id='type-id-341' name='attr' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
-      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
-      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='134' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-86' name='values' filepath='../../module/zcommon/zprop_common.c' line='133' column='1'/>
+      <parameter type-id='type-id-86' name='colname' filepath='../../module/zcommon/zprop_common.c' line='134' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_string' mangled-name='zprop_register_string' filepath='../../module/zcommon/zprop_common.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-104' name='def' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
-      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-86' name='def' filepath='../../module/zcommon/zprop_common.c' line='122' column='1'/>
+      <parameter type-id='type-id-341' name='attr' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
-      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
-      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='124' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-86' name='values' filepath='../../module/zcommon/zprop_common.c' line='123' column='1'/>
+      <parameter type-id='type-id-86' name='colname' filepath='../../module/zcommon/zprop_common.c' line='124' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' filepath='../../module/zcommon/zprop_common.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
       <parameter type-id='type-id-6' name='prop' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
-      <parameter type-id='type-id-104' name='name' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
-      <parameter type-id='type-id-355' name='type' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
-      <parameter type-id='type-id-27' name='numdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
-      <parameter type-id='type-id-104' name='strdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
-      <parameter type-id='type-id-359' name='attr' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-86' name='name' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-337' name='type' filepath='../../module/zcommon/zprop_common.c' line='89' column='1'/>
+      <parameter type-id='type-id-26' name='numdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-86' name='strdefault' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
+      <parameter type-id='type-id-341' name='attr' filepath='../../module/zcommon/zprop_common.c' line='90' column='1'/>
       <parameter type-id='type-id-6' name='objset_types' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
-      <parameter type-id='type-id-104' name='values' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
-      <parameter type-id='type-id-104' name='colname' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-86' name='values' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
+      <parameter type-id='type-id-86' name='colname' filepath='../../module/zcommon/zprop_common.c' line='91' column='1'/>
       <parameter type-id='type-id-5' name='rightalign' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
       <parameter type-id='type-id-5' name='visible' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
-      <parameter type-id='type-id-360' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
-      <return type-id='type-id-52'/>
+      <parameter type-id='type-id-342' name='idx_tbl' filepath='../../module/zcommon/zprop_common.c' line='92' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__ctype_tolower_loc' mangled-name='__ctype_tolower_loc' filepath='/usr/include/ctype.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' filepath='../../include/sys/zfs_sysfs.h' line='38' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
-      <parameter type-id='type-id-23' name='options' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1'/>
-      <parameter type-id='type-id-23' name='proto' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
+      <parameter type-id='type-id-23' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='299' column='1'/>
+      <parameter type-id='type-id-23' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='299' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
-      <parameter type-id='type-id-6' name='err' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='182' column='1'/>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
+      <parameter type-id='type-id-6' name='err' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='182' column='1'/>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
-      <parameter type-id='type-id-104' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='166' column='1'/>
-      <return type-id='type-id-52'/>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
+      <parameter type-id='type-id-86' name='protocol' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='166' column='1'/>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='144' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='144' column='1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='115' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='115' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
-      <parameter type-id='type-id-104' name='zfsname' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1'/>
-      <parameter type-id='type-id-104' name='mountpoint' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='80' column='1'/>
-      <parameter type-id='type-id-104' name='shareopts' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='81' column='1'/>
-      <parameter type-id='type-id-23' name='protocol' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
+      <parameter type-id='type-id-86' name='zfsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-86' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='80' column='1'/>
+      <parameter type-id='type-id-86' name='shareopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='81' column='1'/>
+      <parameter type-id='type-id-23' name='protocol' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='81' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='53' column='1' id='type-id-366'>
+    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='53' column='1' id='type-id-348'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-367' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='54' column='1'/>
+        <var-decl name='next' type-id='type-id-349' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='54' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='name' type-id='type-id-104' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='56' column='1'/>
+        <var-decl name='name' type-id='type-id-86' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ops' type-id='type-id-368' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='57' column='1'/>
+        <var-decl name='ops' type-id='type-id-350' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fsinfo_index' type-id='type-id-6' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='58' column='1'/>
+        <var-decl name='fsinfo_index' type-id='type-id-6' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-366' size-in-bits='64' id='type-id-367'/>
-    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='42' column='1' id='type-id-369'>
+    <pointer-type-def type-id='type-id-348' size-in-bits='64' id='type-id-349'/>
+    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='42' column='1' id='type-id-351'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='enable_share' type-id='type-id-370' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='43' column='1'/>
+        <var-decl name='enable_share' type-id='type-id-352' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='disable_share' type-id='type-id-370' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='44' column='1'/>
+        <var-decl name='disable_share' type-id='type-id-352' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='is_shared' type-id='type-id-371' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='45' column='1'/>
+        <var-decl name='is_shared' type-id='type-id-353' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='validate_shareopts' type-id='type-id-372' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='46' column='1'/>
+        <var-decl name='validate_shareopts' type-id='type-id-354' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='46' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='update_shareopts' type-id='type-id-373' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='47' column='1'/>
+        <var-decl name='update_shareopts' type-id='type-id-355' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='47' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='clear_shareopts' type-id='type-id-374' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='49' column='1'/>
+        <var-decl name='clear_shareopts' type-id='type-id-356' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='49' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='commit_shares' type-id='type-id-375' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='50' column='1'/>
+        <var-decl name='commit_shares' type-id='type-id-357' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='50' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='32' column='1' id='type-id-376'>
+    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='32' column='1' id='type-id-358'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sa_mountpoint' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='33' column='1'/>
+        <var-decl name='sa_mountpoint' type-id='type-id-23' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='33' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sa_zfsname' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='34' column='1'/>
+        <var-decl name='sa_zfsname' type-id='type-id-23' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sa_fsinfo' type-id='type-id-377' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='36' column='1'/>
+        <var-decl name='sa_fsinfo' type-id='type-id-359' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='28' column='1' id='type-id-378'>
+    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='28' column='1' id='type-id-360'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='shareopts' type-id='type-id-23' visibility='default' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='29' column='1'/>
+        <var-decl name='shareopts' type-id='type-id-23' visibility='default' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='29' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-378' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='30' column='1' id='type-id-379'/>
-    <pointer-type-def type-id='type-id-379' size-in-bits='64' id='type-id-377'/>
-    <pointer-type-def type-id='type-id-376' size-in-bits='64' id='type-id-380'/>
-    <typedef-decl name='sa_share_impl_t' type-id='type-id-380' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='37' column='1' id='type-id-381'/>
-    <pointer-type-def type-id='type-id-382' size-in-bits='64' id='type-id-370'/>
-    <pointer-type-def type-id='type-id-383' size-in-bits='64' id='type-id-371'/>
-    <pointer-type-def type-id='type-id-384' size-in-bits='64' id='type-id-372'/>
-    <pointer-type-def type-id='type-id-385' size-in-bits='64' id='type-id-373'/>
-    <pointer-type-def type-id='type-id-386' size-in-bits='64' id='type-id-374'/>
-    <pointer-type-def type-id='type-id-387' size-in-bits='64' id='type-id-375'/>
-    <typedef-decl name='sa_share_ops_t' type-id='type-id-369' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='51' column='1' id='type-id-388'/>
-    <qualified-type-def type-id='type-id-388' const='yes' id='type-id-389'/>
-    <pointer-type-def type-id='type-id-389' size-in-bits='64' id='type-id-368'/>
-    <typedef-decl name='sa_fstype_t' type-id='type-id-366' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare_impl.h' line='59' column='1' id='type-id-390'/>
-    <pointer-type-def type-id='type-id-390' size-in-bits='64' id='type-id-391'/>
-    <function-decl name='register_fstype' mangled-name='register_fstype' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='register_fstype'>
-      <parameter type-id='type-id-104' name='name' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1'/>
-      <parameter type-id='type-id-368' name='ops' filepath='/home/colm/src/zfs/zfs/lib/libshare/libshare.c' line='51' column='1'/>
-      <return type-id='type-id-391'/>
+    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-360' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='30' column='1' id='type-id-361'/>
+    <pointer-type-def type-id='type-id-361' size-in-bits='64' id='type-id-359'/>
+    <pointer-type-def type-id='type-id-358' size-in-bits='64' id='type-id-362'/>
+    <typedef-decl name='sa_share_impl_t' type-id='type-id-362' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='37' column='1' id='type-id-363'/>
+    <pointer-type-def type-id='type-id-364' size-in-bits='64' id='type-id-352'/>
+    <pointer-type-def type-id='type-id-365' size-in-bits='64' id='type-id-353'/>
+    <pointer-type-def type-id='type-id-366' size-in-bits='64' id='type-id-354'/>
+    <pointer-type-def type-id='type-id-367' size-in-bits='64' id='type-id-355'/>
+    <pointer-type-def type-id='type-id-368' size-in-bits='64' id='type-id-356'/>
+    <pointer-type-def type-id='type-id-369' size-in-bits='64' id='type-id-357'/>
+    <typedef-decl name='sa_share_ops_t' type-id='type-id-351' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='51' column='1' id='type-id-370'/>
+    <qualified-type-def type-id='type-id-370' const='yes' id='type-id-371'/>
+    <pointer-type-def type-id='type-id-371' size-in-bits='64' id='type-id-350'/>
+    <typedef-decl name='sa_fstype_t' type-id='type-id-348' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare_impl.h' line='59' column='1' id='type-id-372'/>
+    <pointer-type-def type-id='type-id-372' size-in-bits='64' id='type-id-373'/>
+    <function-decl name='register_fstype' mangled-name='register_fstype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='register_fstype'>
+      <parameter type-id='type-id-86' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <parameter type-id='type-id-350' name='ops' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/libshare.c' line='51' column='1'/>
+      <return type-id='type-id-373'/>
     </function-decl>
-    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' filepath='/home/colm/src/zfs/zfs/lib/libshare/nfs.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/nfs.h' line='27' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' filepath='/home/colm/src/zfs/zfs/lib/libshare/smb.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' filepath='/home/nabijaczleweli/store/code/zfs/lib/libshare/smb.h' line='49' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-67'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-387'>
+    <function-type size-in-bits='64' id='type-id-369'>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-384'>
-      <parameter type-id='type-id-104'/>
+    <function-type size-in-bits='64' id='type-id-366'>
+      <parameter type-id='type-id-86'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-382'>
-      <parameter type-id='type-id-381'/>
+    <function-type size-in-bits='64' id='type-id-364'>
+      <parameter type-id='type-id-363'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-385'>
-      <parameter type-id='type-id-381'/>
-      <parameter type-id='type-id-104'/>
+    <function-type size-in-bits='64' id='type-id-367'>
+      <parameter type-id='type-id-363'/>
+      <parameter type-id='type-id-86'/>
       <return type-id='type-id-6'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-383'>
-      <parameter type-id='type-id-381'/>
+    <function-type size-in-bits='64' id='type-id-365'>
+      <parameter type-id='type-id-363'/>
       <return type-id='type-id-5'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-386'>
-      <parameter type-id='type-id-381'/>
-      <return type-id='type-id-52'/>
+    <function-type size-in-bits='64' id='type-id-368'>
+      <parameter type-id='type-id-363'/>
+      <return type-id='type-id-67'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
     <function-decl name='register_fstype' mangled-name='register_fstype' filepath='./libshare_impl.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='unlink' mangled-name='unlink' filepath='/usr/include/unistd.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fputs' mangled-name='fputs' filepath='/usr/include/stdio.h' line='632' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mkstemp' mangled-name='mkstemp64' filepath='/usr/include/stdlib.h' line='688' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='mkdir' mangled-name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='__builtin_stpcpy' mangled-name='stpcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='flock' mangled-name='flock' filepath='/usr/include/x86_64-linux-gnu/sys/file.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='rename' mangled-name='rename' filepath='/usr/include/stdio.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/colm/src/zfs/zfs/lib/libshare' language='LANG_C99'>
-    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' filepath='./smb.h' line='38' column='1' id='type-id-392'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
+    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' filepath='./smb.h' line='38' column='1' id='type-id-374'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-393' visibility='default' filepath='./smb.h' line='39' column='1'/>
+        <var-decl name='name' type-id='type-id-375' visibility='default' filepath='./smb.h' line='39' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2040'>
-        <var-decl name='path' type-id='type-id-143' visibility='default' filepath='./smb.h' line='40' column='1'/>
+        <var-decl name='path' type-id='type-id-125' visibility='default' filepath='./smb.h' line='40' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='34808'>
-        <var-decl name='comment' type-id='type-id-393' visibility='default' filepath='./smb.h' line='41' column='1'/>
+        <var-decl name='comment' type-id='type-id-375' visibility='default' filepath='./smb.h' line='41' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='36864'>
         <var-decl name='guest_ok' type-id='type-id-5' visibility='default' filepath='./smb.h' line='42' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='36928'>
-        <var-decl name='next' type-id='type-id-394' visibility='default' filepath='./smb.h' line='44' column='1'/>
+        <var-decl name='next' type-id='type-id-376' visibility='default' filepath='./smb.h' line='44' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='2040' id='type-id-393'>
-      <subrange length='255' type-id='type-id-48' id='type-id-395'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='2040' id='type-id-375'>
+      <subrange length='255' type-id='type-id-37' id='type-id-377'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-392' size-in-bits='64' id='type-id-394'/>
-    <typedef-decl name='smb_share_t' type-id='type-id-392' filepath='./smb.h' line='45' column='1' id='type-id-396'/>
-    <pointer-type-def type-id='type-id-396' size-in-bits='64' id='type-id-397'/>
-    <var-decl name='smb_shares' type-id='type-id-397' mangled-name='smb_shares' visibility='default' filepath='./smb.h' line='47' column='1' elf-symbol-id='smb_shares'/>
+    <pointer-type-def type-id='type-id-374' size-in-bits='64' id='type-id-376'/>
+    <typedef-decl name='smb_share_t' type-id='type-id-374' filepath='./smb.h' line='45' column='1' id='type-id-378'/>
+    <pointer-type-def type-id='type-id-378' size-in-bits='64' id='type-id-379'/>
+    <var-decl name='smb_shares' type-id='type-id-379' mangled-name='smb_shares' visibility='default' filepath='./smb.h' line='47' column='1' elf-symbol-id='smb_shares'/>
     <function-decl name='opendir' mangled-name='opendir' filepath='/usr/include/dirent.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
     <function-decl name='fgets' mangled-name='fgets' filepath='/usr/include/stdio.h' line='570' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-52'/>
+      <return type-id='type-id-67'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1505,6 +1505,7 @@ int
 zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 {
 	int used, alloc;
+	FILE *mnttab;
 	struct mnttab entry;
 	size_t namelen;
 	char **mountpoints = NULL;
@@ -1516,12 +1517,11 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 
 	namelen = strlen(zhp->zpool_name);
 
-	/* Reopen MNTTAB to prevent reading stale data from open file */
-	if (freopen(MNTTAB, "re", hdl->libzfs_mnttab) == NULL)
+	if ((mnttab = fopen(MNTTAB, "re")) == NULL)
 		return (ENOENT);
 
 	used = alloc = 0;
-	while (getmntent(hdl->libzfs_mnttab, &entry) == 0) {
+	while (getmntent(mnttab, &entry) == 0) {
 		/*
 		 * Ignore non-ZFS entries.
 		 */
@@ -1623,6 +1623,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 
 	ret = 0;
 out:
+	(void) fclose(mnttab);
 	for (i = 0; i < used; i++) {
 		if (datasets[i])
 			zfs_close(datasets[i]);


### PR DESCRIPTION
### Motivation and Context
Well, one's a leak, and the other's Weird?

### Description
See individual commit messages.

This conflicts with #11866 and both will need a rebase if the other is merged.

### How Has This Been Tested?
I ran `zfs mount` and it closed `/proc/self/mounts` and `zfs list` and it didn't even touch it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv) – libzfs but only a private opaque member; also technically changes the ABI of libspl too to no longer leak the FILE*s, but, y'know
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
