### PR TITLE
improve l2arc tests and add improve platform identification

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -134,6 +134,19 @@ function is_dilos
 	fi
 }
 
+# Determine platform name
+#
+# Return platform name
+
+function platform_name
+{
+	if is_dilos; then
+		echo "dilos"
+	else
+		echo $(uname)
+	fi
+}
+
 # Determine if this is a 32-bit system
 #
 # Return 0 if platform is 32-bit, 1 if otherwise
@@ -3608,7 +3621,7 @@ function zed_rc_restore
 function zed_setup
 {
 	if ! is_linux; then
-		log_unsupported "No zed on $(uname)"
+		log_unsupported "No zed on $(platform_name)"
 	fi
 
 	if [[ ! -d $ZEDLET_DIR ]]; then
@@ -3849,7 +3862,7 @@ function set_tunable_impl
 	eval "typeset tunable=\$$name"
 	case "$tunable" in
 	UNSUPPORTED)
-		log_unsupported "Tunable '$name' is unsupported on $(uname)"
+		log_unsupported "Tunable '$name' is unsupported on $(platform_name)"
 		;;
 	"")
 		log_fail "Tunable '$name' must be added to tunables.cfg"
@@ -3861,7 +3874,7 @@ function set_tunable_impl
 	[[ -z "$value" ]] && return 1
 	[[ -z "$mdb_cmd" ]] && return 1
 
-	case "$(uname)" in
+	case "$(platform_name)" in
 	Linux)
 		typeset zfs_tunables="/sys/module/$module/parameters"
 		[[ -w "$zfs_tunables/$tunable" ]] || return 1
@@ -3872,9 +3885,12 @@ function set_tunable_impl
 		sysctl vfs.zfs.$tunable=$value
 		return "$?"
 		;;
-	SunOS)
+	dilos)
 		[[ "$module" -eq "zfs" ]] || return 1
-		echo "${tunable}/${mdb_cmd}0t${value}" | mdb -kw
+		typeset svalue=""
+		svalue=$(printf "0x%llx" "${value}")
+#		echo "mdb set: ${tunable}/${mdb_cmd} ${svalue}"
+		mdb -kwe "${tunable}/${mdb_cmd} ${svalue}"
 		return $?
 		;;
 	esac
@@ -3898,7 +3914,7 @@ function get_tunable_impl
 	eval "typeset tunable=\$$name"
 	case "$tunable" in
 	UNSUPPORTED)
-		log_unsupported "Tunable '$name' is unsupported on $(uname)"
+		log_unsupported "Tunable '$name' is unsupported on $(platform_name)"
 		;;
 	"")
 		log_fail "Tunable '$name' must be added to tunables.cfg"
@@ -3907,7 +3923,7 @@ function get_tunable_impl
 		;;
 	esac
 
-	case "$(uname)" in
+	case "$(platform_name)" in
 	Linux)
 		typeset zfs_tunables="/sys/module/$module/parameters"
 		[[ -f "$zfs_tunables/$tunable" ]] || return 1
@@ -3917,8 +3933,18 @@ function get_tunable_impl
 	FreeBSD)
 		sysctl -n vfs.zfs.$tunable
 		;;
-	SunOS)
+	dilos)
 		[[ "$module" -eq "zfs" ]] || return 1
+		typeset -li value=0
+		# value=$(mdb -k -e "$tunable/X | ::eval .=U" | sed -e 's/^[[:space:]]*//')
+		value=$(mdb -ke "$tunable::print")
+		if [[ $? -ne 0 ]]; then
+#			log_fail "Failed to get value of '$tunable' from mdb."
+			return 1
+		fi
+		echo "$value"
+		return 0
+
 		;;
 	esac
 
@@ -4083,7 +4109,7 @@ function get_xattr # name path
 	typeset name=$1
 	typeset path=$2
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		getextattr -qq user "${name}" "${path}"
 		;;
@@ -4099,7 +4125,7 @@ function set_xattr # name value path
 	typeset value=$2
 	typeset path=$3
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		setextattr user "${name}" "${value}" "${path}"
 		;;
