### PR TITLE
libzfs: On FreeBSD, use MNT_NOWAIT with getfsstat

### DIFF
--- a/include/sys/zfs_ioctl_impl.h
+++ b/include/sys/zfs_ioctl_impl.h
@@ -82,6 +82,7 @@ void zfs_ioctl_register(const char *, zfs_ioc_t, zfs_ioc_func_t *,
     boolean_t, boolean_t, const zfs_ioc_key_t *, size_t);
 
 uint64_t zfs_max_nvlist_src_size_os(void);
+void zfs_ioctl_update_mount_cache(const char *dsname);
 void zfs_ioctl_init_os(void);
 
 boolean_t zfs_vfs_held(zfsvfs_t *);

--- a/lib/libspl/os/freebsd/mnttab.c
+++ b/lib/libspl/os/freebsd/mnttab.c
@@ -140,14 +140,14 @@ statfs_init(void)
 		free(gsfs);
 		gsfs = NULL;
 	}
-	allfs = getfsstat(NULL, 0, MNT_WAIT);
+	allfs = getfsstat(NULL, 0, MNT_NOWAIT);
 	if (allfs == -1)
 		goto fail;
 	gsfs = malloc(sizeof (gsfs[0]) * allfs * 2);
 	if (gsfs == NULL)
 		goto fail;
 	allfs = getfsstat(gsfs, (long)(sizeof (gsfs[0]) * allfs * 2),
-	    MNT_WAIT);
+	    MNT_NOWAIT);
 	if (allfs == -1)
 		goto fail;
 	sfs = realloc(gsfs, allfs * sizeof (gsfs[0]));

--- a/module/os/freebsd/zfs/zfs_ioctl_os.c
+++ b/module/os/freebsd/zfs/zfs_ioctl_os.c
@@ -138,6 +138,23 @@ zfs_ioc_nextboot(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 	return (error);
 }
 
+/* Update the VFS's cache of mountpoint properties */
+void
+zfs_ioctl_update_mount_cache(const char *dsname)
+{
+	zfsvfs_t *zfsvfs;
+
+	if (getzfsvfs(dsname, &zfsvfs) == 0) {
+		struct mount *mp = zfsvfs->z_vfs;
+		VFS_STATFS(mp, &mp->mnt_stat);
+		zfs_vfs_rele(zfsvfs);
+	}
+	/*
+	 * Ignore errors; we can't do anything useful if either getzfsvfs or
+	 * VFS_STATFS fails.
+	 */
+}
+
 uint64_t
 zfs_max_nvlist_src_size_os(void)
 {

--- a/module/os/linux/zfs/zfs_ioctl_os.c
+++ b/module/os/linux/zfs/zfs_ioctl_os.c
@@ -157,6 +157,12 @@ zfs_max_nvlist_src_size_os(void)
 	return (MIN(ptob(zfs_totalram_pages) / 4, 128 * 1024 * 1024));
 }
 
+/* Update the VFS's cache of mountpoint properties */
+void
+zfs_ioctl_update_mount_cache(const char *dsname)
+{
+}
+
 void
 zfs_ioctl_init_os(void)
 {


### PR DESCRIPTION
`getfsstat(2)` is used to retrieve the list of mounted file systems,
which libzfs uses when fetching properties like mountpoint, atime,
setuid, etc.  The `mode` parameter may be `MNT_NOWAIT`, which uses
information in the VFS's cache, or `MNT_WAIT`, which effectively does a
`statfs` on every single mounted file system in order to fetch the most
up-to-date information.  As far as I can tell, the only fields that
libzfs cares about are the filesystem's name, mountpoint, fstypename,
and mount flags.  Those things should always be accurate in the VFS's
cache, except in the case of a file system that is busy unmounting.  So
switching to `MNT_NOWAIT` will greatly improve speed with no downside.

For comparison, Illumos gets this information using the native
`getmntany` and `getmntent` functions, which also use cached
information.  The illumos function that would refresh the cache,
`resetmnttab`, is never called by libzfs.

And on GNU/Linux, `getmntany` and `getmntent` don't even communicate
with the kernel directly.  They simply parse the file they are given,
which is usually /etc/mtab or /proc/mounts.

Sponsored-by:	Axcient
Sign-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Some operations, especially `zfs get all`, can be very slow on a FreeBSD server with many ZFS file systems and heavy ZFS control path activity.  The reason is that these operations must iterate over all mountpoints, and with `MNT_WAIT` they effectively do `statfs` on each one.  That `statfs` operation can block inside of ZFS when control operations are in progress.  This is the same problem that was earlier addressed by #11955 .

### Description
Replace `MNT_WAIT` with `MNT_NOWAIT` when libzfs calls `getfsstat`.  I can find no reason why libzfs would need the former.  And on other operating systems, ZFS uses something equivalent to the latter.

### How Has This Been Tested?
Tested using various permutations of the `zfs get` command with datasets that have properties derived from different sources.  The same results are returned with and without the patch.  In terms of performance, on one busy server `zfs get setuid <DS>` could previously take hundreds of seconds, and sometimes even 1000s to return.  Now it usually completes in less than 1 second.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
