### PR TITLE
Allow txg_kick() even there is a txg still syncing

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -171,6 +171,7 @@ void dsl_pool_mos_diduse_space(dsl_pool_t *dp,
 void dsl_pool_ckpoint_diduse_space(dsl_pool_t *dp,
     int64_t used, int64_t comp, int64_t uncomp);
 boolean_t dsl_pool_need_dirty_delay(dsl_pool_t *dp);
+boolean_t dsl_pool_need_dirty_sync(dsl_pool_t *dp, uint64_t txg);
 void dsl_pool_config_enter(dsl_pool_t *dp, void *tag);
 void dsl_pool_config_enter_prio(dsl_pool_t *dp, void *tag);
 void dsl_pool_config_exit(dsl_pool_t *dp, void *tag);

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -59,6 +59,7 @@ struct dsl_deadlist;
 extern unsigned long zfs_dirty_data_max;
 extern unsigned long zfs_dirty_data_max_max;
 extern int zfs_dirty_data_sync_percent;
+extern unsigned long zfs_txg_quiesce_advance;
 extern int zfs_dirty_data_max_percent;
 extern int zfs_dirty_data_max_max_percent;
 extern int zfs_delay_min_dirty_percent;
@@ -171,7 +172,6 @@ void dsl_pool_mos_diduse_space(dsl_pool_t *dp,
 void dsl_pool_ckpoint_diduse_space(dsl_pool_t *dp,
     int64_t used, int64_t comp, int64_t uncomp);
 boolean_t dsl_pool_need_dirty_delay(dsl_pool_t *dp);
-boolean_t dsl_pool_need_dirty_sync(dsl_pool_t *dp, uint64_t txg);
 void dsl_pool_config_enter(dsl_pool_t *dp, void *tag);
 void dsl_pool_config_enter_prio(dsl_pool_t *dp, void *tag);
 void dsl_pool_config_exit(dsl_pool_t *dp, void *tag);

--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -78,7 +78,7 @@ extern void txg_register_callbacks(txg_handle_t *txghp, list_t *tx_callbacks);
 
 extern void txg_delay(struct dsl_pool *dp, uint64_t txg, hrtime_t delta,
     hrtime_t resolution);
-extern void txg_kick(struct dsl_pool *dp);
+extern void txg_kick(struct dsl_pool *dp, uint64_t txg);
 
 /*
  * Wait until the given transaction group has finished syncing.

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -38,7 +38,6 @@
 #include <sys/sa_impl.h>
 #include <sys/zfs_context.h>
 #include <sys/trace_zfs.h>
-#include <sys/txg.h>
 
 typedef void (*dmu_tx_hold_func_t)(dmu_tx_t *tx, struct dnode *dn,
     uint64_t arg1, uint64_t arg2);
@@ -1056,9 +1055,6 @@ dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 
 	txg_rele_to_quiesce(&tx->tx_txgh);
 
-	if (dsl_pool_need_dirty_sync(tx->tx_pool, tx->tx_txg)) {
-		txg_kick(tx->tx_pool, tx->tx_txg);
-	}
 	return (0);
 }
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -38,6 +38,7 @@
 #include <sys/sa_impl.h>
 #include <sys/zfs_context.h>
 #include <sys/trace_zfs.h>
+#include <sys/txg.h>
 
 typedef void (*dmu_tx_hold_func_t)(dmu_tx_t *tx, struct dnode *dn,
     uint64_t arg1, uint64_t arg2);
@@ -1055,6 +1056,9 @@ dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 
 	txg_rele_to_quiesce(&tx->tx_txgh);
 
+	if (dsl_pool_need_dirty_sync(tx->tx_pool, tx->tx_txg)) {
+		txg_kick(tx->tx_pool, tx->tx_txg);
+	}
 	return (0);
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Provide a general summary of your changes in the Title above -->
Current txg_kick() only works if there is no txg in either quiescing
or syncing. This commit allow txg_kick() to work as long as there is
no txg is quiescing.

This keeps syncing stage busy, which should benefit write throughput.

Also txg_kick() should be triggered on dp_dirty_pertxg[] instead of
dp_dirty_total, because dp_dirty_total won't be decreased until the dirty
txg is synced. This change prevents pushing a empty txg through pipeline
in a row.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should improve write throughput, especially with SSD and NVMe pool.
However, the improvement on HDD based pool is not measurable, because quiescing stage is so fast comparing to HDD. 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Test with fio, doing sequential write. The testing VM is running with 2G memory. zfs_arc_min is bumped to 1G. Other parameters remain default.
Before patch:
```shell
root@dev:~# tail /proc/spl/kstat/zfs/test/txgs
71498    65043363629648   C     43925504     0            43208192     0        409      864390244    2828         29510        498654107
71499    65044228019892   C     101597184    0            100833280    0        842      498719485    2114         13211        619938757
71500    65044726739377   C     43925504     0            43409408     0        414      620010094    1782         19106        515227503
71501    65045346749471   C     101597184    0            100971520    0        840      515275769    1734         13760        698601092
71502    65045862025240   C     43925504     0            43195904     0        411      698653111    1877         4463859      396687228
71503    65046560678351   C     101597184    0            100919296    0        836      401169143    1166         6028         1805292783
71504    65046961847494   C     43925504     0            43279872     0        414      1805322266   1161         10955        383355578
71505    65048767169760   C     101728256    0            101112320    0        839      383452517    95278        408263       613475420
71506    65049150622277   S     0            0            0            0        0        613997275    1704         9604         0
71507    65049764619552   O     0            0            0            0        0        0            0            0            0
```

After patch:
```shell
root@dev:~# tail /proc/spl/kstat/zfs/test/txgs
70648    60985322448558   C     55721984     0            55094784     0        498      791474596    2859         267504511    925455339
70649    60986113923154   C     44318720     0            43598336     0        413      267580813    307888       925133065    201306178
70650    60986381503967   C     47726592     0            47099904     0        440      925436392    1316         201323924    708992030
70651    60987306940359   C     55590912     0            54942208     0        492      201664659    6605516      702092920    232786526
70652    60987508605018   C     44318720     0            43713536     0        416      708832391    279971       232420066    262959123
70653    60988217437409   C     47857664     0            47221760     0        444      232834897    4869         262833639    1175621968
70654    60988450272306   C     55328768     0            54640128     0        490      272623304    3986242      1161879733   435899211
70655    60988722895610   S     0            0            0            0        0        1165884947   109646       435806457    0
70656    60989888780557   W     0            0            0            0        0        436512899    1850207      0            0
70657    60990325293456   O     0            0            0            0        0        0            0            0            0
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
