### PR TITLE
Add 2 Module Parameters Regarding Log Size Limit

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -58,6 +58,8 @@ struct dsl_deadlist;
 
 extern unsigned long zfs_dirty_data_max;
 extern unsigned long zfs_dirty_data_max_max;
+extern unsigned long zfs_wrlog_data_max;
+extern int zfs_wrlog_data_sync_percent;
 extern int zfs_dirty_data_sync_percent;
 extern int zfs_dirty_data_max_percent;
 extern int zfs_dirty_data_max_max_percent;
@@ -119,6 +121,11 @@ typedef struct dsl_pool {
 	uint64_t dp_mos_compressed_delta;
 	uint64_t dp_mos_uncompressed_delta;
 
+	/* Uses dp_wrlog_lock */
+	kmutex_t dp_wrlog_lock;
+	uint64_t dp_wrlog_pertxg[TXG_SIZE];
+	uint64_t dp_wrlog_total;
+
 	/*
 	 * Time of most recently scheduled (furthest in the future)
 	 * wakeup for delayed transactions.
@@ -158,6 +165,8 @@ int dsl_pool_sync_context(dsl_pool_t *dp);
 uint64_t dsl_pool_adjustedsize(dsl_pool_t *dp, zfs_space_check_t slop_policy);
 uint64_t dsl_pool_unreserved_space(dsl_pool_t *dp,
     zfs_space_check_t slop_policy);
+void dsl_pool_wrlog_count(dsl_pool_t *dp, int64_t size, uint64_t txg);
+boolean_t dsl_pool_wrlog_over_max(dsl_pool_t *dp);
 void dsl_pool_dirty_space(dsl_pool_t *dp, int64_t space, dmu_tx_t *tx);
 void dsl_pool_undirty_space(dsl_pool_t *dp, int64_t space, uint64_t txg);
 void dsl_free(dsl_pool_t *dp, uint64_t txg, const blkptr_t *bpp);

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1905,6 +1905,28 @@ Default value: \fB20\fR% of \fBzfs_dirty_data_max\fR.
 .sp
 .ne 2
 .na
+\fBzfs_wrlog_data_max\fR (ulong)
+.ad
+.RS 12n
+The upper limit of write-transaction zil log data size in bytes. Once it is reached, write operation is blocked, until log data is cleared out after transaction group sync. It should be set larger than \fBzfs_dirty_data_max\fR to prevent harming write throughput. It also should be smaller than the size of the slog device if slog is present.
+.sp
+Default value: \fB120\fR% of \fBzfs_dirty_data_max\fR in bytes.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_wrlog_data_sync_percent\fR (int)
+.ad
+.RS 12n
+The least write-transaction zil log data (as a percentage of \fBzfs_wrlog_data_max\fR) to trigger a transaction group sync. The calculated size in bytes should be greater than \fBzfs_dirty_data_max\fR * \fBzfs_dirty_data_sync_percent\fR, to prevent harming write throughput.
+.sp
+Default value: \fB30\fR% of \fBzfs_wrlog_data_max\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_fallocate_reserve_percent\fR (uint)
 .ad
 .RS 12n

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7706,6 +7706,11 @@ arc_init(void)
 		zfs_dirty_data_max = MIN(zfs_dirty_data_max,
 		    zfs_dirty_data_max_max);
 	}
+
+	if (zfs_wrlog_data_max == 0) {
+		/* default to 120% of zfs_dirty_data_max */
+		zfs_wrlog_data_max = zfs_dirty_data_max * 120 / 100;
+	}
 }
 
 void

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -884,6 +884,11 @@ dmu_tx_try_assign(dmu_tx_t *tx, uint64_t txg_how)
 	}
 
 	if (!tx->tx_dirty_delayed &&
+	    dsl_pool_wrlog_over_max(tx->tx_pool)) {
+		return (SET_ERROR(ERESTART));
+	}
+
+	if (!tx->tx_dirty_delayed &&
 	    dsl_pool_need_dirty_delay(tx->tx_pool)) {
 		tx->tx_wait_dirty = B_TRUE;
 		DMU_TX_STAT_BUMP(dmu_tx_dirty_delay);
@@ -1120,6 +1125,7 @@ dmu_tx_wait(dmu_tx_t *tx)
 		 * out a TXG at which point we'll hopefully have synced
 		 * a portion of the changes.
 		 */
+
 		txg_wait_synced(dp, spa_last_synced_txg(spa) + 1);
 	}
 

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -45,6 +45,8 @@
 #include <sys/spa.h>
 #include <sys/zfs_fuid.h>
 #include <sys/dsl_dataset.h>
