### PR TITLE
Simple change to fix building in recent environments.

### DIFF
--- a/module/os/linux/zfs/zfs_ioctl_os.c
+++ b/module/os/linux/zfs/zfs_ioctl_os.c
@@ -228,7 +228,7 @@ zfsdev_detach(void)
 #endif
 
 static int __init
-_init(void)
+openzfs_init(void)
 {
 	int error;
 
@@ -254,7 +254,7 @@ _init(void)
 }
 
 static void __exit
-_fini(void)
+openzfs_fini(void)
 {
 	zfs_sysfs_fini();
 	zfs_kmod_fini();
@@ -264,8 +264,8 @@ _fini(void)
 }
 
 #if defined(_KERNEL)
-module_init(_init);
-module_exit(_fini);
+module_init(openzfs_init);
+module_exit(openzfs_fini);
 #endif
 
 ZFS_MODULE_DESCRIPTION("ZFS");


### PR DESCRIPTION
### Motivation and Context
Quick change that was the sole thing required to unbreak building with 5.12.4.

### Description
[Per @ensch](https://github.com/openzfs/zfs/issues/11987#issuecomment-832167327):
`Just renaming the _init function to something else, so that the macro expansion does not confuse it with __init, fixes the problem for me.`

### How Has This Been Tested?
It built with bb-build-linux.sh. That's all I've tried.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
