### PR TITLE
Disable normalization implicitly when setting "utf8only=off".

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1562,6 +1562,9 @@ badlabel:
 	 *
 	 * If normalization was chosen, but rejecting non-UTF8 names
 	 * was explicitly not chosen, it is an error.
+	 *
+	 * If utf8only was turned off, but the parent has normalization,
+	 * turn off normalization.
 	 */
 	if (chosen_normal > 0 && chosen_utf < 0) {
 		if (nvlist_add_uint64(ret,
@@ -1575,6 +1578,12 @@ badlabel:
 		    zfs_prop_to_name(ZFS_PROP_UTF8ONLY));
 		(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 		goto error;
+	} else if (chosen_normal < 0 && chosen_utf == 0) {
+		if (nvlist_add_uint64(ret,
+		    zfs_prop_to_name(ZFS_PROP_NORMALIZE), 0) != 0) {
+			(void) no_memory(hdl);
+			goto error;
+		}
 	}
 	return (ret);
 

--- a/tests/zfs-tests/tests/functional/casenorm/norm_all_values.ksh
+++ b/tests/zfs-tests/tests/functional/casenorm/norm_all_values.ksh
@@ -58,4 +58,15 @@ for form in formC formD formKC formKD; do
 	destroy_testfs
 done
 
+for form in formC formD formKC formKD; do
+	create_testfs "-o normalization=$form"
+	log_must zfs create -o utf8only=off $TESTPOOL/$TESTFS/$TESTSUBFS
+	normalization=$(zfs get -H -o value normalization $TESTPOOL/$TESTFS/$TESTSUBFS)
+	if [[ $normalization != "none" ]]; then
+		log_fail "Turning off utf8only didn't set normalization to none"
+	fi
+	log_must zfs destroy $TESTPOOL/$TESTFS/$TESTSUBFS
+	destroy_testfs
+done
+
 log_pass "Can create FS with all supported normalization forms"


### PR DESCRIPTION
### Motivation and Context
When creating a new zfs file system and `-o utf8only=off` is passed as a parameter, the option could silently be overridden and switched to the **on** state due to the parent dataset having a **normalization** value != **none**. This is counter-intuitive and potentially harmful as it may go unnoticed until a non-UTF8 conforming file name is attempted to be created, at which moment the normal error about an invalid UTF8 sequence will be returned.

The zfsprops(8) manpage for **utf8only** has language already that might imply this: "If this property is explicitly set to off, the normalization property must either not be explicitly set or be set to none."

I describe the issue in #11892 with an example sequence of commands that triggers the bad behavior.

### Description
`lib/libzfs/libzfs_dataset.c` already has code that detects when the **normalization** property is set and switches **utf8only** to **on**. Added another conditional to set **normalization** to **none** when **utf8only** is set to **off**.

### How Has This Been Tested?
Compiled a version of ZFS with this change, ran my sample commands as I presented in the open issue, and checked the utf8only and normalization properties to make sure they are set as appropriate.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