+#include <sys/dsl_pool.h>
+
 
 /*
  * These zfs_log_* functions must be called within a dmu tx, in one
@@ -541,6 +543,7 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	itx_wr_state_t write_state;
 	uintptr_t fsync_cnt;
 	uint64_t gen = 0;
+	ssize_t size = resid;
 
 	if (zil_replaying(zilog, tx) || zp->z_unlinked ||
 	    zfs_xattr_owner_unlinked(zp)) {
@@ -625,6 +628,10 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 
 		off += len;
 		resid -= len;
+	}
+
+	if (write_state == WR_COPIED || write_state == WR_NEED_COPY) {
+		dsl_pool_wrlog_count(zilog->zl_dmu_pool, size, tx->tx_txg);
 	}
 }
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -84,9 +84,8 @@
 #include <sys/zfs_rlock.h>
 #include <sys/spa_impl.h>
 #include <sys/zvol.h>
-
 #include <sys/zvol_impl.h>
-
+#include <sys/dsl_pool.h>
 
 unsigned int zvol_inhibit_dev = 0;
 unsigned int zvol_volmode = ZFS_VOLMODE_GEOM;
@@ -579,6 +578,7 @@ zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
 	uint32_t blocksize = zv->zv_volblocksize;
 	zilog_t *zilog = zv->zv_zilog;
 	itx_wr_state_t write_state;
+	uint64_t sz = size;
 
 	if (zil_replaying(zilog, tx))
 		return;
@@ -629,6 +629,10 @@ zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
 
 		offset += len;
 		size -= len;
+	}
+
+	if (write_state == WR_COPIED || write_state == WR_NEED_COPY) {
+		dsl_pool_wrlog_count(zilog->zl_dmu_pool, sz, tx->tx_txg);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
I add 2 module parameters regarding total log data size. These can prevent slog device overflow, and long hang on fsync.
zfs_wrlog_data_max 
zfs_wrlog_data_sync_percent

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It resolves long hang regarding fsync under some specific work load. The issue can be reliably produced with fio.
Here is the script.
`fio --name=fio-seq-write --rw=write --bs=1M --direct=1 --numjobs=1 --time_based=1 --runtime=30 --fsync=1000 --filename=fio-seq-write  --size=20M --ioengine=libaio --iodepth=16`
The command repeatedly overwrites a small file. Since the dirty data space never exceed zfs_dirty_data_sync_percent, write operations are cached in the memory and are never throttled. You will see over 1GB/s write speed on reasonable hardware. If slog device cannot keep up the speed, all the write operations are backed up in ram. That cause long system hang and huge memory usage.
The solution is find a way to "kick" txg sync based on current total size of zil log data (log could be either on memory, or on the slog device), and also throttle write when txg sync doesn't help. 

### Description
<!--- Describe your changes in detail -->
I add 2 module parameters regarding total log data size.

zfs_wrlog_data_max
The upper limit of TX_WRITE log data. Once it is reached,
write operation is blocked, until log data is cleared out
after txg sync. It only counts TX_WRITE log with WR_COPIED
or WR_NEED_COPY.

zfs_wrlog_data_sync_percent
The least TX_WRITE log data (as a percentage
of zfs_wrlog_data_max) to kick a txg sync.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with fio, please see the example above.

<!--- Include details of your testing environment, and the tests you ran to -->
System:
Ubuntu groovy running in kvm, 8 cores, 2GB memory. Host is using HDD (not SSD)
Created a zpool based on file with 1GB slog.
Run fio on the pool.

PS: This pull request is based on  #11876 

<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
