### PR TITLE
zed: a lock-based pickle indeed

### DIFF
--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -142,8 +142,10 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 		    prog, eid, strerror(ENAMETOOLONG));
 		return;
 	}
+	(void) pthread_mutex_lock(&_launched_processes_lock);
 	pid = fork();
 	if (pid < 0) {
+		(void) pthread_mutex_unlock(&_launched_processes_lock);
 		zed_log_msg(LOG_WARNING,
 		    "Failed to fork \"%s\" for eid=%llu: %s",
 		    prog, eid, strerror(errno));
@@ -166,20 +168,19 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 
 	/* parent process */
 
-	__atomic_sub_fetch(&_launched_processes_limit, 1, __ATOMIC_SEQ_CST);
-	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%llu pid=%d",
-	    prog, eid, pid);
-
 	node = calloc(1, sizeof (*node));
 	if (node) {
 		node->pid = pid;
 		node->eid = eid;
 		node->name = strdup(prog);
 
-		(void) pthread_mutex_lock(&_launched_processes_lock);
 		avl_add(&_launched_processes, node);
-		(void) pthread_mutex_unlock(&_launched_processes_lock);
 	}
+	(void) pthread_mutex_unlock(&_launched_processes_lock);
+
+	__atomic_sub_fetch(&_launched_processes_limit, 1, __ATOMIC_SEQ_CST);
+	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%llu pid=%d",
+	    prog, eid, pid);
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
#11963

### Description
~~Lock around fork() and in the SIGCHLD handler. The latter should always lock as soon as a child dies and, if Linux does in fact re-use zombie PIDs, always come before the next fork().~~

~~But if this doesn't work then I genuinely don't know if this is possible under UNIX or if it's just always gonna race like this.~~ See commit message.

### How Has This Been Tested?
~~It wasn't. I mean, it runs, but.~~ See commit message.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
