### PR TITLE
raidz_test: signal handling correctness

### DIFF
--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -37,11 +37,11 @@
 static int *rand_data;
 raidz_test_opts_t rto_opts;
 
-static char gdb[256];
-static const char gdb_tmpl[] = "gdb -ex \"set pagination 0\" -p %d";
+static char pid_s[16];
 
 static void sig_handler(int signo)
 {
+	int old_errno = errno;
 	struct sigaction action;
 	/*
 	 * Restore default action and re-raise signal so SIGSEGV and
@@ -52,10 +52,19 @@ static void sig_handler(int signo)
 	action.sa_flags = 0;
 	(void) sigaction(signo, &action, NULL);
 
-	if (rto_opts.rto_gdb)
-		if (system(gdb)) { }
+	if (rto_opts.rto_gdb) {
+		pid_t pid = fork();
+		if (pid == 0) {
+			execlp("gdb", "gdb", "-ex", "set pagination 0",
+			    "-p", pid_s, NULL);
+			_exit(-1);
+		} else if (pid > 0)
+			while (waitpid(pid, NULL, 0) == -1 && errno == EINTR)
+				;
+	}
 
 	raise(signo);
+	errno = old_errno;
 }
 
 static void print_opts(raidz_test_opts_t *opts, boolean_t force)
@@ -978,8 +987,8 @@ main(int argc, char **argv)
 	struct sigaction action;
 	int err = 0;
 
-	/* init gdb string early */
-	(void) sprintf(gdb, gdb_tmpl, getpid());
+	/* init gdb pid string early */
+	(void) sprintf(pid_s, "%d", getpid());
 
 	action.sa_handler = sig_handler;
 	sigemptyset(&action.sa_mask);


### PR DESCRIPTION
### Motivation and Context
system(3) isn't

### Description
See commit message.

This would be perfect for vfork actually, and I see no reason it wouldn't be async-signal-safe, but no documentation would conclusively tell me.

### How Has This Been Tested?
Ex situ.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none hopefully apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
