### PR TITLE
libzfs: run_process: avoid deadlock, remove leaks

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -889,7 +889,7 @@ libzfs_run_process_impl(const char *path, char *argv[], char *env[], int flags,
 	 * Setup a pipe between our child and parent process if we're
 	 * reading stdout.
 	 */
-	if ((lines != NULL) && pipe2(link, O_CLOEXEC) == -1)
+	if (lines != NULL && pipe2(link, O_NONBLOCK | O_CLOEXEC) == -1)
 		return (-EPIPE);
 
 	pid = vfork();
@@ -928,7 +928,8 @@ libzfs_run_process_impl(const char *path, char *argv[], char *env[], int flags,
 		int status;
 
 		while ((error = waitpid(pid, &status, 0)) == -1 &&
-		    errno == EINTR) { }
+		    errno == EINTR)
+			;
 		if (error < 0 || !WIFEXITED(status))
 			return (-1);
 

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -849,8 +849,10 @@ libzfs_read_stdout_from_fd(int fd, char **lines[])
 	char **tmp_lines = NULL, **tmp;
 
 	fp = fdopen(fd, "r");
-	if (fp == NULL)
+	if (fp == NULL) {
+		close(fd);
 		return (0);
+	}
 	while (getline(&line, &len, fp) != -1) {
 		tmp = realloc(tmp_lines, sizeof (*tmp_lines) * (lines_cnt + 1));
 		if (tmp == NULL) {


### PR DESCRIPTION
### Motivation and Context
Dunno, noticed it I guess

### Description
See individual commit messages.

An alternative solution would be to drain the pipe and *then* wait for the child, but that potentially grows our memory infinitely for what is an interface designed for seven short lines of text.

### How Has This Been Tested?
Ran it, I guess?

Slap (variants of) this in your `~/.zpool.d/` and see how it strikes you:
```sh
#!/bin/sh
exec 3>/dev/pts/3
for $(seq 1000000); do
  echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && printf "." >&3
done
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none hopefully apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
