### PR TITLE
Fix vdev health padding in zpool list -v

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6021,7 +6021,7 @@ print_one_column(zpool_prop_t prop, uint64_t value, const char *str,
 		break;
 	case ZPOOL_PROP_HEALTH:
 		width = 8;
-		snprintf(propval, sizeof (propval), "%-*s", (int)width, str);
+		(void) strlcpy(propval, str, sizeof (propval));
 		break;
 	default:
 		zfs_nicenum_format(value, propval, sizeof (propval), format);


### PR DESCRIPTION
Do not (incorrectly, right instead left) pad health string itself,
it will be taken care of when printing property value below.

Signed-off-by: Yuri Pankov <yuripv@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per-vdev health in `zpool list -v` is padded inconsistently.

### Description
<!--- Describe your changes in detail -->
Don't pad (incorrectly at that) the health value separately, it will be properly padded when printing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Before:
```
$ zpool list -v
NAME         SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
data        14.5T  12.4G  14.5T        -         -     0%     0%  1.00x    ONLINE  -
  raidz1    14.5T  12.4G  14.5T        -         -     0%  0.08%      -  ONLINE
    ada1p1      -      -      -        -         -      -      -      -  ONLINE
    ada2p1      -      -      -        -         -      -      -      -  ONLINE
    ada3p1      -      -      -        -         -      -      -      -  ONLINE
    ada4p1      -      -      -        -         -      -      -      -  ONLINE
system       672G  12.2G   660G        -         -     0%     1%  1.00x    ONLINE  -
  ada0p3     672G  12.2G   660G        -         -     0%  1.81%      -  ONLINE
```
After:
```
$ zpool list -v
NAME         SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
data        14.5T  12.4G  14.5T        -         -     0%     0%  1.00x    ONLINE  -
  raidz1    14.5T  12.4G  14.5T        -         -     0%  0.08%      -    ONLINE
    ada1p1      -      -      -        -         -      -      -      -    ONLINE
    ada2p1      -      -      -        -         -      -      -      -    ONLINE
    ada3p1      -      -      -        -         -      -      -      -    ONLINE
    ada4p1      -      -      -        -         -      -      -      -    ONLINE
system       672G  12.2G   660G        -         -     0%     1%  1.00x    ONLINE  -
  ada0p3     672G  12.2G   660G        -         -     0%  1.81%      -    ONLINE
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
