### PR TITLE
asprintf(3) error handling, mostly

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -494,19 +494,25 @@ vdev_run_cmd(vdev_cmd_data_t *data, char *cmd)
 	/* Setup our custom environment variables */
 	rc = asprintf(&env[1], "VDEV_PATH=%s",
 	    data->path ? data->path : "");
-	if (rc == -1)
+	if (rc == -1) {
+		env[1] = NULL;
 		goto out;
+	}
 
 	rc = asprintf(&env[2], "VDEV_UPATH=%s",
 	    data->upath ? data->upath : "");
-	if (rc == -1)
+	if (rc == -1) {
+		env[2] = NULL;
 		goto out;
+	}
 
 	rc = asprintf(&env[3], "VDEV_ENC_SYSFS_PATH=%s",
 	    data->vdev_enc_sysfs_path ?
 	    data->vdev_enc_sysfs_path : "");
-	if (rc == -1)
+	if (rc == -1) {
+		env[3] = NULL;
 		goto out;
+	}
 
 	/* Run the command */
 	rc = libzfs_run_process_get_stdout_nopath(cmd, argv, env, &lines,
@@ -525,8 +531,7 @@ out:
 
 	/* Start with i = 1 since env[0] was statically allocated */
 	for (i = 1; i < ARRAY_SIZE(env); i++)
-		if (env[i] != NULL)
-			free(env[i]);
+		free(env[i]);
 }
 
 /*

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -782,8 +782,10 @@ zfs_asprintf(libzfs_handle_t *hdl, const char *fmt, ...)
 
 	va_end(ap);
 
-	if (err < 0)
+	if (err < 0) {
 		(void) no_memory(hdl);
+		ret = NULL;
+	}
 
 	return (ret);
 }

--- a/lib/libzfsbootenv/lzbe_device.c
+++ b/lib/libzfsbootenv/lzbe_device.c
@@ -88,12 +88,11 @@ lzbe_set_boot_device(const char *pool, lzbe_flags_t flag, const char *device)
 		if (strncmp(device, "zfs:", 4) == 0) {
 			fnvlist_add_string(nv, OS_BOOTONCE, device);
 		} else {
-			descriptor = NULL;
-			if (asprintf(&descriptor, "zfs:%s:", device) > 0)
+			if (asprintf(&descriptor, "zfs:%s:", device) > 0) {
 				fnvlist_add_string(nv, OS_BOOTONCE, descriptor);
-			else
+				free(descriptor);
+			} else
 				rv = ENOMEM;
-			free(descriptor);
 		}
 	}
 

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -306,9 +306,10 @@ dm_get_underlying_path(const char *dm_name)
 	else
 		dev_str = tmp;
 
-	size = asprintf(&tmp, "/sys/block/%s/slaves/", dev_str);
-	if (size == -1 || !tmp)
+	if ((size = asprintf(&tmp, "/sys/block/%s/slaves/", dev_str)) == -1) {
+		tmp = NULL;
 		goto end;
+	}
 
 	dp = opendir(tmp);
 	if (dp == NULL)
@@ -334,7 +335,9 @@ dm_get_underlying_path(const char *dm_name)
 			if (!enclosure_path)
 				continue;
 
-			size = asprintf(&path, "/dev/%s", ep->d_name);
+			if ((size = asprintf(
+			    &path, "/dev/%s", ep->d_name)) == -1)
+				path = NULL;
 			free(enclosure_path);
 			break;
 		}
@@ -352,7 +355,8 @@ end:
 		 * enclosure devices.  Throw up out hands and return the first
 		 * underlying path.
 		 */
-		size = asprintf(&path, "/dev/%s", first_path);
+		if ((size = asprintf(&path, "/dev/%s", first_path)) == -1)
+			path = NULL;
 	}
 
 	free(first_path);

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -195,10 +195,8 @@ zfs_get_enclosure_sysfs_path(const char *dev_name)
 	}
 
 	dp = opendir(tmp1);
-	if (dp == NULL) {
-		tmp1 = NULL;	/* To make free() at the end a NOP */
+	if (dp == NULL)
 		goto end;
-	}
 
 	/*
 	 * Look though all sysfs entries in /sys/block/<dev>/device for
@@ -216,11 +214,8 @@ zfs_get_enclosure_sysfs_path(const char *dev_name)
 		size = readlink(tmp2, buf, sizeof (buf));
 
 		/* Did readlink fail or crop the link name? */
-		if (size == -1 || size >= sizeof (buf)) {
-			free(tmp2);
-			tmp2 = NULL;	/* To make free() at the end a NOP */
+		if (size == -1 || size >= sizeof (buf))
 			break;
-		}
 
 		/*
 		 * We got a valid link.  readlink() doesn't terminate strings

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -207,9 +207,10 @@ zfs_get_enclosure_sysfs_path(const char *dev_name)
 		if (strstr(ep->d_name, "enclosure_device") == NULL)
 			continue;
 
-		if (asprintf(&tmp2, "%s/%s", tmp1, ep->d_name) == -1 ||
-		    tmp2 == NULL)
+		if (asprintf(&tmp2, "%s/%s", tmp1, ep->d_name) == -1) {
+			tmp2 = NULL;
 			break;
+		}
 
 		size = readlink(tmp2, buf, sizeof (buf));
 


### PR DESCRIPTION
### Motivation and Context
If `asprintf(&p) == -1`, the value of `p` is undefined. And we all know how much fun freeing random pointers is.

### Description
The first patch cleans up libzfs/zpool_load_compat() by:
  * initalising	`l_features` with an initialiser list instead of a for loop
  * passing file open flags to file open flags (and adding O_CLOEXEC to the now flags flags)
  * correctly detecting a failed map
  * prefaulting the whole file (supported on both Linux (MAP_POPULATE) and FreeBSD (MAP_PREFAULT_READ)), since we're writing to every page anyway

The fourth patch removes a deliberate leak(!?) and useless short path from zutil_device_path/linux/zfs_get_enclosure_sysfs_path()

The rest fix asprintf(3) usage. If you wanna have a go, too: `git grep asprintf | grep -vE '(zfs_|kmem_|kv|kmem_v)asprintf'`.
I didn't touch extraneous `ret == -1 || p == NULL` error checks.

Also, `zfs_asprintf()` and `zfs_alloc()` say "which will die if the allocation fails", which is strictly false. `no_memory()` in the same file says "Display an out of memory error message and abort the current program.", which is also wrong, on both counts.

### How Has This Been Tested?
Looked at it. Tested some ex situ, but this hardly requires a week-long test regime.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
