### PR TITLE
libspl: staticify buf and pagesize, rename aok to libspl_assert_ok

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -8493,7 +8493,7 @@ main(int argc, char **argv)
 			dump_opt[c] += verbose;
 	}
 
-	aok = (dump_opt['A'] == 1) || (dump_opt['A'] > 2);
+	libspl_assert_ok = (dump_opt['A'] == 1) || (dump_opt['A'] > 2);
 	zfs_recover = (dump_opt['A'] > 1);
 
 	argc -= optind;

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -160,8 +160,6 @@ extern void vpanic(const char *, va_list)  __NORETURN;
 
 #define	fm_panic	panic
 
-extern int aok;
-
 /*
  * DTrace SDT probes have different signatures in userland than they do in
  * the kernel.  If they're being used in kernel code, re-define them out of

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -1,6 +1,5 @@
 <abi-corpus path='libnvpair.so' architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
   <elf-needed>
-    <dependency name='libtirpc.so.3'/>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
@@ -231,7 +230,7 @@
     <elf-symbol name='nvpair_value_uint8_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <elf-variable-symbols>
-    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assert_ok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nv_alloc_nosleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nv_alloc_nosleep_def' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nv_alloc_sleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -241,59 +240,814 @@
     <elf-symbol name='nvlist_hashtable_init_size' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvpair_max_recursion' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libnvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-
-
-    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-2'>
-      <subrange length='1' type-id='type-id-3' id='type-id-4'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-5'>
-      <subrange length='20' type-id='type-id-3' id='type-id-6'/>
-
-    </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-7'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-8'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-9'/>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-10'/>
-    <type-decl name='double' size-in-bits='64' id='type-id-11'/>
-    <type-decl name='int' size-in-bits='32' id='type-id-12'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-13'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-14'/>
-    <type-decl name='short int' size-in-bits='16' id='type-id-15'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-16'/>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-17'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-18'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-19'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-20'/>
-    <type-decl name='void' id='type-id-21'/>
-    <typedef-decl name='nvpair_t' type-id='type-id-22' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-23'/>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-22'>
+  <abi-instr version='1.0' address-size='64' path='libnvpair.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <type-decl name='void' id='type-id-1'/>
+    <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='91' column='1' id='type-id-2'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='type-id-25' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='type-id-25' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+        <var-decl name='nvprt_fp' type-id='type-id-3' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+        <var-decl name='nvprt_indent_mode' type-id='type-id-4' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='type-id-26' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+        <var-decl name='nvprt_indent' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvprt_indentinc' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='nvprt_nmfmt' type-id='type-id-6' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nvprt_eomfmt' type-id='type-id-6' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='nvprt_btwnarrfmt' type-id='type-id-6' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='nvprt_btwnarrfmt_nl' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='nvprt_dfltops' type-id='type-id-7' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='nvprt_custops' type-id='type-id-7' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='101' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='int32_t' type-id='type-id-27' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-24'/>
-    <typedef-decl name='__int32_t' type-id='type-id-12' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-27'/>
-    <typedef-decl name='int16_t' type-id='type-id-28' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-25'/>
-    <typedef-decl name='__int16_t' type-id='type-id-15' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-28'/>
-    <typedef-decl name='data_type_t' type-id='type-id-29' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-26'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-29'>
-      <underlying-type type-id='type-id-17'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-8'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-10' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-12' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-13' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-14' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-15' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-16' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-17' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-18' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-11' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-19' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-21' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-5'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-9'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-11'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-24'/>
+    <typedef-decl name='__off_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-12'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-13'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-14'/>
+    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-25'/>
+
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='8' id='type-id-15'>
+      <subrange length='1' type-id='type-id-25' id='type-id-26'/>
+
+    </array-type-def>
+    <typedef-decl name='__off64_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-16'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-17'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-19'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-29'/>
+    <typedef-decl name='size_t' type-id='type-id-29' filepath='/usr/lib/llvm-13/lib/clang/13.0.0/include/stddef.h' line='46' column='1' id='type-id-20'/>
+
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='160' id='type-id-21'>
+      <subrange length='20' type-id='type-id-25' id='type-id-30'/>
+
+    </array-type-def>
+    <typedef-decl name='FILE' type-id='type-id-8' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-32'/>
+    <enum-decl name='nvlist_indent_mode' filepath='../../include/libnvpair.h' line='86' column='1' id='type-id-4'>
+      <underlying-type type-id='type-id-32'/>
+      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
+      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
+    </enum-decl>
+    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-6'/>
+    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='61' column='1' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='print_boolean' type-id='type-id-35' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='print_boolean_value' type-id='type-id-36' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='print_byte' type-id='type-id-37' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='print_int8' type-id='type-id-38' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='print_uint8' type-id='type-id-39' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='print_int16' type-id='type-id-40' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='print_uint16' type-id='type-id-41' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='print_int32' type-id='type-id-42' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='print_uint32' type-id='type-id-43' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='print_int64' type-id='type-id-44' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='print_uint64' type-id='type-id-45' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='print_double' type-id='type-id-46' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='print_string' type-id='type-id-47' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='print_hrtime' type-id='type-id-48' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='print_nvlist' type-id='type-id-49' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='print_boolean_array' type-id='type-id-50' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='print_byte_array' type-id='type-id-51' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='print_int8_array' type-id='type-id-52' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='print_uint8_array' type-id='type-id-53' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='print_int16_array' type-id='type-id-54' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='print_uint16_array' type-id='type-id-55' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='print_int32_array' type-id='type-id-56' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='print_uint32_array' type-id='type-id-57' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2944'>
+        <var-decl name='print_int64_array' type-id='type-id-58' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='print_uint64_array' type-id='type-id-59' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3200'>
+        <var-decl name='print_string_array' type-id='type-id-60' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='print_nvlist_array' type-id='type-id-61' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='62' column='1' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-62' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-63'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='type-id-65' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='type-id-66' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='type-id-67' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='type-id-66' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-65' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int32_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-68'/>
+    <typedef-decl name='int32_t' type-id='type-id-68' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-65'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-69'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-69' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-70'/>
+    <typedef-decl name='uint32_t' type-id='type-id-70' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-66'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-29' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-71'/>
+    <typedef-decl name='uint64_t' type-id='type-id-71' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-67'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-64' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-72'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-62'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='63' column='1' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-75' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-76'>
+      <underlying-type type-id='type-id-32'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='type-id-76' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-75'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='64' column='1' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-79' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-80'/>
+    <typedef-decl name='uchar_t' type-id='type-id-80' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-79'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='65' column='1' id='type-id-38'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-83' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int8_t' type-id='type-id-14' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='36' column='1' id='type-id-84'/>
+    <typedef-decl name='int8_t' type-id='type-id-84' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-83'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='66' column='1' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-87' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__uint8_t' type-id='type-id-80' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-88'/>
+    <typedef-decl name='uint8_t' type-id='type-id-88' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-87'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='67' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-91' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='short int' size-in-bits='16' id='type-id-92'/>
+    <typedef-decl name='__int16_t' type-id='type-id-92' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-93'/>
+    <typedef-decl name='int16_t' type-id='type-id-93' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-91'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='68' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-96' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__uint16_t' type-id='type-id-13' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-97'/>
+    <typedef-decl name='uint16_t' type-id='type-id-97' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-96'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='69' column='1' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-100' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-100'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='70' column='1' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-102' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-102'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='71' column='1' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-104' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int64_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='43' column='1' id='type-id-105'/>
+    <typedef-decl name='int64_t' type-id='type-id-105' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-104'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='72' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-108' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-108'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='73' column='1' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-110' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='double' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-110'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='74' column='1' id='type-id-47'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-113' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-113'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='75' column='1' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-115' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-116'/>
+    <typedef-decl name='hrtime_t' type-id='type-id-116' filepath='../../lib/libspl/include/sys/time.h' line='78' column='1' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-115'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='76' column='1' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-119' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-119'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='77' column='1' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-121' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-122'/>
+    <typedef-decl name='uint_t' type-id='type-id-69' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-121'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='78' column='1' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-125' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-125'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='79' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-128' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-128'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='80' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-131' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-131'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='81' column='1' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-134' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-134'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='82' column='1' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-137' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-137'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='83' column='1' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-140' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-140'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='84' column='1' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-143' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-143'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='85' column='1' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-146' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-147'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-146'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='86' column='1' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-149' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-149'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='87' column='1' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-152' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-152'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='88' column='1' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-155' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-7'/>
+    <typedef-decl name='nvlist_prtctl_t' type-id='type-id-63' filepath='../../include/libnvpair.h' line='84' column='1' id='type-id-158'/>
+    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
+      <parameter type-id='type-id-3' name='fp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='318' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
+      <parameter type-id='type-id-4' name='mode' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
+      <parameter type-id='type-id-5' name='start' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
+      <parameter type-id='type-id-5' name='inc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
+      <parameter type-id='type-id-5' name='onemore' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='nvlist_prtctl_fmt' filepath='../../include/libnvpair.h' line='104' column='1' id='type-id-159'>
+      <underlying-type type-id='type-id-32'/>
+      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
+      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
+      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
+    </enum-decl>
+    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
+      <parameter type-id='type-id-159' name='which' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
+      <parameter type-id='type-id-6' name='fmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='351' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
+      <parameter type-id='type-id-159' name='which' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-161'/>
+    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <parameter type-id='type-id-161' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-163'/>
+    <function-decl name='nvlist_prtctlop_boolean_value' mangled-name='nvlist_prtctlop_boolean_value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_value'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-163' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
+    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <parameter type-id='type-id-165' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-167'/>
+    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <parameter type-id='type-id-167' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-169'/>
+    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <parameter type-id='type-id-169' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-171'/>
+    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <parameter type-id='type-id-171' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
+    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <parameter type-id='type-id-173' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
+    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <parameter type-id='type-id-175' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
+    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <parameter type-id='type-id-177' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-179'/>
+    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-179' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-181'/>
+    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <parameter type-id='type-id-181' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-183'/>
+    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <parameter type-id='type-id-183' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-185'/>
+    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <parameter type-id='type-id-185' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-186' size-in-bits='64' id='type-id-187'/>
+    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <parameter type-id='type-id-187' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='444' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <parameter type-id='type-id-189' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-191'/>
+    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <parameter type-id='type-id-191' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-193'/>
+    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <parameter type-id='type-id-193' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
+    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <parameter type-id='type-id-195' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
+    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <parameter type-id='type-id-197' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-199'/>
+    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <parameter type-id='type-id-199' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <parameter type-id='type-id-201' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-203'/>
+    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='462' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <parameter type-id='type-id-203' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
+    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-205' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-207'/>
+    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <parameter type-id='type-id-207' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-209'/>
+    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <parameter type-id='type-id-209' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-211'/>
+    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='466' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <parameter type-id='type-id-211' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-212' size-in-bits='64' id='type-id-213'/>
+    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <parameter type-id='type-id-213' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <parameter type-id='type-id-19' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
+      <return type-id='type-id-158'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='546' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
+      <parameter type-id='type-id-3' name='fp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
+      <parameter type-id='type-id-73' name='nvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-214'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvp_size' type-id='type-id-65' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvp_name_sz' type-id='type-id-94' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='type-id-94' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvp_value_elem' type-id='type-id-65' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='type-id-215' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-216'>
+      <underlying-type type-id='type-id-32'/>
       <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
       <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
       <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
@@ -324,2482 +1078,2571 @@
       <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
       <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
     </enum-decl>
-    <typedef-decl name='nvlist_t' type-id='type-id-30' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-31'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-30'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-32' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-33' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-32' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-24' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint32_t' type-id='type-id-34' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-32'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-19' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-34'/>
-    <typedef-decl name='uint64_t' type-id='type-id-35' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-33'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='45' column='1' id='type-id-35'/>
-    <typedef-decl name='nvlist_prtctl_t' type-id='type-id-36' filepath='../../include/libnvpair.h' line='84' column='1' id='type-id-37'/>
-    <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='91' column='1' id='type-id-38'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvprt_fp' type-id='type-id-39' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvprt_indent_mode' type-id='type-id-40' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvprt_indent' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvprt_indentinc' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nvprt_nmfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nvprt_eomfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='97' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='nvprt_btwnarrfmt' type-id='type-id-41' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='nvprt_btwnarrfmt_nl' type-id='type-id-12' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='nvprt_dfltops' type-id='type-id-42' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='nvprt_custops' type-id='type-id-42' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='101' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='FILE' type-id='type-id-43' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-44'/>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-43'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-45' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-47' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-48' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-16' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-50' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-51' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-52' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-47' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-53' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-54' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__off_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-48'/>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-21' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-55'/>
-    <typedef-decl name='__off64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-50'/>
-    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-54'/>
-    <enum-decl name='nvlist_indent_mode' filepath='../../include/libnvpair.h' line='86' column='1' id='type-id-40'>
-      <underlying-type type-id='type-id-17'/>
-      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
-      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
-    </enum-decl>
-    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='61' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='print_boolean' type-id='type-id-57' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='print_boolean_value' type-id='type-id-58' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='print_byte' type-id='type-id-59' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='print_int8' type-id='type-id-60' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='print_uint8' type-id='type-id-61' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='print_int16' type-id='type-id-62' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='print_uint16' type-id='type-id-63' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='print_int32' type-id='type-id-64' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='print_uint32' type-id='type-id-65' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='print_int64' type-id='type-id-66' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='print_uint64' type-id='type-id-67' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='print_double' type-id='type-id-68' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='print_string' type-id='type-id-69' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='print_hrtime' type-id='type-id-70' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='print_nvlist' type-id='type-id-71' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='print_boolean_array' type-id='type-id-72' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='print_byte_array' type-id='type-id-73' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='print_int8_array' type-id='type-id-74' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='print_uint8_array' type-id='type-id-75' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='print_int16_array' type-id='type-id-76' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='print_uint16_array' type-id='type-id-77' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='print_int32_array' type-id='type-id-78' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2816'>
-        <var-decl name='print_uint32_array' type-id='type-id-79' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2944'>
-        <var-decl name='print_int64_array' type-id='type-id-80' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3072'>
-        <var-decl name='print_uint64_array' type-id='type-id-81' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='print_string_array' type-id='type-id-82' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3328'>
-        <var-decl name='print_nvlist_array' type-id='type-id-83' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1' id='type-id-57'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-84' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='62' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-85' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='63' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-86' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-87'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-86'>
-      <underlying-type type-id='type-id-17'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1' id='type-id-59'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-88' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='64' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uchar_t' type-id='type-id-18' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-89'/>
-    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1' id='type-id-60'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-90' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='65' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int8_t' type-id='type-id-91' filepath='/usr/include/bits/stdint-intn.h' line='24' column='1' id='type-id-92'/>
-    <typedef-decl name='__int8_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-91'/>
-    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1' id='type-id-61'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-93' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='66' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint8_t' type-id='type-id-94' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-95'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-18' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-94'/>
-    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1' id='type-id-62'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-96' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='67' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1' id='type-id-63'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-97' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='68' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint16_t' type-id='type-id-98' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-99'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-20' filepath='/usr/include/bits/types.h' line='40' column='1' id='type-id-98'/>
-    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1' id='type-id-64'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-100' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='69' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1' id='type-id-65'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-101' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='70' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1' id='type-id-66'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-102' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='71' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int64_t' type-id='type-id-103' filepath='/usr/include/bits/stdint-intn.h' line='27' column='1' id='type-id-104'/>
-    <typedef-decl name='__int64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-103'/>
-    <class-decl name='__anonymous_struct__10' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1' id='type-id-67'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-105' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='72' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__11' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1' id='type-id-68'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-106' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='73' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1' id='type-id-69'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-107' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='74' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1' id='type-id-70'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-108' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='75' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='hrtime_t' type-id='type-id-14' filepath='../../lib/libspl/include/sys/time.h' line='78' column='1' id='type-id-109'/>
-    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1' id='type-id-71'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-110' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='76' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__15' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1' id='type-id-72'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-111' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='77' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint_t' type-id='type-id-19' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-112'/>
-    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1' id='type-id-73'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-113' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='78' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1' id='type-id-74'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-114' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='79' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1' id='type-id-75'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-115' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='80' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1' id='type-id-76'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-116' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='81' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1' id='type-id-77'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-117' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='82' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__21' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1' id='type-id-78'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-118' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='83' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__22' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1' id='type-id-79'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-119' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='84' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1' id='type-id-80'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-120' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='85' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1' id='type-id-81'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-121' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='86' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1' id='type-id-82'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-122' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='87' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__26' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1' id='type-id-83'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-123' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-53' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='88' column='1'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='nvlist_prtctl_fmt' filepath='../../include/libnvpair.h' line='104' column='1' id='type-id-124'>
-      <underlying-type type-id='type-id-17'/>
-      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
-      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
-      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
-    </enum-decl>
-    <typedef-decl name='regex_t' type-id='type-id-125' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-126'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-125'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='type-id-127' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='type-id-128' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='type-id-128' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='type-id-129' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fastmap' type-id='type-id-45' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='type-id-130' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='type-id-54' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='type-id-19' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__re_long_size_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-128'/>
-    <typedef-decl name='reg_syntax_t' type-id='type-id-3' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-129'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-39'/>
-    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-47'/>
-    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-55' size-in-bits='64' id='type-id-49'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-131'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-45'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-132'/>
-    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-133'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-41'/>
-    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-107'/>
-    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-122'/>
-    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-84'/>
-    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-116'/>
-    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-118'/>
-    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-120'/>
-    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-114'/>
-    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-123'/>
-    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-96'/>
-    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-100'/>
-    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-102'/>
-    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-90'/>
-    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-88'/>
-    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-97'/>
-    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-101'/>
-    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-105'/>
-    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-93'/>
-    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-113'/>
-    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-119'/>
-    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-121'/>
-    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-115'/>
-    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-162'/>
-    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-164'/>
-    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
-    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-168'/>
-    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-170'/>
-    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
-    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-174'/>
-    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
-    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-178'/>
-    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-180'/>
-    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-182'/>
-    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-184'/>
-    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
-    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-188'/>
-    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-190'/>
-    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-192'/>
-    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-194'/>
-    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-196'/>
-    <pointer-type-def type-id='type-id-197' size-in-bits='64' id='type-id-198'/>
-    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-200'/>
-    <pointer-type-def type-id='type-id-201' size-in-bits='64' id='type-id-202'/>
-    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-204'/>
-    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-206'/>
-    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
-    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-210'/>
-    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-212'/>
-    <pointer-type-def type-id='type-id-213' size-in-bits='64' id='type-id-214'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-215'/>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-216'/>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-217'/>
-    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-218'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-42'/>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-36'/>
-    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-219'/>
-    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-220'/>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-221'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-127'/>
-    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-222'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-223'/>
-    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-224'/>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-225'/>
-    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-226'/>
-    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-130'/>
-    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-53'/>
-    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
-      <parameter type-id='type-id-221' name='nvp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
-      <parameter type-id='type-id-12' name='ai' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
-      <parameter type-id='type-id-45' name='value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
-      <parameter type-id='type-id-132' name='ep' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
-      <parameter type-id='type-id-219' name='list' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
-      <parameter type-id='type-id-12' name='indent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
-      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_print' mangled-name='nvlist_print' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
-      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
-      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='757' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='546' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
-      <parameter type-id='type-id-182' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='467' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
-      <parameter type-id='type-id-166' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='466' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
-      <parameter type-id='type-id-212' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='465' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
-      <parameter type-id='type-id-176' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='464' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
-      <parameter type-id='type-id-210' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='463' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
-      <parameter type-id='type-id-174' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='462' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
-      <parameter type-id='type-id-208' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='461' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
-      <parameter type-id='type-id-172' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='460' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
-      <parameter type-id='type-id-214' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='459' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
-      <parameter type-id='type-id-178' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='458' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
-      <parameter type-id='type-id-206' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='457' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
-      <parameter type-id='type-id-162' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='456' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
-      <parameter type-id='type-id-180' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='444' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
-      <parameter type-id='type-id-186' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='443' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
-      <parameter type-id='type-id-164' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='442' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
-      <parameter type-id='type-id-168' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='441' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
-      <parameter type-id='type-id-202' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='440' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
-      <parameter type-id='type-id-192' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='439' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
-      <parameter type-id='type-id-200' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='438' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
-      <parameter type-id='type-id-190' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='437' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
-      <parameter type-id='type-id-198' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='436' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
-      <parameter type-id='type-id-188' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='435' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
-      <parameter type-id='type-id-204' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='434' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
-      <parameter type-id='type-id-194' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='433' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
-      <parameter type-id='type-id-196' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='432' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_boolean_value' mangled-name='nvlist_prtctlop_boolean_value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_value'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
-      <parameter type-id='type-id-184' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='431' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
-      <parameter type-id='type-id-170' name='func' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
-      <parameter type-id='type-id-53' name='private' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='430' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
-      <parameter type-id='type-id-124' name='which' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='383' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
-      <parameter type-id='type-id-124' name='which' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='350' column='1'/>
-      <parameter type-id='type-id-41' name='fmt' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='351' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
-      <parameter type-id='type-id-12' name='onemore' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='343' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
-      <parameter type-id='type-id-40' name='mode' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='325' column='1'/>
-      <parameter type-id='type-id-12' name='start' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
-      <parameter type-id='type-id-12' name='inc' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='326' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='318' column='1'/>
-      <return type-id='type-id-39'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
-      <parameter type-id='type-id-37' name='pctl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
-      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='312' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
-      <parameter type-id='type-id-221' name='nvp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
-      <parameter type-id='type-id-12' name='ai' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
-      <parameter type-id='type-id-45' name='value' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
-      <parameter type-id='type-id-222' name='value_regex' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
-      <parameter type-id='type-id-132' name='ep' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='__builtin_fputs' mangled-name='fputs' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='__builtin_strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-134'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-131'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-135'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-136'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-132'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-137'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-138'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-12'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-139'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-215'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-140'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-216'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-141'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-142'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
+    <typedef-decl name='data_type_t' type-id='type-id-216' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-215'/>
+    <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-218'/>
+    <function-decl name='nvlist_next_nvpair' filepath='../../include/sys/nvpair.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-143'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-144'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-145'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-146'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-109'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-147'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-25'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-148'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-24'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-149'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-150'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-92'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-151'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-152'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-99'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-153'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-154'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-33'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-155'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-95'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-156'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-157'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-224'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-158'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-225'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-159'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-160'>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-227'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-161'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-131'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-163'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-165'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-132'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-167'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-11'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-169'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-12'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-171'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-215'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-173'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-216'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-175'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-177'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-179'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-181'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-183'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-185'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-109'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-187'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-25'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-189'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-24'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-191'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-193'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-92'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-195'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-197'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-99'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-199'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-32'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-201'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-33'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-203'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-95'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-205'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-207'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-224'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-209'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-225'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-211'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-213'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-41'/>
-      <parameter type-id='type-id-227'/>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-    <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
-      <parameter type-id='type-id-39' name='fp' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
-      <parameter type-id='type-id-219' name='nvl' filepath='/home/fedora/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-228'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-19' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-19' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-53' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-53' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='125' column='1' id='type-id-229'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nva_ops' type-id='type-id-230' visibility='default' filepath='../../include/sys/nvpair.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nva_arg' type-id='type-id-53' visibility='default' filepath='../../include/sys/nvpair.h' line='127' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='nv_alloc_ops_t' type-id='type-id-231' filepath='../../include/sys/nvpair.h' line='123' column='1' id='type-id-232'/>
-    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='130' column='1' id='type-id-231'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nv_ao_init' type-id='type-id-233' visibility='default' filepath='../../include/sys/nvpair.h' line='131' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nv_ao_fini' type-id='type-id-234' visibility='default' filepath='../../include/sys/nvpair.h' line='132' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nv_ao_alloc' type-id='type-id-235' visibility='default' filepath='../../include/sys/nvpair.h' line='133' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nv_ao_free' type-id='type-id-236' visibility='default' filepath='../../include/sys/nvpair.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nv_ao_reset' type-id='type-id-234' visibility='default' filepath='../../include/sys/nvpair.h' line='135' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='nv_alloc_t' type-id='type-id-229' filepath='../../include/sys/nvpair.h' line='128' column='1' id='type-id-237'/>
-    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-238'/>
-    <qualified-type-def type-id='type-id-232' const='yes' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-239' size-in-bits='64' id='type-id-230'/>
-    <pointer-type-def type-id='type-id-240' size-in-bits='64' id='type-id-233'/>
-    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-241'/>
-    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-234'/>
-    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-236'/>
-    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-235'/>
-    <var-decl name='nv_alloc_sleep_def' type-id='type-id-237' mangled-name='nv_alloc_sleep_def' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1' elf-symbol-id='nv_alloc_sleep_def'/>
-    <var-decl name='nv_alloc_nosleep_def' type-id='type-id-237' mangled-name='nv_alloc_nosleep_def' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='59' column='1' elf-symbol-id='nv_alloc_nosleep_def'/>
-    <var-decl name='nv_alloc_sleep' type-id='type-id-241' mangled-name='nv_alloc_sleep' visibility='default' filepath='/home/fedora/zfs/lib/libnvpair/nvpair_alloc_system.c' line='64' column='1' elf-symbol-id='nv_alloc_sleep'/>
-    <var-decl name='nv_alloc_nosleep' type-id='type-id-241' mangled-name='nv_alloc_nosleep' visibility='default' filepath='../../include/sys/nvpair.h' line='139' column='1' elf-symbol-id='nv_alloc_nosleep'/>
-    <function-type size-in-bits='64' id='type-id-240'>
-      <parameter type-id='type-id-241'/>
-      <parameter type-id='type-id-238'/>
-      <return type-id='type-id-12'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-242'>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-21'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-243'>
-      <parameter type-id='type-id-241'/>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-21'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-244'>
-      <parameter type-id='type-id-241'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-53'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-    <var-decl name='nv_fixed_ops_def' type-id='type-id-239' mangled-name='nv_fixed_ops_def' visibility='default' filepath='../../module/nvpair/nvpair_alloc_fixed.c' line='103' column='1' elf-symbol-id='nv_fixed_ops_def'/>
-    <var-decl name='nv_fixed_ops' type-id='type-id-230' mangled-name='nv_fixed_ops' visibility='default' filepath='../../include/sys/nvpair.h' line='138' column='1' elf-symbol-id='nv_fixed_ops'/>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-245'/>
-    <qualified-type-def type-id='type-id-45' const='yes' id='type-id-246'/>
-    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
-    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-248'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-250'/>
-    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-251'/>
-    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-252'/>
-    <pointer-type-def type-id='type-id-216' size-in-bits='64' id='type-id-253'/>
-    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-254'/>
-    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-255'/>
-    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-256'/>
-    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-257'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-258'/>
-    <pointer-type-def type-id='type-id-223' size-in-bits='64' id='type-id-259'/>
-    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-260'/>
-    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-261'/>
-    <pointer-type-def type-id='type-id-226' size-in-bits='64' id='type-id-262'/>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-263'/>
-    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-264'/>
-    <var-decl name='nvpair_max_recursion' type-id='type-id-12' mangled-name='nvpair_max_recursion' visibility='default' filepath='../../module/nvpair/nvpair.c' line='151' column='1' elf-symbol-id='nvpair_max_recursion'/>
-    <var-decl name='nvlist_hashtable_init_size' type-id='type-id-33' mangled-name='nvlist_hashtable_init_size' visibility='default' filepath='../../module/nvpair/nvpair.c' line='154' column='1' elf-symbol-id='nvlist_hashtable_init_size'/>
-    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' filepath='../../module/nvpair/nvpair.c' line='2721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
-      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
-      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' filepath='../../module/nvpair/nvpair.c' line='2715' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
-      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
-      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
-      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' filepath='../../module/nvpair/nvpair.c' line='2657' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
-      <parameter type-id='type-id-132' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
-      <parameter type-id='type-id-258' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
-      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
-      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2658' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_size' mangled-name='nvlist_size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
-      <parameter type-id='type-id-258' name='size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
-      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' filepath='../../module/nvpair/nvpair.c' line='2279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
-      <parameter type-id='type-id-219' name='dst' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
-      <parameter type-id='type-id-12' name='flag' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' filepath='../../module/nvpair/nvpair.c' line='2262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' filepath='../../module/nvpair/nvpair.c' line='2253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
-      <parameter type-id='type-id-250' name='val' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='2247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
-      <parameter type-id='type-id-256' name='val' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' filepath='../../module/nvpair/nvpair.c' line='2241' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
-      <parameter type-id='type-id-248' name='val' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' filepath='../../module/nvpair/nvpair.c' line='2235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
-      <parameter type-id='type-id-262' name='val' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' filepath='../../module/nvpair/nvpair.c' line='2229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
-      <parameter type-id='type-id-254' name='val' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' filepath='../../module/nvpair/nvpair.c' line='2223' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
-      <parameter type-id='type-id-261' name='val' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' filepath='../../module/nvpair/nvpair.c' line='2217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
-      <parameter type-id='type-id-253' name='val' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' filepath='../../module/nvpair/nvpair.c' line='2211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
-      <parameter type-id='type-id-260' name='val' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' filepath='../../module/nvpair/nvpair.c' line='2205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
-      <parameter type-id='type-id-252' name='val' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' filepath='../../module/nvpair/nvpair.c' line='2199' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
-      <parameter type-id='type-id-263' name='val' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' filepath='../../module/nvpair/nvpair.c' line='2193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
-      <parameter type-id='type-id-255' name='val' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' filepath='../../module/nvpair/nvpair.c' line='2187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
-      <parameter type-id='type-id-259' name='val' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' filepath='../../module/nvpair/nvpair.c' line='2181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
-      <parameter type-id='type-id-245' name='val' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
-      <parameter type-id='type-id-264' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../module/nvpair/nvpair.c' line='2175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
-      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' filepath='../../module/nvpair/nvpair.c' line='2169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
-      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' filepath='../../module/nvpair/nvpair.c' line='2162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
-      <parameter type-id='type-id-249' name='val' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' filepath='../../module/nvpair/nvpair.c' line='2155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
-      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' filepath='../../module/nvpair/nvpair.c' line='2149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
-      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' filepath='../../module/nvpair/nvpair.c' line='2143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
-      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../module/nvpair/nvpair.c' line='2137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
-      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' filepath='../../module/nvpair/nvpair.c' line='2131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
-      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' filepath='../../module/nvpair/nvpair.c' line='2125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
-      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' filepath='../../module/nvpair/nvpair.c' line='2119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
-      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' filepath='../../module/nvpair/nvpair.c' line='2113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
-      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' filepath='../../module/nvpair/nvpair.c' line='2107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
-      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' filepath='../../module/nvpair/nvpair.c' line='2101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
-      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' filepath='../../module/nvpair/nvpair.c' line='2080' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
-      <return type-id='type-id-87'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' filepath='../../module/nvpair/nvpair.c' line='2073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2073' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
-      <parameter type-id='type-id-257' name='ret' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
-      <parameter type-id='type-id-251' name='ip' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
-      <parameter type-id='type-id-132' name='ep' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' filepath='../../module/nvpair/nvpair.c' line='2063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
-      <parameter type-id='type-id-257' name='ret' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' filepath='../../module/nvpair/nvpair.c' line='1813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
-      <parameter type-id='type-id-12' name='flag' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' filepath='../../module/nvpair/nvpair.c' line='1807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
-      <parameter type-id='type-id-250' name='val' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
-      <parameter type-id='type-id-256' name='a' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' filepath='../../module/nvpair/nvpair.c' line='1793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
-      <parameter type-id='type-id-248' name='a' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
-      <parameter type-id='type-id-262' name='a' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' filepath='../../module/nvpair/nvpair.c' line='1779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
-      <parameter type-id='type-id-254' name='a' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
-      <parameter type-id='type-id-261' name='a' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' filepath='../../module/nvpair/nvpair.c' line='1765' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
-      <parameter type-id='type-id-253' name='a' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
-      <parameter type-id='type-id-260' name='a' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' filepath='../../module/nvpair/nvpair.c' line='1751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
-      <parameter type-id='type-id-252' name='a' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
-      <parameter type-id='type-id-263' name='a' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' filepath='../../module/nvpair/nvpair.c' line='1738' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
-      <parameter type-id='type-id-255' name='a' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' filepath='../../module/nvpair/nvpair.c' line='1731' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
-      <parameter type-id='type-id-259' name='a' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1723' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
-      <parameter type-id='type-id-245' name='a' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' filepath='../../module/nvpair/nvpair.c' line='1717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
-      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' filepath='../../module/nvpair/nvpair.c' line='1711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
-      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' filepath='../../module/nvpair/nvpair.c' line='1704' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
-      <parameter type-id='type-id-249' name='val' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' filepath='../../module/nvpair/nvpair.c' line='1697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
-      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' filepath='../../module/nvpair/nvpair.c' line='1691' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
-      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' filepath='../../module/nvpair/nvpair.c' line='1685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
-      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' filepath='../../module/nvpair/nvpair.c' line='1679' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
-      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' filepath='../../module/nvpair/nvpair.c' line='1673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
-      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' filepath='../../module/nvpair/nvpair.c' line='1667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
-      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' filepath='../../module/nvpair/nvpair.c' line='1661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
-      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' filepath='../../module/nvpair/nvpair.c' line='1655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
-      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' filepath='../../module/nvpair/nvpair.c' line='1649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
-      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
-      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' filepath='../../module/nvpair/nvpair.c' line='1636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1636' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1636' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' filepath='../../module/nvpair/nvpair.c' line='1520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1520' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../module/nvpair/nvpair.c' line='1514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1514' column='1'/>
-      <return type-id='type-id-26'/>
-    </function-decl>
-    <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../module/nvpair/nvpair.c' line='1508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1508' column='1'/>
-      <return type-id='type-id-45'/>
-    </function-decl>
-    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' filepath='../../module/nvpair/nvpair.c' line='1496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1496' column='1'/>
-      <return type-id='type-id-87'/>
-    </function-decl>
-    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' filepath='../../module/nvpair/nvpair.c' line='1472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1472' column='1'/>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1472' column='1'/>
-      <return type-id='type-id-221'/>
-    </function-decl>
-    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' filepath='../../module/nvpair/nvpair.c' line='1443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
-      <return type-id='type-id-221'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
-      <parameter type-id='type-id-220' name='a' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' filepath='../../module/nvpair/nvpair.c' line='1430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
-      <parameter type-id='type-id-219' name='val' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' filepath='../../module/nvpair/nvpair.c' line='1424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
-      <parameter type-id='type-id-109' name='val' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' filepath='../../module/nvpair/nvpair.c' line='1417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
-      <parameter type-id='type-id-247' name='a' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
-      <parameter type-id='type-id-226' name='a' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' filepath='../../module/nvpair/nvpair.c' line='1405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
-      <parameter type-id='type-id-217' name='a' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
-      <parameter type-id='type-id-225' name='a' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' filepath='../../module/nvpair/nvpair.c' line='1393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
-      <parameter type-id='type-id-216' name='a' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
-      <parameter type-id='type-id-224' name='a' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' filepath='../../module/nvpair/nvpair.c' line='1381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
-      <parameter type-id='type-id-215' name='a' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
-      <parameter type-id='type-id-227' name='a' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' filepath='../../module/nvpair/nvpair.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
-      <parameter type-id='type-id-218' name='a' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' filepath='../../module/nvpair/nvpair.c' line='1363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
-      <parameter type-id='type-id-223' name='a' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1356' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
-      <parameter type-id='type-id-131' name='a' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' filepath='../../module/nvpair/nvpair.c' line='1350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
-      <parameter type-id='type-id-41' name='val' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' filepath='../../module/nvpair/nvpair.c' line='1343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
-      <parameter type-id='type-id-11' name='val' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' filepath='../../module/nvpair/nvpair.c' line='1336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
-      <parameter type-id='type-id-33' name='val' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' filepath='../../module/nvpair/nvpair.c' line='1330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
-      <parameter type-id='type-id-104' name='val' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' filepath='../../module/nvpair/nvpair.c' line='1324' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
-      <parameter type-id='type-id-32' name='val' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' filepath='../../module/nvpair/nvpair.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
-      <parameter type-id='type-id-24' name='val' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' filepath='../../module/nvpair/nvpair.c' line='1312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
-      <parameter type-id='type-id-99' name='val' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' filepath='../../module/nvpair/nvpair.c' line='1306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
-      <parameter type-id='type-id-25' name='val' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' filepath='../../module/nvpair/nvpair.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
-      <parameter type-id='type-id-95' name='val' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' filepath='../../module/nvpair/nvpair.c' line='1294' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
-      <parameter type-id='type-id-92' name='val' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' filepath='../../module/nvpair/nvpair.c' line='1288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
-      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1282' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
-      <parameter type-id='type-id-87' name='val' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' filepath='../../module/nvpair/nvpair.c' line='1276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../module/nvpair/nvpair.c' line='916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
-      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../module/nvpair/nvpair.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='866' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../module/nvpair/nvpair.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
-      <parameter type-id='type-id-112' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
-      <parameter type-id='type-id-12' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' filepath='../../module/nvpair/nvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='559' column='1'/>
-      <return type-id='type-id-112'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' filepath='../../module/nvpair/nvpair.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='188' column='1'/>
-      <return type-id='type-id-241'/>
-    </function-decl>
-    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' filepath='../../module/nvpair/nvpair.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='181' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' filepath='../../module/nvpair/nvpair.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='174' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' filepath='../../module/nvpair/nvpair.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
-      <parameter type-id='type-id-230' name='nvo' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' filepath='../../module/nvpair/nvpair.c' line='591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
-      <parameter type-id='type-id-112' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' filepath='../../module/nvpair/nvpair.c' line='978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' filepath='../../module/nvpair/nvpair.c' line='945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../module/nvpair/nvpair.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
-      <parameter type-id='type-id-26' name='type' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' filepath='../../module/nvpair/nvpair.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
-      <parameter type-id='type-id-220' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' filepath='../../module/nvpair/nvpair.c' line='2665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
-      <parameter type-id='type-id-132' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
-      <parameter type-id='type-id-258' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
-      <parameter type-id='type-id-12' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
-      <parameter type-id='type-id-241' name='nva' filepath='../../module/nvpair/nvpair.c' line='2666' column='1'/>
-      <return type-id='type-id-12'/>
-    </function-decl>
-    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-21'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' comp-dir-path='/home/fedora/zfs/lib/libnvpair' language='LANG_C99'>
-    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../module/nvpair/fnvpair.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='583' column='1'/>
-      <return type-id='type-id-219'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' filepath='../../module/nvpair/fnvpair.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='575' column='1'/>
-      <return type-id='type-id-45'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' filepath='../../module/nvpair/fnvpair.c' line='567' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='567' column='1'/>
-      <return type-id='type-id-33'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' filepath='../../module/nvpair/fnvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='559' column='1'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' filepath='../../module/nvpair/fnvpair.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='551' column='1'/>
-      <return type-id='type-id-99'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' filepath='../../module/nvpair/fnvpair.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='543' column='1'/>
-      <return type-id='type-id-95'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' filepath='../../module/nvpair/fnvpair.c' line='535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='535' column='1'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' filepath='../../module/nvpair/fnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='527' column='1'/>
-      <return type-id='type-id-24'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' filepath='../../module/nvpair/fnvpair.c' line='519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='519' column='1'/>
-      <return type-id='type-id-25'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' filepath='../../module/nvpair/fnvpair.c' line='511' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='511' column='1'/>
-      <return type-id='type-id-92'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' filepath='../../module/nvpair/fnvpair.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='503' column='1'/>
-      <return type-id='type-id-89'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
-      <parameter type-id='type-id-221' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='495' column='1'/>
-      <return type-id='type-id-87'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='487' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
-      <return type-id='type-id-226'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' filepath='../../module/nvpair/fnvpair.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
       <return type-id='type-id-217'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
-      <return type-id='type-id-225'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' filepath='../../module/nvpair/fnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+    <function-decl name='nvpair_type' filepath='../../include/sys/nvpair.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
       <return type-id='type-id-216'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
-      <return type-id='type-id-224'/>
+    <function-decl name='nvpair_name' filepath='../../include/sys/nvpair.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' filepath='../../module/nvpair/fnvpair.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
-      <return type-id='type-id-215'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-219'/>
+    <function-decl name='nvpair_value_byte' filepath='../../include/sys/nvpair.h' line='248' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
-      <return type-id='type-id-227'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-220'/>
+    <function-decl name='nvpair_value_int16' filepath='../../include/sys/nvpair.h' line='251' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-220'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' filepath='../../module/nvpair/fnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
-      <return type-id='type-id-218'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-221'/>
+    <function-decl name='nvpair_value_uint16' filepath='../../include/sys/nvpair.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-221'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' filepath='../../module/nvpair/fnvpair.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
-      <return type-id='type-id-223'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-222'/>
+    <function-decl name='nvpair_value_int32' filepath='../../include/sys/nvpair.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-222'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
-      <parameter type-id='type-id-264' name='n' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
-      <return type-id='type-id-131'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-223'/>
+    <function-decl name='nvpair_value_uint32' filepath='../../include/sys/nvpair.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' filepath='../../module/nvpair/fnvpair.c' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
-      <return type-id='type-id-219'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-224'/>
+    <function-decl name='nvpair_value_int64' filepath='../../include/sys/nvpair.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-224'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' filepath='../../module/nvpair/fnvpair.c' line='400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
-      <return type-id='type-id-45'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-225'/>
+    <function-decl name='nvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-225'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' filepath='../../module/nvpair/fnvpair.c' line='392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
-      <return type-id='type-id-33'/>
+    <function-decl name='nvpair_value_string' filepath='../../include/sys/nvpair.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-153'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' filepath='../../module/nvpair/fnvpair.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
-      <return type-id='type-id-32'/>
+    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-226'/>
+    <function-decl name='nvpair_value_byte_array' filepath='../../include/sys/nvpair.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' filepath='../../module/nvpair/fnvpair.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
-      <return type-id='type-id-99'/>
+    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-227'/>
+    <function-decl name='nvpair_value_int16_array' filepath='../../include/sys/nvpair.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' filepath='../../module/nvpair/fnvpair.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
-      <return type-id='type-id-95'/>
+    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-228'/>
+    <function-decl name='nvpair_value_uint16_array' filepath='../../include/sys/nvpair.h' line='264' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-228'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' filepath='../../module/nvpair/fnvpair.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
-      <return type-id='type-id-104'/>
+    <pointer-type-def type-id='type-id-222' size-in-bits='64' id='type-id-229'/>
+    <function-decl name='nvpair_value_int32_array' filepath='../../include/sys/nvpair.h' line='265' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-229'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' filepath='../../module/nvpair/fnvpair.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
-      <return type-id='type-id-24'/>
+    <pointer-type-def type-id='type-id-223' size-in-bits='64' id='type-id-230'/>
+    <function-decl name='nvpair_value_uint32_array' filepath='../../include/sys/nvpair.h' line='266' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-230'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' filepath='../../module/nvpair/fnvpair.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
-      <return type-id='type-id-25'/>
+    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-231'/>
+    <function-decl name='nvpair_value_int64_array' filepath='../../include/sys/nvpair.h' line='267' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-231'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' filepath='../../module/nvpair/fnvpair.c' line='336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-232'/>
+    <function-decl name='nvpair_value_uint64_array' filepath='../../include/sys/nvpair.h' line='268' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-232'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-233'/>
+    <function-decl name='nvpair_value_string_array' filepath='../../include/sys/nvpair.h' line='269' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-233'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-234'/>
+    <function-decl name='nvpair_value_hrtime' filepath='../../include/sys/nvpair.h' line='271' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-234'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-235'/>
+    <function-decl name='nvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-235'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
+    <function-decl name='nvpair_value_nvlist_array' filepath='../../include/sys/nvpair.h' line='270' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-237'/>
+    <function-decl name='nvpair_value_boolean_value' filepath='../../include/sys/nvpair.h' line='247' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-237'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-238'/>
+    <function-decl name='nvpair_value_int8' filepath='../../include/sys/nvpair.h' line='249' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-238'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' filepath='../../include/sys/nvpair.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-239'/>
+    <function-decl name='nvpair_value_boolean_array' filepath='../../include/sys/nvpair.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-239'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-240'/>
+    <function-decl name='nvpair_value_int8_array' filepath='../../include/sys/nvpair.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-240'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8_array' filepath='../../include/sys/nvpair.h' line='262' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-241'/>
+    <function-decl name='nvpair_value_double' filepath='../../include/sys/nvpair.h' line='273' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <parameter type-id='type-id-241'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='766' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
+      <parameter type-id='type-id-73' name='nvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
+      <parameter type-id='type-id-158' name='pctl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='766' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='794' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
+      <parameter type-id='type-id-73' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
+      <parameter type-id='type-id-5' name='indent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='794' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <typedef-decl name='nvpair_t' type-id='type-id-214' filepath='../../include/sys/nvpair.h' line='82' column='1' id='type-id-242'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/regex.h' line='413' column='1' id='type-id-244'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='buffer' type-id='type-id-245' visibility='default' filepath='/usr/include/regex.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='allocated' type-id='type-id-246' visibility='default' filepath='/usr/include/regex.h' line='420' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='used' type-id='type-id-246' visibility='default' filepath='/usr/include/regex.h' line='423' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='syntax' type-id='type-id-247' visibility='default' filepath='/usr/include/regex.h' line='426' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fastmap' type-id='type-id-9' visibility='default' filepath='/usr/include/regex.h' line='431' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='translate' type-id='type-id-219' visibility='default' filepath='/usr/include/regex.h' line='437' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='re_nsub' type-id='type-id-20' visibility='default' filepath='/usr/include/regex.h' line='440' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='can_be_null' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='446' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='29'>
+        <var-decl name='regs_allocated' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='457' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='28'>
+        <var-decl name='fastmap_accurate' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='461' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='27'>
+        <var-decl name='no_sub' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='465' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='26'>
+        <var-decl name='not_bol' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='469' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='25'>
+        <var-decl name='not_eol' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='472' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24'>
+        <var-decl name='newline_anchor' type-id='type-id-69' visibility='default' filepath='/usr/include/regex.h' line='475' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-248'/>
+    <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-245'/>
+    <typedef-decl name='__re_long_size_t' type-id='type-id-29' filepath='/usr/include/regex.h' line='56' column='1' id='type-id-246'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-29' filepath='/usr/include/regex.h' line='72' column='1' id='type-id-247'/>
+    <typedef-decl name='regex_t' type-id='type-id-244' filepath='/usr/include/regex.h' line='478' column='1' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='949' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
+      <parameter type-id='type-id-243' name='nvp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
+      <parameter type-id='type-id-5' name='ai' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='949' column='1'/>
+      <parameter type-id='type-id-9' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <parameter type-id='type-id-250' name='value_regex' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <parameter type-id='type-id-153' name='ep' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='950' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' filepath='../../include/sys/nvpair.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-244' const='yes' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/regex.h' line='517' column='1' id='type-id-253'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='rm_so' type-id='type-id-254' visibility='default' filepath='/usr/include/regex.h' line='519' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='rm_eo' type-id='type-id-254' visibility='default' filepath='/usr/include/regex.h' line='520' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='regoff_t' type-id='type-id-5' filepath='/usr/include/regex.h' line='490' column='1' id='type-id-254'/>
+    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-255'/>
+    <function-decl name='regexec' filepath='/usr/include/regex.h' line='643' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-252'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-255'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
+      <parameter type-id='type-id-243' name='nvp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-5' name='ai' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-9' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <parameter type-id='type-id-153' name='ep' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair.c' line='1274' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-124'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-122'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-114'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-154'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-111'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-74'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-136'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-141'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-148'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-147'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-130'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-129'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-120'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-157'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-156'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-78'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-118'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-95'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-94'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-65'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-106'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-86'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-82'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-81'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-67'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-90'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-127'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-126'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-138'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-144'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-151'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-150'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-133'>
+      <parameter type-id='type-id-63'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-190'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-122'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-184'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-210'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-182'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-111'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-160'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-198'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-202'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-141'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-206'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-147'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-194'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-129'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-188'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-212'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-156'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-162'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-186'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-94'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-65'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-106'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-166'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-164'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-81'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-66'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-180'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-67'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-168'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-192'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-126'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-200'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-138'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-204'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-144'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-208'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-150'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-196'>
+      <parameter type-id='type-id-158'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
+      <parameter type-id='type-id-3' name='fp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
+      <parameter type-id='type-id-73' name='nvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/libnvpair_json.c' line='118' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' filepath='../../include/sys/nvpair.h' line='342' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-80'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' filepath='../../include/sys/nvpair.h' line='344' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
       <return type-id='type-id-92'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' filepath='../../module/nvpair/fnvpair.c' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
-      <return type-id='type-id-89'/>
+    <function-decl name='fnvpair_value_uint16' filepath='../../include/sys/nvpair.h' line='348' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
-      <return type-id='type-id-87'/>
+    <function-decl name='fnvpair_value_int32' filepath='../../include/sys/nvpair.h' line='345' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' filepath='../../module/nvpair/fnvpair.c' line='314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
-      <return type-id='type-id-87'/>
+    <function-decl name='fnvpair_value_uint32' filepath='../../include/sys/nvpair.h' line='349' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' filepath='../../module/nvpair/fnvpair.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
-      <return type-id='type-id-221'/>
+    <function-decl name='fnvpair_value_int64' filepath='../../include/sys/nvpair.h' line='346' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-24'/>
     </function-decl>
-    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' filepath='../../module/nvpair/fnvpair.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='299' column='1'/>
-      <parameter type-id='type-id-221' name='pair' filepath='../../module/nvpair/fnvpair.c' line='299' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-29'/>
     </function-decl>
-    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' filepath='../../module/nvpair/fnvpair.c' line='293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='293' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='293' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_string' filepath='../../include/sys/nvpair.h' line='351' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' filepath='../../module/nvpair/fnvpair.c' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
-      <parameter type-id='type-id-220' name='val' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-6'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' filepath='../../module/nvpair/fnvpair.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
-      <parameter type-id='type-id-247' name='val' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-218'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
-      <parameter type-id='type-id-226' name='val' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_boolean_value' filepath='../../include/sys/nvpair.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-76'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' filepath='../../module/nvpair/fnvpair.c' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
-      <parameter type-id='type-id-217' name='val' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_int8' filepath='../../include/sys/nvpair.h' line='343' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
-      <parameter type-id='type-id-225' name='val' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
-      <return type-id='type-id-21'/>
+    <function-decl name='fnvpair_value_uint8' filepath='../../include/sys/nvpair.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-80'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' filepath='../../module/nvpair/fnvpair.c' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
-      <parameter type-id='type-id-216' name='val' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
-      <parameter type-id='type-id-224' name='val' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' filepath='../../module/nvpair/fnvpair.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
-      <parameter type-id='type-id-215' name='val' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
-      <parameter type-id='type-id-227' name='val' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' filepath='../../module/nvpair/fnvpair.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
-      <parameter type-id='type-id-218' name='val' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' filepath='../../module/nvpair/fnvpair.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
-      <parameter type-id='type-id-223' name='val' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
-      <parameter type-id='type-id-131' name='val' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
-      <parameter type-id='type-id-112' name='n' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
-      <parameter type-id='type-id-221' name='pair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' filepath='../../module/nvpair/fnvpair.c' line='203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
-      <parameter type-id='type-id-219' name='val' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' filepath='../../module/nvpair/fnvpair.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
-      <parameter type-id='type-id-41' name='val' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../module/nvpair/fnvpair.c' line='191' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
-      <parameter type-id='type-id-33' name='val' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' filepath='../../module/nvpair/fnvpair.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
-      <parameter type-id='type-id-104' name='val' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' filepath='../../module/nvpair/fnvpair.c' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
-      <parameter type-id='type-id-32' name='val' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' filepath='../../module/nvpair/fnvpair.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
-      <parameter type-id='type-id-24' name='val' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' filepath='../../module/nvpair/fnvpair.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
-      <parameter type-id='type-id-99' name='val' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' filepath='../../module/nvpair/fnvpair.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
-      <parameter type-id='type-id-25' name='val' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' filepath='../../module/nvpair/fnvpair.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
-      <parameter type-id='type-id-95' name='val' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' filepath='../../module/nvpair/fnvpair.c' line='149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
-      <parameter type-id='type-id-92' name='val' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' filepath='../../module/nvpair/fnvpair.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
-      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
-      <parameter type-id='type-id-87' name='val' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' filepath='../../module/nvpair/fnvpair.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
-      <parameter type-id='type-id-41' name='name' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' filepath='../../module/nvpair/fnvpair.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='119' column='1'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../module/nvpair/fnvpair.c' line='113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
-      <parameter type-id='type-id-219' name='dst' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
-      <parameter type-id='type-id-219' name='src' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' filepath='../../module/nvpair/fnvpair.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='105' column='1'/>
-      <return type-id='type-id-219'/>
-    </function-decl>
-    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' filepath='../../module/nvpair/fnvpair.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
-      <parameter type-id='type-id-45' name='buf' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
-      <parameter type-id='type-id-54' name='buflen' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
-      <return type-id='type-id-219'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' filepath='../../module/nvpair/fnvpair.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
-      <parameter type-id='type-id-45' name='pack' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
-      <parameter type-id='type-id-54' name='size' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' filepath='../../module/nvpair/fnvpair.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
-      <parameter type-id='type-id-258' name='sizep' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
-      <return type-id='type-id-45'/>
-    </function-decl>
-    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' filepath='../../module/nvpair/fnvpair.c' line='65' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='65' column='1'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' filepath='../../module/nvpair/fnvpair.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
-      <parameter type-id='type-id-219' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='59' column='1'/>
-      <return type-id='type-id-21'/>
-    </function-decl>
-    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../module/nvpair/fnvpair.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
-      <return type-id='type-id-219'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='13' column='1' id='type-id-256'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__count' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='15' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__value' type-id='type-id-257' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='20' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='16' column='1' id='type-id-257'>
+      <data-member access='private'>
+        <var-decl name='__wch' type-id='type-id-69' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='18' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__wchb' type-id='type-id-258' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__mbstate_t.h' line='19' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='32' id='type-id-258'>
+      <subrange length='4' type-id='type-id-25' id='type-id-259'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-260'/>
+    <function-decl name='mbrtowc' filepath='/usr/include/wchar.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-222'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-260'/>
+      <return type-id='type-id-29'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='aok' type-id='type-id-12' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
-    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
-      <parameter type-id='type-id-41' name='file' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-41' name='func' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-12' name='line' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-41' name='format' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='33' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='125' column='1' id='type-id-261'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nva_ops' type-id='type-id-262' visibility='default' filepath='../../include/sys/nvpair.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nva_arg' type-id='type-id-19' visibility='default' filepath='../../include/sys/nvpair.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='130' column='1' id='type-id-263'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nv_ao_init' type-id='type-id-264' visibility='default' filepath='../../include/sys/nvpair.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nv_ao_fini' type-id='type-id-265' visibility='default' filepath='../../include/sys/nvpair.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nv_ao_alloc' type-id='type-id-266' visibility='default' filepath='../../include/sys/nvpair.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='nv_ao_free' type-id='type-id-267' visibility='default' filepath='../../include/sys/nvpair.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nv_ao_reset' type-id='type-id-265' visibility='default' filepath='../../include/sys/nvpair.h' line='135' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nv_alloc_t' type-id='type-id-261' filepath='../../include/sys/nvpair.h' line='128' column='1' id='type-id-268'/>
+    <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-269'/>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-270'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-69' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-69' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-19' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-270' size-in-bits='64' id='type-id-271'/>
+    <pointer-type-def type-id='type-id-272' size-in-bits='64' id='type-id-264'/>
+    <pointer-type-def type-id='type-id-273' size-in-bits='64' id='type-id-265'/>
+    <pointer-type-def type-id='type-id-274' size-in-bits='64' id='type-id-266'/>
+    <pointer-type-def type-id='type-id-275' size-in-bits='64' id='type-id-267'/>
+    <typedef-decl name='nv_alloc_ops_t' type-id='type-id-263' filepath='../../include/sys/nvpair.h' line='123' column='1' id='type-id-276'/>
+    <qualified-type-def type-id='type-id-276' const='yes' id='type-id-277'/>
+    <pointer-type-def type-id='type-id-277' size-in-bits='64' id='type-id-262'/>
+    <var-decl name='nv_alloc_sleep_def' type-id='type-id-268' mangled-name='nv_alloc_sleep_def' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='54' column='1' elf-symbol-id='nv_alloc_sleep_def'/>
+    <var-decl name='nv_alloc_nosleep_def' type-id='type-id-268' mangled-name='nv_alloc_nosleep_def' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='59' column='1' elf-symbol-id='nv_alloc_nosleep_def'/>
+    <var-decl name='nv_alloc_sleep' type-id='type-id-269' mangled-name='nv_alloc_sleep' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='64' column='1' elf-symbol-id='nv_alloc_sleep'/>
+    <var-decl name='nv_alloc_nosleep' type-id='type-id-269' mangled-name='nv_alloc_nosleep' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair/nvpair_alloc_system.c' line='65' column='1' elf-symbol-id='nv_alloc_nosleep'/>
+    <function-type size-in-bits='64' id='type-id-272'>
+      <parameter type-id='type-id-269'/>
+      <parameter type-id='type-id-271'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-273'>
+      <parameter type-id='type-id-269'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-275'>
+      <parameter type-id='type-id-269'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-274'>
+      <parameter type-id='type-id-269'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-19'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <var-decl name='nv_fixed_ops_def' type-id='type-id-277' mangled-name='nv_fixed_ops_def' visibility='default' filepath='../../module/nvpair/nvpair_alloc_fixed.c' line='103' column='1' elf-symbol-id='nv_fixed_ops_def'/>
+    <var-decl name='nv_fixed_ops' type-id='type-id-262' mangled-name='nv_fixed_ops' visibility='default' filepath='../../module/nvpair/nvpair_alloc_fixed.c' line='111' column='1' elf-symbol-id='nv_fixed_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <var-decl name='nvpair_max_recursion' type-id='type-id-5' mangled-name='nvpair_max_recursion' visibility='default' filepath='../../module/nvpair/nvpair.c' line='151' column='1' elf-symbol-id='nvpair_max_recursion'/>
+    <var-decl name='nvlist_hashtable_init_size' type-id='type-id-67' mangled-name='nvlist_hashtable_init_size' visibility='default' filepath='../../module/nvpair/nvpair.c' line='154' column='1' elf-symbol-id='nvlist_hashtable_init_size'/>
+    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' filepath='../../module/nvpair/nvpair.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
+      <parameter type-id='type-id-262' name='nvo' filepath='../../module/nvpair/nvpair.c' line='157' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-21'/>
+      <return type-id='type-id-5'/>
     </function-decl>
+    <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' filepath='../../module/nvpair/nvpair.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='174' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' filepath='../../module/nvpair/nvpair.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='174' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' filepath='../../module/nvpair/nvpair.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='188' column='1'/>
+      <return type-id='type-id-269'/>
+    </function-decl>
+    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' filepath='../../module/nvpair/nvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='559' column='1'/>
+      <return type-id='type-id-123'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' filepath='../../module/nvpair/nvpair.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <parameter type-id='type-id-123' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <parameter type-id='type-id-5' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='585' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' filepath='../../module/nvpair/nvpair.c' line='591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <parameter type-id='type-id-123' name='nvflag' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='591' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' filepath='../../module/nvpair/nvpair.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='866' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' filepath='../../module/nvpair/nvpair.c' line='916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <parameter type-id='type-id-5' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='916' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' filepath='../../module/nvpair/nvpair.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='922' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' filepath='../../module/nvpair/nvpair.c' line='945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='945' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' filepath='../../module/nvpair/nvpair.c' line='978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='978' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' filepath='../../module/nvpair/nvpair.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <parameter type-id='type-id-215' name='type' filepath='../../module/nvpair/nvpair.c' line='965' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' filepath='../../module/nvpair/nvpair.c' line='1276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1282' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <parameter type-id='type-id-77' name='val' filepath='../../module/nvpair/nvpair.c' line='1282' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' filepath='../../module/nvpair/nvpair.c' line='1288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <parameter type-id='type-id-81' name='val' filepath='../../module/nvpair/nvpair.c' line='1288' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' filepath='../../module/nvpair/nvpair.c' line='1294' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <parameter type-id='type-id-85' name='val' filepath='../../module/nvpair/nvpair.c' line='1294' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' filepath='../../module/nvpair/nvpair.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/nvpair.c' line='1300' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' filepath='../../module/nvpair/nvpair.c' line='1306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <parameter type-id='type-id-94' name='val' filepath='../../module/nvpair/nvpair.c' line='1306' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' filepath='../../module/nvpair/nvpair.c' line='1312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <parameter type-id='type-id-98' name='val' filepath='../../module/nvpair/nvpair.c' line='1312' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' filepath='../../module/nvpair/nvpair.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <parameter type-id='type-id-65' name='val' filepath='../../module/nvpair/nvpair.c' line='1318' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' filepath='../../module/nvpair/nvpair.c' line='1324' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <parameter type-id='type-id-66' name='val' filepath='../../module/nvpair/nvpair.c' line='1324' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' filepath='../../module/nvpair/nvpair.c' line='1330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <parameter type-id='type-id-106' name='val' filepath='../../module/nvpair/nvpair.c' line='1330' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' filepath='../../module/nvpair/nvpair.c' line='1336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <parameter type-id='type-id-67' name='val' filepath='../../module/nvpair/nvpair.c' line='1336' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' filepath='../../module/nvpair/nvpair.c' line='1343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <parameter type-id='type-id-111' name='val' filepath='../../module/nvpair/nvpair.c' line='1343' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' filepath='../../module/nvpair/nvpair.c' line='1350' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <parameter type-id='type-id-6' name='val' filepath='../../module/nvpair/nvpair.c' line='1350' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1356' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1356' column='1'/>
+      <parameter type-id='type-id-122' name='a' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1357' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' filepath='../../module/nvpair/nvpair.c' line='1363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-126' name='a' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1363' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' filepath='../../module/nvpair/nvpair.c' line='1369' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-129' name='a' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1369' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-132' name='a' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1375' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' filepath='../../module/nvpair/nvpair.c' line='1381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-135' name='a' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1381' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-138' name='a' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1387' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' filepath='../../module/nvpair/nvpair.c' line='1393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-141' name='a' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1393' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-144' name='a' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1399' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' filepath='../../module/nvpair/nvpair.c' line='1405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-147' name='a' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1405' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-150' name='a' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1411' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-278'/>
+    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-279'/>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' filepath='../../module/nvpair/nvpair.c' line='1417' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1417' column='1'/>
+      <parameter type-id='type-id-279' name='a' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1418' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' filepath='../../module/nvpair/nvpair.c' line='1424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <parameter type-id='type-id-117' name='val' filepath='../../module/nvpair/nvpair.c' line='1424' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' filepath='../../module/nvpair/nvpair.c' line='1430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <parameter type-id='type-id-73' name='val' filepath='../../module/nvpair/nvpair.c' line='1430' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-156' name='a' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/nvpair.c' line='1436' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' filepath='../../module/nvpair/nvpair.c' line='1443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <return type-id='type-id-243'/>
+    </function-decl>
+    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' filepath='../../module/nvpair/nvpair.c' line='1472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1443' column='1'/>
+      <return type-id='type-id-243'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' filepath='../../module/nvpair/nvpair.c' line='1496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1496' column='1'/>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' filepath='../../module/nvpair/nvpair.c' line='1508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1508' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' filepath='../../module/nvpair/nvpair.c' line='1514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1514' column='1'/>
+      <return type-id='type-id-215'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' filepath='../../module/nvpair/nvpair.c' line='1520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='1520' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' filepath='../../module/nvpair/nvpair.c' line='1636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1276' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' filepath='../../module/nvpair/nvpair.c' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <parameter type-id='type-id-122' name='val' filepath='../../module/nvpair/nvpair.c' line='1642' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' filepath='../../module/nvpair/nvpair.c' line='1649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <parameter type-id='type-id-126' name='val' filepath='../../module/nvpair/nvpair.c' line='1649' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' filepath='../../module/nvpair/nvpair.c' line='1655' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <parameter type-id='type-id-129' name='val' filepath='../../module/nvpair/nvpair.c' line='1655' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' filepath='../../module/nvpair/nvpair.c' line='1661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='1661' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' filepath='../../module/nvpair/nvpair.c' line='1667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <parameter type-id='type-id-135' name='val' filepath='../../module/nvpair/nvpair.c' line='1667' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' filepath='../../module/nvpair/nvpair.c' line='1673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <parameter type-id='type-id-138' name='val' filepath='../../module/nvpair/nvpair.c' line='1673' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' filepath='../../module/nvpair/nvpair.c' line='1679' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <parameter type-id='type-id-141' name='val' filepath='../../module/nvpair/nvpair.c' line='1679' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' filepath='../../module/nvpair/nvpair.c' line='1685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <parameter type-id='type-id-144' name='val' filepath='../../module/nvpair/nvpair.c' line='1685' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' filepath='../../module/nvpair/nvpair.c' line='1691' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <parameter type-id='type-id-147' name='val' filepath='../../module/nvpair/nvpair.c' line='1691' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' filepath='../../module/nvpair/nvpair.c' line='1697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <parameter type-id='type-id-150' name='val' filepath='../../module/nvpair/nvpair.c' line='1697' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' filepath='../../module/nvpair/nvpair.c' line='1704' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <parameter type-id='type-id-241' name='val' filepath='../../module/nvpair/nvpair.c' line='1704' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' filepath='../../module/nvpair/nvpair.c' line='1711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <parameter type-id='type-id-153' name='val' filepath='../../module/nvpair/nvpair.c' line='1711' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' filepath='../../module/nvpair/nvpair.c' line='1717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <parameter type-id='type-id-156' name='val' filepath='../../module/nvpair/nvpair.c' line='1717' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-122' size-in-bits='64' id='type-id-280'/>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-281'/>
+    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' filepath='../../module/nvpair/nvpair.c' line='1723' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1723' column='1'/>
+      <parameter type-id='type-id-280' name='a' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1724' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-282'/>
+    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' filepath='../../module/nvpair/nvpair.c' line='1731' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1731' column='1'/>
+      <parameter type-id='type-id-282' name='a' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1732' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-283'/>
+    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' filepath='../../module/nvpair/nvpair.c' line='1738' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-283' name='a' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1738' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-284'/>
+    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' filepath='../../module/nvpair/nvpair.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1744' column='1'/>
+      <parameter type-id='type-id-284' name='a' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1745' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-285'/>
+    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' filepath='../../module/nvpair/nvpair.c' line='1751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1751' column='1'/>
+      <parameter type-id='type-id-285' name='a' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1752' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-286'/>
+    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' filepath='../../module/nvpair/nvpair.c' line='1758' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1758' column='1'/>
+      <parameter type-id='type-id-286' name='a' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1759' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-287'/>
+    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' filepath='../../module/nvpair/nvpair.c' line='1765' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1765' column='1'/>
+      <parameter type-id='type-id-287' name='a' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1766' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-288'/>
+    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' filepath='../../module/nvpair/nvpair.c' line='1772' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1772' column='1'/>
+      <parameter type-id='type-id-288' name='a' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1773' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-289'/>
+    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' filepath='../../module/nvpair/nvpair.c' line='1779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1779' column='1'/>
+      <parameter type-id='type-id-289' name='a' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1780' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-290'/>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' filepath='../../module/nvpair/nvpair.c' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1786' column='1'/>
+      <parameter type-id='type-id-290' name='a' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1787' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' filepath='../../module/nvpair/nvpair.c' line='1793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1793' column='1'/>
+      <parameter type-id='type-id-233' name='a' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1794' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-291'/>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='1800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1800' column='1'/>
+      <parameter type-id='type-id-291' name='a' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/nvpair.c' line='1801' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-292'/>
+    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' filepath='../../module/nvpair/nvpair.c' line='1807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <parameter type-id='type-id-292' name='val' filepath='../../module/nvpair/nvpair.c' line='1807' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' filepath='../../module/nvpair/nvpair.c' line='1813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
+      <parameter type-id='type-id-5' name='flag' filepath='../../module/nvpair/nvpair.c' line='1813' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-293'/>
+    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' filepath='../../module/nvpair/nvpair.c' line='2063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <parameter type-id='type-id-293' name='ret' filepath='../../module/nvpair/nvpair.c' line='2063' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' filepath='../../module/nvpair/nvpair.c' line='2073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2073' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-293' name='ret' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-222' name='ip' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <parameter type-id='type-id-153' name='ep' filepath='../../module/nvpair/nvpair.c' line='2074' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' filepath='../../module/nvpair/nvpair.c' line='2080' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/nvpair.c' line='2080' column='1'/>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' filepath='../../module/nvpair/nvpair.c' line='2101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
+      <parameter type-id='type-id-122' name='val' filepath='../../module/nvpair/nvpair.c' line='2101' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' filepath='../../module/nvpair/nvpair.c' line='2107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
+      <parameter type-id='type-id-126' name='val' filepath='../../module/nvpair/nvpair.c' line='2107' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' filepath='../../module/nvpair/nvpair.c' line='2113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
+      <parameter type-id='type-id-129' name='val' filepath='../../module/nvpair/nvpair.c' line='2113' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' filepath='../../module/nvpair/nvpair.c' line='2119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
+      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/nvpair.c' line='2119' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' filepath='../../module/nvpair/nvpair.c' line='2125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
+      <parameter type-id='type-id-135' name='val' filepath='../../module/nvpair/nvpair.c' line='2125' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' filepath='../../module/nvpair/nvpair.c' line='2131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
+      <parameter type-id='type-id-138' name='val' filepath='../../module/nvpair/nvpair.c' line='2131' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' filepath='../../module/nvpair/nvpair.c' line='2137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
+      <parameter type-id='type-id-141' name='val' filepath='../../module/nvpair/nvpair.c' line='2137' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' filepath='../../module/nvpair/nvpair.c' line='2143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
+      <parameter type-id='type-id-144' name='val' filepath='../../module/nvpair/nvpair.c' line='2143' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' filepath='../../module/nvpair/nvpair.c' line='2149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
+      <parameter type-id='type-id-147' name='val' filepath='../../module/nvpair/nvpair.c' line='2149' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' filepath='../../module/nvpair/nvpair.c' line='2155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
+      <parameter type-id='type-id-150' name='val' filepath='../../module/nvpair/nvpair.c' line='2155' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' filepath='../../module/nvpair/nvpair.c' line='2162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
+      <parameter type-id='type-id-241' name='val' filepath='../../module/nvpair/nvpair.c' line='2162' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' filepath='../../module/nvpair/nvpair.c' line='2169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
+      <parameter type-id='type-id-153' name='val' filepath='../../module/nvpair/nvpair.c' line='2169' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' filepath='../../module/nvpair/nvpair.c' line='2175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
+      <parameter type-id='type-id-156' name='val' filepath='../../module/nvpair/nvpair.c' line='2175' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' filepath='../../module/nvpair/nvpair.c' line='2181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <parameter type-id='type-id-280' name='val' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2181' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' filepath='../../module/nvpair/nvpair.c' line='2187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <parameter type-id='type-id-282' name='val' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2187' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' filepath='../../module/nvpair/nvpair.c' line='2193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <parameter type-id='type-id-283' name='val' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2193' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' filepath='../../module/nvpair/nvpair.c' line='2199' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <parameter type-id='type-id-284' name='val' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2199' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' filepath='../../module/nvpair/nvpair.c' line='2205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <parameter type-id='type-id-285' name='val' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2205' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' filepath='../../module/nvpair/nvpair.c' line='2211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <parameter type-id='type-id-286' name='val' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2211' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' filepath='../../module/nvpair/nvpair.c' line='2217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <parameter type-id='type-id-287' name='val' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2217' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' filepath='../../module/nvpair/nvpair.c' line='2223' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <parameter type-id='type-id-288' name='val' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2223' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' filepath='../../module/nvpair/nvpair.c' line='2229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <parameter type-id='type-id-289' name='val' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2229' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' filepath='../../module/nvpair/nvpair.c' line='2235' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <parameter type-id='type-id-290' name='val' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2235' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' filepath='../../module/nvpair/nvpair.c' line='2241' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <parameter type-id='type-id-233' name='val' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2241' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' filepath='../../module/nvpair/nvpair.c' line='2247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <parameter type-id='type-id-291' name='val' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <parameter type-id='type-id-281' name='nelem' filepath='../../module/nvpair/nvpair.c' line='2247' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' filepath='../../module/nvpair/nvpair.c' line='2253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
+      <parameter type-id='type-id-292' name='val' filepath='../../module/nvpair/nvpair.c' line='2253' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' filepath='../../module/nvpair/nvpair.c' line='2262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/nvpair.c' line='2262' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' filepath='../../module/nvpair/nvpair.c' line='2279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
+      <parameter type-id='type-id-73' name='dst' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <parameter type-id='type-id-5' name='flag' filepath='../../module/nvpair/nvpair.c' line='2279' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-294'/>
+    <function-decl name='nvlist_size' mangled-name='nvlist_size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <parameter type-id='type-id-294' name='size' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <parameter type-id='type-id-5' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2648' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <class-decl name='XDR' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/rpc/xdr.h' line='110' column='1' id='type-id-295'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x_op' type-id='type-id-296' visibility='default' filepath='/usr/include/rpc/xdr.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='x_ops' type-id='type-id-297' visibility='default' filepath='/usr/include/rpc/xdr.h' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='x_public' type-id='type-id-298' visibility='default' filepath='/usr/include/rpc/xdr.h' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='x_private' type-id='type-id-298' visibility='default' filepath='/usr/include/rpc/xdr.h' line='138' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='x_base' type-id='type-id-298' visibility='default' filepath='/usr/include/rpc/xdr.h' line='139' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='x_handy' type-id='type-id-299' visibility='default' filepath='/usr/include/rpc/xdr.h' line='140' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='xdr_op' filepath='/usr/include/rpc/xdr.h' line='81' column='1' id='type-id-296'>
+      <underlying-type type-id='type-id-32'/>
+      <enumerator name='XDR_ENCODE' value='0'/>
+      <enumerator name='XDR_DECODE' value='1'/>
+      <enumerator name='XDR_FREE' value='2'/>
+    </enum-decl>
+    <class-decl name='xdr_ops' size-in-bits='640' is-struct='yes' visibility='default' filepath='/usr/include/rpc/xdr.h' line='113' column='1' id='type-id-300'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x_getlong' type-id='type-id-301' visibility='default' filepath='/usr/include/rpc/xdr.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='x_putlong' type-id='type-id-302' visibility='default' filepath='/usr/include/rpc/xdr.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='x_getbytes' type-id='type-id-303' visibility='default' filepath='/usr/include/rpc/xdr.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='x_putbytes' type-id='type-id-304' visibility='default' filepath='/usr/include/rpc/xdr.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='x_getpostn' type-id='type-id-305' visibility='default' filepath='/usr/include/rpc/xdr.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='x_setpostn' type-id='type-id-306' visibility='default' filepath='/usr/include/rpc/xdr.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='x_inline' type-id='type-id-307' visibility='default' filepath='/usr/include/rpc/xdr.h' line='127' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='x_destroy' type-id='type-id-308' visibility='default' filepath='/usr/include/rpc/xdr.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='x_getint32' type-id='type-id-309' visibility='default' filepath='/usr/include/rpc/xdr.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='x_putint32' type-id='type-id-310' visibility='default' filepath='/usr/include/rpc/xdr.h' line='133' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='bool_t' type-id='type-id-5' filepath='/usr/include/rpc/types.h' line='37' column='1' id='type-id-311'/>
+    <typedef-decl name='XDR' type-id='type-id-295' filepath='/usr/include/rpc/xdr.h' line='109' column='1' id='type-id-312'/>
+    <pointer-type-def type-id='type-id-312' size-in-bits='64' id='type-id-313'/>
+    <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-301'/>
+    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-315'/>
+    <pointer-type-def type-id='type-id-315' size-in-bits='64' id='type-id-316'/>
+    <pointer-type-def type-id='type-id-317' size-in-bits='64' id='type-id-302'/>
+    <typedef-decl name='__caddr_t' type-id='type-id-9' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='201' column='1' id='type-id-318'/>
+    <typedef-decl name='caddr_t' type-id='type-id-318' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='115' column='1' id='type-id-298'/>
+    <typedef-decl name='__u_int' type-id='type-id-69' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='32' column='1' id='type-id-319'/>
+    <typedef-decl name='u_int' type-id='type-id-319' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='35' column='1' id='type-id-299'/>
+    <pointer-type-def type-id='type-id-320' size-in-bits='64' id='type-id-303'/>
+    <pointer-type-def type-id='type-id-321' size-in-bits='64' id='type-id-304'/>
+    <qualified-type-def type-id='type-id-312' const='yes' id='type-id-322'/>
+    <pointer-type-def type-id='type-id-322' size-in-bits='64' id='type-id-323'/>
+    <pointer-type-def type-id='type-id-324' size-in-bits='64' id='type-id-305'/>
+    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-306'/>
+    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-307'/>
+    <pointer-type-def type-id='type-id-327' size-in-bits='64' id='type-id-308'/>
+    <pointer-type-def type-id='type-id-328' size-in-bits='64' id='type-id-309'/>
+    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-329'/>
+    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-330'/>
+    <pointer-type-def type-id='type-id-331' size-in-bits='64' id='type-id-310'/>
+    <pointer-type-def type-id='type-id-300' size-in-bits='64' id='type-id-297'/>
+    <function-decl name='xdrmem_create' filepath='/usr/include/rpc/xdr.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-69'/>
+      <parameter type-id='type-id-296'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' filepath='../../module/nvpair/nvpair.c' line='2657' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-153' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-294' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-5' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2657' column='1'/>
+      <parameter type-id='type-id-5' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2658' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' filepath='../../module/nvpair/nvpair.c' line='2665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-153' name='bufp' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-294' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-5' name='encoding' filepath='../../module/nvpair/nvpair.c' line='2665' column='1'/>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='2666' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' filepath='../../module/nvpair/nvpair.c' line='2715' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
+      <parameter type-id='type-id-9' name='buf' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-20' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <parameter type-id='type-id-5' name='kmflag' filepath='../../module/nvpair/nvpair.c' line='2715' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' filepath='../../module/nvpair/nvpair.c' line='2721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
+      <parameter type-id='type-id-9' name='buf' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-20' name='buflen' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-156' name='nvlp' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <parameter type-id='type-id-269' name='nva' filepath='../../module/nvpair/nvpair.c' line='2721' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_int' filepath='/usr/include/rpc/xdr.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-222'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_u_int' filepath='/usr/include/rpc/xdr.h' line='289' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_string' filepath='/usr/include/rpc/xdr.h' line='314' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_char' filepath='/usr/include/rpc/xdr.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_longlong_t' filepath='/usr/include/rpc/xdr.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-224'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_short' filepath='/usr/include/rpc/xdr.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-220'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_u_short' filepath='/usr/include/rpc/xdr.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-221'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_u_longlong_t' filepath='/usr/include/rpc/xdr.h' line='295' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-225'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_opaque' filepath='/usr/include/rpc/xdr.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-333'/>
+    <function-decl name='xdr_array' filepath='/usr/include/rpc/xdr.h' line='308' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-223'/>
+      <parameter type-id='type-id-69'/>
+      <parameter type-id='type-id-69'/>
+      <parameter type-id='type-id-333'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='xdr_double' filepath='/usr/include/rpc/xdr.h' line='323' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-241'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-332'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-19'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-326'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-299'/>
+      <return type-id='type-id-141'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-321'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-299'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-331'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-330'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-317'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-316'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-328'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-141'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-314'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-224'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-320'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-298'/>
+      <parameter type-id='type-id-299'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-325'>
+      <parameter type-id='type-id-313'/>
+      <parameter type-id='type-id-299'/>
+      <return type-id='type-id-311'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-324'>
+      <parameter type-id='type-id-323'/>
+      <return type-id='type-id-299'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-327'>
+      <parameter type-id='type-id-313'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' filepath='../../module/nvpair/fnvpair.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' filepath='../../include/sys/nvpair.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-235'/>
+      <parameter type-id='type-id-69'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' filepath='../../module/nvpair/fnvpair.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='59' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_free' filepath='../../include/sys/nvpair.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' filepath='../../module/nvpair/fnvpair.c' line='65' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='65' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='nvlist_size' filepath='../../include/sys/nvpair.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-225'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' filepath='../../module/nvpair/fnvpair.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
+      <parameter type-id='type-id-294' name='sizep' filepath='../../module/nvpair/fnvpair.c' line='77' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' filepath='../../include/sys/nvpair.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-225'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' filepath='../../module/nvpair/fnvpair.c' line='87' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
+      <parameter type-id='type-id-9' name='pack' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
+      <parameter type-id='type-id-20' name='size' filepath='../../module/nvpair/fnvpair.c' line='87' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' filepath='../../module/nvpair/fnvpair.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
+      <parameter type-id='type-id-9' name='buf' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
+      <parameter type-id='type-id-20' name='buflen' filepath='../../module/nvpair/fnvpair.c' line='97' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' filepath='../../include/sys/nvpair.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-235'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' filepath='../../module/nvpair/fnvpair.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='105' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' filepath='../../include/sys/nvpair.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-235'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' filepath='../../module/nvpair/fnvpair.c' line='113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
+      <parameter type-id='type-id-73' name='dst' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
+      <parameter type-id='type-id-73' name='src' filepath='../../module/nvpair/fnvpair.c' line='113' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_merge' filepath='../../include/sys/nvpair.h' line='157' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' filepath='../../module/nvpair/fnvpair.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='119' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' filepath='../../module/nvpair/fnvpair.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='168' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <parameter type-id='type-id-77' name='val' filepath='../../module/nvpair/fnvpair.c' line='137' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' filepath='../../include/sys/nvpair.h' line='169' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' filepath='../../module/nvpair/fnvpair.c' line='143' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <parameter type-id='type-id-81' name='val' filepath='../../module/nvpair/fnvpair.c' line='143' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' filepath='../../include/sys/nvpair.h' line='170' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-80'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' filepath='../../module/nvpair/fnvpair.c' line='149' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <parameter type-id='type-id-85' name='val' filepath='../../module/nvpair/fnvpair.c' line='149' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' filepath='../../include/sys/nvpair.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' filepath='../../module/nvpair/fnvpair.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <parameter type-id='type-id-89' name='val' filepath='../../module/nvpair/fnvpair.c' line='155' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' filepath='../../include/sys/nvpair.h' line='172' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-80'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' filepath='../../module/nvpair/fnvpair.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <parameter type-id='type-id-94' name='val' filepath='../../module/nvpair/fnvpair.c' line='161' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' filepath='../../include/sys/nvpair.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-92'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' filepath='../../module/nvpair/fnvpair.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <parameter type-id='type-id-98' name='val' filepath='../../module/nvpair/fnvpair.c' line='167' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' filepath='../../include/sys/nvpair.h' line='174' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' filepath='../../module/nvpair/fnvpair.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <parameter type-id='type-id-65' name='val' filepath='../../module/nvpair/fnvpair.c' line='173' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' filepath='../../include/sys/nvpair.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' filepath='../../module/nvpair/fnvpair.c' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <parameter type-id='type-id-66' name='val' filepath='../../module/nvpair/fnvpair.c' line='179' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' filepath='../../include/sys/nvpair.h' line='176' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' filepath='../../module/nvpair/fnvpair.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <parameter type-id='type-id-106' name='val' filepath='../../module/nvpair/fnvpair.c' line='185' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' filepath='../../include/sys/nvpair.h' line='177' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' filepath='../../module/nvpair/fnvpair.c' line='191' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <parameter type-id='type-id-67' name='val' filepath='../../module/nvpair/fnvpair.c' line='191' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' filepath='../../module/nvpair/fnvpair.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <parameter type-id='type-id-6' name='val' filepath='../../module/nvpair/fnvpair.c' line='197' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' filepath='../../include/sys/nvpair.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' filepath='../../module/nvpair/fnvpair.c' line='203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <parameter type-id='type-id-73' name='val' filepath='../../module/nvpair/fnvpair.c' line='203' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-218'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <parameter type-id='type-id-243' name='pair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' filepath='../../include/sys/nvpair.h' line='167' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='215' column='1'/>
+      <parameter type-id='type-id-122' name='val' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='216' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' filepath='../../include/sys/nvpair.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-237'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' filepath='../../module/nvpair/fnvpair.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-126' name='val' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='222' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' filepath='../../include/sys/nvpair.h' line='182' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' filepath='../../module/nvpair/fnvpair.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-129' name='val' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='228' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' filepath='../../include/sys/nvpair.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-238'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-132' name='val' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='234' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' filepath='../../include/sys/nvpair.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-219'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' filepath='../../module/nvpair/fnvpair.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-135' name='val' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='240' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' filepath='../../include/sys/nvpair.h' line='185' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-220'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='246' column='1'/>
+      <parameter type-id='type-id-138' name='val' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='247' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' filepath='../../include/sys/nvpair.h' line='186' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-221'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' filepath='../../module/nvpair/fnvpair.c' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-141' name='val' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='253' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' filepath='../../include/sys/nvpair.h' line='187' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-222'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='259' column='1'/>
+      <parameter type-id='type-id-144' name='val' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='260' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' filepath='../../include/sys/nvpair.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-223'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' filepath='../../module/nvpair/fnvpair.c' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-147' name='val' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='266' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' filepath='../../include/sys/nvpair.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-224'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='272' column='1'/>
+      <parameter type-id='type-id-150' name='val' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='273' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' filepath='../../include/sys/nvpair.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-225'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' filepath='../../module/nvpair/fnvpair.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='279' column='1'/>
+      <parameter type-id='type-id-279' name='val' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='280' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string_array' filepath='../../include/sys/nvpair.h' line='191' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-279'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' filepath='../../module/nvpair/fnvpair.c' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='286' column='1'/>
+      <parameter type-id='type-id-156' name='val' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
+      <parameter type-id='type-id-123' name='n' filepath='../../module/nvpair/fnvpair.c' line='287' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' filepath='../../include/sys/nvpair.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-235'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' filepath='../../module/nvpair/fnvpair.c' line='293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='131' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' filepath='../../include/sys/nvpair.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' filepath='../../module/nvpair/fnvpair.c' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <parameter type-id='type-id-243' name='pair' filepath='../../module/nvpair/fnvpair.c' line='209' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_nvpair' filepath='../../include/sys/nvpair.h' line='200' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-217'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' filepath='../../module/nvpair/fnvpair.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='305' column='1'/>
+      <return type-id='type-id-243'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-334'/>
+    <function-decl name='nvlist_lookup_nvpair' filepath='../../include/sys/nvpair.h' line='235' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-334'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' filepath='../../module/nvpair/fnvpair.c' line='314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='314' column='1'/>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' filepath='../../include/sys/nvpair.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='320' column='1'/>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' filepath='../../include/sys/nvpair.h' line='203' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-237'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' filepath='../../module/nvpair/fnvpair.c' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='328' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' filepath='../../include/sys/nvpair.h' line='204' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' filepath='../../module/nvpair/fnvpair.c' line='336' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='336' column='1'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' filepath='../../include/sys/nvpair.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-238'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' filepath='../../module/nvpair/fnvpair.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='344' column='1'/>
+      <return type-id='type-id-94'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' filepath='../../include/sys/nvpair.h' line='207' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-220'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' filepath='../../module/nvpair/fnvpair.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='352' column='1'/>
+      <return type-id='type-id-65'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' filepath='../../include/sys/nvpair.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-222'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' filepath='../../module/nvpair/fnvpair.c' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='360' column='1'/>
+      <return type-id='type-id-106'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' filepath='../../include/sys/nvpair.h' line='211' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-224'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' filepath='../../module/nvpair/fnvpair.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='368' column='1'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' filepath='../../include/sys/nvpair.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-219'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' filepath='../../module/nvpair/fnvpair.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='376' column='1'/>
+      <return type-id='type-id-98'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' filepath='../../include/sys/nvpair.h' line='208' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-221'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' filepath='../../module/nvpair/fnvpair.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='384' column='1'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' filepath='../../include/sys/nvpair.h' line='210' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' filepath='../../module/nvpair/fnvpair.c' line='392' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='392' column='1'/>
+      <return type-id='type-id-67'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='212' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-225'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' filepath='../../module/nvpair/fnvpair.c' line='400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='400' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-153'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' filepath='../../module/nvpair/fnvpair.c' line='408' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='408' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='214' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-235'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' filepath='../../module/nvpair/fnvpair.c' line='415' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='415' column='1'/>
+      <return type-id='type-id-122'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_array' filepath='../../include/sys/nvpair.h' line='215' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-239'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' filepath='../../module/nvpair/fnvpair.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='423' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte_array' filepath='../../include/sys/nvpair.h' line='217' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' filepath='../../module/nvpair/fnvpair.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='431' column='1'/>
+      <return type-id='type-id-129'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8_array' filepath='../../include/sys/nvpair.h' line='218' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-240'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' filepath='../../module/nvpair/fnvpair.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='439' column='1'/>
+      <return type-id='type-id-132'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8_array' filepath='../../include/sys/nvpair.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-226'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' filepath='../../module/nvpair/fnvpair.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='447' column='1'/>
+      <return type-id='type-id-135'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16_array' filepath='../../include/sys/nvpair.h' line='220' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' filepath='../../module/nvpair/fnvpair.c' line='455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='455' column='1'/>
+      <return type-id='type-id-138'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16_array' filepath='../../include/sys/nvpair.h' line='221' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-228'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' filepath='../../module/nvpair/fnvpair.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='463' column='1'/>
+      <return type-id='type-id-141'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32_array' filepath='../../include/sys/nvpair.h' line='222' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-229'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' filepath='../../module/nvpair/fnvpair.c' line='471' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='471' column='1'/>
+      <return type-id='type-id-144'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32_array' filepath='../../include/sys/nvpair.h' line='223' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-230'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' filepath='../../module/nvpair/fnvpair.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='479' column='1'/>
+      <return type-id='type-id-147'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64_array' filepath='../../include/sys/nvpair.h' line='224' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-231'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' filepath='../../module/nvpair/fnvpair.c' line='487' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-73' name='nvl' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <parameter type-id='type-id-6' name='name' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <parameter type-id='type-id-281' name='n' filepath='../../module/nvpair/fnvpair.c' line='487' column='1'/>
+      <return type-id='type-id-150'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-218'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-232'/>
+      <parameter type-id='type-id-223'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' filepath='../../module/nvpair/fnvpair.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='495' column='1'/>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' filepath='../../module/nvpair/fnvpair.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='503' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' filepath='../../module/nvpair/fnvpair.c' line='511' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='511' column='1'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' filepath='../../module/nvpair/fnvpair.c' line='519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='519' column='1'/>
+      <return type-id='type-id-94'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' filepath='../../module/nvpair/fnvpair.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='527' column='1'/>
+      <return type-id='type-id-65'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' filepath='../../module/nvpair/fnvpair.c' line='535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='535' column='1'/>
+      <return type-id='type-id-106'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' filepath='../../module/nvpair/fnvpair.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='543' column='1'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' filepath='../../module/nvpair/fnvpair.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='551' column='1'/>
+      <return type-id='type-id-98'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' filepath='../../module/nvpair/fnvpair.c' line='559' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='559' column='1'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' filepath='../../module/nvpair/fnvpair.c' line='567' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='567' column='1'/>
+      <return type-id='type-id-67'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' filepath='../../module/nvpair/fnvpair.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='575' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' filepath='../../module/nvpair/fnvpair.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
+      <parameter type-id='type-id-243' name='nvp' filepath='../../module/nvpair/fnvpair.c' line='583' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='libspl_assert_ok' type-id='type-id-5' mangled-name='libspl_assert_ok' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/assert.c' line='28' column='1' elf-symbol-id='libspl_assert_ok'/>
   </abi-instr>
 </abi-corpus>

--- a/lib/libspl/assert.c
+++ b/lib/libspl/assert.c
@@ -25,7 +25,7 @@
 
 #include <assert.h>
 
-int aok = 0;
+int libspl_assert_ok = 0;
 
 /* printf version of libspl_assert */
 void
