### PR TITLE
Update tmpfile() existence detection

### DIFF
--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -3,23 +3,43 @@ dnl # 3.11 API change
 dnl # Add support for i_op->tmpfile
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+	dnl #
+	dnl # 5.11 API change
+	dnl # add support for userns parameter to tmpfile
+	dnl #
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_userns], [
 		#include <linux/fs.h>
-		int tmpfile(struct inode *inode, struct dentry *dentry,
+		int tmpfile(struct user_namespace *userns,
+		    struct inode *inode, struct dentry *dentry,
 		    umode_t mode) { return 0; }
 		static struct inode_operations
 		    iops __attribute__ ((unused)) = {
 			.tmpfile = tmpfile,
 		};
 	],[])
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+			#include <linux/fs.h>
+			int tmpfile(struct inode *inode, struct dentry *dentry,
+			    umode_t mode) { return 0; }
+			static struct inode_operations
+			    iops __attribute__ ((unused)) = {
+				.tmpfile = tmpfile,
+			};
+	],[])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 	AC_MSG_CHECKING([whether i_op->tmpfile() exists])
-	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_userns], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+		AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
 	],[
-		AC_MSG_RESULT(no)
+		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+		],[
+			AC_MSG_RESULT(no)
+		])
 	])
 ])

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -224,7 +224,12 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 
 #ifdef HAVE_TMPFILE
 static int
+#ifdef HAVE_TMPFILE_USERNS
+zpl_tmpfile(struct user_namespace *userns, struct inode *dir,
+    struct dentry *dentry, umode_t mode)
+#else
 zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
+#endif
 {
 	cred_t *cr = CRED();
 	struct inode *ip;


### PR DESCRIPTION
### Motivation and Context
Linux changed the tmpfile() signature again in torvalds/linux@6521f89,
which in turn broke our HAVE_TMPFILE detection in configure, leading to
#12060 .

### Description

Update that macro to include the new case, and change the signature of
zpl_tmpfile as appropriate based on the new detection.


### How Has This Been Tested?
* Verified that O_TMPFILE failed with EOPNOTSUPP on ZFS on Debian bullseye, kernel 5.12.0 with vanilla git and passed with this PR.
* Verified that O_TMPFILE still works as expected on the aforementioned system running a 5.10.0 kernel
* Verified same on Ubuntu 18.04 box running 4.15.0-143-generic
* Verified that all the above systems pass all the tmpfile-related tests in ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
