### PR TITLE
Fix endianness issues with zstd

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2259,7 +2259,8 @@ snprintf_zstd_header(spa_t *spa, char *blkbuf, size_t buflen,
 		(void) snprintf(blkbuf + strlen(blkbuf),
 		    buflen - strlen(blkbuf),
 		    " ZSTD:size=%u:version=%u:level=%u:EMBEDDED",
-		    zstd_hdr.c_len, zstd_hdr.version, zstd_hdr.level);
+		    zstd_hdr.c_len, zfs_get_hdrversion(&zstd_hdr),
+		    zfs_get_hdrlevel(&zstd_hdr));
 		return;
 	}
 
@@ -2283,7 +2284,8 @@ snprintf_zstd_header(spa_t *spa, char *blkbuf, size_t buflen,
 	(void) snprintf(blkbuf + strlen(blkbuf),
 	    buflen - strlen(blkbuf),
 	    " ZSTD:size=%u:version=%u:level=%u:NORMAL",
-	    zstd_hdr.c_len, zstd_hdr.version, zstd_hdr.level);
+	    zstd_hdr.c_len, zfs_get_hdrversion(&zstd_hdr),
+	    zfs_get_hdrlevel(&zstd_hdr));
 
 	abd_return_buf_copy(pabd, buf, BP_GET_LSIZE(bp));
 }

--- a/module/zstd/Makefile.in
+++ b/module/zstd/Makefile.in
@@ -33,6 +33,7 @@ $(obj)/zfs_zstd.o: c_flags += -include $(zstd_include)/zstd_compat_wrapper.h
 
 $(MODULE)-objs += zfs_zstd.o
 $(MODULE)-objs += lib/zstd.o
+$(MODULE)-objs += zstd_sparc.o
 
 all:
 	mkdir -p lib

--- a/module/zstd/include/sparc_compat.h
+++ b/module/zstd/include/sparc_compat.h
@@ -1,0 +1,4 @@
+#if defined(__sparc)
+uint64_t __bswapdi2(uint64_t in);
+uint32_t __bswapsi2(uint32_t in);
+#endif

--- a/module/zstd/zstd_sparc.c
+++ b/module/zstd/zstd_sparc.c
@@ -1,0 +1,11 @@
+#ifdef __sparc__
+#include <stdint.h>
+#include <sys/byteorder.h>
+#include "include/sparc_compat.h"
+uint64_t __bswapdi2(uint64_t in) {
+	return (BSWAP_64(in));
+}
+uint32_t __bswapsi2(uint32_t in) {
+	return (BSWAP_32(in));
+}
+#endif


### PR DESCRIPTION
All right, heck it, let's start soliciting feedback.

### Motivation and Context
After working around the trivial issue in #12008 (which is also in this PR; I can separate it out if need be), it was discovered that using compress=zstd on any(? at least Linux/ppc64 and Linux/sparc64) big-endian platform results in incorrect storage of the header for the record, such that any similarly incorrect system can read/write the data fine, but "correct" systems (e.g. Linux/x86_64) will EIO on reading that data.

~~(Fascinatingly, FBSD/ppc64 encodes it differently than Linux/{ppc64,sparc64,x86_64}, such that Linux/{ppc64,sparc64} can read its data and vice-versa, which is why I included samples of all three in the test case in #12030 )~~ As I commented in #12030, apparently my prior Linux/sparc64 test case was generated by a WIP patchset which mangled bytes differently, since I can no longer reproduce it, so that's been removed.

### Description
This PR essentially contains two changes:
* a simple fix to provide an implementation for two builtins that aren't available on sparc64 when compiling a kernel module 
* (as was pointed out to me in #11992, this is undefined behavior, because I'm defining a thing with two underscores, but the alternative seemed to be changing the "stock" zstd code. Whichever one people think is the lesser of two evils, I'm happy to do.)
* a heavy-handed fix to the issue of having formerly used varying behavior in the zfs_zstd header, that allows all platforms to read the data written by all other platforms, and makes them all write in the arrangement x86_64 used before this patch.

(It occurs to me that specifying the relevant struct definition here might help. The header is defined as:
```
typedef struct zfs_zstd_header {
        /* Compressed size of data */
        uint32_t c_len;

        /*
         * Version and compression level
         * We use a union to be able to big endian encode a single 32 bit
         * unsigned integer, but still access the individual bitmasked
         * components easily.
         */
        union {
                uint32_t raw_version_level;
                struct {
                        uint32_t version : 24;
                        uint8_t level;
                };
        };

        char data[];
} zfs_zstdhdr_t;
```

and a troublesome thing that's done with it is:
`        hdr->raw_version_level = BE_32(hdr->raw_version_level);`
)

We were basically relying on the encoding of the bitfield in memory and serializing that out to disk, resulting in problems for interoperability.

This PR removes the bitfield (but leaves the raw_version_level uint32_t, as among other things a convenient pointer to the right place...), and wraps all access to the formerly-bitfielded contents of that uint32_t with get/set functions that search to determine the correct encoding (in the get case) and use pointer math to lay things out the same way for everyone (in the set case).

To quote the get method's comment, for how we do that:
```
        /*
         * So we're searching 4 bytes to figure out where the version
         * and level bytes are. The level bytes can cover the whole range
         * of uint8_t, and so are not helpful. Fortunately, the version
         * field is going to have a leading 00 from now until version
         * 6.55.56 or higher with how it's represented, so we can dig
         * that out, and know that wherever we found it, the two bytes
         * "next" to it in the range are the other version bytes, in order,
         * and whichever byte remains is the level field.
         */
```

**Question**: Do we want to somehow increment the zstd module version, e.g. 1.4.5a? Because from my own experience, at least DKMS will sometimes report "hey the module version is the same I totally don't have to replace it", and that would lead to all sorts of problems..

**Question**: Do we want to restrict set to both values at once? Either by making the individual setters private or by making them each individually call the other's zfs_get_hdr...() and call some combination setter that sets both at once - because the code currently only sets them both (on a new hdr, no less), but if one ever got used on a hdr with the incorrect ordering without the other, we'd have lossily mangled that hdr.

### How Has This Been Tested?
* Without the first of the two groups of changes in this PR, confirmed Linux/sparc64 does not compile (but e.g. Linux/ppc64 does).
* Without the second of these changes, confirmed that a Linux/sparc64 or Linux/ppc64 host would EIO on reading files written by an x86_64 host, and files written by one of them could be read by the other but cause similar EIO on x86_64.
* With both changes, confirmed both a ppc64 host and sparc64 host could read and write data interoperably with each other and both an unpatched and patched x86_64 host (and vice-versa).
* Confirmed the changes build and pass the "[sendsanity](https://gist.github.com/rincebrain/e2f8220e12720eae82e8e9991f4cba39)" runfile on a Debian bullseye x86_64 host.
* Confirmed the changes build and "pass"* the "sendsanity" runfile on a Debian sid ppc64 host. 
* Confirmed the changes build and "pass"* the "sendsanity" runfile on a FreeBSD 13 ppc64 host.
* Confirmed all the above hosts pass the test added by #12030  
* Confirmed the changes build and can successfully import and read/write in the right order on a Debian sid sparc64 host (who knew, an UltraSPARC IIi is slow...I'll update when it finishes testing.)

("pass" because there are existing failures I should go report that happen on unmodified git master...)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
