### PR TITLE
Remove strtok(3)

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5360,7 +5360,7 @@ print_zpool_dir_scripts(char *dirpath)
 static void
 print_zpool_script_list(char *subcommand)
 {
-	char *dir, *sp;
+	char *dir, *sp, *tmp;
 
 	printf(gettext("Available 'zpool %s -c' commands:\n"), subcommand);
 
@@ -5368,11 +5368,10 @@ print_zpool_script_list(char *subcommand)
 	if (sp == NULL)
 		return;
 
-	dir = strtok(sp, ":");
-	while (dir != NULL) {
+	for (dir = strtok_r(sp, ":", &tmp);
+	    dir != NULL;
+	    dir = strtok_r(NULL, ":", &tmp))
 		print_zpool_dir_scripts(dir);
-		dir = strtok(NULL, ":");
-	}
 
 	free(sp);
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3490,16 +3490,8 @@ zpool_do_import(int argc, char **argv)
 			cachefile = optarg;
 			break;
 		case 'd':
-			if (searchdirs == NULL) {
-				searchdirs = safe_malloc(sizeof (char *));
-			} else {
-				char **tmp = safe_malloc((nsearch + 1) *
-				    sizeof (char *));
-				bcopy(searchdirs, tmp, nsearch *
-				    sizeof (char *));
-				free(searchdirs);
-				searchdirs = tmp;
-			}
+			searchdirs = safe_realloc(searchdirs,
+			    (nsearch + 1) * sizeof (char *));
 			searchdirs[nsearch++] = optarg;
 			break;
 		case 'D':
@@ -3689,24 +3681,16 @@ zpool_do_import(int argc, char **argv)
 	 * Check the environment for the preferred search path.
 	 */
 	if ((searchdirs == NULL) && (env = getenv("ZPOOL_IMPORT_PATH"))) {
-		char *dir;
+		char *dir, *tmp = NULL;
 
 		envdup = strdup(env);
 
-		dir = strtok(envdup, ":");
-		while (dir != NULL) {
-			if (searchdirs == NULL) {
-				searchdirs = safe_malloc(sizeof (char *));
-			} else {
-				char **tmp = safe_malloc((nsearch + 1) *
-				    sizeof (char *));
-				bcopy(searchdirs, tmp, nsearch *
-				    sizeof (char *));
-				free(searchdirs);
-				searchdirs = tmp;
-			}
+		for (dir = strtok_r(envdup, ":", &tmp);
+		    dir != NULL;
+		    dir = strtok_r(NULL, ":", &tmp)) {
+			searchdirs = safe_realloc(searchdirs,
+			    (nsearch + 1) * sizeof (char *));
 			searchdirs[nsearch++] = dir;
-			dir = strtok(NULL, ":");
 		}
 	}
 
@@ -3745,10 +3729,8 @@ zpool_do_import(int argc, char **argv)
 	}
 
 	if (err == 1) {
-		if (searchdirs != NULL)
-			free(searchdirs);
-		if (envdup != NULL)
-			free(envdup);
+		free(searchdirs);
+		free(envdup);
 		nvlist_free(policy);
 		nvlist_free(pools);
 		nvlist_free(props);
@@ -3786,10 +3768,8 @@ error:
 	nvlist_free(props);
 	nvlist_free(pools);
 	nvlist_free(policy);
-	if (searchdirs != NULL)
-		free(searchdirs);
-	if (envdup != NULL)
-		free(envdup);
+	free(searchdirs);
+	free(envdup);
 
 	return (err ? 1 : 0);
 }

--- a/cmd/zpool/zpool_util.c
+++ b/cmd/zpool/zpool_util.c
@@ -50,6 +50,22 @@ safe_malloc(size_t size)
 }
 
 /*
+ * Utility function to guarantee realloc() success.
+ */
+void *
+safe_realloc(void *from, size_t size)
+{
+	void *data;
+
+	if ((data = realloc(from, size)) == NULL) {
+		(void) fprintf(stderr, "internal error: out of memory\n");
+		exit(1);
+	}
+
+	return (data);
+}
+
+/*
  * Display an out of memory error message and abort the current program.
  */
 void

