### PR TITLE
vdev_mirror: don't scrub/resilver devices that can't be read

### DIFF
--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -649,6 +649,15 @@ vdev_mirror_io_start(zio_t *zio)
 			 */
 			for (c = 0; c < mm->mm_children; c++) {
 				mc = &mm->mm_child[c];
+
+				/* Don't issue ZIOs to offline children */
+				if (!vdev_mirror_child_readable(mc)) {
+					mc->mc_error = SET_ERROR(ENXIO);
+					mc->mc_tried = 1;
+					mc->mc_skipped = 1;
+					continue;
+				}
+
 				zio_nowait(zio_vdev_child_io(zio, zio->io_bp,
 				    mc->mc_vd, mc->mc_offset,
 				    abd_alloc_sametype(zio->io_abd,


### PR DESCRIPTION
### Motivation and Context

This ensures that we don't accumulate checksum errors against offline or
unavailable devices but, more importantly, means that we don't needlessly create
DTL entries for offline devices that are already up-to-date.

Consider a 3-way mirror, with disk A always online (and so always with an empty
DTL) and B and C only occasionally online.  When A & B resilver with C offline,
B's DTL will effectively be appended to C's due to these spurious ZIOs even as
the resilver empties B's DTL:

  * These ZIOs eventually land in vdev_mirror_scrub_done() and flag an error

  * That flagged error causes vdev_mirror_io_done() to see unexpected_errors, so
    it issues a ZIO_TYPE_WRITE repair ZIO, which inherits ZIO_FLAG_SCAN_THREAD
    because zio_vdev_child_io() includes that flag in ZIO_VDEV_CHILD_FLAGS.

  * That ZIO fails, too, and eventually zio_done() gets its hands on it and
    calls vdev_stat_update().

  * vdev_stat_update() sees the error and this zio...

    * is not speculative,
    * is not due to EIO (but rather ENXIO, since the device is closed)
    * has an ->io_vd != NULL (specifically, the offline leaf device)
    * is a write
    * is for a txg != 0 (but rather the read block's physical birth txg)
    * has ZIO_FLAG_SCAN_THREAD asserted

  * and so, vdev_stat_update() calls vdev_dtl_dirty() on the offline device.

Then, when A & C resilver with B offline, that story gets replayed and C's DTL
will be appended to B's.

In fact, one does not need this permanently-broken-mirror scenario to induce
badness: breaking a mirror with no DTLs and then scrubbing will create DTLs for
all offline devices.  These DTLs will persist until the entire mirror is
reassembled for the duration of the *resilver*, which, incidentally, will not
consider the devices with good data to be sources of good data in the case of a
read failure.

### Description

To fix the above, just don't issue child zios to devices that are not considered readable.

### How Has This Been Tested?

Manual inspection of DTLs with `zdb` after 2-online-of-3 mirror scrubs.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