@@ -4114,7 +4140,7 @@ function set_xattr_stdin # name value
 	typeset name=$1
 	typeset path=$2
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		setextattr -i user "${name}" "${path}"
 		;;
@@ -4129,7 +4155,7 @@ function rm_xattr # name path
 	typeset name=$1
 	typeset path=$2
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		rmextattr -q user "${name}" "${path}"
 		;;
@@ -4143,7 +4169,7 @@ function ls_xattr # path
 {
 	typeset path=$1
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		lsextattr -qq user "${path}"
 		;;
@@ -4158,7 +4184,7 @@ function kstat # stat flags?
 	typeset stat=$1
 	typeset flags=${2-"-n"}
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		sysctl $flags kstat.zfs.misc.$stat
 		;;
@@ -4166,6 +4192,9 @@ function kstat # stat flags?
 		typeset zfs_kstat="/proc/spl/kstat/zfs/$stat"
 		[[ -f "$zfs_kstat" ]] || return 1
 		cat $zfs_kstat
+		;;
+	dilos)
+		/usr/bin/kstat -pC $stat
 		;;
 	*)
 		false
@@ -4177,12 +4206,15 @@ function get_arcstat # stat
 {
 	typeset stat=$1
 
-	case $(uname) in
+	case $(platform_name) in
 	FreeBSD)
 		kstat arcstats.$stat
 		;;
 	Linux)
 		kstat arcstats | awk "/$stat/ { print \$3 }"
+		;;
+	dilos)
+		kstat zfs:0:arcstats:$stat | cut -d ':' -f 5
 		;;
 	*)
 		false
@@ -4206,9 +4238,9 @@ function arcstat_quiescence # stat echo
 	fi
 
 	while $do_once || [ $stat1 -ne $stat2 ] || [ $stat2 -eq 0 ]; do
-		typeset stat1=$(get_arcstat $stat)
+		typeset -li stat1=$(get_arcstat $stat)
 		sleep 2
-		typeset stat2=$(get_arcstat $stat)
+		typeset -li stat2=$(get_arcstat $stat)
 		do_once=false
 	done
 

--- a/tests/zfs-tests/tests/functional/l2arc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/l2arc/Makefile.am
@@ -15,4 +15,5 @@ dist_pkgdata_SCRIPTS = \
 	persist_l2arc_008_pos.ksh
 
 dist_pkgdata_DATA = \
-	l2arc.cfg
+	l2arc.cfg \
+	l2arc_common.shlib

--- a/tests/zfs-tests/tests/functional/l2arc/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/cleanup.ksh
@@ -19,13 +19,12 @@
 #
 
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 verify_runnable "global"
 
-if poolexists $TESTPOOL ; then
-	log_must destroy_pool $TESTPOOL
-fi
+rm_devs
 
-log_must rm -rf $VDIR
+[[ -e $TESTDIR ]] && log_must rm -rf $TESTDIR
 
 log_pass

--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_arcstats_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_arcstats_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -44,13 +46,13 @@ log_assert "L2ARC MFU/MRU arcstats do not leak."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_common.shlib
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_common.shlib
@@ -15,11 +15,29 @@
 #
 
 #
-# Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
 
 verify_runnable "global"
 
-log_pass
+function mk_devs
+{
+	rm -rf $VDIR
+	log_must mkdir -p $VDIR
+	log_must mkfile -n $SIZE $VDEV
+	log_must mkfile -n $SIZE $VDEV1
+}
+
+function rm_devs
+{
+	if poolexists $TESTPOOL ; then
+		log_must destroy_pool $TESTPOOL
+	fi
+	if poolexists $TESTPOOL1 ; then
+		log_must destroy_pool $TESTPOOL1
+	fi
+
+	rm -rf $VDIR
+}

--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_mfuonly_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_mfuonly_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -43,15 +45,15 @@ log_assert "l2arc_mfuonly does not cache MRU buffers."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 	log_must set_tunable32 L2ARC_MFUONLY $mfuonly
 	log_must set_tunable32 PREFETCH_DISABLE $zfsprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 1 as some prefetched buffers may
 # transition to MRU.

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_001_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -53,15 +55,15 @@ log_assert "Persistent L2ARC with an unencrypted ZFS file system succeeds."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 	log_must set_tunable32 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE \
 		$rebuild_blocks_min_l2size
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_002_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
 
 #
