### PR TITLE
Drop "All rights reserved" from files by trasz@FreeBSD.org

### DIFF
--- a/module/os/freebsd/spl/spl_acl.c
+++ b/module/os/freebsd/spl/spl_acl.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2008, 2009 Edward Tomasz Napierała <trasz@FreeBSD.org>
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
### Motivation and Context
Due to FreeBSD project policy, file copyright holders in FreeBSD keep removing the "All rights reserved" line from BSD-licensed code. To keep files with OpenZFS in sync, I am requesting to remove this copyright.

External-issue: https://reviews.freebsd.org/D26980
FreeBSD commit: freebsd/freebsd-src@bce7ee9d4

### Description
Removal of "All rights reserved" in a file copyrighted by trasz@FreeBSD.org

### How Has This Been Tested?
Copyright disclaimer change only

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
