### PR TITLE
ZTS: remove verify_slog_support helper

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1897,13 +1897,11 @@ function zfs_zones_setup #zone_name zone_root zone_ip
 	block_device_wait
 
 	#
-	# If current system support slog, add slog device for pool
+	# Add slog device for pool
 	#
-	if verify_slog_support ; then
-		typeset sdevs="$TEST_BASE_DIR/sdev1 $TEST_BASE_DIR/sdev2"
-		log_must mkfile $MINVDEVSIZE $sdevs
-		log_must zpool add $pool_name log mirror $sdevs
-	fi
+	typeset sdevs="$TEST_BASE_DIR/sdev1 $TEST_BASE_DIR/sdev2"
+	log_must mkfile $MINVDEVSIZE $sdevs
+	log_must zpool add $pool_name log mirror $sdevs
 
 	# this isn't supported just yet.
 	# Create a filesystem. In order to add this to
@@ -3065,28 +3063,6 @@ function random_get_with_non
 function random_get
 {
 	_random_get "$#" "$@"
-}
-
-#
-# Detect if the current system support slog
-#
-function verify_slog_support
-{
-	typeset dir=$TEST_BASE_DIR/disk.$$
-	typeset pool=foo.$$
-	typeset vdev=$dir/a
-	typeset sdev=$dir/b
-
-	mkdir -p $dir
-	mkfile $MINVDEVSIZE $vdev $sdev
-
-	typeset -i ret=0
-	if ! zpool create -n $pool $vdev log $sdev > /dev/null 2>&1; then
-		ret=1
-	fi
-	rm -r $dir
-
-	return $ret
 }
 
 #

--- a/tests/zfs-tests/tests/functional/pool_names/pool_names_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/pool_names/pool_names_002_neg.ksh
@@ -111,9 +111,9 @@ set -A POOLNAME \
     "2222222222222222222" "mirror_pool" "raidz_pool" \
     "mirror-pool" "raidz-pool" "spare" "spare_pool" \
     "spare-pool" "raidz1-" "raidz2:" ":aaa" "-bbb" "_ccc" ".ddd"
-if verify_slog_support ; then
-	POOLNAME[${#POOLNAME[@]}]='log'
-fi
+
+POOLNAME[${#POOLNAME[@]}]='log'
+
 typeset -i i=0
 while ((i < ${#POOLNAME[@]})); do
 	log_mustnot zpool create -m $TESTDIR ${POOLNAME[$i]} $DISK

--- a/tests/zfs-tests/tests/functional/slog/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/slog/cleanup.ksh
@@ -34,10 +34,6 @@
 
 verify_runnable "global"
 
-if ! verify_slog_support ; then
-	log_unsupported "This system doesn't support separate intent logs"
-fi
-
 if datasetexists $TESTPOOL ; then
 	log_must zpool destroy -f $TESTPOOL
 fi

--- a/tests/zfs-tests/tests/functional/slog/setup.ksh
+++ b/tests/zfs-tests/tests/functional/slog/setup.ksh
@@ -34,8 +34,4 @@
 
 verify_runnable "global"
 
-if ! verify_slog_support ; then
-	log_unsupported "This system doesn't support separate intent logs"
-fi
-
 log_pass


### PR DESCRIPTION
This seems to be a relict of the past.

Signed-off-by: Christian Schwarz <me@cschwarz.com>

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