--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -39,6 +39,7 @@ extern "C" {
  * Basic utility functions
  */
 void *safe_malloc(size_t);
+void *safe_realloc(void *, size_t);
 void zpool_no_memory(void);
 uint_t num_logs(nvlist_t *nv);
 uint64_t array64_max(uint64_t array[], unsigned int len);

--- a/config/Rules.am
+++ b/config/Rules.am
@@ -53,6 +53,7 @@ endif
 if BUILD_FREEBSD
 AM_CPPFLAGS += -DTEXT_DOMAIN=\"zfs-freebsd-user\"
 endif
+AM_CPPFLAGS += -D"strtok(...)=strtok(__VA_ARGS__) __attribute__((deprecated(\"Use strtok_r(3) instead!\")))"
 
 AM_LDFLAGS  = $(DEBUG_LDFLAGS)
 AM_LDFLAGS += $(ASAN_LDFLAGS)

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -158,8 +158,7 @@ libzfs_core_fini(void)
 	(void) pthread_mutex_lock(&g_lock);
 	ASSERT3S(g_refcount, >, 0);
 
-	if (g_refcount > 0)
-		g_refcount--;
+	g_refcount--;
 
 	if (g_refcount == 0 && g_fd != -1) {
 		(void) close(g_fd);

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -283,21 +283,20 @@ zpool_default_search_paths(size_t *count)
 static int
 zfs_path_order(char *name, int *order)
 {
-	int i = 0, error = ENOENT;
-	char *dir, *env, *envdup;
+	int i, error = ENOENT;
+	char *dir, *env, *envdup, *tmp = NULL;
 
 	env = getenv("ZPOOL_IMPORT_PATH");
 	if (env) {
 		envdup = strdup(env);
-		dir = strtok(envdup, ":");
-		while (dir) {
+		for (dir = strtok_r(envdup, ":", &tmp), i = 0;
+		    dir != NULL;
+		    dir = strtok_r(NULL, ":", &tmp), i++) {
 			if (strncmp(name, dir, strlen(dir)) == 0) {
 				*order = i;
 				error = 0;
 				break;
 			}
-			dir = strtok(NULL, ":");
-			i++;
 		}
 		free(envdup);
 	} else {

--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -141,18 +141,17 @@ zfs_strcmp_pathname(const char *name, const char *cmp, int wholedisk)
 	int path_len, cmp_len;
 	char path_name[MAXPATHLEN];
 	char cmp_name[MAXPATHLEN];
-	char *dir, *dup;
+	char *dir, *tmp = NULL;
 
-	/* Strip redundant slashes if one exists due to ZPOOL_IMPORT_PATH */
-	memset(cmp_name, 0, MAXPATHLEN);
-	dup = strdup(cmp);
-	dir = strtok(dup, "/");
-	while (dir) {
+	/* Strip redundant slashes if they exist due to ZPOOL_IMPORT_PATH */
+	cmp_name[0] = '\0';
+	(void) strlcpy(path_name, cmp, sizeof (path_name));
+	for (dir = strtok_r(path_name, "/", &tmp);
+	    dir != NULL;
+	    dir = strtok_r(NULL, "/", &tmp)) {
 		strlcat(cmp_name, "/", sizeof (cmp_name));
 		strlcat(cmp_name, dir, sizeof (cmp_name));
-		dir = strtok(NULL, "/");
 	}
-	free(dup);
 
 	if (name[0] != '/')
 		return (zfs_strcmp_shortname(name, cmp_name, wholedisk));

--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -41,18 +41,18 @@ int
 zfs_resolve_shortname(const char *name, char *path, size_t len)
 {
 	int i, error = -1;
-	char *dir, *env, *envdup;
+	char *dir, *env, *envdup, *tmp = NULL;
 
 	env = getenv("ZPOOL_IMPORT_PATH");
 	errno = ENOENT;
 
 	if (env) {
 		envdup = strdup(env);
-		dir = strtok(envdup, ":");
-		while (dir && error) {
+		for (dir = strtok_r(envdup, ":", &tmp);
+		    dir != NULL && error != 0;
+		    dir = strtok_r(NULL, ":", &tmp)) {
 			(void) snprintf(path, len, "%s/%s", dir, name);
 			error = access(path, F_OK);
-			dir = strtok(NULL, ":");
 		}
 		free(envdup);
 	} else {

--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -82,21 +82,20 @@ static int
 zfs_strcmp_shortname(const char *name, const char *cmp_name, int wholedisk)
 {
 	int path_len, cmp_len, i = 0, error = ENOENT;
-	char *dir, *env, *envdup = NULL;
+	char *dir, *env, *envdup = NULL, *tmp = NULL;
 	char path_name[MAXPATHLEN];
-	const char * const *zpool_default_import_path;
+	const char * const *zpool_default_import_path = NULL;
 	size_t count;
-
-	zpool_default_import_path = zpool_default_search_paths(&count);
 
 	cmp_len = strlen(cmp_name);
 	env = getenv("ZPOOL_IMPORT_PATH");
 
 	if (env) {
 		envdup = strdup(env);
-		dir = strtok(envdup, ":");
+		dir = strtok_r(envdup, ":", &tmp);
 	} else {
-		dir =  (char *)zpool_default_import_path[i];
+		zpool_default_import_path = zpool_default_search_paths(&count);
+		dir = (char *)zpool_default_import_path[i];
 	}
 
 	while (dir) {
@@ -116,7 +115,7 @@ zfs_strcmp_shortname(const char *name, const char *cmp_name, int wholedisk)
 		}
 
 		if (env) {
-			dir = strtok(NULL, ":");
+			dir = strtok_r(NULL, ":", &tmp);
 		} else if (++i < count) {
 			dir = (char *)zpool_default_import_path[i];
 		} else {


### PR DESCRIPTION
### Motivation and Context
I have many words to spill about strtok(3), especially when used in libraries in multi-threaded contexts, unfortunately they've been replaced by an import path.

### Description
It's mostly what it says on the can. See individual commit messages for where it's more.

I also normalised, where applicable, to `for (s = strtok_r(str); s != NULL, s = strtok_r(NULL))`. Initialising `tmp` to NULL will, if the string is also NULL (e.g. due to a failed strdup(), which most of these do, since most of these parse `$ZPOOL_IMPORT_PATH`), yield no entries, instead of garbage or whatever's on tap in the global buffer.

### How Has This Been Tested?
Ran the libzutil bits and zpool. zdb bits are trivial.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency) – zpool realloc-as-realloc instead of realloc-as-malloc-plus-memmove
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none should apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
