### PR TITLE
zfs-allow.8: mention 'bookmark' permission

### DIFF
--- a/man/man8/zfs-allow.8
+++ b/man/man8/zfs-allow.8
@@ -195,6 +195,7 @@ The following permissions are available:
 NAME             TYPE           NOTES
 allow            subcommand     Must also have the permission that is
                                 being allowed
+bookmark         subcommand
 clone            subcommand     Must also have the 'create' ability and
                                 'mount' ability in the origin file system
 create           subcommand     Must also have the 'mount' ability.


### PR DESCRIPTION
'bookmark' permission is missing from the zfs-allow(8) manpage.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
