### PR TITLE
Fix 'make checkbashisms` warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,7 +161,7 @@ checkbashisms:
 				-o -name '90zfs' -prune \
 				-o -type f ! -name 'config*' \
 				! -name 'libtool' \
-			-exec sh -c 'awk "NR==1 && /\#\!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \
+			-exec sh -c 'awk "NR==1 && /#!.*bin\/sh.*/ {print FILENAME;}" "{}"' \;); \
 	else \
 		echo "skipping checkbashisms because checkbashisms is not installed"; \
 	fi


### PR DESCRIPTION
### Motivation and Context

Resolve the warnings when running `make checkstyle`.

```
awk: cmd. line:1: warning: regexp escape sequence `\!' is not a known regexp operator
awk: cmd. line:1: warning: regexp escape sequence `\#' is not a known regexp operator
```

### Description

The awk command used by the checkcheckbashisms target incorrectly
adds the escape character before the ! and # characters.  This
results in the following warnings because these characters do not
need to be escaped.

    awk: cmd. line:1: warning: regexp escape sequence
        `\!' is not a known regexp operator
    awk: cmd. line:1: warning: regexp escape sequence
        `\#' is not a known regexp operator

Remove the unneeded escape character before ! and #.

Valid escape sequences are:

    https://www.gnu.org/software/gawk/manual/html_node/Escape-Sequences.html

### How Has This Been Tested?

Manually verified using `gawk` and `mawk` that the correct files
names were matched and no warnings were issued.  Testing was
done on Fedora 33 and Ubuntu 20.04.

```
make checkbashisms
<no warnings printed>
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
