### PR TITLE
zfs-send(8): Restore sorting of flags

### DIFF
--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -30,7 +30,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd April 15, 2021
 .Dt ZFS-SEND 8
 .Os
 .Sh NAME
@@ -39,12 +39,12 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm send
-.Op Fl DLPRsbcehnpvw
+.Op Fl DLPRbcehnpsvw
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Nm zfs
 .Cm send
-.Op Fl DLPRscenpvw
+.Op Fl DLPRcenpsvw
 .Op Fl i Ar snapshot Ns | Ns Ar bookmark
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Nm zfs
@@ -139,12 +139,6 @@ do not exist on the sending side are destroyed. If the
 flag is used to send encrypted datasets, then
 .Fl w
 must also be specified.
-.It Fl s, -skip-missing
-Allows sending a replication stream even when there are snapshots missing in the
-hierarchy. When a snapshot is missing, instead of throwing an error and aborting
-the send, a warning is printed to STDERR and the dataset to which it belongs
-and its descendents are skipped. This flag can only be used in conjunction with
-.Fl R .
 .It Fl e, -embed
 Generate a more compact stream by using
 .Sy WRITE_EMBEDDED
@@ -269,6 +263,12 @@ The receiving system must also support this feature. Sends of encrypted datasets
 must use
 .Fl w
 when using this flag.
+.It Fl s, -skip-missing
+Allows sending a replication stream even when there are snapshots missing in the
+hierarchy. When a snapshot is missing, instead of throwing an error and aborting
+the send, a warning is printed to STDERR and the dataset to which it belongs
+and its descendents are skipped. This flag can only be used in conjunction with
+.Fl R .
 .It Fl v, -verbose
 Print verbose information about the stream package generated.
 This information includes a per-second report of how much data has been sent.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before #11710 the flags in zfs-send(8) were sorted.

### Description
<!--- Describe your changes in detail -->
Restore order and bump the date.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
