### PR TITLE
freebsd/libzfs: import execvPe() from FreeBSD 13

### DIFF
--- a/lib/libzfs/os/freebsd/libzfs_compat.c
+++ b/lib/libzfs/os/freebsd/libzfs_compat.c
@@ -52,8 +52,8 @@ execvPe(const char *name, const char *path, char * const *argv,
 	const char **memp;
 	size_t cnt, lp, ln;
 	int eacces, save_errno;
-	char *cur, buf[MAXPATHLEN];
-	const char *p, *bp;
+	char buf[MAXPATHLEN];
+	const char *bp, *np, *op, *p;
 	struct stat sb;
 
 	eacces = 0;
@@ -61,7 +61,7 @@ execvPe(const char *name, const char *path, char * const *argv,
 	/* If it's an absolute or relative path name, it's easy. */
 	if (strchr(name, '/')) {
 		bp = name;
-		cur = NULL;
+		op = NULL;
 		goto retry;
 	}
 	bp = buf;
@@ -72,23 +72,30 @@ execvPe(const char *name, const char *path, char * const *argv,
 		return (-1);
 	}
 
-	cur = alloca(strlen(path) + 1);
-	if (cur == NULL) {
-		errno = ENOMEM;
-		return (-1);
-	}
-	strcpy(cur, path);
-	while ((p = strsep(&cur, ":")) != NULL) {
+	op = path;
+	ln = strlen(name);
+	while (op != NULL) {
+		np = strchrnul(op, ':');
+
 		/*
 		 * It's a SHELL path -- double, leading and trailing colons
 		 * mean the current directory.
 		 */
-		if (*p == '\0') {
+		if (np == op) {
+			/* Empty component. */
 			p = ".";
 			lp = 1;
-		} else
-			lp = strlen(p);
-		ln = strlen(name);
+		} else {
+			/* Non-empty component. */
+			p = op;
+			lp = np - op;
+		}
+
+		/* Advance to the next component or terminate after this. */
+		if (*np == '\0')
+			op = NULL;
+		else
+			op = np + 1;
 
 		/*
 		 * If the path is too long complain.  This is a possible
@@ -118,15 +125,31 @@ retry:		(void) execve(bp, argv, envp);
 		case ENOEXEC:
 			for (cnt = 0; argv[cnt]; ++cnt)
 				;
-			memp = alloca((cnt + 2) * sizeof (char *));
+
+			/*
+			 * cnt may be 0 above; always allocate at least
+			 * 3 entries so that we can at least fit "sh", bp, and
+			 * the NULL terminator.  We can rely on cnt to take into
+			 * account the NULL terminator in all other scenarios,
+			 * as we drop argv[0].
+			 */
+			memp = alloca(MAX(3, cnt + 2) * sizeof (char *));
 			if (memp == NULL) {
 				/* errno = ENOMEM; XXX override ENOEXEC? */
 				goto done;
 			}
-			memp[0] = "sh";
-			memp[1] = bp;
-			bcopy(argv + 1, memp + 2, cnt * sizeof (char *));
-			execve(_PATH_BSHELL, __DECONST(char **, memp), envp);
+			if (cnt > 0) {
+				memp[0] = argv[0];
+				memp[1] = bp;
+				bcopy(argv + 1, memp + 2,
+				    cnt * sizeof (char *));
+			} else {
+				memp[0] = "sh";
+				memp[1] = bp;
+				memp[2] = NULL;
+			}
+			(void) execve(_PATH_BSHELL,
+			    __DECONST(char **, memp), envp);
 			goto done;
 		case ENOMEM:
 			goto done;


### PR DESCRIPTION
### Motivation and Context
The FreeBSD libc *already has* an execvpe(), but doesn't export it because it "caused some ports to break" thirteen years ago.

### Description
Copied it out of https://download.freebsd.org/ftp/development/tarballs/src_stable_13.tar.zst, repaired some whitespace damage, replaced `_exec*` with `exec*`, rearranged `(void)`s and keywords to have a space after them, and restored the direct string printing.

This seems to correspond to https://cgit.freebsd.org/src/commit/lib/libc/gen/exec.c?id=301cb491ea417e54c29e63ebe00afbc8de47cd1f and https://cgit.freebsd.org/src/commit/lib/libc/gen/exec.c?id=f0fbdf1f4f2153f4c036f5ebd7c7717525437e25.

### How Has This Been Tested?
Consider the following program:
```c
#include <stdlib.h>
#include <sys/param.h>
#include <sys/stat.h>
#include <paths.h>
#include <stdio.h>
#include <errno.h>
#include <string.h>
#include <unistd.h>
static int
execvPe(const char *name, const char *path, char * const *argv,
    char * const *envp)
{
	const char **memp;
	size_t cnt, lp, ln;
	int eacces, save_errno;
	char *cur, buf[MAXPATHLEN];
	const char *p, *bp;
	struct stat sb;

	eacces = 0;

	/* If it's an absolute or relative path name, it's easy. */
	if (strchr(name, '/')) {
		bp = name;
		cur = NULL;
		goto retry;
	}
	bp = buf;

	/* If it's an empty path name, fail in the usual POSIX way. */
	if (*name == '\0') {
		errno = ENOENT;
		return (-1);
	}

	cur = alloca(strlen(path) + 1);
	if (cur == NULL) {
		errno = ENOMEM;
		return (-1);
	}
	strcpy(cur, path);
	while ((p = strsep(&cur, ":")) != NULL) {
		/*
		 * It's a SHELL path -- double, leading and trailing colons
		 * mean the current directory.
		 */
		if (*p == '\0') {
			p = ".";
			lp = 1;
		} else
			lp = strlen(p);
		ln = strlen(name);

		/*
		 * If the path is too long complain.  This is a possible
		 * security issue; given a way to make the path too long
		 * the user may execute the wrong program.
		 */
		if (lp + ln + 2 > sizeof (buf)) {
			(void) write(STDERR_FILENO, "execvP: ", 8);
			(void) write(STDERR_FILENO, p, lp);
			(void) write(STDERR_FILENO, ": path too long\n",
			    16);
			continue;
		}
		bcopy(p, buf, lp);
		buf[lp] = '/';
		bcopy(name, buf + lp + 1, ln);
		buf[lp + ln + 1] = '\0';

retry:		(void) execve(bp, argv, envp);
		switch (errno) {
		case E2BIG:
			goto done;
		case ELOOP:
		case ENAMETOOLONG:
		case ENOENT:
			break;
		case ENOEXEC:
			for (cnt = 0; argv[cnt]; ++cnt)
				;
			memp = alloca((cnt + 2) * sizeof (char *));
			if (memp == NULL) {
				/* errno = ENOMEM; XXX override ENOEXEC? */
				goto done;
			}
			memp[0] = "sh";
			memp[1] = bp;
			bcopy(argv + 1, memp + 2, cnt * sizeof (char *));
			execve(_PATH_BSHELL, __DECONST(char **, memp), envp);
			goto done;
		case ENOMEM:
			goto done;
		case ENOTDIR:
			break;
		case ETXTBSY:
			/*
			 * We used to retry here, but sh(1) doesn't.
			 */
			goto done;
		default:
			/*
			 * EACCES may be for an inaccessible directory or
			 * a non-executable file.  Call stat() to decide
			 * which.  This also handles ambiguities for EFAULT
			 * and EIO, and undocumented errors like ESTALE.
			 * We hope that the race for a stat() is unimportant.
			 */
			save_errno = errno;
			if (stat(bp, &sb) != 0)
				break;
			if (save_errno == EACCES) {
				eacces = 1;
				continue;
			}
			errno = save_errno;
			goto done;
		}
	}
	if (eacces)
		errno = EACCES;
	else
		errno = ENOENT;
done:
	return (-1);
}

int
execvpe(const char *name, char * const argv[], char * const envp[])
{
	const char *path;

	/* Get the path we're searching. */
	if ((path = getenv("PATH")) == NULL)
		path = _PATH_DEFPATH;

	return (execvPe(name, path, argv, envp));
}

int main() {
	char *argvp[] = {NULL};
	char *envp[] = {NULL};
	execvpe("ENOENT", argvp, envp);
}
```
everything between the defines and main is copied wholesale from libzfs_compat.c.

Now build it, and run like so
```
echo hehe > ENOENT
chmod +x ENOENT
PATH=.:$PATH ./ex
```

If you break at line 90 in a debugger, you'll see
```
(gdb) p memp
$1 = (const char **) 0x7fffffffd520
(gdb) p memp[0]
$2 = 0x200836 "sh"
(gdb) p memp[1]
$3 = 0x7fffffffd660 "./ENOENT"
(gdb) p memp[2]
$4 = 0x3a6e6962732f002e <error: Cannot access memory at address 0x3a6e6962732f002e>
```
and a ktrace confirms this:
```
  1083 ex       CALL  execve(0x7fffffffd690,0x7fffffffdb20,0x7fffffffdb28)
  1083 ex       NAMI  "./ENOENT"
  1083 ex       RET   execve -1 errno 8 Exec format error
  1083 ex       CALL  execve(0x2007ca,0x7fffffffd550,0x7fffffffdb28)
  1083 ex       RET   execve -1 errno 14 Bad address
```

Compare this to the same driver with the new implementation:
```
(gdb) p memp
$3 = (const char **) 0x7fffffffd550
(gdb) p memp[0]
$4 = 0x20080e "sh"
(gdb) p memp[1]
$5 = 0x7fffffffd570 "./ENOENT"
(gdb) p memp[2]
$6 = 0x0
```
and
```
  1143 ex3      CALL  execve(0x7fffffffd5a0,0x7fffffffdb20,0x7fffffffdb28)
  1143 ex3      NAMI  "./ENOENT"
  1143 ex3      RET   execve -1 errno 8 Exec format error
  1143 ex3      CALL  execve(0x2007a2,0x7fffffffd580,0x7fffffffdb28)
  1143 ex3      NAMI  "/bin/sh"
  1143 ex3      NAMI  "/libexec/ld-elf.so.1"
  1143 sh       RET   execve JUSTRETURN
```

I don't think this is *exploitable* per se, but you know.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
