### PR TITLE
libshare: nfs: deduplication, don't SIGHUP everyone, retry flock() on EINTR, don't reopen temporary file

### DIFF
--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -50,7 +50,9 @@ nfs_exports_lock(const char *name)
 		return (err);
 	}
 
-	if (flock(nfs_lock_fd, LOCK_EX) != 0) {
+	while ((err = flock(nfs_lock_fd, LOCK_EX)) != 0 && errno == EINTR)
+		;
+	if (err != 0) {
 		err = errno;
 		fprintf(stderr, "failed to lock %s: %s\n", name, strerror(err));
 		(void) close(nfs_lock_fd);

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -89,11 +89,9 @@ struct tmpfile {
 static boolean_t
 nfs_init_tmpfile(const char *prefix, const char *mdir, struct tmpfile *tmpf)
 {
-	struct stat sb;
-
 	if (mdir != NULL &&
-	    stat(mdir, &sb) < 0 &&
-	    mkdir(mdir, 0755) < 0) {
+	    mkdir(mdir, 0755) < 0 &&
+	    errno != EEXIST) {
 		fprintf(stderr, "failed to create %s: %s\n",
 		    mdir, strerror(errno));
 		return (B_FALSE);

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -144,6 +144,7 @@ nfs_fini_tmpfile(const char *exports, struct tmpfile *tmpf)
 		return (SA_SYSTEM_ERR);
 	}
 
+	(void) fchmod(fileno(tmpf->fp), 0644);
 	fclose(tmpf->fp);
 	return (SA_OK);
 }

--- a/lib/libshare/nfs.h
+++ b/lib/libshare/nfs.h
@@ -30,7 +30,6 @@
 
 void libshare_nfs_init(void);
 
-int nfs_copy_entries(FILE *tmpfile, const char *mountpoint);
 int nfs_toggle_share(const char *lockfile, const char *exports,
     const char *expdir, sa_share_impl_t impl_share,
     int(*cbk)(sa_share_impl_t impl_share, FILE *tmpfile));

--- a/lib/libshare/nfs.h
+++ b/lib/libshare/nfs.h
@@ -30,7 +30,7 @@
 
 void libshare_nfs_init(void);
 
-int nfs_copy_entries(char *filename, const char *mountpoint);
+int nfs_copy_entries(FILE *tmpfile, const char *mountpoint);
 int nfs_toggle_share(const char *lockfile, const char *exports,
     const char *expdir, sa_share_impl_t impl_share,
-    int(*cbk)(sa_share_impl_t impl_share, char *filename));
+    int(*cbk)(sa_share_impl_t impl_share, FILE *tmpfile));

--- a/lib/libshare/nfs.h
+++ b/lib/libshare/nfs.h
@@ -30,6 +30,7 @@
 
 void libshare_nfs_init(void);
 
+boolean_t nfs_is_shared_impl(const char *exports, sa_share_impl_t impl_share);
 int nfs_toggle_share(const char *lockfile, const char *exports,
     const char *expdir, sa_share_impl_t impl_share,
     int(*cbk)(sa_share_impl_t impl_share, FILE *tmpfile));

--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -306,15 +306,21 @@ nfs_commit_shares(void)
 	struct pidfh *pfh;
 	pid_t mountdpid;
 
+start:
 	pfh = pidfile_open(_PATH_MOUNTDPID, 0600, &mountdpid);
 	if (pfh != NULL) {
-		/* Mountd is not running. */
+		/* mountd(8) is not running. */
 		pidfile_remove(pfh);
 		return (SA_OK);
 	}
 	if (errno != EEXIST) {
 		/* Cannot open pidfile for some reason. */
 		return (SA_SYSTEM_ERR);
+	}
+	if (mountdpid == -1) {
+		/* mountd(8) exists, but didn't write the PID yet */
+		usleep(500);
+		goto start;
 	}
 	/* We have mountd(8) PID in mountdpid variable. */
 	kill(mountdpid, SIGHUP);

--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -148,35 +148,7 @@ nfs_disable_share(sa_share_impl_t impl_share)
 static boolean_t
 nfs_is_shared(sa_share_impl_t impl_share)
 {
-	char *s, last, line[MAXLINESIZE];
-	size_t len;
-	char *mntpoint = impl_share->sa_mountpoint;
-	size_t mntlen = strlen(mntpoint);
-
-	FILE *fp = fopen(ZFS_EXPORTS_FILE, "re");
-	if (fp == NULL)
-		return (B_FALSE);
-
-	for (;;) {
-		s = fgets(line, sizeof (line), fp);
-		if (s == NULL)
-			return (B_FALSE);
-		/* Skip empty lines and comments. */
-		if (line[0] == '\n' || line[0] == '#')
-			continue;
-		len = strlen(line);
-		if (line[len - 1] == '\n')
-			line[len - 1] = '\0';
-		last = line[mntlen];
-		/* Skip the given mountpoint. */
-		if (strncmp(mntpoint, line, mntlen) == 0 &&
-		    (last == '\t' || last == ' ' || last == '\0')) {
-			fclose(fp);
-			return (B_TRUE);
-		}
-	}
-	fclose(fp);
-	return (B_FALSE);
+	return (nfs_is_shared_impl(ZFS_EXPORTS_FILE, impl_share));
 }
 
 static int

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -467,31 +467,7 @@ nfs_disable_share(sa_share_impl_t impl_share)
 static boolean_t
 nfs_is_shared(sa_share_impl_t impl_share)
 {
-	size_t buflen = 0;
-	char *buf = NULL;
-
-	FILE *fp = fopen(ZFS_EXPORTS_FILE, "re");
-	if (fp == NULL) {
-		return (B_FALSE);
-	}
-	while ((getline(&buf, &buflen, fp)) != -1) {
-		char *space = NULL;
-
-		if ((space = strchr(buf, ' ')) != NULL) {
-			int mountpoint_len = strlen(impl_share->sa_mountpoint);
-
-			if (space - buf == mountpoint_len &&
-			    strncmp(impl_share->sa_mountpoint, buf,
-			    mountpoint_len) == 0) {
-				fclose(fp);
-				free(buf);
-				return (B_TRUE);
-			}
-		}
-	}
-	free(buf);
-	fclose(fp);
-	return (B_FALSE);
+	return (nfs_is_shared_impl(ZFS_EXPORTS_FILE, impl_share));
 }
 
 /*

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -51,7 +51,7 @@ static sa_fstype_t *nfs_fstype;
 typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
     void *cookie);
 
-typedef int (*nfs_host_callback_t)(const char *sharepath, const char *filename,
+typedef int (*nfs_host_callback_t)(FILE *tmpfile, const char *sharepath,
     const char *host, const char *security, const char *access, void *cookie);
 
 /*
@@ -122,7 +122,7 @@ typedef struct nfs_host_cookie_s {
 	nfs_host_callback_t callback;
 	const char *sharepath;
 	void *cookie;
-	const char *filename;
+	FILE *tmpfile;
 	const char *security;
 } nfs_host_cookie_t;
 
@@ -203,7 +203,7 @@ foreach_nfs_host_cb(const char *opt, const char *value, void *pcookie)
 				}
 			}
 
-			error = udata->callback(udata->filename,
+			error = udata->callback(udata->tmpfile,
 			    udata->sharepath, host, udata->security,
 			    access, udata->cookie);
 
@@ -226,7 +226,7 @@ foreach_nfs_host_cb(const char *opt, const char *value, void *pcookie)
  * Invokes a callback function for all NFS hosts that are set for a share.
  */
 static int
-foreach_nfs_host(sa_share_impl_t impl_share, char *filename,
+foreach_nfs_host(sa_share_impl_t impl_share, FILE *tmpfile,
     nfs_host_callback_t callback, void *cookie)
 {
 	nfs_host_cookie_t udata;
@@ -235,7 +235,7 @@ foreach_nfs_host(sa_share_impl_t impl_share, char *filename,
 	udata.callback = callback;
 	udata.sharepath = impl_share->sa_mountpoint;
 	udata.cookie = cookie;
-	udata.filename = filename;
+	udata.tmpfile = tmpfile;
 	udata.security = "sys";
 
 	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
@@ -393,7 +393,7 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
  * automatically exported upon boot or whenever the nfs server restarts.
  */
 static int
-nfs_add_entry(const char *filename, const char *sharepath,
+nfs_add_entry(FILE *tmpfile, const char *sharepath,
     const char *host, const char *security, const char *access_opts,
     void *pcookie)
 {
@@ -408,50 +408,29 @@ nfs_add_entry(const char *filename, const char *sharepath,
 	if (linux_opts == NULL)
 		linux_opts = "";
 
-	FILE *fp = fopen(filename, "a+e");
-	if (fp == NULL) {
-		fprintf(stderr, "failed to open %s file: %s", filename,
-		    strerror(errno));
-		free(linuxhost);
-		return (SA_SYSTEM_ERR);
-	}
-
-	if (fprintf(fp, "%s %s(sec=%s,%s,%s)\n", sharepath, linuxhost,
+	if (fprintf(tmpfile, "%s %s(sec=%s,%s,%s)\n", sharepath, linuxhost,
 	    security, access_opts, linux_opts) < 0) {
-		fprintf(stderr, "failed to write to %s\n", filename);
+		fprintf(stderr, "failed to write to temporary file\n");
 		free(linuxhost);
-		fclose(fp);
 		return (SA_SYSTEM_ERR);
 	}
 
 	free(linuxhost);
-	if (fclose(fp) != 0) {
-		fprintf(stderr, "Unable to close file %s: %s\n",
-		    filename, strerror(errno));
-		return (SA_SYSTEM_ERR);
-	}
 	return (SA_OK);
 }
 
 /*
- * This function copies all entries from the exports file to "filename",
+ * This function copies all entries from the exports file to newfp,
  * omitting any entries for the specified mountpoint.
  */
 int
-nfs_copy_entries(char *filename, const char *mountpoint)
+nfs_copy_entries(FILE *newfp, const char *mountpoint)
 {
 	char *buf = NULL;
 	size_t buflen = 0;
 	int error = SA_OK;
 
 	FILE *oldfp = fopen(ZFS_EXPORTS_FILE, "re");
-	FILE *newfp = fopen(filename, "w+e");
-	if (newfp == NULL) {
-		fprintf(stderr, "failed to open %s file: %s", filename,
-		    strerror(errno));
-		fclose(oldfp);
-		return (SA_SYSTEM_ERR);
-	}
 	fputs(FILE_HEADER, newfp);
 
 	/*
@@ -482,21 +461,15 @@ nfs_copy_entries(char *filename, const char *mountpoint)
 		}
 		if (fclose(oldfp) != 0) {
 			fprintf(stderr, "Unable to close file %s: %s\n",
-			    filename, strerror(errno));
+			    ZFS_EXPORTS_FILE, strerror(errno));
 			error = error != 0 ? error : SA_SYSTEM_ERR;
 		}
 	}
 
-	if (error == 0 && ferror(newfp) != 0) {
+	if (error == SA_OK && ferror(newfp) != 0)
 		error = ferror(newfp);
-	}
 
 	free(buf);
-	if (fclose(newfp) != 0) {
-		fprintf(stderr, "Unable to close file %s: %s\n",
-		    filename, strerror(errno));
-		error = error != 0 ? error : SA_SYSTEM_ERR;
-	}
 	return (error);
 }
 
@@ -504,7 +477,7 @@ nfs_copy_entries(char *filename, const char *mountpoint)
  * Enables NFS sharing for the specified share.
  */
 static int
-nfs_enable_share_impl(sa_share_impl_t impl_share, char *filename)
+nfs_enable_share_impl(sa_share_impl_t impl_share, FILE *tmpfile)
 {
 	char *shareopts, *linux_opts;
 	int error;
@@ -514,7 +487,7 @@ nfs_enable_share_impl(sa_share_impl_t impl_share, char *filename)
 	if (error != SA_OK)
 		return (error);
 
-	error = foreach_nfs_host(impl_share, filename, nfs_add_entry,
+	error = foreach_nfs_host(impl_share, tmpfile, nfs_add_entry,
 	    linux_opts);
 	free(linux_opts);
 	return (error);
@@ -532,7 +505,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
  * Disables NFS sharing for the specified share.
  */
 static int
-nfs_disable_share_impl(sa_share_impl_t impl_share, char *filename)
+nfs_disable_share_impl(sa_share_impl_t impl_share, FILE *tmpfile)
 {
 	return (SA_OK);
 }

--- a/lib/libshare/os/linux/smb.c
+++ b/lib/libshare/os/linux/smb.c
@@ -254,7 +254,7 @@ smb_enable_share_one(const char *sharename, const char *sharepath)
 	argv[5] = (char *)name;
 	argv[6] = (char *)sharepath;
 	argv[7] = (char *)comment;
-	argv[8] = "Everyone:F";
+	argv[8] = (char *)"Everyone:F";
 	argv[9] = NULL;
 
 	rc = libzfs_run_process(argv[0], argv, 0);

--- a/man/man8/zfs-share.8
+++ b/man/man8/zfs-share.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd May 17, 2021
 .Dt ZFS-SHARE 8
 .Os
 .
@@ -39,6 +39,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm share
+.Op Fl l
 .Fl a Ns | Ns Ar filesystem
 .Nm zfs
 .Cm unshare
@@ -49,10 +50,19 @@
 .It Xo
 .Nm zfs
 .Cm share
+.Op Fl l
 .Fl a Ns | Ns Ar filesystem
 .Xc
 Shares available ZFS file systems.
 .Bl -tag -width "-a"
+.It Fl l
+Load keys for encrypted filesystems as they are being mounted.
+This is equivalent to executing
+.Nm zfs Cm load-key
+on each encryption root before mounting it.
+Note that if a filesystem has
+.Sy keylocation Ns = Ns Sy prompt ,
+this will cause the terminal to interactively block after asking for the key.
 .It Fl a
 Share all available ZFS file systems.
 Invoked automatically as part of the boot process.


### PR DESCRIPTION
### Motivation and Context
Assorted bag of duplicate code and subtle deficiencies and/or improvements I found.

### Description
See individual commit messages, all logically disparate.

### How Has This Been Tested?
Ran zfs unshare -a and zfs share -a on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply hopefully
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
