### PR TITLE
Return required size when encode_fh size too small

### DIFF
--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -3950,6 +3950,13 @@ zfs_fid(struct inode *ip, fid_t *fidp)
 	int		size, i, error;
 
 	ZFS_ENTER(zfsvfs);
+
+	if (fidp->fid_len < SHORT_FID_LEN) {
+		fidp->fid_len = SHORT_FID_LEN;
+		ZFS_EXIT(zfsvfs);
+		return (SET_ERROR(ENOSPC));
+	}
+
 	ZFS_VERIFY_ZP(zp);
 
 	if ((error = sa_lookup(zp->z_sa_hdl, SA_ZPL_GEN(zfsvfs),

--- a/module/os/linux/zfs/zpl_export.c
+++ b/module/os/linux/zfs/zpl_export.c
@@ -41,15 +41,19 @@ zpl_encode_fh(struct dentry *dentry, __u32 *fh, int *max_len, int connectable)
 	struct inode *ip = dentry->d_inode;
 #endif /* HAVE_ENCODE_FH_WITH_INODE */
 	fstrans_cookie_t cookie;
-	fid_t *fid = (fid_t *)fh;
+	ushort_t empty_fid = 0;
+	fid_t *fid;
 	int len_bytes, rc;
 
 	len_bytes = *max_len * sizeof (__u32);
 
-	if (len_bytes < offsetof(fid_t, fid_data))
-		return (255);
+	if (len_bytes < offsetof(fid_t, fid_data)) {
+		fid = (fid_t *)&empty_fid;
+	} else {
+		fid = (fid_t *)fh;
+		fid->fid_len = len_bytes - offsetof(fid_t, fid_data);
+	}
 
-	fid->fid_len = len_bytes - offsetof(fid_t, fid_data);
 	cookie = spl_fstrans_mark();
 
 	if (zfsctl_is_node(ip))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I [noticed](https://lists.strace.io/pipermail/strace-devel/2021-May/010520.html) that the [strace](https://strace.io) test suite did not run correctly on ZFS.  This was because it called `name_to_handle_at(2)`, with a zero-sized handle, expecting the kernel to change the `handle_bytes` value to the size required for a handle, so it could call `name_to_handle_at()` again with a correctly-sized handle.  (This behavior is documented in the [man page](https://man7.org/linux/man-pages/man2/name_to_handle_at.2.html).)

I then further noticed that the t_name_to_handle_at.c example in the same man page also didn't work properly on ZFS.

### Description
<!--- Describe your changes in detail -->

Quoting [<linux/exportfs.h>](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/exportfs.h?id=5e321ded302da4d8c5d5dd953423d9b748ab3775#n150):

> `encode_fh()` should return the `fileid_type` on success and on error returns 255 (if the space needed to encode `fh` is greater than `max_len`*4 bytes). On error `max_len` contains the minimum size (in 4 byte unit) needed to encode the file handle.

ZFS was not setting `max_len` in the case where the handle was too small.

`zfsctl_fid()` will itself set `max_len` if called with a `fid` that is too small, so if we give `zfs_fid()` that behavior as well, the fix is quite easy: if the handle is too small, just use a zero-size `fid` instead of the handle.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I ran the t_name_to_handle_at.c example from [name_to_handle_at(2)][https://man7.org/linux/man-pages/man2/name_to_handle_at.2.html] on a normal file, a directory, a .zfs directory, and a snapshot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
