### PR TITLE
Fix AVX512BW Fletcher code on AVX512-but-not-BW machines.

### DIFF
--- a/module/zcommon/zfs_fletcher_avx512.c
+++ b/module/zcommon/zfs_fletcher_avx512.c
@@ -210,6 +210,12 @@ fletcher_4_avx512bw_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
 }
 STACK_FRAME_NON_STANDARD(fletcher_4_avx512bw_byteswap);
 
+static boolean_t
+fletcher_4_avx512bw_valid(void)
+{
+	return (fletcher_4_avx512f_valid() && zfs_avx512bw_available());
+}
+
 const fletcher_4_ops_t fletcher_4_avx512bw_ops = {
 	.init_native = fletcher_4_avx512f_init,
 	.fini_native = fletcher_4_avx512f_fini,
@@ -217,7 +223,7 @@ const fletcher_4_ops_t fletcher_4_avx512bw_ops = {
 	.init_byteswap = fletcher_4_avx512f_init,
 	.fini_byteswap = fletcher_4_avx512f_fini,
 	.compute_byteswap = fletcher_4_avx512bw_byteswap,
-	.valid = fletcher_4_avx512f_valid,
+	.valid = fletcher_4_avx512bw_valid,
 	.name = "avx512bw"
 };
 #endif


### PR DESCRIPTION
Closes #11937

Signed-off-by: Romain Dolbeau <romain@dolbeau.org>

### Motivation and Context

See #11937; the wrong simd code is run on x86-64 machine with AVX512F but not AVX512BW (i.e., only Knight Landings a.k.a. Xeon Phi).

### Description

Introduce a specific valid function for avx512f+avx512bw (instead of checking only for avx512f).

### How Has This Been Tested?

Original bug reported confirms it solves the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
