### PR TITLE
Correct flaws in arc_summary[23] and their test.

### DIFF
--- a/cmd/arc_summary/arc_summary2
+++ b/cmd/arc_summary/arc_summary2
@@ -102,18 +102,6 @@ show_tunable_descriptions = False
 alternate_tunable_layout = False
 
 
-def handle_Exception(ex_cls, ex, tb):
-    if ex is IOError:
-        if ex.errno == errno.EPIPE:
-            sys.exit()
-
-    if ex is KeyboardInterrupt:
-        sys.exit()
-
-
-sys.excepthook = handle_Exception
-
-
 def get_Kstat():
     """Collect information on the ZFS subsystem from the /proc virtual
     file system. The name "kstat" is a holdover from the Solaris utility
@@ -1137,48 +1125,55 @@ def main():
     global alternate_tunable_layout
 
     try:
-        opts, args = getopt.getopt(
-            sys.argv[1:],
-            "adp:h", ["alternate", "description", "page=", "help"]
-        )
-    except getopt.error as e:
-        sys.stderr.write("Error: %s\n" % e.msg)
-        usage()
-        sys.exit(1)
-
-    args = {}
-    for opt, arg in opts:
-        if opt in ('-a', '--alternate'):
-            args['a'] = True
-        if opt in ('-d', '--description'):
-            args['d'] = True
-        if opt in ('-p', '--page'):
-            args['p'] = arg
-        if opt in ('-h', '--help'):
-            usage()
-            sys.exit(0)
-
-    Kstat = get_Kstat()
-
-    alternate_tunable_layout = 'a' in args
-    show_tunable_descriptions = 'd' in args
-
-    pages = []
-
-    if 'p' in args:
         try:
-            pages.append(unSub[int(args['p']) - 1])
-        except IndexError:
-            sys.stderr.write('the argument to -p must be between 1 and ' +
-                             str(len(unSub)) + '\n')
+            opts, args = getopt.getopt(
+                sys.argv[1:],
+                "adp:h", ["alternate", "description", "page=", "help"]
+            )
+        except getopt.error as e:
+            sys.stderr.write("Error: %s\n" % e.msg)
+            usage()
             sys.exit(1)
-    else:
-        pages = unSub
 
-    zfs_header()
-    for page in pages:
-        page(Kstat)
-        sys.stdout.write("\n")
+        args = {}
+        for opt, arg in opts:
+            if opt in ('-a', '--alternate'):
+                args['a'] = True
+            if opt in ('-d', '--description'):
+                args['d'] = True
+            if opt in ('-p', '--page'):
+                args['p'] = arg
+            if opt in ('-h', '--help'):
+                usage()
+                sys.exit(0)
+
+        Kstat = get_Kstat()
+
+        alternate_tunable_layout = 'a' in args
+        show_tunable_descriptions = 'd' in args
+
+        pages = []
+
+        if 'p' in args:
+            try:
+                pages.append(unSub[int(args['p']) - 1])
+            except IndexError:
+                sys.stderr.write('the argument to -p must be between 1 and ' +
+                                 str(len(unSub)) + '\n')
+                sys.exit(1)
+        else:
+            pages = unSub
+
+        zfs_header()
+        for page in pages:
+            page(Kstat)
+            sys.stdout.write("\n")
+    except IOError as ex:
+        if (ex.errno == errno.EPIPE):
+            sys.exit(0)
+        raise
+    except KeyboardInterrupt:
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -43,6 +43,12 @@ import subprocess
 import sys
 import time
 
+# We can't use env -S portably, and we need python3 -u to handle pipes in
+# the shell abruptly closing the way we want to, so...
+import io
+if isinstance(sys.__stderr__.buffer, io.BufferedWriter):
+    os.execv(sys.executable, [sys.executable, "-u"] + sys.argv)
+
 DESCRIPTION = 'Print ARC and other statistics for OpenZFS'
 INDENT = ' '*8
 LINE_LENGTH = 72
@@ -220,6 +226,24 @@ elif sys.platform.startswith('linux'):
             descs[name.strip()] = desc.strip()
 
         return descs
+
+def handle_unraisableException(exc_type, exc_value=None, exc_traceback=None,
+                               err_msg=None, object=None):
+   handle_Exception(exc_type, object, exc_traceback)
+
+def handle_Exception(ex_cls, ex, tb):
+    if ex_cls is KeyboardInterrupt:
+        sys.exit()
+
+    if ex_cls is BrokenPipeError:
+        # It turns out that while sys.exit() triggers an exception
+        # not handled message on Python 3.8+, os._exit() does not.
+        os._exit(0)
+    raise ex
+
+if hasattr(sys,'unraisablehook'): # Python 3.8+
+    sys.unraisablehook = handle_unraisableException
+sys.excepthook = handle_Exception
 
 
 def cleanup_line(single_line):

--- a/tests/zfs-tests/tests/functional/cli_user/misc/arc_summary_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/arc_summary_001_pos.ksh
@@ -48,6 +48,9 @@ else
 	set -A args  "" "-a" "-d" "-p 1"
 fi
 
+# Without this, the below checks aren't going to work the way we hope...
+set -o pipefail
+
 typeset -i i=0
 while [[ $i -lt ${#args[*]} ]]; do
 	log_must eval "arc_summary ${args[i]} > /dev/null"


### PR DESCRIPTION
### Motivation and Context
#12036

### Description
So, it turns out arc_summary[23] still have problems like the
one documented in #6965, and the test case didn't notice due to
a flaw.

Redid fixes for both arc_summary scripts, corrected the test case to
fail correctly.

### How Has This Been Tested?
I ran the modified test case on a system without the changes to arc_summary3 and with arc_summary pointing to arc_summary3 and watched it fail. Then I copied the modified version in and watched it pass.

Also tested the arc_summary3 changed on Python 3.6, 3.7, and 3.9.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
