### PR TITLE
zed: cloexec on persistent fds, test to validate ZEDLETs only inherit 0-3

### DIFF
--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -54,7 +54,7 @@ zed_event_init(struct zed_conf *zcp)
 		zed_log_die("Failed to initialize libzfs");
 	}
 
-	zcp->zevent_fd = open(ZFS_DEV, O_RDWR);
+	zcp->zevent_fd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 	if (zcp->zevent_fd < 0) {
 		if (zcp->do_idle)
 			return (-1);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -90,7 +90,7 @@ tests = ['devices_001_pos', 'devices_002_neg', 'devices_003_pos']
 tags = ['functional', 'devices']
 
 [tests/functional/events:Linux]
-tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter']
+tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill']
 tags = ['functional', 'events']
 
 [tests/functional/fallocate:Linux]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3577,16 +3577,11 @@ function wait_replacing #pool
 # Wait for a pool to be scrubbed
 #
 # $1 pool name
-# $2 number of seconds to wait (optional)
-#
-# Returns true when pool has been scrubbed, or false if there's a timeout or if
-# no scrub was done.
 #
 function wait_scrubbed
 {
 	typeset pool=${1:-$TESTPOOL}
-	while true ; do
-		is_pool_scrubbed $pool && break
+	while ! is_pool_scrubbed $pool ; do
 		sleep 1
 	done
 }

--- a/tests/zfs-tests/tests/functional/events/.gitignore
+++ b/tests/zfs-tests/tests/functional/events/.gitignore
@@ -1,0 +1,1 @@
+/zed_fd_spill-zedlet

--- a/tests/zfs-tests/tests/functional/events/Makefile.am
+++ b/tests/zfs-tests/tests/functional/events/Makefile.am
@@ -1,3 +1,5 @@
+include $(top_srcdir)/config/Rules.am
+
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/events
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
@@ -10,3 +12,7 @@ dist_pkgdata_SCRIPTS = \
 dist_pkgdata_DATA = \
 	events.cfg \
 	events_common.kshlib
+
+pkgexecdir = $(pkgdatadir)
+pkgexec_PROGRAMS = zed_fd_spill-zedlet
+zed_fd_spill_zedlet_SOURCES = zed_fd_spill-zedlet.c

--- a/tests/zfs-tests/tests/functional/events/Makefile.am
+++ b/tests/zfs-tests/tests/functional/events/Makefile.am
@@ -4,7 +4,8 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	events_001_pos.ksh \
 	events_002_pos.ksh \
-	zed_rc_filter.ksh
+	zed_rc_filter.ksh \
+	zed_fd_spill.ksh
 
 dist_pkgdata_DATA = \
 	events.cfg \

--- a/tests/zfs-tests/tests/functional/events/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/events/cleanup.ksh
@@ -26,6 +26,6 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-zed_cleanup all-debug.sh all-syslog.sh
+zed_cleanup all-debug.sh all-syslog.sh all-dumpfds
 
 default_cleanup

--- a/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
@@ -50,11 +50,11 @@ function cleanup
 		[[ -f $file ]] && rm -f $file
 	done
 
-	log_must rm -f $TMP_EVENTS_ZED $TMP_EVENTS_ZED
+	log_must rm -f $TMP_EVENTS_ZED
 	log_must zed_stop
 }
 
-log_assert "Verify ZED handles missed events on when starting"
+log_assert "Verify ZED handles missed events when starting"
 log_onexit cleanup
 
 log_must truncate -s $MINVDEVSIZE $VDEV1 $VDEV2

--- a/tests/zfs-tests/tests/functional/events/zed_fd_spill-zedlet.c
+++ b/tests/zfs-tests/tests/functional/events/zed_fd_spill-zedlet.c
@@ -1,0 +1,36 @@
+/*
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(void) {
+	if (fork()) {
+		int err;
+		wait(&err);
+		return (err);
+	}
+
+	char buf[64];
+	sprintf(buf, "/tmp/zts-zed_fd_spill-logdir/%d", getppid());
+	dup2(creat(buf, 0644), STDOUT_FILENO);
+
+	snprintf(buf, sizeof (buf), "/proc/%d/fd", getppid());
+	execlp("ls", "ls", buf, NULL);
+	_exit(127);
+}

--- a/tests/zfs-tests/tests/functional/events/zed_fd_spill.ksh
+++ b/tests/zfs-tests/tests/functional/events/zed_fd_spill.ksh
@@ -1,0 +1,98 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# DESCRIPTION:
+# Verify ZEDLETs only inherit the fds specified in the manpage
+#
+# STRATEGY:
+# 1. Inject a ZEDLET that dumps the fds it gets to a file.
+# 2. Generate some events.
+# 3. Read back the generated files and assert that there is no fd past 3,
+#    and there are exactly 4 fds.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/events/events_common.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must rm -rf "$logdir"
+	log_must zed_stop
+}
+
+log_assert "Verify ZEDLETs inherit only the fds specified"
+log_onexit cleanup
+
+logdir="$(mktemp -d)"
+log_must cc -xc -o${ZEDLET_DIR}/all-dumpfds << EOF
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+	if(fork()) {
+		int err;
+		wait(&err);
+		return err;
+	}
+
+	char buf[4096];
+	snprintf(buf, sizeof (buf), "$logdir/%d", getppid());
+	dup2(creat(buf, 0644), STDOUT_FILENO);
+
+	// Fault injexion!
+	snprintf(buf, sizeof (buf), "%d", (getppid() % 20) + 4);
+	puts(buf);
+
+	snprintf(buf, sizeof (buf), "/proc/%d/fd", getppid());
+	execlp("ls", "ls", buf, NULL);
+	_exit(127);
+}
+EOF
+
+log_must zpool events -c
+log_must zed_stop
+log_must zed_start
+
+truncate -s 0 $ZED_DEBUG_LOG
+log_must zpool scrub $testpool
+log_must zfs set compression=off $TESTPOOL/$TESTFS
+wait_scrubbed $TESTPOOL
+log_must file_wait $ZED_DEBUG_LOG 3
+
+log_must ls -l "$logdir"
+log_must awk '
+!/^[0123]$/ {
+	print FILENAME ": " $0 >"/dev/stderr"
+	err=1
+}
+END {
+	exit err
+}
+' "$logdir"/*
+wc -l "$logdir"/* | log_must awk '$1 != "3" && $2 != "total" {print; exit 1}'
+
+log_pass "ZED doesn't leak fds to ZEDLETs"


### PR DESCRIPTION
### Motivation and Context
See individual commit messages.

### Description
The first patch slightly shortens the zed pre-exec path (and slightly more if run without -F).

The second patch adds a test to verify this remains right; the test currently has a fault injected into it to verify it's run at all – it should fail on most buildds. I'll clean it out when the builds go through.

### How Has This Been Tested?
Ran it, looked at strace and listings of inherited fds. For later reference, it's best to comment out `dup2(zfd, ZEVENT_FILENO)` when testing, since it used to mask the pidfile.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
