### PR TITLE
zfs.spec.in: remove post ldconfig scriptlets

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -172,8 +172,12 @@ Obsoletes:      libzpool4
 This package contains the zpool library, which provides support
 for managing zpools
 
+%if %{defined ldconfig_scriptlets}
+%ldconfig_scriptlets -n libzpool5
+%else
 %post -n libzpool5 -p /sbin/ldconfig
 %postun -n libzpool5 -p /sbin/ldconfig
+%endif
 
 %package -n libnvpair3
 Summary:        Solaris name-value library for Linux
@@ -186,8 +190,12 @@ pairs.  This functionality is used to portably transport data across
 process boundaries, between kernel and user space, and can be used
 to write self describing data structures on disk.
 
+%if %{defined ldconfig_scriptlets}
+%ldconfig_scriptlets -n libnvpair3
+%else
 %post -n libnvpair3 -p /sbin/ldconfig
 %postun -n libnvpair3 -p /sbin/ldconfig
+%endif
 
 %package -n libuutil3
 Summary:        Solaris userland utility library for Linux
@@ -205,8 +213,12 @@ This library provides a variety of compatibility functions for OpenZFS:
    partitioning.
  * libshare: NFS, SMB, and iSCSI service integration for ZFS.
 
+%if %{defined ldconfig_scriptlets}
+%ldconfig_scriptlets -n libuutil3
+%else
 %post -n libuutil3 -p /sbin/ldconfig
 %postun -n libuutil3 -p /sbin/ldconfig
+%endif
 
 # The library version is encoded in the package name.  When updating the
 # version information it is important to add an obsoletes line below for
@@ -220,8 +232,12 @@ Obsoletes:      libzfs4
 %description -n libzfs5
 This package provides support for managing ZFS filesystems
 
+%if %{defined ldconfig_scriptlets}
+%ldconfig_scriptlets -n libzfs5
+%else
 %post -n libzfs5 -p /sbin/ldconfig
 %postun -n libzfs5 -p /sbin/ldconfig
+%endif
 
 %package -n libzfs5-devel
 Summary:        Development headers


### PR DESCRIPTION
### Motivation and Context

When installing packages on Fedora 33 the following warning is printed:

```
/sbin/ldconfig: relative path `1' used to build cache
warning: %postun(...) scriptlet failed, exit status `
```

The packages should install cleanly without any warnings.

### Description

In Fedora 28 the packaging guidelines were changed such that `ldconfig`
should no longer be called in either the `%pos`t or `%postun` scriptlets.
Instead the new compatibility macros `%ldconfig_post`, `%ldconfig_postun`,
and `%ldocnfig_scriptlets` should be used.

Since we only support Fedora 31 and newer, we could drop the
`%post` and `%postun` scriptlets entirely according to the guidelines.
However, since we also use the same spec file for CentOS / RHEL
it's convenient to call the macros which are available starting
with CentOS / RHEL 8.  For CentOS / RHEL 7 we must still call
`ldconfig` in the traditional way.

https://fedoraproject.org/wiki/Changes/Removing_ldconfig_scriptlets

### How Has This Been Tested?

Verified the packages install cleanly and work on Fedora 33.
Verified the required macros are installed on CentOS / RHEL 8.
No functional change for CentOS / RHEL 7.

Pending additional confirmation from the CI which builds and installs
packages for all of these platforms.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
