### PR TITLE
Updated zfs_dbgmsg_enable documentation to be more accurate.

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -14,7 +14,7 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH ZFS-MODULE-PARAMETERS 5 "Mar 31, 2021" OpenZFS
+.TH ZFS-MODULE-PARAMETERS 5 "May 5, 2021" OpenZFS
 .SH NAME
 zfs\-module\-parameters \- ZFS module parameters
 .SH DESCRIPTION
@@ -1506,11 +1506,14 @@ Default value: \fB131,072\fR.
 .ad
 .RS 12n
 Internally ZFS keeps a small log to facilitate debugging.  By default the log
-is disabled, to enable it set this option to 1.  The contents of the log can
+is enabled, to disable it set this option to 0.  The contents of the log can
 be accessed by reading the /proc/spl/kstat/zfs/dbgmsg file.  Writing 0 to
 this proc file clears the log.
 .sp
-Default value: \fB0\fR.
+This setting does not influence debug prints due to \fBzfs_flags\fR
+settings.
+.sp
+Default value: \fB1\fR.
 .RE
 
 .sp


### PR DESCRIPTION
### Motivation and Context
#11984

### Description
Changed the default specified for zfs_dbgmsg_enable, added clarification of interaction with zfs_flags.

(If people think that instead the default should be changed, that can be done too.)

### How Has This Been Tested?
`man man/man5/zfs-module-parameters.5` didn't produce any errors, `make checkstyle` didn't either.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