@@ -56,15 +58,15 @@ log_assert "Persistent L2ARC with an encrypted ZFS file system succeeds."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 	log_must set_tunable32 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE \
 		$rebuild_blocks_min_l2size
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_003_neg.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -42,14 +44,14 @@ log_assert "Persistent L2ARC fails as expected when L2ARC_REBUILD_ENABLED = 0."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_REBUILD_ENABLED $rebuild_enabled
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_004_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -45,13 +47,13 @@ log_assert "Persistent L2ARC restores all written log blocks."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_005_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
 
 #
@@ -48,13 +50,13 @@ log_assert "Persistent L2ARC restores all written log blocks with encryption."
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_006_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -44,15 +46,15 @@ log_assert "Off/onlining an L2ARC device results in rebuilding L2ARC, vdev not p
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 	log_must set_tunable32 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE \
 		$rebuild_blocks_min_l2size
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)
@@ -91,7 +93,7 @@ log_must test $l2_dh_log_blk -eq $(( $l2_rebuild_log_blk_end - \
 	$l2_rebuild_log_blk_start ))
 log_must test $l2_dh_log_blk -gt 0
 
-log must zpool offline $TESTPOOL $VDEV_CACHE
+log_must zpool offline $TESTPOOL $VDEV_CACHE
 arcstat_quiescence_noecho l2_size
 
 log_must zdb -lq $VDEV_CACHE

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_007_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -43,15 +45,15 @@ log_assert "Off/onlining an L2ARC device results in rebuilding L2ARC, vdev prese
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 	log_must set_tunable32 L2ARC_REBUILD_BLOCKS_MIN_L2SIZE \
 		$rebuild_blocks_min_l2size
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)

--- a/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/persist_l2arc_008_pos.ksh
@@ -16,10 +16,12 @@
 
 #
 # Copyright (c) 2020, George Amanakis. All rights reserved.
+# Copyright (c) 2021, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/l2arc/l2arc.cfg
+. $STF_SUITE/tests/functional/l2arc/l2arc_common.shlib
 
 #
 # DESCRIPTION:
@@ -57,13 +59,13 @@ log_assert "Off/onlining an L2ARC device restores all written blocks , vdev pres
 
 function cleanup
 {
-	if poolexists $TESTPOOL ; then
-		destroy_pool $TESTPOOL
-	fi
+	rm_devs
 
 	log_must set_tunable32 L2ARC_NOPREFETCH $noprefetch
 }
 log_onexit cleanup
+
+mk_devs
 
 # L2ARC_NOPREFETCH is set to 0 to let L2ARC handle prefetches
 typeset noprefetch=$(get_tunable L2ARC_NOPREFETCH)
@@ -133,7 +135,7 @@ log_must test $l2_dh_log_blk3 -eq $(( $l2_rebuild_log_blk_end - \
 	$l2_rebuild_log_blk_start ))
 log_must test $l2_dh_log_blk3 -gt 0
 
-log must zpool offline $TESTPOOL $VDEV_CACHE
+log_must zpool offline $TESTPOOL $VDEV_CACHE
 arcstat_quiescence_noecho l2_size
 
 log_must zdb -lq $VDEV_CACHE


### PR DESCRIPTION
Signed-off-by: Igor Kozhukhov <igor@dilos.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
improve l2arc tests and improve platform identification

### Description
<!--- Describe your changes in detail -->
on DilOS platform we are using ZFS as primary filesystem = rootfs where we have /var/tmp on dataset with sync=disabled.
for works with correct l2arc calculation we have to use new = fresh file based VDEVs

another update - it is improve platform identification.
DilOS is based on illumos, but has many updates in userland where we are very different with illumos.
we have extended platform detect do not use uname on dilos because it has SunOS on illumos and dilos.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
many tries ZTS in loop on DilOS platform

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
