### PR TITLE
zfs get: don't lookup mount options when using "-s local"

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1882,7 +1882,6 @@ get_callback(zfs_handle_t *zhp, void *data)
 {
 	char buf[ZFS_MAXPROPLEN];
 	char rbuf[ZFS_MAXPROPLEN];
-	zprop_source_t sourcetype;
 	char source[ZFS_MAX_DATASET_NAME_LEN];
 	zprop_get_cbdata_t *cbp = data;
 	nvlist_t *user_props = zfs_get_user_props(zhp);
@@ -1893,6 +1892,7 @@ get_callback(zfs_handle_t *zhp, void *data)
 	boolean_t received = is_recvd_column(cbp);
 
 	for (; pl != NULL; pl = pl->pl_next) {
+		zprop_source_t sourcetype = cbp->cb_sources;
 		char *recvdval = NULL;
 		/*
 		 * Skip the special fake placeholder.  This will also skip over
@@ -4660,7 +4660,7 @@ zfs_do_send(int argc, char **argv)
 	 */
 	if (fromname && (cp = strchr(fromname, '@')) != NULL) {
 		char origin[ZFS_MAX_DATASET_NAME_LEN];
-		zprop_source_t src;
+		zprop_source_t src = ZPROP_SRC_NONE;
 
 		(void) zfs_prop_get(zhp, ZFS_PROP_ORIGIN,
 		    origin, sizeof (origin), &src, NULL, 0, B_FALSE);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -2180,7 +2180,8 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 	 * its presence.
 	 */
 	if (!zhp->zfs_mntcheck &&
-	    (mntopt_on != NULL || prop == ZFS_PROP_MOUNTED)) {
+	    (mntopt_on != NULL || prop == ZFS_PROP_MOUNTED) &&
+	    (src && (*src & ZPROP_SRC_TEMPORARY))) {
 		libzfs_handle_t *hdl = zhp->zfs_hdl;
 		struct mnttab entry;
 
@@ -2595,9 +2596,16 @@ zcp_check(zfs_handle_t *zhp, zfs_prop_t prop, uint64_t intval,
 }
 
 /*
- * Retrieve a property from the given object.  If 'literal' is specified, then
- * numbers are left as exact values.  Otherwise, numbers are converted to a
- * human-readable form.
+ * Retrieve a property from the given object.
+ *
+ * Arguments:
+ *  src :	On call, this must contain the bitmap of ZPROP_SRC_* types to
+ * 		query.  Properties whose values come from a different source
+ * 		may not be returned. NULL will be treated as ZPROP_SRC_ALL.  On
+ * 		return, if not NULL, this variable will contain the source for
+ * 		the queried property.
+ *  literal :	If specified, then numbers are left as exact values.  Otherwise,
+ *		they are converted to a human-readable form.
  *
  * Returns 0 on success, or -1 on error.
  */
@@ -2619,9 +2627,6 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 
 	if (received && zfs_prop_readonly(prop))
 		return (-1);
-
-	if (src)
-		*src = ZPROP_SRC_NONE;
 
 	switch (prop) {
 	case ZFS_PROP_CREATION:

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -575,7 +575,7 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
 		 * tosnap is a clone of a fromsnap descendant.
 		 */
 		char origin[ZFS_MAX_DATASET_NAME_LEN];
-		zprop_source_t src;
+		zprop_source_t src = ZPROP_SRC_NONE;
 		zfs_handle_t *zhp;
 
 		di->ds = zfs_alloc(di->zhp->zfs_hdl, tdslen + 1);

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -266,7 +266,7 @@ zfs_is_mountable(zfs_handle_t *zhp, char *buf, size_t buflen,
     zprop_source_t *source, int flags)
 {
 	char sourceloc[MAXNAMELEN];
-	zprop_source_t sourcetype;
+	zprop_source_t sourcetype = ZPROP_SRC_NONE;
 
 	if (!zfs_prop_valid_for_type(ZFS_PROP_MOUNTPOINT, zhp->zfs_type,
 	    B_FALSE))
@@ -765,7 +765,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 	char shareopts[ZFS_MAXPROPLEN];
 	char sourcestr[ZFS_MAXPROPLEN];
 	zfs_share_proto_t *curr_proto;
-	zprop_source_t sourcetype;
+	zprop_source_t sourcetype = ZPROP_SRC_NONE;
 	int err = 0;
 
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL, 0))

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2662,7 +2662,7 @@ static zfs_handle_t *
 recv_open_grand_origin(zfs_handle_t *zhp)
 {
 	char origin[ZFS_MAX_DATASET_NAME_LEN];
-	zprop_source_t src;
+	zprop_source_t src = ZPROP_SRC_NONE;
 	zfs_handle_t *ozhp = zfs_handle_dup(zhp);
 
 	while (ozhp != NULL) {


### PR DESCRIPTION
Looking up mount options can be very expensive on servers with many
mounted file systems.  When doing "zfs get" with any "-s" option that
does not include "temporary", the mount list will never be used.  This
commit optimizes for that case.

This is a breaking commit for libzfs!  Callers of zfs_get_prop are now
required to initialize src.  To preserve existing behavior, they should
initialize it to ZPROP_SRC_NONE.

Sponsored by: Axcient

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
