### PR TITLE
libspl: getexecname() cleanup and gethostid() fixes, /proc/sys/kernel/spl/hostid fix for recent kernels in SPL

### DIFF
--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -21,6 +21,8 @@ libspl_assert_la_SOURCES = \
 	assert.c
 
 USER_C = \
+	libspl_impl.h \
+	getexecname.c \
 	list.c \
 	mkdirp.c \
 	page.c \

--- a/lib/libspl/libspl_impl.h
+++ b/lib/libspl/libspl_impl.h
@@ -20,21 +20,5 @@
  * CDDL HEADER END
  */
 
-#include <stdint.h>
-#include <limits.h>
-#include <sys/param.h>
-#include <sys/sysctl.h>
-#include <sys/types.h>
-#include "../../libspl_impl.h"
 
-__attribute__((visibility("hidden"))) ssize_t
-getexecname_impl(char *execname)
-{
-	size_t len = PATH_MAX;
-	int name[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
-
-	if (sysctl(name, nitems(name), execname, &len, NULL, 0) != 0)
-		return (-1);
-
-	return (len);
-}
+extern ssize_t getexecname_impl(char *execname);

--- a/lib/libspl/os/linux/getexecname.c
+++ b/lib/libspl/os/linux/getexecname.c
@@ -19,41 +19,14 @@
  *
  * CDDL HEADER END
  */
-/*
- * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
- * Use is subject to license terms.
- */
-
 
 #include <limits.h>
-#include <pthread.h>
-#include <stdlib.h>
-#include <string.h>
+#include <stdint.h>
 #include <unistd.h>
+#include "../../libspl_impl.h"
 
-const char *
-getexecname(void)
+__attribute__((visibility("hidden"))) ssize_t
+getexecname_impl(char *execname)
 {
-	static char execname[PATH_MAX + 1] = "";
-	static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
-	char *ptr = NULL;
-	ssize_t rc;
-
-	(void) pthread_mutex_lock(&mtx);
-
-	if (strlen(execname) == 0) {
-		rc = readlink("/proc/self/exe",
-		    execname, sizeof (execname) - 1);
-		if (rc == -1) {
-			execname[0] = '\0';
-		} else {
-			execname[rc] = '\0';
-			ptr = execname;
-		}
-	} else {
-		ptr = execname;
-	}
-
-	(void) pthread_mutex_unlock(&mtx);
-	return (ptr);
+	return (readlink("/proc/self/exe", execname, PATH_MAX));
 }

--- a/lib/libspl/os/linux/gethostid.c
+++ b/lib/libspl/os/linux/gethostid.c
@@ -40,47 +40,40 @@ get_spl_hostid(void)
 	 * Allow the hostid to be subverted for testing.
 	 */
 	env = getenv("ZFS_HOSTID");
-	if (env) {
-		hostid = strtoull(env, NULL, 0);
-		return (hostid & HOSTID_MASK);
-	}
+	if (env)
+		return (strtoull(env, NULL, 0));
 
-	f = fopen("/sys/module/spl/parameters/spl_hostid", "re");
+	f = fopen("/proc/sys/kernel/spl/hostid", "re");
 	if (!f)
 		return (0);
 
-	if (fscanf(f, "%lu", &hostid) != 1)
+	if (fscanf(f, "%lx", &hostid) != 1)
 		hostid = 0;
 
 	fclose(f);
 
-	return (hostid & HOSTID_MASK);
+	return (hostid);
 }
 
 unsigned long
 get_system_hostid(void)
 {
-	unsigned long system_hostid = get_spl_hostid();
+	unsigned long hostid = get_spl_hostid();
+
 	/*
-	 * We do not use the library call gethostid() because
-	 * it generates a hostid value that the kernel is
-	 * unaware of, if the spl_hostid module parameter has not
-	 * been set and there is no system hostid file (e.g.
-	 * /etc/hostid).  The kernel and userspace must agree.
+	 * We do not use gethostid(3) because it can return a bogus ID,
+	 * depending on the libc and /etc/hostid presence,
+	 * and the kernel and userspace must agree.
 	 * See comments above hostid_read() in the SPL.
 	 */
-	if (system_hostid == 0) {
-		int fd, rc;
-		unsigned long hostid;
-		int hostid_size = 4;  /* 4 bytes regardless of arch */
-
-		fd = open("/etc/hostid", O_RDONLY | O_CLOEXEC);
+	if (hostid == 0) {
+		int fd = open("/etc/hostid", O_RDONLY | O_CLOEXEC);
 		if (fd >= 0) {
-			rc = read(fd, &hostid, hostid_size);
-			if (rc > 0)
-				system_hostid = (hostid & HOSTID_MASK);
-			close(fd);
+			if (read(fd, &hostid, 4) < 0)
+				hostid = 0;
+			(void) close(fd);
 		}
 	}
-	return (system_hostid);
+
+	return (hostid & HOSTID_MASK);
 }

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -53,60 +53,6 @@ static struct proc_dir_entry *proc_spl_taskq_all = NULL;
 static struct proc_dir_entry *proc_spl_taskq = NULL;
 struct proc_dir_entry *proc_spl_kstat = NULL;
 
-static int
-proc_copyin_string(char *kbuffer, int kbuffer_size, const char *ubuffer,
-    int ubuffer_size)
-{
-	int size;
-
-	if (ubuffer_size > kbuffer_size)
-		return (-EOVERFLOW);
-
-	if (copy_from_user((void *)kbuffer, (void *)ubuffer, ubuffer_size))
-		return (-EFAULT);
-
-	/* strip trailing whitespace */
-	size = strnlen(kbuffer, ubuffer_size);
-	while (size-- >= 0)
-		if (!isspace(kbuffer[size]))
-			break;
-
-	/* empty string */
-	if (size < 0)
-		return (-EINVAL);
-
-	/* no space to terminate */
-	if (size == kbuffer_size)
-		return (-EOVERFLOW);
-
-	kbuffer[size + 1] = 0;
-	return (0);
-}
-
-static int
-proc_copyout_string(char *ubuffer, int ubuffer_size, const char *kbuffer,
-    char *append)
-{
-	/*
-	 * NB if 'append' != NULL, it's a single character to append to the
-	 * copied out string - usually "\n", for /proc entries and
-	 * (i.e. a terminating zero byte) for sysctl entries
-	 */
-	int size = MIN(strlen(kbuffer), ubuffer_size);
-
-	if (copy_to_user(ubuffer, kbuffer, size))
-		return (-EFAULT);
-
-	if (append != NULL && size < ubuffer_size) {
-		if (copy_to_user(ubuffer + size, append, 1))
-			return (-EFAULT);
-
-		size++;
-	}
-
-	return (size);
-}
-
 #ifdef DEBUG_KMEM
 static int
 proc_domemused(struct ctl_table *table, int write,
@@ -187,39 +133,34 @@ static int
 proc_dohostid(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
-	int len, rc = 0;
 	char *end, str[32];
+	unsigned long hid;
+	spl_ctl_table dummy = *table;
+
+	dummy.data = str;
+	dummy.maxlen = sizeof (str) - 1;
+
+	if (!write)
+		snprintf(str, sizeof (str), "%lx",
+		    (unsigned long) zone_get_hostid(NULL));
+
+	/* always returns 0 */
+	proc_dostring(&dummy, write, buffer, lenp, ppos);
 
 	if (write) {
 		/*
 		 * We can't use proc_doulongvec_minmax() in the write
-		 * case here because hostid while a hex value has no
-		 * leading 0x which confuses the helper function.
+		 * case here because hostid, while a hex value, has no
+		 * leading 0x, which confuses the helper function.
 		 */
-		rc = proc_copyin_string(str, sizeof (str), buffer, *lenp);
-		if (rc < 0)
-			return (rc);
 
-		spl_hostid = simple_strtoul(str, &end, 16);
+		hid = simple_strtoul(str, &end, 16);
 		if (str == end)
 			return (-EINVAL);
-
-	} else {
-		len = snprintf(str, sizeof (str), "%lx",
-		    (unsigned long) zone_get_hostid(NULL));
-		if (*ppos >= len)
-			rc = 0;
-		else
-			rc = proc_copyout_string(buffer,
-			    *lenp, str + *ppos, "\n");
-
-		if (rc >= 0) {
-			*lenp = rc;
-			*ppos += rc;
-		}
+		spl_hostid = hid;
 	}
 
-	return (rc);
+	return (0);
 }
 
 static void

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -59,13 +59,13 @@ proc_domemused(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
 	int rc = 0;
-	unsigned long min = 0, max = ~0, val;
+	unsigned long val;
 	spl_ctl_table dummy = *table;
 
 	dummy.data = &val;
 	dummy.proc_handler = &proc_dointvec;
-	dummy.extra1 = &min;
-	dummy.extra2 = &max;
+	dummy.extra1 = &table_min;
+	dummy.extra2 = &table_max;
 
 	if (write) {
 		*ppos += *lenp;
@@ -87,14 +87,14 @@ proc_doslab(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
 	int rc = 0;
-	unsigned long min = 0, max = ~0, val = 0, mask;
+	unsigned long val = 0, mask;
 	spl_ctl_table dummy = *table;
 	spl_kmem_cache_t *skc = NULL;
 
 	dummy.data = &val;
 	dummy.proc_handler = &proc_dointvec;
-	dummy.extra1 = &min;
-	dummy.extra2 = &max;
+	dummy.extra1 = &table_min;
+	dummy.extra2 = &table_max;
 
 	if (write) {
 		*ppos += *lenp;

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1383,10 +1383,6 @@ zvol_set_snapdev_impl(char *name, uint64_t snapdev)
 	spl_fstrans_unmark(cookie);
 }
 
-typedef struct zvol_volmode_cb_arg {
-	uint64_t volmode;
-} zvol_volmode_cb_arg_t;
-
 static void
 zvol_set_volmode_impl(char *name, uint64_t volmode)
 {


### PR DESCRIPTION
### Motivation and Context
See individual commit messages, #11878.

### Description
The second patch merges the actual implementations of getexecname() (and slightly cleans up the FreeBSD one, which I haven't tested, but I can't see why it wouldn't be identical (beside maybe the header reduxion going badly)).

The third patch fixes `/proc/sys/kernel/spl/hostid` on 5.7+ kernels. I haven't actually tested this on any older kernel, but the blame of `kernel/sysctl.c#_proc_do_string()` says there's no need to worry:
```
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  243) 
f88083005ab31 (Kees Cook                      2014-06-06 14:37:17 -0700  244) static int _proc_do_string(char *data, int maxlen, int write,
32927393dc1cc (Christoph Hellwig              2020-04-24 08:43:38 +0200  245) 		char *buffer, size_t *lenp, loff_t *ppos)
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  246) {
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  247) 	size_t len;
32927393dc1cc (Christoph Hellwig              2020-04-24 08:43:38 +0200  248) 	char c, *p;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  249) 
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  250) 	if (!data || !maxlen || !*lenp) {
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  251) 		*lenp = 0;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  252) 		return 0;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  253) 	}
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  254) 
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  255) 	if (write) {
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  256) 		if (sysctl_writes_strict == SYSCTL_WRITES_STRICT) {
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  257) 			/* Only continue writes not past the end of buffer. */
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  258) 			len = strlen(data);
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  259) 			if (len > maxlen - 1)
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  260) 				len = maxlen - 1;
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  261) 
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  262) 			if (*ppos > len)
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  263) 				return 0;
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  264) 			len = *ppos;
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  265) 		} else {
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  266) 			/* Start writing from beginning of buffer. */
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  267) 			len = 0;
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  268) 		}
f4aacea2f5d1a (Kees Cook                      2014-06-06 14:37:19 -0700  269) 
2ca9bb456ada8 (Kees Cook                      2014-06-06 14:37:18 -0700  270) 		*ppos += *lenp;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  271) 		p = buffer;
2ca9bb456ada8 (Kees Cook                      2014-06-06 14:37:18 -0700  272) 		while ((p - buffer) < *lenp && len < maxlen - 1) {
32927393dc1cc (Christoph Hellwig              2020-04-24 08:43:38 +0200  273) 			c = *(p++);
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  274) 			if (c == 0 || c == '\n')
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  275) 				break;
2ca9bb456ada8 (Kees Cook                      2014-06-06 14:37:18 -0700  276) 			data[len++] = c;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  277) 		}
f88083005ab31 (Kees Cook                      2014-06-06 14:37:17 -0700  278) 		data[len] = 0;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  279) 	} else {
f5dd3d6fadf98 (Sam Vilain                     2006-10-02 02:18:04 -0700  280) 		len = strlen(data);
f5dd3d6fadf98 (Sam Vilain                     2006-10-02 02:18:04 -0700  281) 		if (len > maxlen)
f5dd3d6fadf98 (Sam Vilain                     2006-10-02 02:18:04 -0700  282) 			len = maxlen;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  283) 
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  284) 		if (*ppos > len) {
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  285) 			*lenp = 0;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  286) 			return 0;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  287) 		}
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  288) 
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  289) 		data += *ppos;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  290) 		len  -= *ppos;
8d06087714b78 (Oleg Nesterov                  2007-02-10 01:46:38 -0800  291) 
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  292) 		if (len > *lenp)
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  293) 			len = *lenp;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  294) 		if (len)
32927393dc1cc (Christoph Hellwig              2020-04-24 08:43:38 +0200  295) 			memcpy(buffer, data, len);
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  296) 		if (len < *lenp) {
32927393dc1cc (Christoph Hellwig              2020-04-24 08:43:38 +0200  297) 			buffer[len] = '\n';
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  298) 			len++;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  299) 		}
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  300) 		*lenp = len;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  301) 		*ppos += len;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  302) 	}
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  303) 	return 0;
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  304) }
^1da177e4c3f4 (Linus Torvalds                 2005-04-16 15:20:36 -0700  305) 
```

The fourth patch (a) fixes get_system_hostid() if it was set via the aforementioned sysctl, (b) makes it mildly faster, considering no-one sets spl_hostid, and (c) simplifies the code a bit.

The fifth patch uses the same limits in dummy tables as in the global ones.

### How Has This Been Tested?
Ran the functions, they return the right results (on Linux), the module behaves right on the kernel from #11878.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change) – likely irrelevant, and I'd argue it's a bug-fix, but see the third patch
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly. – there's none
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply, I'm pretty sure; maybe some should? but dunno where I'd start with that
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).