@@ -39,7 +39,7 @@ libspl_assertf(const char *file, const char *func, int line,
 	fprintf(stderr, "\n");
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
 	va_end(args);
-	if (aok) {
+	if (libspl_assert_ok) {
 		return;
 	}
 	abort();

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -34,7 +34,7 @@
 #include <stdarg.h>
 
 /* Set to non-zero to avoid abort()ing on an assertion failure */
-extern int aok;
+extern int libspl_assert_ok;
 
 /* printf version of libspl_assert */
 extern void libspl_assertf(const char *file, const char *func, int line,

--- a/lib/libspl/os/linux/getmntany.c
+++ b/lib/libspl/os/linux/getmntany.c
@@ -41,7 +41,7 @@
 
 #define	BUFSIZE	(MNT_LINE_MAX + 2)
 
-__thread char buf[BUFSIZE];
+static __thread char buf[BUFSIZE];
 
 #define	DIFF(xx)	( \
 	    (mrefp->xx != NULL) && \

--- a/lib/libspl/page.c
+++ b/lib/libspl/page.c
@@ -22,7 +22,7 @@
 
 #include <unistd.h>
 
-size_t pagesize = 0;
+static size_t pagesize = 0;
 
 size_t
 spl_pagesize(void)

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -1,27 +1,28 @@
 <abi-corpus path='libuutil.so' architecture='elf-amd-x86_64' soname='libuutil.so.3'>
   <elf-needed>
+    <dependency name='libatomic.so.1'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_short' is-defined='yes'/>
-    <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_int_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_char_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_8' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_32' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_long' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64,atomic_add_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64_nv,atomic_add_long_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -29,98 +30,98 @@
     <elf-symbol name='atomic_and_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_uchar_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_8' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_and_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_64' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16' is-defined='yes'/>
-    <elf-symbol name='atomic_and_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ptr,atomic_cas_64' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_16' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_clear_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ulong_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_8_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_64' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_32_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_64' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint' is-defined='yes'/>
-    <elf-symbol name='atomic_or_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8' is-defined='yes'/>
-    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64' is-defined='yes'/>
-    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_or_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_16' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_set_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_int_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_ptr,atomic_sub_long' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_char' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_8_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_32' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_long_nv,atomic_sub_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ushort' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uint' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ulong,atomic_swap_ptr' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -253,20 +254,18 @@
     <elf-symbol name='uu_zalloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <elf-variable-symbols>
-    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='buf' size='4110' type='tls-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='pagesize' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assert_ok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='uu_exit_fatal_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='uu_exit_ok_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='uu_exit_usage_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
     <type-decl name='void' id='type-id-1'/>
     <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-2'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
-    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='46' column='1' id='type-id-4'/>
-    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
-      <parameter type-id='type-id-4' name='n' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='33' column='1'/>
+    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/llvm-13/lib/clang/13.0.0/include/stddef.h' line='46' column='1' id='type-id-4'/>
+    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
+      <parameter type-id='type-id-4' name='n' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='33' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <type-decl name='unsigned int' size-in-bits='32' id='type-id-5'/>
@@ -274,21 +273,21 @@
       <parameter type-id='type-id-5'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_free' mangled-name='uu_free' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
-      <parameter type-id='type-id-2' name='p' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='48' column='1'/>
+    <function-decl name='uu_free' mangled-name='uu_free' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
+      <parameter type-id='type-id-2' name='p' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='48' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <type-decl name='char' size-in-bits='8' id='type-id-6'/>
     <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
     <qualified-type-def type-id='type-id-6' const='yes' id='type-id-8'/>
     <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-9'/>
-    <function-decl name='uu_strdup' mangled-name='uu_strdup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
-      <parameter type-id='type-id-9' name='str' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='54' column='1'/>
+    <function-decl name='uu_strdup' mangled-name='uu_strdup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
+      <parameter type-id='type-id-9' name='str' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='54' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='uu_strndup' mangled-name='uu_strndup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
-      <parameter type-id='type-id-9' name='s' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
-      <parameter type-id='type-id-4' name='n' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
+    <function-decl name='uu_strndup' mangled-name='uu_strndup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
+      <parameter type-id='type-id-9' name='s' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
+      <parameter type-id='type-id-4' name='n' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='strnlen' filepath='/usr/include/string.h' line='390' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -296,18 +295,18 @@
       <parameter type-id='type-id-3'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='uu_memdup' mangled-name='uu_memdup' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
-      <parameter type-id='type-id-2' name='buf' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
-      <parameter type-id='type-id-4' name='sz' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
+    <function-decl name='uu_memdup' mangled-name='uu_memdup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
+      <parameter type-id='type-id-2' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
+      <parameter type-id='type-id-4' name='sz' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_alloc.c' line='108' column='1'/>
+    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='108' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-7'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_avl.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='uu_avl.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
     <class-decl name='uu_avl_pool' size-in-bits='2176' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='148' column='1' id='type-id-10'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='uap_next' type-id='type-id-11' visibility='default' filepath='../../include/libuutil_impl.h' line='149' column='1'/>
@@ -352,63 +351,63 @@
     <typedef-decl name='uu_compare_fn_t' type-id='type-id-21' filepath='../../include/libuutil.h' line='131' column='1' id='type-id-22'/>
     <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-13'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-23'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-23' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-24'/>
-    <typedef-decl name='uint8_t' type-id='type-id-24' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-14'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' id='type-id-25'>
+    <typedef-decl name='__uint8_t' type-id='type-id-23' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-24'/>
+    <typedef-decl name='uint8_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-14'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-25'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
+        <var-decl name='__data' type-id='type-id-26' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-27' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
+        <var-decl name='__size' type-id='type-id-27' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
+        <var-decl name='__align' type-id='type-id-28' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='118' column='1' id='type-id-26'>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-26'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='120' column='1'/>
+        <var-decl name='__lock' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='121' column='1'/>
+        <var-decl name='__count' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='122' column='1'/>
+        <var-decl name='__owner' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='124' column='1'/>
+        <var-decl name='__nusers' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='148' column='1'/>
+        <var-decl name='__kind' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__spins' type-id='type-id-29' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__elision' type-id='type-id-29' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-30' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='155' column='1'/>
+        <var-decl name='__list' type-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
       </data-member>
     </class-decl>
     <type-decl name='short int' size-in-bits='16' id='type-id-29'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='82' column='1' id='type-id-31'>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-31'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-32' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='84' column='1'/>
+        <var-decl name='__prev' type-id='type-id-32' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-32' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='85' column='1'/>
+        <var-decl name='__next' type-id='type-id-32' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-32'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-31' filepath='/usr/include/bits/thread-shared-types.h' line='86' column='1' id='type-id-30'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-31' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-30'/>
 
     <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='320' id='type-id-27'>
       <subrange length='40' type-id='type-id-18' id='type-id-33'/>
 
     </array-type-def>
     <type-decl name='long int' size-in-bits='64' id='type-id-28'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-25' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-15'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-25' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-15'/>
     <class-decl name='uu_avl' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='131' column='1' id='type-id-34'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ua_next_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='132' column='1'/>
@@ -494,16 +493,16 @@
     <typedef-decl name='uu_avl_t' type-id='type-id-34' filepath='../../include/libuutil.h' line='260' column='1' id='type-id-16'/>
     <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-47'/>
     <type-decl name='signed char' size-in-bits='8' id='type-id-49'/>
-    <typedef-decl name='__int8_t' type-id='type-id-49' filepath='/usr/include/bits/types.h' line='36' column='1' id='type-id-50'/>
-    <typedef-decl name='int8_t' type-id='type-id-50' filepath='/usr/include/bits/stdint-intn.h' line='24' column='1' id='type-id-48'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-51'/>
-    <typedef-decl name='uint32_t' type-id='type-id-51' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-52'/>
-    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
-      <parameter type-id='type-id-9' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-4' name='objsize' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-4' name='nodeoffset' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-13' name='compare_func' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
+    <typedef-decl name='__int8_t' type-id='type-id-49' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='36' column='1' id='type-id-50'/>
+    <typedef-decl name='int8_t' type-id='type-id-50' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-48'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-51'/>
+    <typedef-decl name='uint32_t' type-id='type-id-51' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-52'/>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
+      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-4' name='objsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-4' name='nodeoffset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
+      <parameter type-id='type-id-13' name='compare_func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
       <return type-id='type-id-11'/>
     </function-decl>
     <function-decl name='uu_check_name' filepath='../../include/libuutil.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -522,12 +521,12 @@
       <return type-id='type-id-3'/>
     </function-decl>
     <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-53'/>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='32' column='1' id='type-id-54'>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-54'>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-55' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='34' column='1'/>
+        <var-decl name='__size' type-id='type-id-55' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='35' column='1'/>
+        <var-decl name='__align' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
       </data-member>
     </union-decl>
 
@@ -550,8 +549,8 @@
       <parameter type-id='type-id-53'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
-      <parameter type-id='type-id-11' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='114' column='1'/>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
+      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='114' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='uu_panic' filepath='../../include/libuutil_impl.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -575,22 +574,22 @@
     </array-type-def>
     <typedef-decl name='uu_avl_node_t' type-id='type-id-59' filepath='../../include/libuutil.h' line='268' column='1' id='type-id-62'/>
     <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-63'/>
-    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_init'>
-      <parameter type-id='type-id-2' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
-      <parameter type-id='type-id-63' name='np' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
-      <parameter type-id='type-id-11' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
+    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_init'>
+      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
+      <parameter type-id='type-id-63' name='np' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
+      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
-      <parameter type-id='type-id-2' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
-      <parameter type-id='type-id-63' name='np' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
-      <parameter type-id='type-id-11' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
+    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
+      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
+      <parameter type-id='type-id-63' name='np' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
+      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
-      <parameter type-id='type-id-11' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
-      <parameter type-id='type-id-2' name='parent' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
+      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
+      <parameter type-id='type-id-2' name='parent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
       <return type-id='type-id-47'/>
     </function-decl>
     <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-64'/>
@@ -601,8 +600,8 @@
       <parameter type-id='type-id-3'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='250' column='1'/>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='250' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_numnodes' filepath='../../include/sys/avl.h' line='281' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -613,29 +612,29 @@
       <parameter type-id='type-id-64'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='279' column='1'/>
+    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='279' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='avl_first' filepath='../../include/sys/avl.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-64'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='avl_last' filepath='../../include/sys/avl.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-64'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <parameter type-id='type-id-2' name='node' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
+      <parameter type-id='type-id-2' name='node' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -644,36 +643,36 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <parameter type-id='type-id-2' name='node' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
+    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
+      <parameter type-id='type-id-2' name='node' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='364' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
-      <parameter type-id='type-id-46' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='384' column='1'/>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
+      <parameter type-id='type-id-46' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='384' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
-      <parameter type-id='type-id-46' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='390' column='1'/>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
+      <parameter type-id='type-id-46' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='390' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <typedef-decl name='uu_walk_fn_t' type-id='type-id-44' filepath='../../include/libuutil.h' line='155' column='1' id='type-id-65'/>
     <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
-    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='397' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-66' name='func' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
+    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
+      <parameter type-id='type-id-66' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
+      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_remove' filepath='../../include/sys/avl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -682,9 +681,9 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-67'/>
-    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
+      <parameter type-id='type-id-67' name='cookie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='avl_destroy_nodes' filepath='../../include/sys/avl.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -694,11 +693,11 @@
     </function-decl>
     <typedef-decl name='uu_avl_index_t' type-id='type-id-35' filepath='../../include/libuutil.h' line='272' column='1' id='type-id-68'/>
     <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-69'/>
-    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='473' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-69' name='out' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
+      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
+      <parameter type-id='type-id-69' name='out' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-70'/>
@@ -708,10 +707,10 @@
       <parameter type-id='type-id-70'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
+      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_insert' filepath='../../include/sys/avl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -720,9 +719,9 @@
       <parameter type-id='type-id-3'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
+    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
+      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='avl_nearest' filepath='../../include/sys/avl.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -731,15 +730,15 @@
       <parameter type-id='type-id-20'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='538' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
-      <parameter type-id='type-id-47' name='ap' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
+    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='538' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
+      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
+      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
+    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' filepath='/home/fedora/zfs/lib/libuutil/uu_avl.c' line='562' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
+    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='562' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-44'>
@@ -754,15 +753,15 @@
       <return type-id='type-id-20'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_ident.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='uu_ident.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
     <typedef-decl name='uint_t' type-id='type-id-5' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-71'/>
-    <function-decl name='uu_check_name' mangled-name='uu_check_name' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
-      <parameter type-id='type-id-9' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
+    <function-decl name='uu_check_name' mangled-name='uu_check_name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
+      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
+      <parameter type-id='type-id-71' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_list.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='uu_list.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
     <class-decl name='uu_list_pool' size-in-bits='2112' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='102' column='1' id='type-id-72'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ulp_next' type-id='type-id-73' visibility='default' filepath='../../include/libuutil_impl.h' line='103' column='1'/>
@@ -867,16 +866,16 @@
     <typedef-decl name='uu_list_t' type-id='type-id-76' filepath='../../include/libuutil.h' line='161' column='1' id='type-id-74'/>
     <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-83'/>
     <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-84'/>
-    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
-      <parameter type-id='type-id-9' name='name' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
-      <parameter type-id='type-id-4' name='objsize' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
-      <parameter type-id='type-id-4' name='nodeoffset' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
-      <parameter type-id='type-id-13' name='compare_func' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
+      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
+      <parameter type-id='type-id-4' name='objsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
+      <parameter type-id='type-id-4' name='nodeoffset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='compare_func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
       <return type-id='type-id-73'/>
     </function-decl>
-    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
-      <parameter type-id='type-id-73' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='110' column='1'/>
+    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
+      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='110' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil.h' line='163' column='1' id='type-id-85'>
@@ -891,133 +890,128 @@
     </array-type-def>
     <typedef-decl name='uu_list_node_t' type-id='type-id-85' filepath='../../include/libuutil.h' line='165' column='1' id='type-id-87'/>
     <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-88'/>
-    <function-decl name='uu_list_node_init' mangled-name='uu_list_node_init' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_init'>
-      <parameter type-id='type-id-2' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
-      <parameter type-id='type-id-88' name='np_arg' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
-      <parameter type-id='type-id-73' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+    <function-decl name='uu_list_node_init' mangled-name='uu_list_node_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_init'>
+      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+      <parameter type-id='type-id-88' name='np_arg' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
+      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
-      <parameter type-id='type-id-2' name='base' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
-      <parameter type-id='type-id-88' name='np_arg' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
-      <parameter type-id='type-id-73' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
+      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+      <parameter type-id='type-id-88' name='np_arg' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
+      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_list_create' mangled-name='uu_list_create' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
-      <parameter type-id='type-id-73' name='pp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
-      <parameter type-id='type-id-2' name='parent' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+    <function-decl name='uu_list_create' mangled-name='uu_list_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
+      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+      <parameter type-id='type-id-2' name='parent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
       <return type-id='type-id-83'/>
     </function-decl>
-    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='231' column='1'/>
+    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='231' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <typedef-decl name='uu_list_index_t' type-id='type-id-35' filepath='../../include/libuutil.h' line='169' column='1' id='type-id-89'/>
-    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
+      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-90'/>
-    <function-decl name='uu_list_find' mangled-name='uu_list_find' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-90' name='out' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+    <function-decl name='uu_list_find' mangled-name='uu_list_find' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
+      <parameter type-id='type-id-90' name='out' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
+      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
+    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
       <return type-id='type-id-82'/>
     </function-decl>
-    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
-      <parameter type-id='type-id-82' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='476' column='1'/>
+    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
+      <parameter type-id='type-id-82' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='476' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
-      <parameter type-id='type-id-82' name='wp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='488' column='1'/>
+    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
+      <parameter type-id='type-id-82' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='488' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-66' name='func' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-66' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
+      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
+    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
+    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
+      <parameter type-id='type-id-67' name='cookie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_first' mangled-name='uu_list_first' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='656' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
+    <function-decl name='uu_list_first' mangled-name='uu_list_first' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='target' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-2' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='target' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-2' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='650' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='650' column='1'/>
+    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='650' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='650' column='1'/>
       <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='uu_list_last' mangled-name='uu_list_last' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
+    <function-decl name='uu_list_last' mangled-name='uu_list_last' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_next' mangled-name='uu_list_next' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+    <function-decl name='uu_list_next' mangled-name='uu_list_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
-      <parameter type-id='type-id-83' name='lp' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
+      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
+      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
+    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_list_release' mangled-name='uu_list_release' filepath='/home/fedora/zfs/lib/libuutil/uu_list.c' line='710' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
+    <function-decl name='uu_list_release' mangled-name='uu_list_release' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='710' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_misc.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
-    <function-decl name='uu_set_error' mangled-name='uu_set_error' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
-      <parameter type-id='type-id-71' name='code' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='73' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='uu_misc.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_set_error' mangled-name='uu_set_error' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
+      <parameter type-id='type-id-71' name='code' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='73' column='1'/>
       <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_setspecific' filepath='/usr/include/pthread.h' line='1123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-20'/>
     </function-decl>
     <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-91'/>
     <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-93'/>
@@ -1026,15 +1020,20 @@
       <parameter type-id='type-id-93'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='uu_error' mangled-name='uu_error' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
+    <function-decl name='pthread_setspecific' filepath='/usr/include/pthread.h' line='1123' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='uu_error' mangled-name='uu_error' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
       <return type-id='type-id-52'/>
     </function-decl>
     <function-decl name='pthread_getspecific' filepath='/usr/include/pthread.h' line='1120' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-5'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_strerror' mangled-name='uu_strerror' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
-      <parameter type-id='type-id-52' name='code' filepath='/home/fedora/zfs/lib/libuutil/uu_misc.c' line='118' column='1'/>
+    <function-decl name='uu_strerror' mangled-name='uu_strerror' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
+      <parameter type-id='type-id-52' name='code' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='118' column='1'/>
       <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -1064,83 +1063,83 @@
       <return type-id='type-id-1'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_pname.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
-    <var-decl name='uu_exit_ok_value' type-id='type-id-20' mangled-name='uu_exit_ok_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='49' column='1' elf-symbol-id='uu_exit_ok_value'/>
-    <var-decl name='uu_exit_fatal_value' type-id='type-id-20' mangled-name='uu_exit_fatal_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='50' column='1' elf-symbol-id='uu_exit_fatal_value'/>
-    <var-decl name='uu_exit_usage_value' type-id='type-id-20' mangled-name='uu_exit_usage_value' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='51' column='1' elf-symbol-id='uu_exit_usage_value'/>
+  <abi-instr version='1.0' address-size='64' path='uu_pname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
+    <var-decl name='uu_exit_ok_value' type-id='type-id-20' mangled-name='uu_exit_ok_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='49' column='1' elf-symbol-id='uu_exit_ok_value'/>
+    <var-decl name='uu_exit_fatal_value' type-id='type-id-20' mangled-name='uu_exit_fatal_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='50' column='1' elf-symbol-id='uu_exit_fatal_value'/>
+    <var-decl name='uu_exit_usage_value' type-id='type-id-20' mangled-name='uu_exit_usage_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='51' column='1' elf-symbol-id='uu_exit_usage_value'/>
     <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-96'/>
-    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
+    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
       <return type-id='type-id-96'/>
     </function-decl>
-    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
+    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
       <return type-id='type-id-96'/>
     </function-decl>
-    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
+    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
       <return type-id='type-id-96'/>
     </function-decl>
-    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
-      <parameter type-id='type-id-20' name='profile' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='72' column='1'/>
+    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
+      <parameter type-id='type-id-20' name='profile' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='72' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-97'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='gp_offset' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='fp_offset' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-2' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='overflow_arg_area' type-id='type-id-2' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-2' visibility='default' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='reg_save_area' type-id='type-id-2' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-98'/>
-    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
+    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
+      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_warn' mangled-name='uu_warn' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='108' column='1'/>
+    <function-decl name='uu_warn' mangled-name='uu_warn' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='108' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_vdie' mangled-name='uu_vdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
+    <function-decl name='uu_vdie' mangled-name='uu_vdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
+      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_die' mangled-name='uu_die' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='142' column='1'/>
+    <function-decl name='uu_die' mangled-name='uu_die' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='142' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_vxdie' mangled-name='uu_vxdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vxdie'>
-      <parameter type-id='type-id-20' name='status' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+    <function-decl name='uu_vxdie' mangled-name='uu_vxdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vxdie'>
+      <parameter type-id='type-id-20' name='status' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
+      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_xdie' mangled-name='uu_xdie' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
-      <parameter type-id='type-id-20' name='status' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
-      <parameter type-id='type-id-9' name='format' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
+    <function-decl name='uu_xdie' mangled-name='uu_xdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
+      <parameter type-id='type-id-20' name='status' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
+      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uu_setpname' mangled-name='uu_setpname' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
-      <parameter type-id='type-id-7' name='arg0' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='167' column='1'/>
+    <function-decl name='uu_setpname' mangled-name='uu_setpname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
+      <parameter type-id='type-id-7' name='arg0' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='167' column='1'/>
       <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='getexecname' filepath='../../lib/libspl/include/stdlib.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='uu_getpname' mangled-name='uu_getpname' filepath='/home/fedora/zfs/lib/libuutil/uu_pname.c' line='204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
+    <function-decl name='uu_getpname' mangled-name='uu_getpname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
       <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_string.c' comp-dir-path='/home/fedora/zfs/lib/libuutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='uu_string.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
     <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-99'/>
     <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-100'>
       <underlying-type type-id='type-id-99'/>
@@ -1148,78 +1147,57 @@
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
     <typedef-decl name='boolean_t' type-id='type-id-100' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-101'/>
-    <function-decl name='uu_streq' mangled-name='uu_streq' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
-      <parameter type-id='type-id-9' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+    <function-decl name='uu_streq' mangled-name='uu_streq' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
+      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
       <return type-id='type-id-101'/>
     </function-decl>
-    <function-decl name='uu_strcaseeq' mangled-name='uu_strcaseeq' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strcaseeq'>
-      <parameter type-id='type-id-9' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+    <function-decl name='uu_strcaseeq' mangled-name='uu_strcaseeq' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strcaseeq'>
+      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
       <return type-id='type-id-101'/>
     </function-decl>
-    <function-decl name='uu_strbw' mangled-name='uu_strbw' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
-      <parameter type-id='type-id-9' name='a' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/home/fedora/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+    <function-decl name='uu_strbw' mangled-name='uu_strbw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
+      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
+      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
       <return type-id='type-id-101'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/fedora/zfs/lib/libavl' language='LANG_C99'>
-
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libavl' language='LANG_C99'>
     <typedef-decl name='avl_tree_t' type-id='type-id-36' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-102'/>
     <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='962' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='../../module/avl/avl.c' line='962' column='1'/>
+    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-2' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-20' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='934' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='934' column='1'/>
-      <return type-id='type-id-101'/>
+    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='927' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='927' column='1'/>
-      <return type-id='type-id-40'/>
+    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='915' column='1'/>
-      <return type-id='type-id-1'/>
+    <typedef-decl name='avl_index_t' type-id='type-id-35' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-104'/>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-20' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='892' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='892' column='1'/>
-      <parameter type-id='type-id-39' name='compar' filepath='../../module/avl/avl.c' line='892' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='../../module/avl/avl.c' line='893' column='1'/>
-      <parameter type-id='type-id-4' name='offset' filepath='../../module/avl/avl.c' line='893' column='1'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
+    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-2' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-105' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='type-id-103' name='tree1' filepath='../../module/avl/avl.c' line='871' column='1'/>
-      <parameter type-id='type-id-103' name='tree2' filepath='../../module/avl/avl.c' line='871' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='851' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='851' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='834' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='834' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='834' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='834' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='834' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='669' column='1'/>
-      <parameter type-id='type-id-2' name='data' filepath='../../module/avl/avl.c' line='669' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='636' column='1'/>
-      <parameter type-id='type-id-2' name='new_node' filepath='../../module/avl/avl.c' line='636' column='1'/>
+    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-2' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
@@ -1229,46 +1207,701 @@
       <parameter type-id='type-id-20' name='direction' filepath='../../module/avl/avl.c' line='579' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <typedef-decl name='avl_index_t' type-id='type-id-35' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-104'/>
-    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-2' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
+    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='636' column='1'/>
+      <parameter type-id='type-id-2' name='new_node' filepath='../../module/avl/avl.c' line='636' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
-    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-105' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
+    <function-decl name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-9'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='669' column='1'/>
+      <parameter type-id='type-id-2' name='data' filepath='../../module/avl/avl.c' line='669' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <return type-id='type-id-101'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='834' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <return type-id='type-id-101'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='851' column='1'/>
+      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='851' column='1'/>
+      <return type-id='type-id-101'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-103' name='tree1' filepath='../../module/avl/avl.c' line='871' column='1'/>
+      <parameter type-id='type-id-103' name='tree2' filepath='../../module/avl/avl.c' line='871' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='892' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='892' column='1'/>
+      <parameter type-id='type-id-39' name='compar' filepath='../../module/avl/avl.c' line='892' column='1'/>
+      <parameter type-id='type-id-4' name='size' filepath='../../module/avl/avl.c' line='893' column='1'/>
+      <parameter type-id='type-id-4' name='offset' filepath='../../module/avl/avl.c' line='893' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='915' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='927' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='927' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='934' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='934' column='1'/>
+      <return type-id='type-id-101'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='962' column='1'/>
+      <parameter type-id='type-id-67' name='cookie' filepath='../../module/avl/avl.c' line='962' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-20' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-14' volatile='yes' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='uchar_t' type-id='type-id-23' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-108'/>
+    <qualified-type-def type-id='type-id-108' volatile='yes' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-110'/>
+    <function-decl name='atomic_inc_uchar' mangled-name='atomic_inc_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-111'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-111' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-112'/>
+    <typedef-decl name='uint16_t' type-id='type-id-112' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-113'/>
+    <qualified-type-def type-id='type-id-113' volatile='yes' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-115'/>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='ushort_t' type-id='type-id-111' filepath='../../lib/libspl/include/sys/stdtypes.h' line='32' column='1' id='type-id-116'/>
+    <qualified-type-def type-id='type-id-116' volatile='yes' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
+    <function-decl name='atomic_inc_ushort' mangled-name='atomic_inc_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-52' volatile='yes' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-120'/>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-71' volatile='yes' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
+    <function-decl name='atomic_inc_uint' mangled-name='atomic_inc_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-40' volatile='yes' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-124'/>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-125'/>
+    <typedef-decl name='uint64_t' type-id='type-id-125' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-126'/>
+    <qualified-type-def type-id='type-id-126' volatile='yes' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
+    <function-decl name='atomic_inc_64' mangled-name='atomic_inc_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uchar' mangled-name='atomic_dec_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='56' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ushort' mangled-name='atomic_dec_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='58' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uint' mangled-name='atomic_dec_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_dec_64' mangled-name='atomic_dec_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_add_char' mangled-name='atomic_add_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-29' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-129'/>
+    <typedef-decl name='int16_t' type-id='type-id-129' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-130'/>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_add_short' mangled-name='atomic_add_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='__int32_t' type-id='type-id-20' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-131'/>
+    <typedef-decl name='int32_t' type-id='type-id-131' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-132'/>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_add_int' mangled-name='atomic_add_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='__int64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='43' column='1' id='type-id-133'/>
+    <typedef-decl name='int64_t' type-id='type-id-133' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-134'/>
+    <function-decl name='atomic_add_64' mangled-name='atomic_add_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-1' volatile='yes' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-136'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='191' column='1' id='type-id-137'/>
+    <typedef-decl name='ssize_t' type-id='type-id-137' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-138'/>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_char' mangled-name='atomic_sub_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_short' mangled-name='atomic_sub_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_int' mangled-name='atomic_sub_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_64' mangled-name='atomic_sub_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_uchar' mangled-name='atomic_or_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_ushort' mangled-name='atomic_or_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_uint' mangled-name='atomic_or_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_or_64' mangled-name='atomic_or_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_uchar' mangled-name='atomic_and_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_ushort' mangled-name='atomic_and_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_uint' mangled-name='atomic_and_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_and_64' mangled-name='atomic_and_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_inc_uchar_nv' mangled-name='atomic_inc_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ushort_nv' mangled-name='atomic_inc_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_inc_uint_nv' mangled-name='atomic_inc_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_inc_64_nv' mangled-name='atomic_inc_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uchar_nv' mangled-name='atomic_dec_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ushort_nv' mangled-name='atomic_dec_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uint_nv' mangled-name='atomic_dec_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_dec_64_nv' mangled-name='atomic_dec_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_add_char_nv' mangled-name='atomic_add_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_add_short_nv' mangled-name='atomic_add_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_add_int_nv' mangled-name='atomic_add_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_add_64_nv' mangled-name='atomic_add_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='206' column='1'/>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_sub_char_nv' mangled-name='atomic_sub_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_sub_short_nv' mangled-name='atomic_sub_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='208' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_sub_int_nv' mangled-name='atomic_sub_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='210' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_sub_64_nv' mangled-name='atomic_sub_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='206' column='1'/>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_or_uchar_nv' mangled-name='atomic_or_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_or_ushort_nv' mangled-name='atomic_or_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_or_uint_nv' mangled-name='atomic_or_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_or_64_nv' mangled-name='atomic_or_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_and_uchar_nv' mangled-name='atomic_and_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='244' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar_nv'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_and_ushort_nv' mangled-name='atomic_and_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort_nv'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_and_uint_nv' mangled-name='atomic_and_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint_nv'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_and_64_nv' mangled-name='atomic_and_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64_nv'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <parameter type-id='type-id-14' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <parameter type-id='type-id-14' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_cas_uchar' mangled-name='atomic_cas_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <parameter type-id='type-id-108' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <parameter type-id='type-id-108' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <parameter type-id='type-id-113' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <parameter type-id='type-id-113' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ushort' mangled-name='atomic_cas_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <parameter type-id='type-id-116' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <parameter type-id='type-id-116' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <parameter type-id='type-id-52' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <parameter type-id='type-id-52' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_cas_uint' mangled-name='atomic_cas_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <parameter type-id='type-id-71' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <parameter type-id='type-id-71' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <parameter type-id='type-id-40' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <parameter type-id='type-id-40' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_cas_64' mangled-name='atomic_cas_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <parameter type-id='type-id-126' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <parameter type-id='type-id-126' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
+      <parameter type-id='type-id-2' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
+      <parameter type-id='type-id-2' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-2' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-20' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='atomic_swap_uchar' mangled-name='atomic_swap_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uchar'>
+      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-108'/>
+    </function-decl>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ushort' mangled-name='atomic_swap_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ushort'>
+      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-116'/>
+    </function-decl>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-52'/>
+    </function-decl>
+    <function-decl name='atomic_swap_uint' mangled-name='atomic_swap_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uint'>
+      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='atomic_swap_64' mangled-name='atomic_swap_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_64'>
+      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-126'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
+      <parameter type-id='type-id-2' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
       <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <parameter type-id='type-id-71' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='326' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <parameter type-id='type-id-71' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='334' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='membar_exit' mangled-name='membar_exit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_exit'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='346' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-106'>
+  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='getexecname_impl' filepath='./libspl_impl.h' line='24' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-7'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-139'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='list_size' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
       </data-member>
@@ -1276,247 +1909,436 @@
         <var-decl name='list_offset' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='list_head' type-id='type-id-107' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
+        <var-decl name='list_head' type-id='type-id-140' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-107'>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-140'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-108' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
+        <var-decl name='next' type-id='type-id-141' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='type-id-108' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
+        <var-decl name='prev' type-id='type-id-141' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-108'/>
-    <typedef-decl name='list_t' type-id='type-id-106' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-110'/>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
+    <typedef-decl name='list_t' type-id='type-id-139' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-143'/>
+    <function-decl name='list_create' mangled-name='list_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-4' name='size' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-4' name='offset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-2' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-2' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_remove' mangled-name='list_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_prev' mangled-name='list_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-143' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <parameter type-id='type-id-143' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <typedef-decl name='list_node_t' type-id='type-id-140' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-145'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-145' name='lold' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <parameter type-id='type-id-145' name='lnew' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='type-id-145' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-145' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <typedef-decl name='list_node_t' type-id='type-id-107' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-112'/>
-    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='type-id-112' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1'/>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='type-id-112' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='type-id-112' name='lold' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <parameter type-id='type-id-112' name='lnew' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='type-id-110' name='dst' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <parameter type-id='type-id-110' name='src' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-2' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-2' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='list_create' mangled-name='list_create' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='type-id-110' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='offset' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='__mode_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='148' column='1' id='type-id-113'/>
-    <typedef-decl name='mode_t' type-id='type-id-113' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='69' column='1' id='type-id-114'/>
-    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
-      <parameter type-id='type-id-9' name='d' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
-      <parameter type-id='type-id-114' name='mode' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='__mode_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-146'/>
+    <typedef-decl name='mode_t' type-id='type-id-146' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='69' column='1' id='type-id-147'/>
+    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
+      <parameter type-id='type-id-9' name='d' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <parameter type-id='type-id-147' name='mode' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='strdup' mangled-name='strdup' filepath='/usr/include/string.h' line='166' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='calloc' mangled-name='calloc' filepath='/usr/include/stdlib.h' line='541' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='mbstowcs' mangled-name='mbstowcs' filepath='/usr/include/stdlib.h' line='930' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='wcstombs' mangled-name='wcstombs' filepath='/usr/include/stdlib.h' line='933' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='free' mangled-name='free' filepath='/usr/include/stdlib.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='__errno_location' mangled-name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='mkdir' mangled-name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='strrchr' mangled-name='strrchr' filepath='/usr/include/string.h' line='252' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='access' mangled-name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='pagesize' type-id='type-id-4' mangled-name='pagesize' visibility='default' filepath='/home/fedora/zfs/lib/libspl/page.c' line='25' column='1' elf-symbol-id='pagesize'/>
-    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/home/fedora/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
-      <return type-id='type-id-4'/>
-    </function-decl>
-    <function-decl name='sysconf' mangled-name='sysconf' filepath='/usr/include/unistd.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcat' mangled-name='strlcat' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
-      <parameter type-id='type-id-7' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-9' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-4' name='dstsize' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <return type-id='type-id-4'/>
-    </function-decl>
-    <function-decl name='strlen' mangled-name='strlen' filepath='/usr/include/string.h' line='384' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
-      <parameter type-id='type-id-7' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-9' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <return type-id='type-id-4'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
-      <parameter type-id='type-id-71' name='timestamp_fmt' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='localtime' mangled-name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='strftime' mangled-name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='time' mangled-name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='printf' mangled-name='printf' filepath='/usr/include/stdio.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nl_langinfo' mangled-name='nl_langinfo' filepath='/usr/include/langinfo.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='774' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='readlink' mangled-name='readlink' filepath='/usr/include/unistd.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
+    <function-decl name='mbstowcs' filepath='/usr/include/stdlib.h' line='930' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-3'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
+    <qualified-type-def type-id='type-id-20' const='yes' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-149'/>
+    <function-decl name='wcstombs' filepath='/usr/include/stdlib.h' line='933' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-149'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='read' mangled-name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
+    <function-decl name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='close' mangled-name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='getenv' mangled-name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='strtoull' mangled-name='strtoull' filepath='/usr/include/stdlib.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fopen' mangled-name='fopen64' filepath='/usr/include/stdio.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fscanf' mangled-name='fscanf' filepath='/usr/include/stdio.h' line='391' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fclose' mangled-name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
+    <function-decl name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='sysconf' filepath='/usr/include/unistd.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcat' mangled-name='strlcat' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
+      <parameter type-id='type-id-7' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-9' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-4' name='dstsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
+      <parameter type-id='type-id-7' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-9' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-4' name='len' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
+      <parameter type-id='type-id-71' name='timestamp_fmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-150'/>
+    <function-decl name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-150'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='nl_langinfo' filepath='/usr/include/langinfo.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tm_sec' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='9' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='tm_min' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='10' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tm_hour' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='11' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='tm_mday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='12' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tm_mon' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='13' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='tm_year' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='14' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='tm_wday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='15' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='tm_yday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='16' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='tm_isdst' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='17' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='tm_gmtoff' type-id='type-id-28' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='20' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='tm_zone' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='21' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-152'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-154'/>
+    <function-decl name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-154'/>
+      <return type-id='type-id-152'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-151' const='yes' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-156'/>
+    <function-decl name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-156'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='readlink' filepath='/usr/include/unistd.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-158' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-159' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-160' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-111' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-49' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-161' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-162' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-163' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-164' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-159' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-2' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-4' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-165' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-158'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-159'/>
+    <typedef-decl name='__off_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-160'/>
 
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='32880' id='type-id-115'>
-      <subrange length='4110' type-id='type-id-3' id='type-id-116'/>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='8' id='type-id-161'>
+      <subrange length='1' type-id='type-id-18' id='type-id-167'/>
 
     </array-type-def>
-    <var-decl name='buf' type-id='type-id-115' mangled-name='buf' visibility='default' filepath='os/linux/getmntany.c' line='44' column='1' elf-symbol-id='buf'/>
-    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-117'>
+    <typedef-decl name='__off64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-162'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-163'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-164'/>
+
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='160' id='type-id-165'>
+      <subrange length='20' type-id='type-id-18' id='type-id-170'/>
+
+    </array-type-def>
+    <function-decl name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-159'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-20'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='FILE' type-id='type-id-157' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-171'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-173'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-174'/>
+    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
+      <parameter type-id='type-id-172' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-174' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-174' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/mntent.h' line='51' column='1' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_fsname' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='53' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_dir' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_type' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_opts' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_freq' type-id='type-id-20' visibility='default' filepath='/usr/include/mntent.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_passno' type-id='type-id-20' visibility='default' filepath='/usr/include/mntent.h' line='58' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
+    <function-decl name='getmntent_r' filepath='/usr/include/mntent.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-159'/>
+      <parameter type-id='type-id-176'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-176'/>
+    </function-decl>
+    <function-decl name='feof' filepath='/usr/include/stdio.h' line='765' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-159'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
+      <parameter type-id='type-id-172' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <parameter type-id='type-id-174' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-177'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
       </data-member>
@@ -1536,255 +2358,91 @@
         <var-decl name='mnt_minor' type-id='type-id-71' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/bits/stat.h' line='119' column='1' id='type-id-119'>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-178'/>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='119' column='1' id='type-id-179'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-120' visibility='default' filepath='/usr/include/bits/stat.h' line='121' column='1'/>
+        <var-decl name='st_dev' type-id='type-id-180' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-121' visibility='default' filepath='/usr/include/bits/stat.h' line='123' column='1'/>
+        <var-decl name='st_ino' type-id='type-id-181' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-122' visibility='default' filepath='/usr/include/bits/stat.h' line='124' column='1'/>
+        <var-decl name='st_nlink' type-id='type-id-182' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-113' visibility='default' filepath='/usr/include/bits/stat.h' line='125' column='1'/>
+        <var-decl name='st_mode' type-id='type-id-146' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-123' visibility='default' filepath='/usr/include/bits/stat.h' line='132' column='1'/>
+        <var-decl name='st_uid' type-id='type-id-183' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='132' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-124' visibility='default' filepath='/usr/include/bits/stat.h' line='133' column='1'/>
+        <var-decl name='st_gid' type-id='type-id-184' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='133' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/stat.h' line='135' column='1'/>
+        <var-decl name='__pad0' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='135' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-120' visibility='default' filepath='/usr/include/bits/stat.h' line='136' column='1'/>
+        <var-decl name='st_rdev' type-id='type-id-180' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='136' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-125' visibility='default' filepath='/usr/include/bits/stat.h' line='137' column='1'/>
+        <var-decl name='st_size' type-id='type-id-160' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='137' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/stat.h' line='143' column='1'/>
+        <var-decl name='st_blksize' type-id='type-id-185' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='143' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-127' visibility='default' filepath='/usr/include/bits/stat.h' line='144' column='1'/>
+        <var-decl name='st_blocks' type-id='type-id-186' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='144' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-128' visibility='default' filepath='/usr/include/bits/stat.h' line='152' column='1'/>
+        <var-decl name='st_atim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='152' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-128' visibility='default' filepath='/usr/include/bits/stat.h' line='153' column='1'/>
+        <var-decl name='st_mtim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='153' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-128' visibility='default' filepath='/usr/include/bits/stat.h' line='154' column='1'/>
+        <var-decl name='st_ctim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-129' visibility='default' filepath='/usr/include/bits/stat.h' line='164' column='1'/>
+        <var-decl name='__glibc_reserved' type-id='type-id-188' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='164' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='143' column='1' id='type-id-120'/>
-    <typedef-decl name='__ino64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='147' column='1' id='type-id-121'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='149' column='1' id='type-id-122'/>
-    <typedef-decl name='__uid_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='144' column='1' id='type-id-123'/>
-    <typedef-decl name='__gid_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='145' column='1' id='type-id-124'/>
-    <typedef-decl name='__off_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='150' column='1' id='type-id-125'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='172' column='1' id='type-id-126'/>
-    <typedef-decl name='__blkcnt64_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='178' column='1' id='type-id-127'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='9' column='1' id='type-id-128'>
+    <typedef-decl name='__dev_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='143' column='1' id='type-id-180'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-181'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='149' column='1' id='type-id-182'/>
+    <typedef-decl name='__uid_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-183'/>
+    <typedef-decl name='__gid_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-184'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='172' column='1' id='type-id-185'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='178' column='1' id='type-id-186'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='9' column='1' id='type-id-187'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-130' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='11' column='1'/>
+        <var-decl name='tv_sec' type-id='type-id-189' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='11' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-131' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='12' column='1'/>
+        <var-decl name='tv_nsec' type-id='type-id-190' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='12' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='158' column='1' id='type-id-130'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='194' column='1' id='type-id-131'/>
+    <typedef-decl name='__time_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='158' column='1' id='type-id-189'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-190'/>
 
-    <array-type-def dimensions='1' type-id='type-id-131' size-in-bits='192' id='type-id-129'>
-      <subrange length='3' type-id='type-id-3' id='type-id-61'/>
+    <array-type-def dimensions='1' type-id='type-id-190' size-in-bits='192' id='type-id-188'>
+      <subrange length='3' type-id='type-id-18' id='type-id-61'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-191'/>
     <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
       <parameter type-id='type-id-9' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-118' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-132' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-178' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-191' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
       <return type-id='type-id-20'/>
-    </function-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-133'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-7' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-134' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-135' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-125' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-136' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-49' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-137' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-138' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-139' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-140' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-135' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-4' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-20' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-141' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-142'/>
-    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-134'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-135'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-136'/>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='8' id='type-id-137'>
-      <subrange length='1' type-id='type-id-3' id='type-id-143'/>
-
-    </array-type-def>
-    <typedef-decl name='__off64_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='151' column='1' id='type-id-138'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-144'/>
-    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-139'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-145'/>
-    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-140'/>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='160' id='type-id-141'>
-      <subrange length='20' type-id='type-id-3' id='type-id-146'/>
-
-    </array-type-def>
-    <typedef-decl name='FILE' type-id='type-id-133' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-147'/>
-    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-148'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-149'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-150'/>
-    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
-      <parameter type-id='type-id-148' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-150' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-150' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
-      <parameter type-id='type-id-148' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <parameter type-id='type-id-150' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='__xstat64' mangled-name='__xstat64' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='430' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fprintf' mangled-name='fprintf' filepath='/usr/include/stdio.h' line='326' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='strerror' mangled-name='strerror' filepath='/usr/include/string.h' line='396' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='strcmp' mangled-name='strcmp' filepath='/usr/include/string.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='feof' mangled-name='feof' filepath='/usr/include/stdio.h' line='765' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='getmntent_r' mangled-name='getmntent_r' filepath='/usr/include/mntent.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='zoneid_t' type-id='type-id-20' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-151'/>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-20' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-192'/>
     <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
-      <return type-id='type-id-151'/>
+      <return type-id='type-id-192'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='aok' type-id='type-id-20' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
-    <function-decl name='vfprintf' mangled-name='vfprintf' filepath='/usr/include/stdio.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='abort' mangled-name='abort' filepath='/usr/include/stdlib.h' line='588' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='libspl_assert_ok' type-id='type-id-20' mangled-name='libspl_assert_ok' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/assert.c' line='28' column='1' elf-symbol-id='libspl_assert_ok'/>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1,12 +1,13 @@
 <abi-corpus path='libzfs_core.so' architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
   <elf-needed>
+    <dependency name='libatomic.so.1'/>
     <dependency name='libuuid.so.1'/>
     <dependency name='libz.so.1'/>
+    <dependency name='librt.so.1'/>
     <dependency name='libm.so.6'/>
     <dependency name='libblkid.so.1'/>
     <dependency name='libudev.so.1'/>
     <dependency name='libnvpair.so.3'/>
-    <dependency name='libtirpc.so.3'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
@@ -15,123 +16,123 @@
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_int' is-defined='yes'/>
+    <elf-symbol name='atomic_add_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_ptr,atomic_add_long' is-defined='yes'/>
+    <elf-symbol name='atomic_add_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_char_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_8' is-defined='yes'/>
+    <elf-symbol name='atomic_add_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_64_nv,atomic_add_ptr_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_add_short' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_16' is-defined='yes'/>
-    <elf-symbol name='atomic_add_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_add_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_add_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ushort_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_and_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_and_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_8_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32' is-defined='yes'/>
-    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_and_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_64_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_and_16' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_and_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_and_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_32' is-defined='yes'/>
-    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_cas_ptr,atomic_cas_64' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_cas_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_cas_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_clear_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_uchar_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_dec_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_dec_16_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_dec_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uint_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_ulong_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_uchar_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_8' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_64' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_inc_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16' is-defined='yes'/>
-    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_inc_16_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_or_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort' is-defined='yes'/>
-    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ushort_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uint' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_inc_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_or_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_64' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_ulong' is-defined='yes'/>
+    <elf-symbol name='atomic_or_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_or_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_8_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uchar_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_32_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_uint_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_or_64_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_or_ulong_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_or_ushort_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_set_long_excl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_short_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_int_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_32_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_64_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_char' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_8_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_char' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_8_nv' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_32' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_char_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_int' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_int_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_long' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_64,atomic_sub_ptr' is-defined='yes'/>
-    <elf-symbol name='atomic_sub_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_sub_64_nv,atomic_sub_ptr_nv' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_sub_long_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_ptr_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_short' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_sub_short_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_ushort' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_uchar' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_8' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_ptr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_uchar' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_32' is-defined='yes'/>
-    <elf-symbol name='atomic_swap_ulong' type='func-type' binding='global-binding' visibility='default-visibility' alias='atomic_swap_64,atomic_swap_ptr' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='atomic_swap_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='avl_add' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='avl_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -286,147 +287,779 @@
     <elf-symbol name='zutil_strdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <elf-variable-symbols>
-    <elf-symbol name='aok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='buf' size='4110' type='tls-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='default_vtoc_map' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_debug' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='pagesize' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libspl_assert_ok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' comp-dir-path='/home/fedora/zfs/lib/libzfs_core' language='LANG_C99'>
-
-
-
-
-
-
-
-
-
-    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='2048' id='type-id-2'>
-      <subrange length='256' type-id='type-id-3' id='type-id-4'/>
-
-    </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-5'/>
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='2176' id='type-id-7'>
-      <subrange length='34' type-id='type-id-3' id='type-id-8'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='256' id='type-id-9'>
-      <subrange length='4' type-id='type-id-3' id='type-id-10'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='96' id='type-id-12'>
-      <subrange length='12' type-id='type-id-3' id='type-id-13'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='128' id='type-id-14'>
-      <subrange length='16' type-id='type-id-3' id='type-id-15'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='24' id='type-id-16'>
-      <subrange length='3' type-id='type-id-3' id='type-id-17'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='40' id='type-id-18'>
-      <subrange length='5' type-id='type-id-3' id='type-id-19'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='48' id='type-id-20'>
-      <subrange length='6' type-id='type-id-3' id='type-id-21'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='64' id='type-id-22'>
-      <subrange length='8' type-id='type-id-3' id='type-id-23'/>
-
-    </array-type-def>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-24'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-25'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-26'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
-    <type-decl name='void' id='type-id-27'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-28' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-29'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-28'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core' language='LANG_C99'>
+    <type-decl name='int' size-in-bits='32' id='type-id-1'/>
+    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-2'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-3' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-4' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-3'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-30' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+        <var-decl name='__lock' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-31' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+        <var-decl name='__count' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-6' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+        <var-decl name='__owner' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-31' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+        <var-decl name='__kind' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='148' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-30' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+        <var-decl name='__spins' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='int32_t' type-id='type-id-32' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-30'/>
-    <typedef-decl name='__int32_t' type-id='type-id-5' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-32'/>
-    <typedef-decl name='uint32_t' type-id='type-id-33' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-31'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='42' column='1' id='type-id-33'/>
-    <typedef-decl name='uint64_t' type-id='type-id-34' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-6'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='45' column='1' id='type-id-34'/>
-    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-35' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-36'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1424' column='1' id='type-id-35'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
-      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-6'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-7'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-10' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-10' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-10'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-9' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-8'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-11'/>
+    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-12'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='320' id='type-id-4'>
+      <subrange length='40' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
+    <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='774' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-17'/>
+    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-18'/>
+    <enum-decl name='lzc_dataset_type' filepath='../../include/libzfs_core.h' line='47' column='1' id='type-id-19'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
+      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
     </enum-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-37' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-38'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-37'>
-      <underlying-type type-id='type-id-24'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='85' column='1' id='type-id-20'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='type-id-21' visibility='default' filepath='../../include/sys/nvpair.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='type-id-22' visibility='default' filepath='../../include/sys/nvpair.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='type-id-23' visibility='default' filepath='../../include/sys/nvpair.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='type-id-22' visibility='default' filepath='../../include/sys/nvpair.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-21' visibility='default' filepath='../../include/sys/nvpair.h' line='90' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int32_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-24'/>
+    <typedef-decl name='int32_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-21'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-25'/>
+    <typedef-decl name='uint32_t' type-id='type-id-25' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-22'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-26'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-27'/>
+    <typedef-decl name='uint64_t' type-id='type-id-27' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-23'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-20' filepath='../../include/sys/nvpair.h' line='91' column='1' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-29'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-30'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-30' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-31'/>
+    <typedef-decl name='uint8_t' type-id='type-id-31' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-33'/>
+    <typedef-decl name='uint_t' type-id='type-id-6' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-34'/>
+    <function-decl name='lzc_create' mangled-name='lzc_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-19' name='type' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
+      <parameter type-id='type-id-33' name='wkeydata' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
+      <parameter type-id='type-id-34' name='wkeylen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-35'/>
+    <function-decl name='fnvlist_alloc' filepath='../../include/sys/nvpair.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-35'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32' filepath='../../include/sys/nvpair.h' line='293' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-36'/>
+    <function-decl name='fnvlist_add_uint8_array' filepath='../../include/sys/nvpair.h' line='303' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='nvlist_free' filepath='../../include/sys/nvpair.h' line='152' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-37'/>
+    <function-decl name='strlcpy' filepath='../../lib/libspl/include/string.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-38'/>
+    <function-decl name='fnvlist_pack' filepath='../../include/sys/nvpair.h' line='279' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-16'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_name' type-id='type-id-40' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32768'>
+        <var-decl name='zc_nvlist_src' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32960'>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33024'>
+        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-41' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='483' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33056'>
+        <var-decl name='zc_pad2' type-id='type-id-1' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='484' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33088'>
+        <var-decl name='zc_history' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33152'>
+        <var-decl name='zc_value' type-id='type-id-42' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='98688'>
+        <var-decl name='zc_string' type-id='type-id-43' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100736'>
+        <var-decl name='zc_guid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100800'>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100864'>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100928'>
+        <var-decl name='zc_cookie' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100992'>
+        <var-decl name='zc_objset_type' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101056'>
+        <var-decl name='zc_perm_action' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101120'>
+        <var-decl name='zc_history_len' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101184'>
+        <var-decl name='zc_history_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101248'>
+        <var-decl name='zc_obj' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101312'>
+        <var-decl name='zc_iflags' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101376'>
+        <var-decl name='zc_share' type-id='type-id-44' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101632'>
+        <var-decl name='zc_objset_stats' type-id='type-id-45' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='103936'>
+        <var-decl name='zc_begin_record' type-id='type-id-46' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106368'>
+        <var-decl name='zc_inject_record' type-id='type-id-47' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109184'>
+        <var-decl name='zc_defer_destroy' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109216'>
+        <var-decl name='zc_flags' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109248'>
+        <var-decl name='zc_action_handle' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109312'>
+        <var-decl name='zc_cleanup_fd' type-id='type-id-1' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109344'>
+        <var-decl name='zc_simple' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109352'>
+        <var-decl name='zc_pad' type-id='type-id-48' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109376'>
+        <var-decl name='zc_sendobj' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109440'>
+        <var-decl name='zc_fromobj' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109504'>
+        <var-decl name='zc_createtxg' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109568'>
+        <var-decl name='zc_stat' type-id='type-id-49' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109888'>
+        <var-decl name='zc_zoneid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32768' id='type-id-40'>
+      <subrange length='4096' type-id='type-id-12' id='type-id-50'/>
+
+    </array-type-def>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-51'>
+      <underlying-type type-id='type-id-18'/>
       <enumerator name='B_FALSE' value='0'/>
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-39' filepath='../../include/sys/fs/zfs.h' line='1422' column='1' id='type-id-40'/>
-    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1412' column='1' id='type-id-39'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
-      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
-      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
-      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
-      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
-      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
-      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
-      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
-    </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='type-id-41' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-42'/>
-    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1162' column='1' id='type-id-41'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='POOL_TRIM_START' value='0'/>
-      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
-      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
-      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='type-id-43' filepath='../../include/sys/fs/zfs.h' line='1157' column='1' id='type-id-44'/>
-    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1152' column='1' id='type-id-43'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='POOL_INITIALIZE_START' value='0'/>
-      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
-      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
-      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='uint8_t' type-id='type-id-45' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-11'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-25' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-45'/>
-    <typedef-decl name='uint_t' type-id='type-id-26' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-46'/>
-    <typedef-decl name='dmu_replay_record_t' type-id='type-id-47' filepath='../../include/sys/zfs_ioctl.h' line='385' column='1' id='type-id-48'/>
-    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='242' column='1' id='type-id-47'>
+    <typedef-decl name='boolean_t' type-id='type-id-51' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-41'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='65536' id='type-id-42'>
+      <subrange length='8192' type-id='type-id-12' id='type-id-52'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='2048' id='type-id-43'>
+      <subrange length='256' type-id='type-id-12' id='type-id-53'/>
+
+    </array-type-def>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-54'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_type' type-id='type-id-49' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='drr_payloadlen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='249' column='1'/>
+        <var-decl name='z_exportdata' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_u' type-id='type-id-50' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='384' column='1'/>
+        <var-decl name='z_sharedata' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__3' is-anonymous='yes' filepath='../../include/sys/zfs_ioctl.h' line='243' column='1' id='type-id-49'>
-      <underlying-type type-id='type-id-24'/>
+    <typedef-decl name='zfs_share_t' type-id='type-id-54' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-44'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='931' column='1' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='type-id-23' visibility='default' filepath='../../include/sys/dmu.h' line='932' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='type-id-23' visibility='default' filepath='../../include/sys/dmu.h' line='933' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='type-id-23' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='type-id-56' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='type-id-32' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='type-id-32' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='type-id-32' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='type-id-43' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-57'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-57' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-56'/>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-55' filepath='../../include/sys/dmu.h' line='940' column='1' id='type-id-45'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='type-id-56' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='type-id-43' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='type-id-43' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='type-id-21' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='type-id-58' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-47'/>
+
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='24' id='type-id-48'>
+      <subrange length='3' type-id='type-id-12' id='type-id-59'/>
+
+    </array-type-def>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zs_gen' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zs_mode' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zs_links' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zs_ctime' type-id='type-id-61' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='128' id='type-id-61'>
+      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-60' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-63'/>
+    <function-decl name='zfs_ioctl_fd' filepath='../../include/libzutil.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_unpack' filepath='../../include/sys/nvpair.h' line='281' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-35'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack_free' filepath='../../include/sys/nvpair.h' line='280' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='lzc_clone' mangled-name='lzc_clone' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' filepath='../../include/sys/nvpair.h' line='297' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='lzc_promote' mangled-name='lzc_promote' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <parameter type-id='type-id-37' name='snapnamebuf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <parameter type-id='type-id-1' name='snapnamelen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rename' mangled-name='lzc_rename' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
+      <parameter type-id='type-id-16' name='source' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
+      <parameter type-id='type-id-16' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-64'/>
+    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
+      <parameter type-id='type-id-29' name='snaps' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/nvpair.h' line='73' column='1' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvp_size' type-id='type-id-21' visibility='default' filepath='../../include/sys/nvpair.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvp_name_sz' type-id='type-id-66' visibility='default' filepath='../../include/sys/nvpair.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='type-id-66' visibility='default' filepath='../../include/sys/nvpair.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvp_value_elem' type-id='type-id-21' visibility='default' filepath='../../include/sys/nvpair.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/nvpair.h' line='78' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-7' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-68'/>
+    <typedef-decl name='int16_t' type-id='type-id-68' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-66'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/nvpair.h' line='37' column='1' id='type-id-69'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
+      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
+      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
+      <enumerator name='DATA_TYPE_BYTE' value='2'/>
+      <enumerator name='DATA_TYPE_INT16' value='3'/>
+      <enumerator name='DATA_TYPE_UINT16' value='4'/>
+      <enumerator name='DATA_TYPE_INT32' value='5'/>
+      <enumerator name='DATA_TYPE_UINT32' value='6'/>
+      <enumerator name='DATA_TYPE_INT64' value='7'/>
+      <enumerator name='DATA_TYPE_UINT64' value='8'/>
+      <enumerator name='DATA_TYPE_STRING' value='9'/>
+      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
+      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
+      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
+      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
+      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
+      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
+      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
+      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
+      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
+      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
+      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
+      <enumerator name='DATA_TYPE_INT8' value='22'/>
+      <enumerator name='DATA_TYPE_UINT8' value='23'/>
+      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
+      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
+      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
+      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
+    </enum-decl>
+    <typedef-decl name='data_type_t' type-id='type-id-69' filepath='../../include/sys/nvpair.h' line='71' column='1' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-70'/>
+    <function-decl name='nvlist_next_nvpair' filepath='../../include/sys/nvpair.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-70'/>
+      <return type-id='type-id-70'/>
+    </function-decl>
+    <function-decl name='nvpair_name' filepath='../../include/sys/nvpair.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-70'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
+      <parameter type-id='type-id-29' name='snaps' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <parameter type-id='type-id-41' name='defer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' filepath='../../include/sys/nvpair.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-71'/>
+    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
+      <parameter type-id='type-id-16' name='firstsnap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
+      <parameter type-id='type-id-16' name='lastsnap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
+      <parameter type-id='type-id-71' name='usedp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='431' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' filepath='../../include/sys/nvpair.h' line='277' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='lzc_exists' mangled-name='lzc_exists' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
+      <parameter type-id='type-id-16' name='dataset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='lzc_sync' mangled-name='lzc_sync' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
+      <parameter type-id='type-id-16' name='pool_name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-29' name='innvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-64' name='outnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_hold' mangled-name='lzc_hold' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
+      <parameter type-id='type-id-29' name='holds' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_release' mangled-name='lzc_release' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
+      <parameter type-id='type-id-29' name='holds' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <parameter type-id='type-id-64' name='holdsp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='lzc_send_flags' filepath='../../include/libzfs_core.h' line='77' column='1' id='type-id-72'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
+      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
+      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
+      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
+      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
+    </enum-decl>
+    <function-decl name='lzc_send' mangled-name='lzc_send' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='626' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-23' name='resumeobj' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-23' name='resumeoff' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
+      <parameter type-id='type-id-16' name='redactbook' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='663' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
+      <parameter type-id='type-id-16' name='redactbook' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <parameter type-id='type-id-23' name='resumeobj' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <parameter type-id='type-id-23' name='resumeoff' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-23' name='resumeobj' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-23' name='resumeoff' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
+      <parameter type-id='type-id-23' name='resume_bytes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-16' name='redactbook' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <parameter type-id='type-id-71' name='spacep' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
+      <parameter type-id='type-id-16' name='from' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
+      <parameter type-id='type-id-72' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
+      <parameter type-id='type-id-71' name='spacep' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive' mangled-name='lzc_receive' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-41' name='force' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-41' name='raw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-73'/>
+    <function-decl name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte_array' filepath='../../include/sys/nvpair.h' line='301' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='212' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-74'/>
+    <function-decl name='nvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='214' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-74'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_dup' filepath='../../include/sys/nvpair.h' line='282' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-35'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' filepath='../../include/sys/nvpair.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
+      <parameter type-id='type-id-41' name='force' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-41' name='raw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='242' column='1' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_type' type-id='type-id-76' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='drr_payloadlen' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='249' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_u' type-id='type-id-77' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='384' column='1'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/zfs_ioctl.h' line='243' column='1' id='type-id-76'>
+      <underlying-type type-id='type-id-18'/>
       <enumerator name='DRR_BEGIN' value='0'/>
       <enumerator name='DRR_OBJECT' value='1'/>
       <enumerator name='DRR_FREEOBJECTS' value='2'/>
@@ -440,148 +1073,115 @@
       <enumerator name='DRR_REDACT' value='10'/>
       <enumerator name='DRR_NUMTYPES' value='11'/>
     </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='250' column='1' id='type-id-50'>
+    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='250' column='1' id='type-id-77'>
       <data-member access='private'>
-        <var-decl name='drr_begin' type-id='type-id-51' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='251' column='1'/>
+        <var-decl name='drr_begin' type-id='type-id-46' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='251' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_end' type-id='type-id-52' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='255' column='1'/>
+        <var-decl name='drr_end' type-id='type-id-78' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='255' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_object' type-id='type-id-53' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='275' column='1'/>
+        <var-decl name='drr_object' type-id='type-id-79' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='275' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_freeobjects' type-id='type-id-54' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='280' column='1'/>
+        <var-decl name='drr_freeobjects' type-id='type-id-80' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='280' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write' type-id='type-id-55' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='301' column='1'/>
+        <var-decl name='drr_write' type-id='type-id-81' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='301' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_free' type-id='type-id-56' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='307' column='1'/>
+        <var-decl name='drr_free' type-id='type-id-82' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='307' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write_byref' type-id='type-id-57' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='323' column='1'/>
+        <var-decl name='drr_write_byref' type-id='type-id-83' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='323' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_spill' type-id='type-id-58' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='338' column='1'/>
+        <var-decl name='drr_spill' type-id='type-id-84' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='338' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write_embedded' type-id='type-id-59' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='351' column='1'/>
+        <var-decl name='drr_write_embedded' type-id='type-id-85' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='351' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_object_range' type-id='type-id-60' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='361' column='1'/>
+        <var-decl name='drr_object_range' type-id='type-id-86' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='361' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_redact' type-id='type-id-61' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='367' column='1'/>
+        <var-decl name='drr_redact' type-id='type-id-87' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='367' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_checksum' type-id='type-id-62' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='383' column='1'/>
+        <var-decl name='drr_checksum' type-id='type-id-88' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='383' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='231' column='1' id='type-id-51'>
+    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='252' column='1' id='type-id-78'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='232' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='233' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='234' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='type-id-63' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='235' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='236' column='1'/>
+        <var-decl name='drr_checksum' type-id='type-id-89' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='253' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='237' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='238' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_toname' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='239' column='1'/>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='254' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='type-id-64' filepath='../../include/sys/fs/zfs.h' line='72' column='1' id='type-id-63'/>
-    <enum-decl name='dmu_objset_type' filepath='../../include/sys/fs/zfs.h' line='64' column='1' id='type-id-64'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='DMU_OST_NONE' value='0'/>
-      <enumerator name='DMU_OST_META' value='1'/>
-      <enumerator name='DMU_OST_ZFS' value='2'/>
-      <enumerator name='DMU_OST_ZVOL' value='3'/>
-      <enumerator name='DMU_OST_OTHER' value='4'/>
-      <enumerator name='DMU_OST_ANY' value='5'/>
-      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
-    </enum-decl>
-    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='252' column='1' id='type-id-52'>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-90'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_checksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='253' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='254' column='1'/>
+        <var-decl name='zc_word' type-id='type-id-91' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zio_cksum_t' type-id='type-id-66' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-65'/>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/spa_checksum.h' line='38' column='1' id='type-id-66'>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='256' id='type-id-91'>
+      <subrange length='4' type-id='type-id-12' id='type-id-92'/>
+
+    </array-type-def>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-90' filepath='../../include/sys/spa_checksum.h' line='40' column='1' id='type-id-89'/>
+    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='256' column='1' id='type-id-79'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='type-id-9' visibility='default' filepath='../../include/sys/spa_checksum.h' line='39' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='256' column='1' id='type-id-53'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='257' column='1'/>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='257' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='258' column='1'/>
+        <var-decl name='drr_type' type-id='type-id-93' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='258' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_bonustype' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='259' column='1'/>
+        <var-decl name='drr_bonustype' type-id='type-id-93' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='259' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_blksz' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='260' column='1'/>
+        <var-decl name='drr_blksz' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='260' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='drr_bonuslen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='261' column='1'/>
+        <var-decl name='drr_bonuslen' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='261' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='262' column='1'/>
+        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='262' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compress' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='263' column='1'/>
+        <var-decl name='drr_compress' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='263' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_dn_slots' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='264' column='1'/>
+        <var-decl name='drr_dn_slots' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='264' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='216'>
-        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='265' column='1'/>
+        <var-decl name='drr_flags' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='265' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_raw_bonuslen' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='266' column='1'/>
+        <var-decl name='drr_raw_bonuslen' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='266' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='267' column='1'/>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='267' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_indblkshift' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='269' column='1'/>
+        <var-decl name='drr_indblkshift' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='269' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_nlevels' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='270' column='1'/>
+        <var-decl name='drr_nlevels' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='270' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_nblkptr' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='271' column='1'/>
+        <var-decl name='drr_nblkptr' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='271' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad' type-id='type-id-18' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='272' column='1'/>
+        <var-decl name='drr_pad' type-id='type-id-94' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='272' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_maxblkid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='273' column='1'/>
+        <var-decl name='drr_maxblkid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='273' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='dmu_object_type_t' type-id='type-id-68' filepath='../../include/sys/dmu.h' line='272' column='1' id='type-id-67'/>
-    <enum-decl name='dmu_object_type' filepath='../../include/sys/dmu.h' line='168' column='1' id='type-id-68'>
-      <underlying-type type-id='type-id-24'/>
+    <enum-decl name='dmu_object_type' filepath='../../include/sys/dmu.h' line='165' column='1' id='type-id-95'>
+      <underlying-type type-id='type-id-18'/>
       <enumerator name='DMU_OT_NONE' value='0'/>
       <enumerator name='DMU_OT_OBJECT_DIRECTORY' value='1'/>
       <enumerator name='DMU_OT_OBJECT_ARRAY' value='2'/>
@@ -658,2163 +1258,3305 @@
       <enumerator name='DMU_OTN_ZAP_ENC_DATA' value='164'/>
       <enumerator name='DMU_OTN_ZAP_ENC_METADATA' value='228'/>
     </enum-decl>
-    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='276' column='1' id='type-id-54'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='277' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numobjs' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='278' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='279' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='281' column='1' id='type-id-55'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='282' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='283' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_pad' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='284' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='285' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_logical_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='286' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='287' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='288' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='289' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_compressiontype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='290' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad2' type-id='type-id-18' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='291' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_key' type-id='type-id-69' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='293' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='drr_compressed_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='295' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='297' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='298' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='299' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ddt_key_t' type-id='type-id-70' filepath='../../include/sys/ddt.h' line='77' column='1' id='type-id-69'/>
-    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/ddt.h' line='67' column='1' id='type-id-70'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddk_cksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/ddt.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ddk_prop' type-id='type-id-6' visibility='default' filepath='../../include/sys/ddt.h' line='76' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='302' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='303' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='304' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='305' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='306' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='308' column='1' id='type-id-57'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='310' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='311' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='312' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='313' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_refguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='315' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_refobject' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='316' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_refoffset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='317' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='drr_checksumtype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='319' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='456'>
-        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='320' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='464'>
-        <var-decl name='drr_pad2' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='321' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='drr_key' type-id='type-id-69' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='322' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='324' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='325' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='326' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='327' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='328' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compressiontype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='329' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_pad' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='330' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compressed_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='332' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='333' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='334' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='335' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='drr_type' type-id='type-id-67' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='336' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='339' column='1' id='type-id-59'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='340' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='341' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='343' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='344' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compression' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='345' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='drr_etype' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='346' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='drr_pad' type-id='type-id-20' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='347' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_lsize' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='348' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_psize' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='349' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='352' column='1' id='type-id-60'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='353' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numslots' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='354' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='355' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_salt' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='356' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_iv' type-id='type-id-12' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='357' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_mac' type-id='type-id-14' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='358' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_flags' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='359' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='488'>
-        <var-decl name='drr_pad' type-id='type-id-16' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='360' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='362' column='1' id='type-id-61'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='363' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='364' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='365' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='366' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='376' column='1' id='type-id-62'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_pad' type-id='type-id-7' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='377' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='drr_checksum' type-id='type-id-65' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='382' column='1'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='lzc_send_flags' filepath='../../include/libzfs_core.h' line='77' column='1' id='type-id-71'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
-      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
-      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
-      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
-      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
-    </enum-decl>
-    <enum-decl name='lzc_dataset_type' filepath='../../include/libzfs_core.h' line='47' column='1' id='type-id-72'>
-      <underlying-type type-id='type-id-24'/>
-      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
-      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
-    </enum-decl>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-73'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-74'/>
-    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-75'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-48' const='yes' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-29' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-84'/>
-    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1'/>
-      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
-      <parameter type-id='type-id-80' name='env' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
-      <parameter type-id='type-id-76' name='fs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
-      <parameter type-id='type-id-36' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
-      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
-      <parameter type-id='type-id-40' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
-      <parameter type-id='type-id-6' name='tag' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
-      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1599' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_wait' mangled-name='lzc_wait' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
-      <parameter type-id='type-id-40' name='activity' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
-      <parameter type-id='type-id-73' name='waited' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_redact' mangled-name='lzc_redact' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
-      <parameter type-id='type-id-76' name='snapshot' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
-      <parameter type-id='type-id-76' name='bookname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
-      <parameter type-id='type-id-81' name='snapnv' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_trim' mangled-name='lzc_trim' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
-      <parameter type-id='type-id-76' name='poolname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
-      <parameter type-id='type-id-42' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
-      <parameter type-id='type-id-6' name='rate' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
-      <parameter type-id='type-id-38' name='secure' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
-      <parameter type-id='type-id-81' name='vdevs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
-      <parameter type-id='type-id-76' name='poolname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
-      <parameter type-id='type-id-44' name='cmd_type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
-      <parameter type-id='type-id-81' name='vdevs' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
-      <parameter type-id='type-id-76' name='pool_name' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
-      <parameter type-id='type-id-38' name='scrub_restart' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
-      <parameter type-id='type-id-6' name='crypt_cmd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
-      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
-      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
-      <parameter type-id='type-id-38' name='noop' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
-      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
-      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1404' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1'/>
-      <parameter type-id='type-id-76' name='program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1'/>
-      <parameter type-id='type-id-6' name='timeout' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
-      <parameter type-id='type-id-6' name='memlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
-      <parameter type-id='type-id-81' name='argnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
-      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1389' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1360' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
-      <parameter type-id='type-id-76' name='pool' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
-      <parameter type-id='type-id-76' name='program' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
-      <parameter type-id='type-id-6' name='instrlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
-      <parameter type-id='type-id-6' name='memlimit' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
-      <parameter type-id='type-id-81' name='argnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
-      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
-      <parameter type-id='type-id-81' name='bmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
-      <parameter type-id='type-id-76' name='bookmark' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
-      <parameter type-id='type-id-82' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
-      <parameter type-id='type-id-82' name='bmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
-      <parameter type-id='type-id-81' name='bookmarks' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
-      <parameter type-id='type-id-74' name='snapnamebuf' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
-      <parameter type-id='type-id-5' name='snapnamelen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
-      <parameter type-id='type-id-81' name='cmdprops' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
-      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
-      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
-      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
-      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
-      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
-      <parameter type-id='type-id-5' name='input_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
-      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
-      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
-      <parameter type-id='type-id-83' name='read_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
-      <parameter type-id='type-id-83' name='errflags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
-      <parameter type-id='type-id-83' name='action_handle' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
-      <parameter type-id='type-id-82' name='errors' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1052' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
-      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
-      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
-      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
-      <parameter type-id='type-id-5' name='input_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
-      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
-      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
-      <parameter type-id='type-id-83' name='read_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
-      <parameter type-id='type-id-83' name='errflags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
-      <parameter type-id='type-id-83' name='action_handle' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
-      <parameter type-id='type-id-82' name='errors' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1032' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
-      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
-      <parameter type-id='type-id-38' name='resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
-      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
-      <parameter type-id='type-id-78' name='begin_record' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='980' column='1'/>
-      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
-      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='981' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_receive' mangled-name='lzc_receive' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='966' column='1'/>
-      <parameter type-id='type-id-38' name='force' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
-      <parameter type-id='type-id-38' name='raw' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='967' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='749' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
-      <parameter type-id='type-id-83' name='spacep' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='750' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='711' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
-      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
-      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='712' column='1'/>
-      <parameter type-id='type-id-6' name='resume_bytes' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
-      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
-      <parameter type-id='type-id-83' name='spacep' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='713' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='661' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
-      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
-      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='662' column='1'/>
-      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='663' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='641' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
-      <parameter type-id='type-id-6' name='resumeobj' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
-      <parameter type-id='type-id-6' name='resumeoff' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='642' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='633' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
-      <parameter type-id='type-id-76' name='redactbook' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='634' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_send' mangled-name='lzc_send' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
-      <parameter type-id='type-id-76' name='from' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='625' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='626' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
-      <parameter type-id='type-id-76' name='snapname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
-      <parameter type-id='type-id-82' name='holdsp' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_release' mangled-name='lzc_release' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
-      <parameter type-id='type-id-81' name='holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='561' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_hold' mangled-name='lzc_hold' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
-      <parameter type-id='type-id-81' name='holds' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
-      <parameter type-id='type-id-5' name='cleanup_fd' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='514' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_sync' mangled-name='lzc_sync' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
-      <parameter type-id='type-id-76' name='pool_name' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
-      <parameter type-id='type-id-81' name='innvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
-      <parameter type-id='type-id-82' name='outnvl' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_exists' mangled-name='lzc_exists' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
-      <parameter type-id='type-id-76' name='dataset' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='459' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
-      <parameter type-id='type-id-76' name='firstsnap' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
-      <parameter type-id='type-id-76' name='lastsnap' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='430' column='1'/>
-      <parameter type-id='type-id-83' name='usedp' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='431' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
-      <parameter type-id='type-id-81' name='snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
-      <parameter type-id='type-id-38' name='defer' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='404' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
-      <parameter type-id='type-id-81' name='snaps' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
-      <parameter type-id='type-id-82' name='errlist' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='352' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='327' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_rename' mangled-name='lzc_rename' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
-      <parameter type-id='type-id-76' name='source' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
-      <parameter type-id='type-id-76' name='target' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='312' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_promote' mangled-name='lzc_promote' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
-      <parameter type-id='type-id-74' name='snapnamebuf' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
-      <parameter type-id='type-id-5' name='snapnamelen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='290' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_clone' mangled-name='lzc_clone' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
-      <parameter type-id='type-id-76' name='origin' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='274' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='lzc_create' mangled-name='lzc_create' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
-      <parameter type-id='type-id-76' name='fsname' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
-      <parameter type-id='type-id-72' name='type' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
-      <parameter type-id='type-id-81' name='props' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='249' column='1'/>
-      <parameter type-id='type-id-84' name='wkeydata' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
-      <parameter type-id='type-id-46' name='wkeylen' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='250' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' filepath='/home/fedora/zfs/lib/libzfs_core/libzfs_core.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-85'/>
-    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
-      <parameter type-id='type-id-76' name='name' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
-      <parameter type-id='type-id-76' name='cmp' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
-      <parameter type-id='type-id-5' name='wholedisk' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
-      <parameter type-id='type-id-76' name='name' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
-      <parameter type-id='type-id-74' name='path' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
-      <parameter type-id='type-id-85' name='len' filepath='/home/fedora/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
+    <typedef-decl name='dmu_object_type_t' type-id='type-id-95' filepath='../../include/sys/dmu.h' line='269' column='1' id='type-id-93'/>
 
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8192' id='type-id-86'>
-      <subrange length='1024' type-id='type-id-3' id='type-id-87'/>
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='40' id='type-id-94'>
+      <subrange length='5' type-id='type-id-12' id='type-id-96'/>
 
     </array-type-def>
-    <typedef-decl name='importargs_t' type-id='type-id-88' filepath='../../include/libzutil.h' line='71' column='1' id='type-id-89'/>
-    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='62' column='1' id='type-id-88'>
+    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='276' column='1' id='type-id-80'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='path' type-id='type-id-90' visibility='default' filepath='../../include/libzutil.h' line='63' column='1'/>
+        <var-decl name='drr_firstobj' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='277' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='paths' type-id='type-id-5' visibility='default' filepath='../../include/libzutil.h' line='64' column='1'/>
+        <var-decl name='drr_numobjs' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='278' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='poolname' type-id='type-id-76' visibility='default' filepath='../../include/libzutil.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='guid' type-id='type-id-6' visibility='default' filepath='../../include/libzutil.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='cachefile' type-id='type-id-76' visibility='default' filepath='../../include/libzutil.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='can_be_active' type-id='type-id-38' visibility='default' filepath='../../include/libzutil.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='scan' type-id='type-id-38' visibility='default' filepath='../../include/libzutil.h' line='69' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='policy' type-id='type-id-81' visibility='default' filepath='../../include/libzutil.h' line='70' column='1'/>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='279' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-91' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-92'/>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-93'>
+    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='281' column='1' id='type-id-81'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-94' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='282' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-95' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-96' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-97'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-98' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-99'/>
-    <typedef-decl name='libpc_handle_t' type-id='type-id-100' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='48' column='1' id='type-id-101'/>
-    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='41' column='1' id='type-id-100'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='lpc_printerr' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='42' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lpc_open_access_error' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='43' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lpc_desc_active' type-id='type-id-38' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='44' column='1'/>
+        <var-decl name='drr_type' type-id='type-id-93' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='283' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lpc_desc' type-id='type-id-86' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='45' column='1'/>
+        <var-decl name='drr_pad' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='284' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='8320'>
-        <var-decl name='lpc_ops' type-id='type-id-102' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='46' column='1'/>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='285' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='8384'>
-        <var-decl name='lpc_lib_handle' type-id='type-id-103' visibility='default' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.h' line='47' column='1'/>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_logical_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='286' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='287' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='288' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drr_flags' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='289' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='drr_compressiontype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='290' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='drr_pad2' type-id='type-id-94' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='291' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_key' type-id='type-id-97' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='293' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='drr_compressed_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='295' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='drr_salt' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='297' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='drr_iv' type-id='type-id-99' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='298' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='drr_mac' type-id='type-id-100' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='299' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-90'/>
-    <qualified-type-def type-id='type-id-93' const='yes' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-104'/>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-105'/>
-    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-95'/>
-    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-102'/>
-    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-94'/>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-103'/>
-    <function-decl name='zpool_find_config' mangled-name='zpool_find_config' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
-      <parameter type-id='type-id-103' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
-      <parameter type-id='type-id-76' name='target' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
-      <parameter type-id='type-id-82' name='configp' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1536' column='1'/>
-      <parameter type-id='type-id-104' name='args' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1537' column='1'/>
-      <parameter type-id='type-id-102' name='pco' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1537' column='1'/>
+    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/ddt.h' line='67' column='1' id='type-id-101'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ddk_cksum' type-id='type-id-89' visibility='default' filepath='../../include/sys/ddt.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ddk_prop' type-id='type-id-23' visibility='default' filepath='../../include/sys/ddt.h' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ddt_key_t' type-id='type-id-101' filepath='../../include/sys/ddt.h' line='77' column='1' id='type-id-97'/>
+
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='64' id='type-id-98'>
+      <subrange length='8' type-id='type-id-12' id='type-id-102'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='96' id='type-id-99'>
+      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='128' id='type-id-100'>
+      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+
+    </array-type-def>
+    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='302' column='1' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='303' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='304' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='305' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='306' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='308' column='1' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='310' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='311' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='312' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='313' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_refguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='315' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_refobject' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='316' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_refoffset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='317' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='319' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='456'>
+        <var-decl name='drr_flags' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='320' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='464'>
+        <var-decl name='drr_pad2' type-id='type-id-105' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='321' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='drr_key' type-id='type-id-97' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='322' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='48' id='type-id-105'>
+      <subrange length='6' type-id='type-id-12' id='type-id-106'/>
+
+    </array-type-def>
+    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='324' column='1' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='325' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_length' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='326' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='327' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_flags' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='328' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='drr_compressiontype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='329' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='drr_pad' type-id='type-id-105' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='330' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_compressed_size' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='332' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_salt' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='333' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_iv' type-id='type-id-99' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='334' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='drr_mac' type-id='type-id-100' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='335' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='drr_type' type-id='type-id-93' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='336' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='339' column='1' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='340' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='341' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='343' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='344' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_compression' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='345' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='drr_etype' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='346' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='272'>
+        <var-decl name='drr_pad' type-id='type-id-105' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='347' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_lsize' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='348' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='drr_psize' type-id='type-id-22' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='349' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='352' column='1' id='type-id-86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_firstobj' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='353' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_numslots' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='354' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='355' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_salt' type-id='type-id-98' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='356' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_iv' type-id='type-id-99' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='357' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='drr_mac' type-id='type-id-100' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='358' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='drr_flags' type-id='type-id-32' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='359' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='488'>
+        <var-decl name='drr_pad' type-id='type-id-48' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='360' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='362' column='1' id='type-id-87'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='363' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='364' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='365' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='366' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='376' column='1' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_pad' type-id='type-id-107' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='377' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='drr_checksum' type-id='type-id-89' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='382' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='2176' id='type-id-107'>
+      <subrange length='34' type-id='type-id-12' id='type-id-108'/>
+
+    </array-type-def>
+    <typedef-decl name='dmu_replay_record_t' type-id='type-id-75' filepath='../../include/sys/zfs_ioctl.h' line='385' column='1' id='type-id-109'/>
+    <qualified-type-def type-id='type-id-109' const='yes' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
+    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='999' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-41' name='force' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-41' name='resumable' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-41' name='raw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1000' column='1'/>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
+      <parameter type-id='type-id-111' name='begin_record' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1001' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1028' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-41' name='force' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-41' name='resumable' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-41' name='raw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1029' column='1'/>
+      <parameter type-id='type-id-1' name='input_fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-111' name='begin_record' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1030' column='1'/>
+      <parameter type-id='type-id-71' name='read_bytes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-71' name='errflags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-71' name='action_handle' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1031' column='1'/>
+      <parameter type-id='type-id-64' name='errors' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1032' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1047' column='1'/>
+      <parameter type-id='type-id-29' name='cmdprops' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-33' name='wkeydata' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-34' name='wkeylen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-16' name='origin' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1048' column='1'/>
+      <parameter type-id='type-id-41' name='force' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-41' name='resumable' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-41' name='raw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-1' name='input_fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1049' column='1'/>
+      <parameter type-id='type-id-111' name='begin_record' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
+      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1050' column='1'/>
+      <parameter type-id='type-id-71' name='read_bytes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-71' name='errflags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-71' name='action_handle' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1051' column='1'/>
+      <parameter type-id='type-id-64' name='errors' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1052' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <parameter type-id='type-id-37' name='snapnamebuf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <parameter type-id='type-id-1' name='snapnamelen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1070' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1095' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
+      <parameter type-id='type-id-29' name='bookmarks' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
+      <parameter type-id='type-id-16' name='pool_name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-29' name='innvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <parameter type-id='type-id-64' name='outnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='481' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
+      <parameter type-id='type-id-16' name='bookmark' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
+      <parameter type-id='type-id-64' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1201' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
+      <parameter type-id='type-id-29' name='bookmarks' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1125' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-16' name='program' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-23' name='instrlimit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-23' name='memlimit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-29' name='argnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-64' name='outnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' filepath='../../include/sys/nvpair.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-51'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1331' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-16' name='program' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-23' name='instrlimit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1300' column='1'/>
+      <parameter type-id='type-id-23' name='memlimit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-29' name='argnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <parameter type-id='type-id-64' name='outnvl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1301' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-41' name='noop' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-33' name='wkeydata' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1403' column='1'/>
+      <parameter type-id='type-id-34' name='wkeylen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1404' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1427' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
+      <parameter type-id='type-id-16' name='fsname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-23' name='crypt_cmd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-29' name='props' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1433' column='1'/>
+      <parameter type-id='type-id-33' name='wkeydata' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
+      <parameter type-id='type-id-34' name='wkeylen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1434' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
+      <parameter type-id='type-id-16' name='pool_name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
+      <parameter type-id='type-id-41' name='scrub_restart' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1460' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-112'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-112' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-113'/>
+    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
+      <parameter type-id='type-id-16' name='poolname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
+      <parameter type-id='type-id-113' name='cmd_type' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1495' column='1'/>
+      <parameter type-id='type-id-29' name='vdevs' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1496' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-114'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-114' filepath='../../include/sys/fs/zfs.h' line='1182' column='1' id='type-id-115'/>
+    <function-decl name='lzc_trim' mangled-name='lzc_trim' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
+      <parameter type-id='type-id-16' name='poolname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-115' name='cmd_type' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-23' name='rate' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1535' column='1'/>
+      <parameter type-id='type-id-41' name='secure' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <parameter type-id='type-id-29' name='vdevs' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <parameter type-id='type-id-64' name='errlist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1536' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_redact' mangled-name='lzc_redact' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
+      <parameter type-id='type-id-16' name='snapshot' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <parameter type-id='type-id-16' name='bookname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <parameter type-id='type-id-29' name='snapnv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1558' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1427' column='1' id='type-id-116'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-116' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-118'/>
+    <function-decl name='lzc_wait' mangled-name='lzc_wait' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <parameter type-id='type-id-117' name='activity' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <parameter type-id='type-id-118' name='waited' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1592' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_value' filepath='../../include/sys/nvpair.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-51'/>
+    </function-decl>
+    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-117' name='activity' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-23' name='tag' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1598' column='1'/>
+      <parameter type-id='type-id-118' name='waited' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1599' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='1439' column='1' id='type-id-119'>
+      <underlying-type type-id='type-id-18'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-119' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-120'/>
+    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
+      <parameter type-id='type-id-16' name='fs' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <parameter type-id='type-id-120' name='activity' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <parameter type-id='type-id-118' name='waited' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1605' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
+    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
+      <parameter type-id='type-id-16' name='pool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
+      <parameter type-id='type-id-122' name='env' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1628' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='1637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
+      <parameter type-id='type-id-16' name='snapname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <parameter type-id='type-id-64' name='holdsp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzfs_core/libzfs_core.c' line='584' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <typedef-decl name='size_t' type-id='type-id-26' filepath='/usr/lib/llvm-13/lib/clang/13.0.0/include/stddef.h' line='46' column='1' id='type-id-123'/>
+    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
+      <parameter type-id='type-id-16' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <parameter type-id='type-id-37' name='path' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <parameter type-id='type-id-123' name='len' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='41' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-16' const='yes' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-125'/>
+    <function-decl name='zpool_default_search_paths' filepath='../../include/libzutil.h' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-125'/>
+    </function-decl>
+    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
+      <parameter type-id='type-id-16' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <parameter type-id='type-id-16' name='cmp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <parameter type-id='type-id-1' name='wholedisk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_device_path.c' line='139' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strlcat' filepath='../../lib/libspl/include/string.h' line='33' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-decl name='zfs_append_partition' filepath='../../include/libzutil.h' line='96' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' filepath='./zutil_import.h' line='41' column='1' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lpc_printerr' type-id='type-id-41' visibility='default' filepath='./zutil_import.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='lpc_open_access_error' type-id='type-id-41' visibility='default' filepath='./zutil_import.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lpc_desc_active' type-id='type-id-41' visibility='default' filepath='./zutil_import.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='lpc_desc' type-id='type-id-127' visibility='default' filepath='./zutil_import.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8320'>
+        <var-decl name='lpc_ops' type-id='type-id-128' visibility='default' filepath='./zutil_import.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8384'>
+        <var-decl name='lpc_lib_handle' type-id='type-id-73' visibility='default' filepath='./zutil_import.h' line='47' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8192' id='type-id-127'>
+      <subrange length='1024' type-id='type-id-12' id='type-id-129'/>
+
+    </array-type-def>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='51' column='1' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pco_refresh_config' type-id='type-id-131' visibility='default' filepath='../../include/libzutil.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pco_pool_active' type-id='type-id-132' visibility='default' filepath='../../include/libzutil.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-133' filepath='../../include/libzutil.h' line='47' column='1' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-131'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-135' filepath='../../include/libzutil.h' line='49' column='1' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-132'/>
+    <qualified-type-def type-id='type-id-130' const='yes' id='type-id-137'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-137' filepath='../../include/libzutil.h' line='54' column='1' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-128'/>
+    <typedef-decl name='libpc_handle_t' type-id='type-id-126' filepath='./zutil_import.h' line='48' column='1' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
+    <function-decl name='zutil_alloc' mangled-name='zutil_alloc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_alloc'>
+      <parameter type-id='type-id-141' name='hdl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='136' column='1'/>
+      <parameter type-id='type-id-123' name='size' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='136' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='zutil_strdup' mangled-name='zutil_strdup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='147' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_strdup'>
+      <parameter type-id='type-id-141' name='hdl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='147' column='1'/>
+      <parameter type-id='type-id-16' name='str' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='147' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-142'/>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='897' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='897' column='1'/>
+      <parameter type-id='type-id-64' name='config' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='897' column='1'/>
+      <parameter type-id='type-id-142' name='num_labels' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='897' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='ioctl' filepath='/usr/include/x86_64-linux-gnu/sys/ioctl.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-26'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='spl_pagesize' filepath='../../lib/libspl/include/os/linux/sys/param.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-143'/>
+    <function-decl name='posix_memalign' filepath='/usr/include/stdlib.h' line='577' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-143'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='aiocb' size-in-bits='1344' is-struct='yes' visibility='default' filepath='/usr/include/aio.h' line='34' column='1' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='aio_fildes' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='36' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='aio_lio_opcode' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='aio_reqprio' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='38' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='aio_buf' type-id='type-id-145' visibility='default' filepath='/usr/include/aio.h' line='39' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='aio_nbytes' type-id='type-id-123' visibility='default' filepath='/usr/include/aio.h' line='40' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='aio_sigevent' type-id='type-id-146' visibility='default' filepath='/usr/include/aio.h' line='41' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='__next_prio' type-id='type-id-147' visibility='default' filepath='/usr/include/aio.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='__abs_prio' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='45' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='__policy' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='__error_code' type-id='type-id-1' visibility='default' filepath='/usr/include/aio.h' line='47' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__return_value' type-id='type-id-148' visibility='default' filepath='/usr/include/aio.h' line='48' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='aio_offset' type-id='type-id-149' visibility='default' filepath='/usr/include/aio.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='__glibc_reserved' type-id='type-id-150' visibility='default' filepath='/usr/include/aio.h' line='56' column='1'/>
+      </data-member>
+    </class-decl>
+    <qualified-type-def type-id='type-id-17' volatile='yes' id='type-id-151'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-145'/>
+    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='22' column='1' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='sigev_value' type-id='type-id-152' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='24' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='sigev_signo' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='sigev_notify' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_sigev_un' type-id='type-id-153' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='41' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='sigval' size-in-bits='64' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='24' column='1' id='type-id-154'>
+      <data-member access='private'>
+        <var-decl name='sival_int' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sival_ptr' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='27' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='__sigval_t' type-id='type-id-154' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigval_t.h' line='30' column='1' id='type-id-152'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='28' column='1' id='type-id-153'>
+      <data-member access='private'>
+        <var-decl name='_pad' type-id='type-id-155' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='30' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='_tid' type-id='type-id-156' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='_sigev_thread' type-id='type-id-157' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='40' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-155'>
+      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
+
+    </array-type-def>
+    <typedef-decl name='__pid_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-156'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='36' column='1' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_function' type-id='type-id-158' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='38' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_attribute' type-id='type-id-159' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/sigevent_t.h' line='39' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-158'/>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='56' column='1' id='type-id-161'>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-162' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='59' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='448' id='type-id-162'>
+      <subrange length='56' type-id='type-id-12' id='type-id-163'/>
+
+    </array-type-def>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-161' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='62' column='1' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-159'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-147'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='191' column='1' id='type-id-148'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-149'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='256' id='type-id-150'>
+      <subrange length='32' type-id='type-id-12' id='type-id-165'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-147' const='yes' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-168'/>
+    <function-decl name='lio_listio' mangled-name='lio_listio64' filepath='/usr/include/aio.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-167'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-168'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-144' const='yes' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-170'/>
+    <function-decl name='aio_error' mangled-name='aio_error64' filepath='/usr/include/aio.h' line='189' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-170'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='aio_return' mangled-name='aio_return64' filepath='/usr/include/aio.h' line='191' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-147'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='zpool_search_import' mangled-name='zpool_search_import' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
-      <parameter type-id='type-id-103' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1'/>
-      <parameter type-id='type-id-104' name='import' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1492' column='1'/>
-      <parameter type-id='type-id-102' name='pco' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1493' column='1'/>
-      <return type-id='type-id-81'/>
+    <function-decl name='slice_cache_compare' mangled-name='slice_cache_compare' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1010' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='slice_cache_compare'>
+      <parameter type-id='type-id-73' name='arg1' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1010' column='1'/>
+      <parameter type-id='type-id-73' name='arg2' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1010' column='1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='label_paths' mangled-name='label_paths' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='label_paths'>
-      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
-      <parameter type-id='type-id-81' name='label' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
-      <parameter type-id='type-id-90' name='path' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
-      <parameter type-id='type-id-90' name='devid' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='1027' column='1'/>
-      <return type-id='type-id-5'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-171'/>
+    <function-decl name='label_paths' mangled-name='label_paths' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1070' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='label_paths'>
+      <parameter type-id='type-id-141' name='hdl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1070' column='1'/>
+      <parameter type-id='type-id-29' name='label' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1070' column='1'/>
+      <parameter type-id='type-id-171' name='path' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1070' column='1'/>
+      <parameter type-id='type-id-171' name='devid' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1070' column='1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='slice_cache_compare' mangled-name='slice_cache_compare' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='slice_cache_compare'>
-      <parameter type-id='type-id-103' name='arg1' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1'/>
-      <parameter type-id='type-id-103' name='arg2' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='967' column='1'/>
-      <return type-id='type-id-5'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-173'/>
+    <function-decl name='nvlist_lookup_nvlist_array' filepath='../../include/sys/nvpair.h' line='227' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-172'/>
+      <parameter type-id='type-id-173'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
-      <parameter type-id='type-id-82' name='config' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
-      <parameter type-id='type-id-105' name='num_labels' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='887' column='1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_lookup_string' filepath='../../include/sys/nvpair.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-171'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zutil_strdup' mangled-name='zutil_strdup' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_strdup'>
-      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1'/>
-      <parameter type-id='type-id-76' name='str' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='146' column='1'/>
-      <return type-id='type-id-74'/>
+    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzutil.h' line='62' column='1' id='type-id-174'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='path' type-id='type-id-171' visibility='default' filepath='../../include/libzutil.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='paths' type-id='type-id-1' visibility='default' filepath='../../include/libzutil.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='poolname' type-id='type-id-16' visibility='default' filepath='../../include/libzutil.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='guid' type-id='type-id-23' visibility='default' filepath='../../include/libzutil.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='cachefile' type-id='type-id-16' visibility='default' filepath='../../include/libzutil.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='can_be_active' type-id='type-id-41' visibility='default' filepath='../../include/libzutil.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='scan' type-id='type-id-41' visibility='default' filepath='../../include/libzutil.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='policy' type-id='type-id-29' visibility='default' filepath='../../include/libzutil.h' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='importargs_t' type-id='type-id-174' filepath='../../include/libzutil.h' line='71' column='1' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
+    <function-decl name='zpool_search_import' mangled-name='zpool_search_import' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
+      <parameter type-id='type-id-73' name='hdl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1642' column='1'/>
+      <parameter type-id='type-id-176' name='import' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1642' column='1'/>
+      <parameter type-id='type-id-128' name='pco' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1643' column='1'/>
+      <return type-id='type-id-29'/>
     </function-decl>
-    <function-decl name='zutil_alloc' mangled-name='zutil_alloc' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zutil_alloc'>
-      <parameter type-id='type-id-106' name='hdl' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1'/>
-      <parameter type-id='type-id-85' name='size' filepath='/home/fedora/zfs/lib/libzutil/zutil_import.c' line='135' column='1'/>
-      <return type-id='type-id-103'/>
+    <function-decl name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-98'>
-      <parameter type-id='type-id-103'/>
-      <parameter type-id='type-id-76'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-177'>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-178' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32' id='type-id-178'>
+      <subrange length='4' type-id='type-id-12' id='type-id-92'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-177' const='yes' id='type-id-179'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-180'/>
+    <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='750' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-180'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-181'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='type-id-182' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='type-id-183' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='type-id-123' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='type-id-184' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_size' type-id='type-id-123' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-186' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-187' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-182'/>
+
+    <array-type-def dimensions='1' type-id='type-id-182' size-in-bits='128' id='type-id-186'>
+      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
+
+    </array-type-def>
+    <typedef-decl name='uintptr_t' type-id='type-id-26' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-187'/>
+    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-183'/>
+    <typedef-decl name='ulong_t' type-id='type-id-26' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-184'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='avl_create' filepath='../../include/sys/avl.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-183'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='dirname' filepath='/usr/include/libgen.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='realpath' filepath='/usr/include/stdlib.h' line='797' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-37'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' filepath='../../include/sys/avl.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-143'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='755' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-190'/>
+    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-191'/>
+    <function-decl name='zpool_find_import_blkid' filepath='./zutil_import.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-190'/>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-191'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' filepath='../../include/sys/nvpair.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-51'/>
+    </function-decl>
+    <function-decl name='geteuid' filepath='/usr/include/unistd.h' line='678' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' filepath='../../include/sys/nvpair.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-74'/>
       <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-70'/>
+      <return type-id='type-id-35'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvlist' filepath='../../include/sys/nvpair.h' line='329' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-35'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' filepath='../../include/sys/nvpair.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' filepath='../../include/sys/nvpair.h' line='180' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_find_config' mangled-name='zpool_find_config' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
+      <parameter type-id='type-id-73' name='hdl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1685' column='1'/>
+      <parameter type-id='type-id-16' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1685' column='1'/>
+      <parameter type-id='type-id-64' name='configp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1685' column='1'/>
+      <parameter type-id='type-id-176' name='args' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1686' column='1'/>
+      <parameter type-id='type-id-128' name='pco' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_import.c' line='1686' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' filepath='../../include/sys/nvpair.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-70'/>
+      <parameter type-id='type-id-74'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sysconf' filepath='/usr/include/unistd.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
       <return type-id='type-id-5'/>
+    </function-decl>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-192'/>
+    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-193'/>
+    <function-decl name='tpool_create' filepath='../../include/thread_pool.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-159'/>
+      <return type-id='type-id-193'/>
+    </function-decl>
+    <function-decl name='avl_first' filepath='../../include/sys/avl.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
+    <function-decl name='tpool_dispatch' filepath='../../include/thread_pool.h' line='44' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-193'/>
+      <parameter type-id='type-id-195'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='tpool_wait' filepath='../../include/thread_pool.h' line='48' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-193'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' filepath='../../include/thread_pool.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-193'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_destroy' filepath='../../include/sys/avl.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='nvlist_remove' filepath='../../include/sys/nvpair.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-69'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' filepath='../../include/sys/nvpair.h' line='178' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-196'/>
+    <function-decl name='nvlist_lookup_uint64_array' filepath='../../include/sys/nvpair.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-196'/>
+      <parameter type-id='type-id-173'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' filepath='../../include/sys/nvpair.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' filepath='../../include/sys/nvpair.h' line='156' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' filepath='../../include/sys/nvpair.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='__dirstream' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-197'/>
+    <pointer-type-def type-id='type-id-197' size-in-bits='64' id='type-id-198'/>
+    <function-decl name='opendir' filepath='/usr/include/dirent.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-198'/>
+    </function-decl>
+    <class-decl name='dirent64' size-in-bits='2240' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='37' column='1' id='type-id-199'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='d_ino' type-id='type-id-200' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='39' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='d_off' type-id='type-id-149' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='40' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='d_reclen' type-id='type-id-201' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='41' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='144'>
+        <var-decl name='d_type' type-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='152'>
+        <var-decl name='d_name' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='43' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ino64_t' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-200'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-201'/>
+    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-202'/>
+    <function-decl name='readdir64' filepath='/usr/include/dirent.h' line='173' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-198'/>
+      <return type-id='type-id-202'/>
+    </function-decl>
+    <function-decl name='closedir' filepath='/usr/include/dirent.h' line='149' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-198'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='asprintf' filepath='/usr/include/stdio.h' line='372' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-171'/>
+      <parameter type-id='type-id-16'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_find' filepath='../../include/sys/avl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='avl_insert' filepath='../../include/sys/avl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='update_vdev_config_dev_strs' filepath='../../include/libzutil.h' line='87' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-135'>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-118'/>
+      <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-96'>
-      <parameter type-id='type-id-103'/>
-      <parameter type-id='type-id-81'/>
-      <return type-id='type-id-81'/>
+    <function-type size-in-bits='64' id='type-id-188'>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-133'>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-29'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-160'>
+      <parameter type-id='type-id-152'/>
+      <return type-id='type-id-17'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-194'>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-17'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-    <enum-decl name='zfs_nicenum_format' filepath='../../include/libzutil.h' line='123' column='1' id='type-id-107'>
-      <underlying-type type-id='type-id-24'/>
+  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
+      <parameter type-id='type-id-16' name='str' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <enum-decl name='zfs_nicenum_format' filepath='../../include/libzutil.h' line='123' column='1' id='type-id-203'>
+      <underlying-type type-id='type-id-18'/>
       <enumerator name='ZFS_NICENUM_1024' value='0'/>
       <enumerator name='ZFS_NICENUM_BYTES' value='1'/>
       <enumerator name='ZFS_NICENUM_TIME' value='2'/>
       <enumerator name='ZFS_NICENUM_RAW' value='3'/>
       <enumerator name='ZFS_NICENUM_RAWTIME' value='4'/>
     </enum-decl>
-    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
-      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='169' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='52' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
+      <parameter type-id='type-id-23' name='num' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='52' column='1'/>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='52' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='52' column='1'/>
+      <parameter type-id='type-id-203' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='53' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
-      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='160' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
+      <parameter type-id='type-id-23' name='num' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
-      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='151' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
+      <parameter type-id='type-id-23' name='num' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
-      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='141' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
+      <parameter type-id='type-id-23' name='num' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='163' column='1'/>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='163' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='163' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
-      <parameter type-id='type-id-6' name='num' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='49' column='1'/>
-      <parameter type-id='type-id-107' name='format' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='50' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
-      <parameter type-id='type-id-76' name='str' filepath='/home/fedora/zfs/lib/libzutil/zutil_nicenum.c' line='36' column='1'/>
-      <return type-id='type-id-38'/>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
+      <parameter type-id='type-id-23' name='num' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_nicenum.c' line='144' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-
-    <array-type-def dimensions='1' type-id='type-id-108' size-in-bits='32768' id='type-id-109'>
-      <subrange length='64' type-id='type-id-3' id='type-id-110'/>
-
-    </array-type-def>
-    <typedef-decl name='ddt_stat_t' type-id='type-id-111' filepath='../../include/sys/fs/zfs.h' line='1188' column='1' id='type-id-108'/>
-    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1179' column='1' id='type-id-111'>
+  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1194' column='1' id='type-id-204'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_blocks' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1180' column='1'/>
+        <var-decl name='dds_blocks' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_lsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1181' column='1'/>
+        <var-decl name='dds_lsize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1196' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_psize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1182' column='1'/>
+        <var-decl name='dds_psize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1197' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_dsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1183' column='1'/>
+        <var-decl name='dds_dsize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='dds_ref_blocks' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1184' column='1'/>
+        <var-decl name='dds_ref_blocks' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='dds_ref_lsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1185' column='1'/>
+        <var-decl name='dds_ref_lsize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1200' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='dds_ref_psize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1186' column='1'/>
+        <var-decl name='dds_ref_psize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1201' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='dds_ref_dsize' type-id='type-id-6' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1187' column='1'/>
+        <var-decl name='dds_ref_dsize' type-id='type-id-23' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1202' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ddt_histogram_t' type-id='type-id-112' filepath='../../include/sys/fs/zfs.h' line='1192' column='1' id='type-id-113'/>
-    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1190' column='1' id='type-id-112'>
+    <typedef-decl name='ddt_stat_t' type-id='type-id-204' filepath='../../include/sys/fs/zfs.h' line='1203' column='1' id='type-id-205'/>
+    <qualified-type-def type-id='type-id-205' const='yes' id='type-id-206'/>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-207'/>
+    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1205' column='1' id='type-id-208'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddh_stat' type-id='type-id-109' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1191' column='1'/>
+        <var-decl name='ddh_stat' type-id='type-id-209' visibility='default' filepath='../../include/sys/fs/zfs.h' line='1206' column='1'/>
       </data-member>
     </class-decl>
-    <qualified-type-def type-id='type-id-113' const='yes' id='type-id-114'/>
-    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-115'/>
-    <qualified-type-def type-id='type-id-108' const='yes' id='type-id-116'/>
-    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-118'/>
-    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-119'/>
-    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
-      <parameter type-id='type-id-74' name='buf' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
-      <parameter type-id='type-id-6' name='bytes_read' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
-      <parameter type-id='type-id-83' name='leftover' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
-      <parameter type-id='type-id-118' name='records' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
-      <parameter type-id='type-id-119' name='numrecords' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
-      <return type-id='type-id-5'/>
+
+    <array-type-def dimensions='1' type-id='type-id-205' size-in-bits='32768' id='type-id-209'>
+      <subrange length='64' type-id='type-id-12' id='type-id-210'/>
+
+    </array-type-def>
+    <typedef-decl name='ddt_histogram_t' type-id='type-id-208' filepath='../../include/sys/fs/zfs.h' line='1207' column='1' id='type-id-211'/>
+    <qualified-type-def type-id='type-id-211' const='yes' id='type-id-212'/>
+    <pointer-type-def type-id='type-id-212' size-in-bits='64' id='type-id-213'/>
+    <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
+      <parameter type-id='type-id-207' name='dds_total' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
+      <parameter type-id='type-id-213' name='ddh' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
-      <parameter type-id='type-id-117' name='dds_total' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
-      <parameter type-id='type-id-115' name='ddh' filepath='/home/fedora/zfs/lib/libzutil/zutil_pool.c' line='68' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_nicenum' filepath='../../include/libzutil.h' line='135' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
+    <function-decl name='zfs_nicebytes' filepath='../../include/libzutil.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-17'/>
     </function-decl>
-    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-215'/>
+    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
+      <parameter type-id='type-id-37' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-23' name='bytes_read' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-71' name='leftover' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='105' column='1'/>
+      <parameter type-id='type-id-214' name='records' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
+      <parameter type-id='type-id-215' name='numrecords' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil/zutil_pool.c' line='106' column='1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='470' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
-      <parameter type-id='type-id-76' name='path' filepath='os/linux/zutil_device_path_os.c' line='470' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' filepath='os/linux/zutil_device_path_os.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
-      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='348' column='1'/>
-      <return type-id='type-id-74'/>
-    </function-decl>
-    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' filepath='os/linux/zutil_device_path_os.c' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
-      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='312' column='1'/>
-      <return type-id='type-id-74'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='252' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
-      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='252' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' filepath='os/linux/zutil_device_path_os.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
-      <parameter type-id='type-id-76' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='231' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' filepath='os/linux/zutil_device_path_os.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
-      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='152' column='1'/>
-      <return type-id='type-id-74'/>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' filepath='os/linux/zutil_device_path_os.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
+      <parameter type-id='type-id-37' name='path' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
+      <parameter type-id='type-id-123' name='max_len' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' filepath='os/linux/zutil_device_path_os.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
-      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='84' column='1'/>
-      <return type-id='type-id-74'/>
+      <parameter type-id='type-id-37' name='path' filepath='os/linux/zutil_device_path_os.c' line='84' column='1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
-    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' filepath='os/linux/zutil_device_path_os.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
-      <parameter type-id='type-id-74' name='path' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
-      <parameter type-id='type-id-85' name='max_len' filepath='os/linux/zutil_device_path_os.c' line='47' column='1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' filepath='os/linux/zutil_device_path_os.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
+      <parameter type-id='type-id-37'/>
+      <return type-id='type-id-37'/>
     </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-
-
-    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='128' id='type-id-121'>
-      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-123'>
-      <subrange length='40' type-id='type-id-3' id='type-id-124'/>
-
-    </array-type-def>
-    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-125'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-126'/>
-    <type-decl name='short int' size-in-bits='16' id='type-id-127'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-128' filepath='/usr/include/bits/pthreadtypes.h' line='72' column='1' id='type-id-129'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='67' column='1' id='type-id-128'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-130' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='69' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-123' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='22' column='1' id='type-id-130'>
+    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' filepath='os/linux/zutil_device_path_os.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
+      <parameter type-id='type-id-16' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='171' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <class-decl name='dirent' size-in-bits='2240' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='22' column='1' id='type-id-216'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='24' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='25' column='1'/>
+        <var-decl name='d_ino' type-id='type-id-200' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='28' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='26' column='1'/>
+        <var-decl name='d_off' type-id='type-id-149' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='29' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='d_reclen' type-id='type-id-201' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='31' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='144'>
+        <var-decl name='d_type' type-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='152'>
+        <var-decl name='d_name' type-id='type-id-43' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/dirent.h' line='33' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-216' size-in-bits='64' id='type-id-217'/>
+    <function-decl name='readdir' mangled-name='readdir64' filepath='/usr/include/dirent.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-198'/>
+      <return type-id='type-id-217'/>
+    </function-decl>
+    <function-decl name='readlink' filepath='/usr/include/unistd.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' filepath='os/linux/zutil_device_path_os.c' line='367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
+      <parameter type-id='type-id-16' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='367' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='388' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
+      <parameter type-id='type-id-16' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='388' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='316' column='1' id='type-id-218'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='efi_version' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='317' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='efi_nparts' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='318' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='efi_part_size' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='319' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='28' column='1'/>
+        <var-decl name='efi_lbasize' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='321' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='32' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-127' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='34' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-127' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='35' column='1'/>
+        <var-decl name='efi_last_lba' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='322' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-131' visibility='default' filepath='/usr/include/bits/struct_mutex.h' line='36' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-132' filepath='/usr/include/bits/thread-shared-types.h' line='53' column='1' id='type-id-131'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='49' column='1' id='type-id-132'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-133' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-133' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='52' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='avl_tree_t' type-id='type-id-134' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-135'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-134'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-120' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-136' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-137' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
+        <var-decl name='efi_first_u_lba' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='323' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-85' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-138'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-121' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-139' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uintptr_t' type-id='type-id-3' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-139'/>
-    <typedef-decl name='ulong_t' type-id='type-id-3' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-137'/>
-    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-133'/>
-    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-120'/>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-140'/>
-    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
-    <qualified-type-def type-id='type-id-76' const='yes' id='type-id-142'/>
-    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-143'/>
-    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-136'/>
-    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-145'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-146'/>
-    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-147'/>
-    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' filepath='os/linux/zutil_import_os.c' line='801' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
-      <parameter type-id='type-id-81' name='nv' filepath='os/linux/zutil_import_os.c' line='801' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' filepath='os/linux/zutil_import_os.c' line='607' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
-      <parameter type-id='type-id-76' name='path' filepath='os/linux/zutil_import_os.c' line='607' column='1'/>
-      <parameter type-id='type-id-5' name='timeout_ms' filepath='os/linux/zutil_import_os.c' line='607' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' filepath='os/linux/zutil_import_os.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
-      <parameter type-id='type-id-147' name='dev' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
-      <parameter type-id='type-id-74' name='bufptr' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='os/linux/zutil_import_os.c' line='488' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' filepath='os/linux/zutil_import_os.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
-      <parameter type-id='type-id-147' name='dev' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
-      <parameter type-id='type-id-74' name='bufptr' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
-      <parameter type-id='type-id-85' name='buflen' filepath='os/linux/zutil_import_os.c' line='411' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zpool_find_import_blkid' mangled-name='zpool_find_import_blkid' filepath='os/linux/zutil_import_os.c' line='322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_import_blkid'>
-      <parameter type-id='type-id-106' name='hdl' filepath='os/linux/zutil_import_os.c' line='322' column='1'/>
-      <parameter type-id='type-id-145' name='lock' filepath='os/linux/zutil_import_os.c' line='322' column='1'/>
-      <parameter type-id='type-id-141' name='slice_cache' filepath='os/linux/zutil_import_os.c' line='323' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' filepath='os/linux/zutil_import_os.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
-      <parameter type-id='type-id-146' name='count' filepath='os/linux/zutil_import_os.c' line='273' column='1'/>
-      <return type-id='type-id-143'/>
-    </function-decl>
-    <function-decl name='zpool_open_func' mangled-name='zpool_open_func' filepath='os/linux/zutil_import_os.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_func'>
-      <parameter type-id='type-id-103' name='arg' filepath='os/linux/zutil_import_os.c' line='102' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' filepath='os/linux/zutil_import_os.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
-      <parameter type-id='type-id-5' name='fd' filepath='os/linux/zutil_import_os.c' line='96' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-144'>
-      <parameter type-id='type-id-103'/>
-      <parameter type-id='type-id-103'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/home/fedora/zfs/lib/libzutil' language='LANG_C99'>
-
-
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='32768' id='type-id-148'>
-      <subrange length='4096' type-id='type-id-3' id='type-id-149'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='65536' id='type-id-150'>
-      <subrange length='8192' type-id='type-id-3' id='type-id-151'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='128' id='type-id-152'>
-      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
-
-    </array-type-def>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-153' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-154'/>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='477' column='1' id='type-id-153'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_name' type-id='type-id-148' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='478' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32768'>
-        <var-decl name='zc_nvlist_src' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='479' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32832'>
-        <var-decl name='zc_nvlist_src_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='480' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32896'>
-        <var-decl name='zc_nvlist_dst' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='481' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32960'>
-        <var-decl name='zc_nvlist_dst_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='482' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33024'>
-        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-38' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='483' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33056'>
-        <var-decl name='zc_pad2' type-id='type-id-5' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='484' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33088'>
-        <var-decl name='zc_history' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='490' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33152'>
-        <var-decl name='zc_value' type-id='type-id-150' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='491' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='98688'>
-        <var-decl name='zc_string' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='492' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100736'>
-        <var-decl name='zc_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='493' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100800'>
-        <var-decl name='zc_nvlist_conf' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='494' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100864'>
-        <var-decl name='zc_nvlist_conf_size' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='495' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100928'>
-        <var-decl name='zc_cookie' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='496' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100992'>
-        <var-decl name='zc_objset_type' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='497' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101056'>
-        <var-decl name='zc_perm_action' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='498' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101120'>
-        <var-decl name='zc_history_len' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='499' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101184'>
-        <var-decl name='zc_history_offset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='500' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101248'>
-        <var-decl name='zc_obj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='501' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101312'>
-        <var-decl name='zc_iflags' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='502' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101376'>
-        <var-decl name='zc_share' type-id='type-id-155' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='503' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101632'>
-        <var-decl name='zc_objset_stats' type-id='type-id-156' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='504' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='103936'>
-        <var-decl name='zc_begin_record' type-id='type-id-51' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='505' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='type-id-157' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='506' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
-        <var-decl name='zc_defer_destroy' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='507' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
-        <var-decl name='zc_flags' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='508' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
-        <var-decl name='zc_action_handle' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='509' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='zc_cleanup_fd' type-id='type-id-5' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='510' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_simple' type-id='type-id-11' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='511' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
-        <var-decl name='zc_pad' type-id='type-id-16' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='512' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_sendobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='513' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
-        <var-decl name='zc_fromobj' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='514' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
-        <var-decl name='zc_createtxg' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='515' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
-        <var-decl name='zc_stat' type-id='type-id-158' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='516' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
-        <var-decl name='zc_zoneid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='517' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='type-id-159' filepath='../../include/sys/zfs_ioctl.h' line='457' column='1' id='type-id-155'/>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='452' column='1' id='type-id-159'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='453' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='454' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='455' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='456' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-160' filepath='../../include/sys/dmu.h' line='943' column='1' id='type-id-156'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' filepath='../../include/sys/dmu.h' line='934' column='1' id='type-id-160'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='935' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='936' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/dmu.h' line='937' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='type-id-63' visibility='default' filepath='../../include/sys/dmu.h' line='938' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='939' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='940' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='type-id-11' visibility='default' filepath='../../include/sys/dmu.h' line='941' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='248'>
-        <var-decl name='dds_origin' type-id='type-id-2' visibility='default' filepath='../../include/sys/dmu.h' line='942' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='type-id-161' filepath='../../include/sys/zfs_ioctl.h' line='421' column='1' id='type-id-157'/>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='403' column='1' id='type-id-161'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='404' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='405' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='406' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='407' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='408' column='1'/>
+        <var-decl name='efi_last_u_lba' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='324' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='409' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='410' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='411' column='1'/>
+        <var-decl name='efi_disk_uguid' type-id='type-id-220' visibility='default' filepath='../../include/sys/efi_partition.h' line='325' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='412' column='1'/>
+        <var-decl name='efi_flags' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='326' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='413' column='1'/>
+        <var-decl name='efi_reserved1' type-id='type-id-34' visibility='default' filepath='../../include/sys/efi_partition.h' line='327' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zi_func' type-id='type-id-2' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='414' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='415' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='type-id-30' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='416' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='417' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='418' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='419' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='type-id-31' visibility='default' filepath='../../include/sys/zfs_ioctl.h' line='420' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_stat_t' type-id='type-id-162' filepath='../../include/sys/zfs_stat.h' line='47' column='1' id='type-id-158'/>
-    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/zfs_stat.h' line='42' column='1' id='type-id-162'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zs_gen' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='43' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zs_mode' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='44' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zs_links' type-id='type-id-6' visibility='default' filepath='../../include/sys/zfs_stat.h' line='45' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zs_ctime' type-id='type-id-152' visibility='default' filepath='../../include/sys/zfs_stat.h' line='46' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-163'/>
-    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' filepath='os/linux/zutil_compat.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
-      <parameter type-id='type-id-5' name='fd' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
-      <parameter type-id='type-id-3' name='request' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
-      <parameter type-id='type-id-163' name='zc' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/fedora/zfs/lib/libavl' language='LANG_C99'>
-    <typedef-decl name='avl_index_t' type-id='type-id-139' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-164'/>
-    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-166'/>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='965' column='1'/>
-      <parameter type-id='type-id-166' name='cookie' filepath='../../module/avl/avl.c' line='965' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='937' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='937' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='930' column='1'/>
-      <return type-id='type-id-137'/>
-    </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='918' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='918' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='895' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='895' column='1'/>
-      <parameter type-id='type-id-136' name='compar' filepath='../../module/avl/avl.c' line='895' column='1'/>
-      <parameter type-id='type-id-85' name='size' filepath='../../module/avl/avl.c' line='896' column='1'/>
-      <parameter type-id='type-id-85' name='offset' filepath='../../module/avl/avl.c' line='896' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='type-id-140' name='tree1' filepath='../../module/avl/avl.c' line='874' column='1'/>
-      <parameter type-id='type-id-140' name='tree2' filepath='../../module/avl/avl.c' line='874' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='854' column='1'/>
-      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='854' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='837' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='837' column='1'/>
-      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='837' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='820' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='type-id-140' name='t' filepath='../../module/avl/avl.c' line='820' column='1'/>
-      <parameter type-id='type-id-103' name='obj' filepath='../../module/avl/avl.c' line='820' column='1'/>
-      <return type-id='type-id-38'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='670' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='670' column='1'/>
-      <parameter type-id='type-id-103' name='data' filepath='../../module/avl/avl.c' line='670' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='637' column='1'/>
-      <parameter type-id='type-id-103' name='new_node' filepath='../../module/avl/avl.c' line='637' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='577' column='1'/>
-      <parameter type-id='type-id-103' name='new_data' filepath='../../module/avl/avl.c' line='578' column='1'/>
-      <parameter type-id='type-id-103' name='here' filepath='../../module/avl/avl.c' line='579' column='1'/>
-      <parameter type-id='type-id-5' name='direction' filepath='../../module/avl/avl.c' line='580' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-103' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-164' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-103' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-165' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-164' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-5' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='206' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='type-id-140' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-103' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-5' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/home/fedora/zfs/lib/libtpool' language='LANG_C99'>
-
-
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-167'>
-      <subrange length='48' type-id='type-id-3' id='type-id-168'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='448' id='type-id-169'>
-      <subrange length='56' type-id='type-id-3' id='type-id-170'/>
-
-    </array-type-def>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-171'/>
-    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-172'/>
-    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='64' id='type-id-173'>
-      <subrange length='2' type-id='type-id-3' id='type-id-122'/>
-
-    </array-type-def>
-    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='63' column='1' id='type-id-174'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tp_forw' type-id='type-id-175' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tp_back' type-id='type-id-175' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tp_mutex' type-id='type-id-129' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tp_busycv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='tp_workcv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='tp_waitcv' type-id='type-id-176' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='69' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='tp_active' type-id='type-id-177' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='tp_head' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='71' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='tp_tail' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='tp_attr' type-id='type-id-179' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='tp_flags' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2272'>
-        <var-decl name='tp_linger' type-id='type-id-46' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='75' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='tp_njobs' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='76' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2336'>
-        <var-decl name='tp_minimum' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='tp_maximum' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2400'>
-        <var-decl name='tp_current' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='tp_idle' type-id='type-id-5' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='80' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_t' type-id='type-id-174' filepath='../../include/thread_pool.h' line='38' column='1' id='type-id-180'/>
-    <typedef-decl name='pthread_cond_t' type-id='type-id-181' filepath='/usr/include/bits/pthreadtypes.h' line='80' column='1' id='type-id-176'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='75' column='1' id='type-id-181'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-182' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-167' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-171' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='79' column='1'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='92' column='1' id='type-id-182'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='' type-id='type-id-183' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__g_refs' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='112' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__g_size' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='113' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='__g1_orig_size' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='114' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__wrefs' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='__g_signals' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='116' column='1'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='94' column='1' id='type-id-183'>
-      <data-member access='private'>
-        <var-decl name='__wseq' type-id='type-id-172' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__wseq32' type-id='type-id-184' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='101' column='1'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='97' column='1' id='type-id-184'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__low' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__high' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/thread-shared-types.h' line='100' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='55' column='1' id='type-id-185'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpa_next' type-id='type-id-177' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpa_tid' type-id='type-id-186' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='57' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_active_t' type-id='type-id-185' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='54' column='1' id='type-id-187'/>
-    <typedef-decl name='pthread_t' type-id='type-id-3' filepath='/usr/include/bits/pthreadtypes.h' line='27' column='1' id='type-id-186'/>
-    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='45' column='1' id='type-id-188'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpj_next' type-id='type-id-178' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='46' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpj_func' type-id='type-id-189' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='47' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpj_arg' type-id='type-id-103' visibility='default' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='48' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_job_t' type-id='type-id-188' filepath='/home/fedora/zfs/lib/libtpool/thread_pool_impl.h' line='44' column='1' id='type-id-190'/>
-    <typedef-decl name='pthread_attr_t' type-id='type-id-191' filepath='/usr/include/bits/pthreadtypes.h' line='62' column='1' id='type-id-179'/>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='56' column='1' id='type-id-191'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-169' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-126' visibility='default' filepath='/usr/include/bits/pthreadtypes.h' line='59' column='1'/>
-      </data-member>
-    </union-decl>
-    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-192'/>
-    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-177'/>
-    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-178'/>
-    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-175'/>
-    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-189'/>
-    <function-decl name='tpool_member' mangled-name='tpool_member' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='583' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='tpool_resume' mangled-name='tpool_resume' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='560' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='546' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='536' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='tpool_wait' mangled-name='tpool_wait' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='520' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='497' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='459' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
-      <parameter type-id='type-id-175' name='tpool' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
-      <parameter type-id='type-id-189' name='func' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
-      <parameter type-id='type-id-103' name='arg' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='tpool_create' mangled-name='tpool_create' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
-      <parameter type-id='type-id-46' name='min_threads' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
-      <parameter type-id='type-id-46' name='max_threads' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
-      <parameter type-id='type-id-46' name='linger' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
-      <parameter type-id='type-id-192' name='attr' filepath='/home/fedora/zfs/lib/libtpool/thread_pool.c' line='323' column='1'/>
-      <return type-id='type-id-175'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-193'>
-      <parameter type-id='type-id-103'/>
-      <return type-id='type-id-27'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='aok' type-id='type-id-5' mangled-name='aok' visibility='default' filepath='../../lib/libspl/include/assert.h' line='37' column='1' elf-symbol-id='aok'/>
-    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
-      <parameter type-id='type-id-76' name='file' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-76' name='func' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-5' name='line' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='32' column='1'/>
-      <parameter type-id='type-id-76' name='format' filepath='/home/fedora/zfs/lib/libspl/assert.c' line='33' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='getexecname' mangled-name='getexecname' filepath='os/linux/getexecname.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
-      <return type-id='type-id-76'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-
-
-
-    <array-type-def dimensions='1' type-id='type-id-194' size-in-bits='192' id='type-id-195'>
-      <subrange length='3' type-id='type-id-3' id='type-id-17'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-196'>
-      <subrange length='1' type-id='type-id-3' id='type-id-197'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-198'>
-      <subrange length='20' type-id='type-id-3' id='type-id-199'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='32880' id='type-id-200'>
-      <subrange length='4110' type-id='type-id-3' id='type-id-201'/>
-
-    </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-202'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-203'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-204'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-205'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-206'/>
-    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-207'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_major' type-id='type-id-46' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_minor' type-id='type-id-46' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/bits/stat.h' line='119' column='1' id='type-id-208'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-209' visibility='default' filepath='/usr/include/bits/stat.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-210' visibility='default' filepath='/usr/include/bits/stat.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-211' visibility='default' filepath='/usr/include/bits/stat.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-212' visibility='default' filepath='/usr/include/bits/stat.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-213' visibility='default' filepath='/usr/include/bits/stat.h' line='132' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-214' visibility='default' filepath='/usr/include/bits/stat.h' line='133' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/stat.h' line='135' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-209' visibility='default' filepath='/usr/include/bits/stat.h' line='136' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-215' visibility='default' filepath='/usr/include/bits/stat.h' line='137' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-216' visibility='default' filepath='/usr/include/bits/stat.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-217' visibility='default' filepath='/usr/include/bits/stat.h' line='144' column='1'/>
+        <var-decl name='efi_altern_lba' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='328' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='152' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='153' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-218' visibility='default' filepath='/usr/include/bits/stat.h' line='154' column='1'/>
+        <var-decl name='efi_reserved' type-id='type-id-221' visibility='default' filepath='../../include/sys/efi_partition.h' line='329' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-195' visibility='default' filepath='/usr/include/bits/stat.h' line='164' column='1'/>
+        <var-decl name='efi_parts' type-id='type-id-222' visibility='default' filepath='../../include/sys/efi_partition.h' line='330' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='145' column='1' id='type-id-209'/>
-    <typedef-decl name='__ino64_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='149' column='1' id='type-id-210'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-3' filepath='/usr/include/bits/types.h' line='151' column='1' id='type-id-211'/>
-    <typedef-decl name='__mode_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='150' column='1' id='type-id-212'/>
-    <typedef-decl name='__uid_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='146' column='1' id='type-id-213'/>
-    <typedef-decl name='__gid_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='147' column='1' id='type-id-214'/>
-    <typedef-decl name='__off_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-215'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='175' column='1' id='type-id-216'/>
-    <typedef-decl name='__blkcnt64_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-217'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='10' column='1' id='type-id-218'>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-223'/>
+    <typedef-decl name='longlong_t' type-id='type-id-223' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-224'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-224' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-219'/>
+    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/uuid.h' line='68' column='1' id='type-id-220'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-219' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='12' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-194' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='16' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='160' column='1' id='type-id-219'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='197' column='1' id='type-id-194'/>
-    <typedef-decl name='FILE' type-id='type-id-220' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-221'/>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-220'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-74' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-222' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-223' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-215' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-206' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-205' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-196' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-224' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-225' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-226' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-227' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-223' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-103' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-85' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-5' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-198' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-27' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-228'/>
-    <typedef-decl name='__off64_t' type-id='type-id-126' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-225'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-229'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-74' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-230'/>
-    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-223'/>
-    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-226'/>
-    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-224'/>
-    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-222'/>
-    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-227'/>
-    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-231'/>
-    <pointer-type-def type-id='type-id-229' size-in-bits='64' id='type-id-232'/>
-    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-233'/>
-    <var-decl name='buf' type-id='type-id-200' mangled-name='buf' visibility='default' filepath='os/linux/getmntany.c' line='44' column='1' elf-symbol-id='buf'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='type-id-76' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-231' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-233' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
-      <parameter type-id='type-id-230' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-232' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-232' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
-      <parameter type-id='type-id-230' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <parameter type-id='type-id-232' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='list_t' type-id='type-id-234' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-235'/>
-    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-234'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='list_size' type-id='type-id-85' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='list_offset' type-id='type-id-85' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='list_head' type-id='type-id-236' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-236'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-237' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='type-id-237' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='list_node_t' type-id='type-id-236' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-238'/>
-    <pointer-type-def type-id='type-id-236' size-in-bits='64' id='type-id-237'/>
-    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-240'/>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='240' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='type-id-239' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='233' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='type-id-239' name='ln' filepath='/home/fedora/zfs/lib/libspl/list.c' line='226' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='type-id-239' name='lold' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <parameter type-id='type-id-239' name='lnew' filepath='/home/fedora/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='type-id-240' name='dst' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <parameter type-id='type-id-240' name='src' filepath='/home/fedora/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='178' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='159' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='151' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='141' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='131' column='1'/>
-      <return type-id='type-id-103'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='115' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <parameter type-id='type-id-103' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='97' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-103' name='object' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-103' name='nobject' filepath='/home/fedora/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='74' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-    <function-decl name='list_create' mangled-name='list_create' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='type-id-240' name='list' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-85' name='size' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-85' name='offset' filepath='/home/fedora/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='mode_t' type-id='type-id-212' filepath='/usr/include/sys/types.h' line='69' column='1' id='type-id-241'/>
-    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
-      <parameter type-id='type-id-76' name='d' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
-      <parameter type-id='type-id-241' name='mode' filepath='/home/fedora/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='__builtin_strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='pagesize' type-id='type-id-85' mangled-name='pagesize' visibility='default' filepath='/home/fedora/zfs/lib/libspl/page.c' line='25' column='1' elf-symbol-id='pagesize'/>
-    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/home/fedora/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
-      <return type-id='type-id-85'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcat' mangled-name='strlcat' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
-      <parameter type-id='type-id-74' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-76' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-85' name='dstsize' filepath='/home/fedora/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
-      <parameter type-id='type-id-74' name='dst' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-76' name='src' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-85' name='len' filepath='/home/fedora/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
-      <parameter type-id='type-id-46' name='timestamp_fmt' filepath='/home/fedora/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
-      <return type-id='type-id-27'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/fedora/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='zoneid_t' type-id='type-id-5' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-242'/>
-    <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
-      <return type-id='type-id-242'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' comp-dir-path='/home/fedora/zfs/lib/libefi' language='LANG_C99'>
-
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='288' id='type-id-243'>
-      <subrange length='36' type-id='type-id-3' id='type-id-244'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-245' size-in-bits='512' id='type-id-246'>
-      <subrange length='16' type-id='type-id-3' id='type-id-15'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-247' size-in-bits='960' id='type-id-248'>
-      <subrange length='1' type-id='type-id-3' id='type-id-197'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='384' id='type-id-249'>
-      <subrange length='12' type-id='type-id-3' id='type-id-13'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='256' id='type-id-250'>
-      <subrange length='8' type-id='type-id-3' id='type-id-23'/>
-
-    </array-type-def>
-    <class-decl name='dk_map2' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='103' column='1' id='type-id-245'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_tag' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='p_flag' type-id='type-id-251' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint16_t' type-id='type-id-252' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-251'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-206' filepath='/usr/include/bits/types.h' line='40' column='1' id='type-id-252'/>
-    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='316' column='1' id='type-id-253'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='efi_version' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='317' column='1'/>
+        <var-decl name='time_low' type-id='type-id-22' visibility='default' filepath='../../include/sys/uuid.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='efi_nparts' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='318' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='efi_part_size' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='319' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='efi_lbasize' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='321' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='efi_last_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='322' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='efi_first_u_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='323' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='efi_last_u_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='324' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='efi_disk_uguid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='325' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='efi_flags' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='326' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='efi_reserved1' type-id='type-id-46' visibility='default' filepath='../../include/sys/efi_partition.h' line='327' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='efi_altern_lba' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='328' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='efi_reserved' type-id='type-id-249' visibility='default' filepath='../../include/sys/efi_partition.h' line='329' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='efi_parts' type-id='type-id-248' visibility='default' filepath='../../include/sys/efi_partition.h' line='330' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='diskaddr_t' type-id='type-id-256' filepath='../../lib/libspl/include/sys/stdtypes.h' line='41' column='1' id='type-id-254'/>
-    <typedef-decl name='longlong_t' type-id='type-id-171' filepath='../../lib/libspl/include/sys/stdtypes.h' line='36' column='1' id='type-id-256'/>
-    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/sys/uuid.h' line='68' column='1' id='type-id-255'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='time_low' type-id='type-id-31' visibility='default' filepath='../../include/sys/uuid.h' line='69' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time_mid' type-id='type-id-251' visibility='default' filepath='../../include/sys/uuid.h' line='70' column='1'/>
+        <var-decl name='time_mid' type-id='type-id-225' visibility='default' filepath='../../include/sys/uuid.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='time_hi_and_version' type-id='type-id-251' visibility='default' filepath='../../include/sys/uuid.h' line='71' column='1'/>
+        <var-decl name='time_hi_and_version' type-id='type-id-225' visibility='default' filepath='../../include/sys/uuid.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-11' visibility='default' filepath='../../include/sys/uuid.h' line='72' column='1'/>
+        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-32' visibility='default' filepath='../../include/sys/uuid.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='clock_seq_low' type-id='type-id-11' visibility='default' filepath='../../include/sys/uuid.h' line='73' column='1'/>
+        <var-decl name='clock_seq_low' type-id='type-id-32' visibility='default' filepath='../../include/sys/uuid.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='node_addr' type-id='type-id-20' visibility='default' filepath='../../include/sys/uuid.h' line='74' column='1'/>
+        <var-decl name='node_addr' type-id='type-id-105' visibility='default' filepath='../../include/sys/uuid.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='301' column='1' id='type-id-247'>
+    <typedef-decl name='__uint16_t' type-id='type-id-201' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-226'/>
+    <typedef-decl name='uint16_t' type-id='type-id-226' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-225'/>
+
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='384' id='type-id-221'>
+      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
+
+    </array-type-def>
+    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/sys/efi_partition.h' line='301' column='1' id='type-id-227'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_start' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='302' column='1'/>
+        <var-decl name='p_start' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='302' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_size' type-id='type-id-254' visibility='default' filepath='../../include/sys/efi_partition.h' line='303' column='1'/>
+        <var-decl name='p_size' type-id='type-id-219' visibility='default' filepath='../../include/sys/efi_partition.h' line='303' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_guid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='304' column='1'/>
+        <var-decl name='p_guid' type-id='type-id-220' visibility='default' filepath='../../include/sys/efi_partition.h' line='304' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='p_tag' type-id='type-id-257' visibility='default' filepath='../../include/sys/efi_partition.h' line='305' column='1'/>
+        <var-decl name='p_tag' type-id='type-id-228' visibility='default' filepath='../../include/sys/efi_partition.h' line='305' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='p_flag' type-id='type-id-257' visibility='default' filepath='../../include/sys/efi_partition.h' line='306' column='1'/>
+        <var-decl name='p_flag' type-id='type-id-228' visibility='default' filepath='../../include/sys/efi_partition.h' line='306' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='p_name' type-id='type-id-243' visibility='default' filepath='../../include/sys/efi_partition.h' line='307' column='1'/>
+        <var-decl name='p_name' type-id='type-id-229' visibility='default' filepath='../../include/sys/efi_partition.h' line='307' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='p_uguid' type-id='type-id-255' visibility='default' filepath='../../include/sys/efi_partition.h' line='308' column='1'/>
+        <var-decl name='p_uguid' type-id='type-id-220' visibility='default' filepath='../../include/sys/efi_partition.h' line='308' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='p_resv' type-id='type-id-250' visibility='default' filepath='../../include/sys/efi_partition.h' line='309' column='1'/>
+        <var-decl name='p_resv' type-id='type-id-230' visibility='default' filepath='../../include/sys/efi_partition.h' line='309' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ushort_t' type-id='type-id-206' filepath='../../lib/libspl/include/sys/stdtypes.h' line='32' column='1' id='type-id-257'/>
-    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-258'/>
-    <pointer-type-def type-id='type-id-258' size-in-bits='64' id='type-id-259'/>
-    <var-decl name='default_vtoc_map' type-id='type-id-246' mangled-name='default_vtoc_map' visibility='default' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='146' column='1' elf-symbol-id='default_vtoc_map'/>
-    <var-decl name='efi_debug' type-id='type-id-5' mangled-name='efi_debug' visibility='default' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='177' column='1' elf-symbol-id='efi_debug'/>
-    <function-decl name='efi_auto_sense' mangled-name='efi_auto_sense' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_auto_sense'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1'/>
-      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1707' column='1'/>
+    <typedef-decl name='ushort_t' type-id='type-id-201' filepath='../../lib/libspl/include/sys/stdtypes.h' line='32' column='1' id='type-id-228'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='288' id='type-id-229'>
+      <subrange length='36' type-id='type-id-12' id='type-id-231'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='256' id='type-id-230'>
+      <subrange length='8' type-id='type-id-12' id='type-id-102'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-227' size-in-bits='960' id='type-id-222'>
+      <subrange length='1' type-id='type-id-12' id='type-id-232'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-233'/>
+    <pointer-type-def type-id='type-id-233' size-in-bits='64' id='type-id-234'/>
+    <function-decl name='efi_alloc_and_init' filepath='../../include/sys/efi_partition.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-234'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_free' mangled-name='efi_free' filepath='../../include/sys/efi_partition.h' line='370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
+      <parameter type-id='type-id-233'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' filepath='os/linux/zutil_device_path_os.c' line='448' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
+      <parameter type-id='type-id-16' name='dev_name' filepath='os/linux/zutil_device_path_os.c' line='448' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' filepath='os/linux/zutil_device_path_os.c' line='502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
+      <parameter type-id='type-id-16' name='path' filepath='os/linux/zutil_device_path_os.c' line='502' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <class-decl name='udev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-235'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
+    <function-decl name='udev_new' filepath='/usr/include/libudev.h' line='23' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-236'/>
+    </function-decl>
+    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-237'/>
+    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-238'/>
+    <function-decl name='udev_device_new_from_subsystem_sysname' filepath='/usr/include/libudev.h' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-238'/>
+    </function-decl>
+    <function-decl name='udev_device_get_property_value' filepath='/usr/include/libudev.h' line='86' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-238'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='udev_device_unref' filepath='/usr/include/libudev.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-238'/>
+      <return type-id='type-id-238'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' filepath='os/linux/zutil_import_os.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
+      <parameter type-id='type-id-1' name='fd' filepath='os/linux/zutil_import_os.c' line='95' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_open_func' mangled-name='zpool_open_func' filepath='os/linux/zutil_import_os.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_func'>
+      <parameter type-id='type-id-73' name='arg' filepath='os/linux/zutil_import_os.c' line='101' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='zutil_strdup' filepath='./zutil_import.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-190'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='zpool_read_label' filepath='../../include/libzutil.h' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='label_paths' filepath='./zutil_import.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-190'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-171'/>
+      <parameter type-id='type-id-171'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' filepath='os/linux/zutil_import_os.c' line='606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
+      <parameter type-id='type-id-16' name='path' filepath='os/linux/zutil_import_os.c' line='606' column='1'/>
+      <parameter type-id='type-id-1' name='timeout_ms' filepath='os/linux/zutil_import_os.c' line='606' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zutil_alloc' filepath='./zutil_import.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-190'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='9' column='1' id='type-id-239'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-240' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='11' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-241' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='12' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='158' column='1' id='type-id-240'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-241'/>
+    <pointer-type-def type-id='type-id-239' size-in-bits='64' id='type-id-242'/>
+    <function-decl name='clock_gettime' filepath='/usr/include/time.h' line='219' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-242'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='usleep' filepath='/usr/include/unistd.h' line='460' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='udev_list_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-243'/>
+    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-244'/>
+    <function-decl name='udev_device_get_devlinks_list_entry' filepath='/usr/include/libudev.h' line='82' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-238'/>
+      <return type-id='type-id-244'/>
+    </function-decl>
+    <function-decl name='udev_list_entry_get_next' filepath='/usr/include/libudev.h' line='39' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-244'/>
+      <return type-id='type-id-244'/>
+    </function-decl>
+    <function-decl name='udev_list_entry_get_name' filepath='/usr/include/libudev.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-244'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='udev_unref' filepath='/usr/include/libudev.h' line='22' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-236'/>
+      <return type-id='type-id-236'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-245'/>
+    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' filepath='os/linux/zutil_import_os.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
+      <parameter type-id='type-id-245' name='count' filepath='os/linux/zutil_import_os.c' line='272' column='1'/>
+      <return type-id='type-id-125'/>
+    </function-decl>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-2' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-246'/>
+    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-181' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-248'/>
+    <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <function-decl name='zpool_find_import_blkid' mangled-name='zpool_find_import_blkid' filepath='os/linux/zutil_import_os.c' line='321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_import_blkid'>
+      <parameter type-id='type-id-141' name='hdl' filepath='os/linux/zutil_import_os.c' line='321' column='1'/>
+      <parameter type-id='type-id-247' name='lock' filepath='os/linux/zutil_import_os.c' line='321' column='1'/>
+      <parameter type-id='type-id-250' name='slice_cache' filepath='os/linux/zutil_import_os.c' line='322' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='blkid_struct_cache' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
+    <pointer-type-def type-id='type-id-252' size-in-bits='64' id='type-id-253'/>
+    <function-decl name='blkid_get_cache' filepath='/usr/include/blkid/blkid.h' line='143' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-253'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='blkid_probe_all_new' filepath='/usr/include/blkid/blkid.h' line='165' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-252'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='blkid_struct_dev_iterate' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-254'/>
+    <pointer-type-def type-id='type-id-254' size-in-bits='64' id='type-id-255'/>
+    <function-decl name='blkid_dev_iterate_begin' filepath='/usr/include/blkid/blkid.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-252'/>
+      <return type-id='type-id-255'/>
+    </function-decl>
+    <function-decl name='blkid_dev_set_search' filepath='/usr/include/blkid/blkid.h' line='151' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-255'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='blkid_dev_iterate_end' filepath='/usr/include/blkid/blkid.h' line='154' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-255'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <class-decl name='blkid_struct_dev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-256'/>
+    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-257'/>
+    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-258'/>
+    <function-decl name='blkid_dev_next' filepath='/usr/include/blkid/blkid.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-255'/>
+      <parameter type-id='type-id-258'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='blkid_put_cache' filepath='/usr/include/blkid/blkid.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-252'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='blkid_dev_devname' filepath='/usr/include/blkid/blkid.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-257'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' filepath='os/linux/zutil_import_os.c' line='410' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
+      <parameter type-id='type-id-238' name='dev' filepath='os/linux/zutil_import_os.c' line='410' column='1'/>
+      <parameter type-id='type-id-37' name='bufptr' filepath='os/linux/zutil_import_os.c' line='410' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='os/linux/zutil_import_os.c' line='410' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='udev_device_get_parent_with_subsystem_devtype' filepath='/usr/include/libudev.h' line='71' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-238'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-238'/>
+    </function-decl>
+    <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' filepath='os/linux/zutil_import_os.c' line='487' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
+      <parameter type-id='type-id-238' name='dev' filepath='os/linux/zutil_import_os.c' line='487' column='1'/>
+      <parameter type-id='type-id-37' name='bufptr' filepath='os/linux/zutil_import_os.c' line='487' column='1'/>
+      <parameter type-id='type-id-123' name='buflen' filepath='os/linux/zutil_import_os.c' line='487' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' filepath='os/linux/zutil_import_os.c' line='800' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
+      <parameter type-id='type-id-29' name='nv' filepath='os/linux/zutil_import_os.c' line='800' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' filepath='../../include/sys/nvpair.h' line='199' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sched_yield' filepath='/usr/include/sched.h' line='68' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libzutil' language='LANG_C99'>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-39' filepath='../../include/sys/zfs_ioctl.h' line='518' column='1' id='type-id-259'/>
+    <pointer-type-def type-id='type-id-259' size-in-bits='64' id='type-id-260'/>
+    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' filepath='os/linux/zutil_compat.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
+      <parameter type-id='type-id-1' name='fd' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <parameter type-id='type-id-26' name='request' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <parameter type-id='type-id-260' name='zc' filepath='os/linux/zutil_compat.c' line='27' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libavl' language='LANG_C99'>
+    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-73' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <parameter type-id='type-id-1' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <typedef-decl name='avl_index_t' type-id='type-id-187' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-261'/>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-261' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <parameter type-id='type-id-1' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-261' size-in-bits='64' id='type-id-262'/>
+    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-73' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <parameter type-id='type-id-262' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-73' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <parameter type-id='type-id-261' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='576' column='1'/>
+      <parameter type-id='type-id-73' name='new_data' filepath='../../module/avl/avl.c' line='577' column='1'/>
+      <parameter type-id='type-id-73' name='here' filepath='../../module/avl/avl.c' line='578' column='1'/>
+      <parameter type-id='type-id-1' name='direction' filepath='../../module/avl/avl.c' line='579' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='636' column='1'/>
+      <parameter type-id='type-id-73' name='new_node' filepath='../../module/avl/avl.c' line='636' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='669' column='1'/>
+      <parameter type-id='type-id-73' name='data' filepath='../../module/avl/avl.c' line='669' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-249' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <parameter type-id='type-id-73' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='834' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-249' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <parameter type-id='type-id-73' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-249' name='t' filepath='../../module/avl/avl.c' line='851' column='1'/>
+      <parameter type-id='type-id-73' name='obj' filepath='../../module/avl/avl.c' line='851' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-249' name='tree1' filepath='../../module/avl/avl.c' line='871' column='1'/>
+      <parameter type-id='type-id-249' name='tree2' filepath='../../module/avl/avl.c' line='871' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='892' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='892' column='1'/>
+      <parameter type-id='type-id-183' name='compar' filepath='../../module/avl/avl.c' line='892' column='1'/>
+      <parameter type-id='type-id-123' name='size' filepath='../../module/avl/avl.c' line='893' column='1'/>
+      <parameter type-id='type-id-123' name='offset' filepath='../../module/avl/avl.c' line='893' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='915' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='927' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='927' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='934' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='934' column='1'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-249' name='tree' filepath='../../module/avl/avl.c' line='962' column='1'/>
+      <parameter type-id='type-id-143' name='cookie' filepath='../../module/avl/avl.c' line='962' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool' language='LANG_C99'>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' filepath='./thread_pool_impl.h' line='63' column='1' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tp_forw' type-id='type-id-263' visibility='default' filepath='./thread_pool_impl.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tp_back' type-id='type-id-263' visibility='default' filepath='./thread_pool_impl.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tp_mutex' type-id='type-id-246' visibility='default' filepath='./thread_pool_impl.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='tp_busycv' type-id='type-id-264' visibility='default' filepath='./thread_pool_impl.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='tp_workcv' type-id='type-id-264' visibility='default' filepath='./thread_pool_impl.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='tp_waitcv' type-id='type-id-264' visibility='default' filepath='./thread_pool_impl.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='tp_active' type-id='type-id-265' visibility='default' filepath='./thread_pool_impl.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='tp_head' type-id='type-id-266' visibility='default' filepath='./thread_pool_impl.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1728'>
+        <var-decl name='tp_tail' type-id='type-id-266' visibility='default' filepath='./thread_pool_impl.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='tp_attr' type-id='type-id-164' visibility='default' filepath='./thread_pool_impl.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='tp_flags' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2272'>
+        <var-decl name='tp_linger' type-id='type-id-34' visibility='default' filepath='./thread_pool_impl.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='tp_njobs' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='76' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2336'>
+        <var-decl name='tp_minimum' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='tp_maximum' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2400'>
+        <var-decl name='tp_current' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='tp_idle' type-id='type-id-1' visibility='default' filepath='./thread_pool_impl.h' line='80' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_t' type-id='type-id-192' filepath='../../include/thread_pool.h' line='38' column='1' id='type-id-267'/>
+    <pointer-type-def type-id='type-id-267' size-in-bits='64' id='type-id-263'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='75' column='1' id='type-id-268'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-269' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-270' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-223' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='79' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='171' column='1' id='type-id-269'>
+      <member-type access='public'>
+        <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='182' column='1' id='type-id-271'>
+          <data-member access='private'>
+            <var-decl name='__g1_start' type-id='type-id-272' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='184' column='1'/>
+          </data-member>
+          <data-member access='private'>
+            <var-decl name='__g1_start32' type-id='type-id-273' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='189' column='1'/>
+          </data-member>
+        </union-decl>
+      </member-type>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='' type-id='type-id-274' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='173' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__g_refs' type-id='type-id-275' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__g_size' type-id='type-id-275' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='__g1_orig_size' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__wrefs' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='__g_signals' type-id='type-id-275' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='195' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='173' column='1' id='type-id-274'>
+      <data-member access='private'>
+        <var-decl name='__wseq' type-id='type-id-272' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='175' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__wseq32' type-id='type-id-273' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='180' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-272'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='176' column='1' id='type-id-273'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__low' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__high' type-id='type-id-6' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='179' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='64' id='type-id-275'>
+      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='384' id='type-id-270'>
+      <subrange length='48' type-id='type-id-12' id='type-id-276'/>
+
+    </array-type-def>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-268' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='80' column='1' id='type-id-264'/>
+    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' filepath='./thread_pool_impl.h' line='55' column='1' id='type-id-277'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpa_next' type-id='type-id-265' visibility='default' filepath='./thread_pool_impl.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpa_tid' type-id='type-id-278' visibility='default' filepath='./thread_pool_impl.h' line='57' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_active_t' type-id='type-id-277' filepath='./thread_pool_impl.h' line='54' column='1' id='type-id-279'/>
+    <pointer-type-def type-id='type-id-279' size-in-bits='64' id='type-id-265'/>
+    <typedef-decl name='pthread_t' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='27' column='1' id='type-id-278'/>
+    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' filepath='./thread_pool_impl.h' line='45' column='1' id='type-id-280'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpj_next' type-id='type-id-266' visibility='default' filepath='./thread_pool_impl.h' line='46' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpj_func' type-id='type-id-195' visibility='default' filepath='./thread_pool_impl.h' line='47' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tpj_arg' type-id='type-id-73' visibility='default' filepath='./thread_pool_impl.h' line='48' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_job_t' type-id='type-id-280' filepath='./thread_pool_impl.h' line='44' column='1' id='type-id-281'/>
+    <pointer-type-def type-id='type-id-281' size-in-bits='64' id='type-id-266'/>
+    <function-decl name='tpool_create' mangled-name='tpool_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='322' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
+      <parameter type-id='type-id-34' name='min_threads' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-34' name='max_threads' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-34' name='linger' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='322' column='1'/>
+      <parameter type-id='type-id-159' name='attr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='323' column='1'/>
+      <return type-id='type-id-263'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-161' const='yes' id='type-id-282'/>
+    <pointer-type-def type-id='type-id-282' size-in-bits='64' id='type-id-283'/>
+    <function-decl name='pthread_attr_getstack' filepath='/usr/include/pthread.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-143'/>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-284'/>
+    <function-decl name='pthread_cond_init' filepath='/usr/include/pthread.h' line='969' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-284'/>
+      <parameter type-id='type-id-180'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-285'/>
+    <function-decl name='pthread_attr_init' filepath='/usr/include/pthread.h' line='288' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/cpu-set.h' line='39' column='1' id='type-id-286'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-287' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/cpu-set.h' line='41' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__cpu_mask' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/cpu-set.h' line='32' column='1' id='type-id-288'/>
+
+    <array-type-def dimensions='1' type-id='type-id-288' size-in-bits='1024' id='type-id-287'>
+      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-286' size-in-bits='64' id='type-id-289'/>
+    <function-decl name='pthread_attr_getaffinity_np' filepath='/usr/include/pthread.h' line='404' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-289'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-286' const='yes' id='type-id-290'/>
+    <pointer-type-def type-id='type-id-290' size-in-bits='64' id='type-id-291'/>
+    <function-decl name='pthread_attr_setaffinity_np' filepath='/usr/include/pthread.h' line='397' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-291'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getdetachstate' filepath='/usr/include/pthread.h' line='295' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setdetachstate' filepath='/usr/include/pthread.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getguardsize' filepath='/usr/include/pthread.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-38'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setguardsize' filepath='/usr/include/pthread.h' line='311' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getinheritsched' filepath='/usr/include/pthread.h' line='336' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setinheritsched' filepath='/usr/include/pthread.h' line='341' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='sched_param' size-in-bits='32' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_sched_param.h' line='23' column='1' id='type-id-292'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='sched_priority' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_sched_param.h' line='25' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-292' size-in-bits='64' id='type-id-293'/>
+    <function-decl name='pthread_attr_getschedparam' filepath='/usr/include/pthread.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-293'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-292' const='yes' id='type-id-294'/>
+    <pointer-type-def type-id='type-id-294' size-in-bits='64' id='type-id-295'/>
+    <function-decl name='pthread_attr_setschedparam' filepath='/usr/include/pthread.h' line='322' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-295'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getschedpolicy' filepath='/usr/include/pthread.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setschedpolicy' filepath='/usr/include/pthread.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getscope' filepath='/usr/include/pthread.h' line='347' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setscope' filepath='/usr/include/pthread.h' line='352' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setstack' filepath='/usr/include/pthread.h' line='390' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_attr_destroy' filepath='/usr/include/pthread.h' line='291' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-285'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <parameter type-id='type-id-195' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <parameter type-id='type-id-73' name='arg' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='412' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_cond_signal' filepath='/usr/include/pthread.h' line='978' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-284'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='5' column='1' id='type-id-296'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-297' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/__sigset_t.h' line='7' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='1024' id='type-id-297'>
+      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-296' const='yes' id='type-id-298'/>
+    <pointer-type-def type-id='type-id-296' size-in-bits='64' id='type-id-299'/>
+    <function-decl name='pthread_sigmask' filepath='/usr/include/x86_64-linux-gnu/bits/sigthread.h' line='31' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-291'/>
+      <parameter type-id='type-id-299'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-300' size-in-bits='64' id='type-id-301'/>
+    <function-decl name='pthread_create' filepath='/usr/include/pthread.h' line='234' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-283'/>
+      <parameter type-id='type-id-301'/>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='459' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='pthread_cond_broadcast' filepath='/usr/include/pthread.h' line='982' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-284'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_cancel' filepath='/usr/include/pthread.h' line='514' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_cond_wait' filepath='/usr/include/pthread.h' line='990' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-284'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='497' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='520' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='536' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='546' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_resume' mangled-name='tpool_resume' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='560' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='tpool_member' mangled-name='tpool_member' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
+      <parameter type-id='type-id-263' name='tpool' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libtpool/thread_pool.c' line='583' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_self' filepath='/usr/include/pthread.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-239' const='yes' id='type-id-302'/>
+    <pointer-type-def type-id='type-id-302' size-in-bits='64' id='type-id-303'/>
+    <function-decl name='pthread_cond_timedwait' filepath='/usr/include/pthread.h' line='1001' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-284'/>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-303'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_setcanceltype' filepath='/usr/include/pthread.h' line='511' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_setcancelstate' filepath='/usr/include/pthread.h' line='507' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-142'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-300'>
+      <parameter type-id='type-id-73'/>
+      <return type-id='type-id-73'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='libspl_assert_ok' type-id='type-id-1' mangled-name='libspl_assert_ok' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/assert.c' line='28' column='1' elf-symbol-id='libspl_assert_ok'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-32' volatile='yes' id='type-id-304'/>
+    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-305'/>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <typedef-decl name='uchar_t' type-id='type-id-30' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-306'/>
+    <qualified-type-def type-id='type-id-306' volatile='yes' id='type-id-307'/>
+    <pointer-type-def type-id='type-id-307' size-in-bits='64' id='type-id-308'/>
+    <function-decl name='atomic_inc_uchar' mangled-name='atomic_inc_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-225' volatile='yes' id='type-id-309'/>
+    <pointer-type-def type-id='type-id-309' size-in-bits='64' id='type-id-310'/>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-228' volatile='yes' id='type-id-311'/>
+    <pointer-type-def type-id='type-id-311' size-in-bits='64' id='type-id-312'/>
+    <function-decl name='atomic_inc_ushort' mangled-name='atomic_inc_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-22' volatile='yes' id='type-id-313'/>
+    <pointer-type-def type-id='type-id-313' size-in-bits='64' id='type-id-314'/>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-34' volatile='yes' id='type-id-315'/>
+    <pointer-type-def type-id='type-id-315' size-in-bits='64' id='type-id-316'/>
+    <function-decl name='atomic_inc_uint' mangled-name='atomic_inc_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-184' volatile='yes' id='type-id-317'/>
+    <pointer-type-def type-id='type-id-317' size-in-bits='64' id='type-id-318'/>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-23' volatile='yes' id='type-id-319'/>
+    <pointer-type-def type-id='type-id-319' size-in-bits='64' id='type-id-320'/>
+    <function-decl name='atomic_inc_64' mangled-name='atomic_inc_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uchar' mangled-name='atomic_dec_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='56' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ushort' mangled-name='atomic_dec_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='58' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uint' mangled-name='atomic_dec_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_dec_64' mangled-name='atomic_dec_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-321'/>
+    <typedef-decl name='__int8_t' type-id='type-id-321' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='36' column='1' id='type-id-322'/>
+    <typedef-decl name='int8_t' type-id='type-id-322' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-323'/>
+    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <parameter type-id='type-id-323' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_char' mangled-name='atomic_add_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <parameter type-id='type-id-321' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <parameter type-id='type-id-66' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_short' mangled-name='atomic_add_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <parameter type-id='type-id-7' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <parameter type-id='type-id-21' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_int' mangled-name='atomic_add_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <parameter type-id='type-id-1' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <parameter type-id='type-id-5' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <typedef-decl name='__int64_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='43' column='1' id='type-id-324'/>
+    <typedef-decl name='int64_t' type-id='type-id-324' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-325'/>
+    <function-decl name='atomic_add_64' mangled-name='atomic_add_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <parameter type-id='type-id-325' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <typedef-decl name='ssize_t' type-id='type-id-148' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-326'/>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <parameter type-id='type-id-326' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <parameter type-id='type-id-323' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_char' mangled-name='atomic_sub_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <parameter type-id='type-id-321' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <parameter type-id='type-id-66' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_short' mangled-name='atomic_sub_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <parameter type-id='type-id-7' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <parameter type-id='type-id-21' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_int' mangled-name='atomic_sub_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <parameter type-id='type-id-1' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <parameter type-id='type-id-5' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_64' mangled-name='atomic_sub_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <parameter type-id='type-id-325' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <parameter type-id='type-id-326' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <parameter type-id='type-id-32' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_uchar' mangled-name='atomic_or_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <parameter type-id='type-id-306' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <parameter type-id='type-id-225' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_ushort' mangled-name='atomic_or_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <parameter type-id='type-id-228' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_uint' mangled-name='atomic_or_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <parameter type-id='type-id-34' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <parameter type-id='type-id-184' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_or_64' mangled-name='atomic_or_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <parameter type-id='type-id-23' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <parameter type-id='type-id-32' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_uchar' mangled-name='atomic_and_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <parameter type-id='type-id-306' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <parameter type-id='type-id-225' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_ushort' mangled-name='atomic_and_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <parameter type-id='type-id-228' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_uint' mangled-name='atomic_and_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <parameter type-id='type-id-34' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <parameter type-id='type-id-184' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_and_64' mangled-name='atomic_and_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <parameter type-id='type-id-23' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_inc_uchar_nv' mangled-name='atomic_inc_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ushort_nv' mangled-name='atomic_inc_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_inc_uint_nv' mangled-name='atomic_inc_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_inc_64_nv' mangled-name='atomic_inc_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uchar_nv' mangled-name='atomic_dec_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ushort_nv' mangled-name='atomic_dec_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_dec_uint_nv' mangled-name='atomic_dec_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_dec_64_nv' mangled-name='atomic_dec_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <parameter type-id='type-id-323' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_add_char_nv' mangled-name='atomic_add_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <parameter type-id='type-id-321' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <parameter type-id='type-id-66' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_add_short_nv' mangled-name='atomic_add_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <parameter type-id='type-id-7' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <parameter type-id='type-id-21' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_add_int_nv' mangled-name='atomic_add_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <parameter type-id='type-id-1' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <parameter type-id='type-id-5' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_add_64_nv' mangled-name='atomic_add_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <parameter type-id='type-id-325' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <parameter type-id='type-id-326' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <parameter type-id='type-id-323' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_sub_char_nv' mangled-name='atomic_sub_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <parameter type-id='type-id-321' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <parameter type-id='type-id-66' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_sub_short_nv' mangled-name='atomic_sub_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='208' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <parameter type-id='type-id-7' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <parameter type-id='type-id-21' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_sub_int_nv' mangled-name='atomic_sub_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='210' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <parameter type-id='type-id-1' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <parameter type-id='type-id-5' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_sub_64_nv' mangled-name='atomic_sub_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <parameter type-id='type-id-325' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <parameter type-id='type-id-326' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-32' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_or_uchar_nv' mangled-name='atomic_or_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-306' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-225' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_or_ushort_nv' mangled-name='atomic_or_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-228' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_or_uint_nv' mangled-name='atomic_or_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-34' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-184' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_or_64_nv' mangled-name='atomic_or_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-23' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-32' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_and_uchar_nv' mangled-name='atomic_and_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='244' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar_nv'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-306' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-225' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_and_ushort_nv' mangled-name='atomic_and_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort_nv'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-228' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_and_uint_nv' mangled-name='atomic_and_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint_nv'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-34' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-184' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_and_64_nv' mangled-name='atomic_and_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64_nv'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-23' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <parameter type-id='type-id-32' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <parameter type-id='type-id-32' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_cas_uchar' mangled-name='atomic_cas_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <parameter type-id='type-id-306' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <parameter type-id='type-id-306' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <parameter type-id='type-id-225' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <parameter type-id='type-id-225' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ushort' mangled-name='atomic_cas_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <parameter type-id='type-id-228' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <parameter type-id='type-id-228' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <parameter type-id='type-id-22' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <parameter type-id='type-id-22' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_cas_uint' mangled-name='atomic_cas_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <parameter type-id='type-id-34' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <parameter type-id='type-id-34' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <parameter type-id='type-id-184' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <parameter type-id='type-id-184' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_cas_64' mangled-name='atomic_cas_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <parameter type-id='type-id-23' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <parameter type-id='type-id-23' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
+      <parameter type-id='type-id-73' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
+      <parameter type-id='type-id-73' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='type-id-305' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <parameter type-id='type-id-32' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='atomic_swap_uchar' mangled-name='atomic_swap_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uchar'>
+      <parameter type-id='type-id-308' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <parameter type-id='type-id-306' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
+      <return type-id='type-id-306'/>
+    </function-decl>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='type-id-310' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <parameter type-id='type-id-225' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
+      <return type-id='type-id-225'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ushort' mangled-name='atomic_swap_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ushort'>
+      <parameter type-id='type-id-312' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <parameter type-id='type-id-228' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
+      <return type-id='type-id-228'/>
+    </function-decl>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='type-id-314' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_swap_uint' mangled-name='atomic_swap_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uint'>
+      <parameter type-id='type-id-316' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <parameter type-id='type-id-34' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <parameter type-id='type-id-184' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
+      <return type-id='type-id-184'/>
+    </function-decl>
+    <function-decl name='atomic_swap_64' mangled-name='atomic_swap_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_64'>
+      <parameter type-id='type-id-320' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <parameter type-id='type-id-23' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='type-id-145' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
+      <parameter type-id='type-id-73' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <parameter type-id='type-id-34' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='326' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='type-id-318' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <parameter type-id='type-id-34' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='334' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='membar_exit' mangled-name='membar_exit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_exit'>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='346' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='type-id-17'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='getexecname' mangled-name='getexecname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/getexecname.c' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='getexecname_impl' filepath='./libspl_impl.h' line='24' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='efi_err_check' mangled-name='efi_err_check' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1612' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
-      <parameter type-id='type-id-258' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1612' column='1'/>
-      <return type-id='type-id-27'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
+      <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='efi_type' mangled-name='efi_type' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1590' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1590' column='1'/>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-327'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-37' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-328' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-329' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-330' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-201' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-321' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-331' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-149' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='_codecvt' type-id='type-id-332' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_wide_data' type-id='type-id-333' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='_freeres_list' type-id='type-id-329' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='_freeres_buf' type-id='type-id-73' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-123' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-334' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-335'/>
+    <pointer-type-def type-id='type-id-335' size-in-bits='64' id='type-id-328'/>
+    <pointer-type-def type-id='type-id-327' size-in-bits='64' id='type-id-329'/>
+    <typedef-decl name='__off_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-330'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8' id='type-id-331'>
+      <subrange length='1' type-id='type-id-12' id='type-id-232'/>
+
+    </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-336'/>
+    <pointer-type-def type-id='type-id-336' size-in-bits='64' id='type-id-332'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-337'/>
+    <pointer-type-def type-id='type-id-337' size-in-bits='64' id='type-id-333'/>
+
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='160' id='type-id-334'>
+      <subrange length='20' type-id='type-id-12' id='type-id-338'/>
+
+    </array-type-def>
+    <function-decl name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-329'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='FILE' type-id='type-id-327' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-339'/>
+    <pointer-type-def type-id='type-id-339' size-in-bits='64' id='type-id-340'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-341'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-341' size-in-bits='64' id='type-id-342'/>
+    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
+      <parameter type-id='type-id-340' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-342' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <parameter type-id='type-id-342' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/mntent.h' line='51' column='1' id='type-id-343'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_fsname' type-id='type-id-37' visibility='default' filepath='/usr/include/mntent.h' line='53' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_dir' type-id='type-id-37' visibility='default' filepath='/usr/include/mntent.h' line='54' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_type' type-id='type-id-37' visibility='default' filepath='/usr/include/mntent.h' line='55' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_opts' type-id='type-id-37' visibility='default' filepath='/usr/include/mntent.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_freq' type-id='type-id-1' visibility='default' filepath='/usr/include/mntent.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_passno' type-id='type-id-1' visibility='default' filepath='/usr/include/mntent.h' line='58' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-343' size-in-bits='64' id='type-id-344'/>
+    <function-decl name='getmntent_r' filepath='/usr/include/mntent.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-329'/>
+      <parameter type-id='type-id-344'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-344'/>
+    </function-decl>
+    <function-decl name='feof' filepath='/usr/include/stdio.h' line='765' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-329'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
+      <parameter type-id='type-id-340' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <parameter type-id='type-id-342' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-345'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-37' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_major' type-id='type-id-34' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_minor' type-id='type-id-34' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-345' size-in-bits='64' id='type-id-346'/>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='119' column='1' id='type-id-347'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='type-id-348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='type-id-200' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='type-id-349' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-350' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='type-id-351' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='type-id-352' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='133' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='135' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='type-id-348' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='type-id-330' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='type-id-353' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='type-id-354' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='type-id-239' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='152' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-239' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='153' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-239' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-355' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='164' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='143' column='1' id='type-id-348'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-26' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='149' column='1' id='type-id-349'/>
+    <typedef-decl name='__mode_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-350'/>
+    <typedef-decl name='__uid_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-351'/>
+    <typedef-decl name='__gid_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-352'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='172' column='1' id='type-id-353'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='178' column='1' id='type-id-354'/>
+
+    <array-type-def dimensions='1' type-id='type-id-241' size-in-bits='192' id='type-id-355'>
+      <subrange length='3' type-id='type-id-12' id='type-id-59'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-347' size-in-bits='64' id='type-id-356'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='type-id-16' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-346' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <parameter type-id='type-id-356' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-357'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='list_size' type-id='type-id-123' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='list_offset' type-id='type-id-123' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='list_head' type-id='type-id-358' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-358'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-359' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-359' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-358' size-in-bits='64' id='type-id-359'/>
+    <typedef-decl name='list_t' type-id='type-id-357' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-360'/>
+    <pointer-type-def type-id='type-id-360' size-in-bits='64' id='type-id-361'/>
+    <function-decl name='list_create' mangled-name='list_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-123' name='size' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <parameter type-id='type-id-123' name='offset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-73' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <parameter type-id='type-id-73' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_remove' mangled-name='list_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_prev' mangled-name='list_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <parameter type-id='type-id-73' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-361' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <parameter type-id='type-id-361' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <typedef-decl name='list_node_t' type-id='type-id-358' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-362'/>
+    <pointer-type-def type-id='type-id-362' size-in-bits='64' id='type-id-363'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-363' name='lold' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <parameter type-id='type-id-363' name='lnew' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='type-id-363' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-363' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-361' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='mode_t' type-id='type-id-350' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='69' column='1' id='type-id-364'/>
+    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
+      <parameter type-id='type-id-16' name='d' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <parameter type-id='type-id-364' name='mode' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='mbstowcs' filepath='/usr/include/stdlib.h' line='930' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-142'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-365'/>
+    <pointer-type-def type-id='type-id-365' size-in-bits='64' id='type-id-366'/>
+    <function-decl name='wcstombs' filepath='/usr/include/stdlib.h' line='933' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-366'/>
+      <parameter type-id='type-id-26'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-decl name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
+      <return type-id='type-id-123'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcat' mangled-name='strlcat' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
+      <parameter type-id='type-id-37' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-16' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <parameter type-id='type-id-123' name='dstsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
+      <return type-id='type-id-123'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
+      <parameter type-id='type-id-37' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-16' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <parameter type-id='type-id-123' name='len' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
+      <return type-id='type-id-123'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
+      <parameter type-id='type-id-34' name='timestamp_fmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-367'/>
+    <function-decl name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-367'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='efi_free' mangled-name='efi_free' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1579' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
-      <parameter type-id='type-id-258' name='ptr' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1579' column='1'/>
-      <return type-id='type-id-27'/>
+    <function-decl name='nl_langinfo' filepath='/usr/include/langinfo.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
-    <function-decl name='efi_write' mangled-name='efi_write' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1'/>
-      <parameter type-id='type-id-258' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1376' column='1'/>
+    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-368'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tm_sec' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='9' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='tm_min' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='10' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tm_hour' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='11' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='tm_mday' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='12' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tm_mon' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='13' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='tm_year' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='14' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='tm_wday' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='15' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='tm_yday' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='16' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='tm_isdst' type-id='type-id-1' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='17' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='tm_gmtoff' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='20' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='tm_zone' type-id='type-id-16' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='21' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-368' size-in-bits='64' id='type-id-369'/>
+    <qualified-type-def type-id='type-id-5' const='yes' id='type-id-370'/>
+    <pointer-type-def type-id='type-id-370' size-in-bits='64' id='type-id-371'/>
+    <function-decl name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-371'/>
+      <return type-id='type-id-369'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-368' const='yes' id='type-id-372'/>
+    <pointer-type-def type-id='type-id-372' size-in-bits='64' id='type-id-373'/>
+    <function-decl name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-373'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-1' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-374'/>
+    <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
+      <return type-id='type-id-374'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi' language='LANG_C99'>
+    <class-decl name='dk_map2' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='102' column='1' id='type-id-375'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_tag' type-id='type-id-225' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='p_flag' type-id='type-id-225' visibility='default' filepath='../../lib/libspl/include/sys/dklabel.h' line='104' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-375' size-in-bits='512' id='type-id-376'>
+      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+
+    </array-type-def>
+    <var-decl name='default_vtoc_map' type-id='type-id-376' mangled-name='default_vtoc_map' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='146' column='1' elf-symbol-id='default_vtoc_map'/>
+    <var-decl name='efi_debug' type-id='type-id-1' mangled-name='efi_debug' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='177' column='1' elf-symbol-id='efi_debug'/>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <parameter type-id='type-id-22' name='nparts' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <parameter type-id='type-id-234' name='vtoc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uuid_generate' filepath='/usr/include/uuid/uuid.h' line='90' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
+      <parameter type-id='type-id-234' name='vtoc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_rescan' mangled-name='efi_rescan' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='608' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='608' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1161' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_write' mangled-name='efi_write' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1377' column='1'/>
+      <parameter type-id='type-id-233' name='vtoc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1377' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-30' const='yes' id='type-id-377'/>
+    <pointer-type-def type-id='type-id-377' size-in-bits='64' id='type-id-378'/>
+    <function-decl name='uuid_is_null' filepath='/usr/include/uuid/uuid.h' line='99' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-378'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='/usr/include/zlib.h' line='1725' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-378'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-decl name='lseek' mangled-name='lseek64' filepath='/usr/include/unistd.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='1160' column='1'/>
+    <function-decl name='write' filepath='/usr/include/unistd.h' line='366' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-26'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='efi_rescan' mangled-name='efi_rescan' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='607' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='607' column='1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='fsync' filepath='/usr/include/unistd.h' line='954' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
-      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='446' column='1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='efi_type' mangled-name='efi_type' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
-      <parameter type-id='type-id-5' name='fd' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
-      <parameter type-id='type-id-31' name='nparts' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
-      <parameter type-id='type-id-259' name='vtoc' filepath='/home/fedora/zfs/lib/libefi/rdwr_efi.c' line='376' column='1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='efi_err_check' mangled-name='efi_err_check' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1613' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
+      <parameter type-id='type-id-233' name='vtoc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1613' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='efi_auto_sense' mangled-name='efi_auto_sense' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1708' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_auto_sense'>
+      <parameter type-id='type-id-1' name='fd' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1708' column='1'/>
+      <parameter type-id='type-id-234' name='vtoc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libefi/rdwr_efi.c' line='1708' column='1'/>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>


### PR DESCRIPTION
### Motivation and Context
Exporting names this short can easily cause nasty collisions with user code. `aok`, being the "abort or raze my disk" tunable, is particularly fun.

### Description
See above.

### How Has This Been Tested?
It builds, I guess?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv) – though apparently the only use of aok is for zdb, so it don't matter too much
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply, hopefully
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
