### PR TITLE
Fix dmu_recv_stream test for resumable

### DIFF
--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -2880,8 +2880,8 @@ dmu_recv_stream(dmu_recv_cookie_t *drc, offset_t *voffp)
 	int err = 0;
 	struct receive_writer_arg *rwa = kmem_zalloc(sizeof (*rwa), KM_SLEEP);
 
-	if (dsl_dataset_is_zapified(drc->drc_ds)) {
-		uint64_t bytes;
+	if (dsl_dataset_has_resume_receive_state(drc->drc_ds)) {
+		uint64_t bytes = 0;
 		(void) zap_lookup(drc->drc_ds->ds_dir->dd_pool->dp_meta_objset,
 		    drc->drc_ds->ds_object, DS_FIELD_RESUME_BYTES,
 		    sizeof (bytes), 1, &bytes);


### PR DESCRIPTION
Use dsl_dataset_has_resume_receive_state()
not dsl_dataset_is_zapified() to check if
stream is resumable.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

There is code at the top of dmu_recv_stream() to check if the stream is resumable.  The code as written seems to imply that if dsl_dataset_is_zapified(), then a DS_FIELD_RESUME_BYTES zap entry will be found.  This is inconsistent with other places in ZFS where the more complete dsl_dataset_has_resume_receive_state() is used for this.

Because of this test, the zap_lookup for DS_FIELD_RESUME_BYTES does fail from time to time with ENOENT, and an uninitialized value can end up in drc_bytes_read, sometimes causing a panic at places where bytes_read is VERIFY'd.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This caused a panic in https://github.com/openzfs/zfs/pull/9372 automated testing, under FreeBSD 13.
### Description
This fix uses dsl_dataset_has_resume_receive_state() as the test, and initializes the bytes variable to 0 in case the zap lookup fails.

### How Has This Been Tested?
Ran rsend and redacted_send portions of zfs tests.
 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
