### PR TITLE
etc/systemd/zfs-mount-generator: don't fail if no cached pools

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -28,6 +28,7 @@ set -e
 FSLIST="@sysconfdir@/zfs/zfs-list.cache"
 
 [ -d "${FSLIST}" ] || exit 0
+[ "$(echo "${FSLIST}"/*)" = "${FSLIST}/*" ] && exit 0
 
 do_fail() {
   printf 'zfs-mount-generator: %s\n' "$*" > /dev/kmsg


### PR DESCRIPTION
### Motivation and Context
See commit message.

### Description
As a Fun Experiment, if you do `process_line "${fs}" &` and `) &` then wait at the end of the subshell and the end of the file, you go from (zpool overhead removed by excluding it from $PATH, two Xeon E5645s, 36 datasets):
```
real    0m0.380s
user    0m0.264s
sys     0m0.124s
```
to
```
real    0m0.038s
user    0m0.346s
sys     0m0.147s
```
for a ten-fold improvement (or from "very noticeable" to "fine, I guess"), but this breaks $noauto_files.
It'd probably be best to rewrite (the core of) this in Not Shell at some point.

Actually, now that I think about it, $noauto_files is broken anyway, since it's processed at pool scope but is supposed to guard the global mount scope, so.

### How Has This Been Tested?
Ran it, results identical.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – as above
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
