### PR TITLE
libzutil: import filtering optimisation, {base,dir}name(3) removal

### DIFF
--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -38,6 +38,7 @@
 #include <sys/fs/zfs.h>
 #include <sys/fm/protocol.h>
 #include <sys/fm/fs/zfs.h>
+#include <libzutil.h>
 #include <libzfs.h>
 #include <string.h>
 
@@ -240,7 +241,7 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 		    ZPOOL_CONFIG_CHILDREN, &spares[s], 1);
 
 		fmd_hdl_debug(hdl, "zpool_vdev_replace '%s' with spare '%s'",
-		    dev_name, basename(spare_name));
+		    dev_name, zfs_basename(spare_name));
 
 		if (zpool_vdev_attach(zhp, dev_name, spare_name,
 		    replacement, B_TRUE, rebuild) == 0) {

--- a/config/Rules.am
+++ b/config/Rules.am
@@ -54,6 +54,9 @@ if BUILD_FREEBSD
 AM_CPPFLAGS += -DTEXT_DOMAIN=\"zfs-freebsd-user\"
 endif
 AM_CPPFLAGS += -D"strtok(...)=strtok(__VA_ARGS__) __attribute__((deprecated(\"Use strtok_r(3) instead!\")))"
+AM_CPPFLAGS += -D"__xpg_basename(...)=__xpg_basename(__VA_ARGS__) __attribute__((deprecated(\"basename(3) is underspecified. Use zfs_basename() instead!\")))"
+AM_CPPFLAGS += -D"basename(...)=basename(__VA_ARGS__) __attribute__((deprecated(\"basename(3) is underspecified. Use zfs_basename() instead!\")))"
+AM_CPPFLAGS += -D"dirname(...)=dirname(__VA_ARGS__) __attribute__((deprecated(\"dirname(3) is underspecified. Use zfs_dirnamelen() instead!\")))"
 
 AM_LDFLAGS  = $(DEBUG_LDFLAGS)
 AM_LDFLAGS += $(ASAN_LDFLAGS)

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -160,6 +160,9 @@ _LIBZUTIL_H void color_start(char *color);
 _LIBZUTIL_H void color_end(void);
 _LIBZUTIL_H int printf_color(char *color, char *format, ...);
 
+_LIBZUTIL_H const char *zfs_basename(const char *path);
+_LIBZUTIL_H ssize_t zfs_dirnamelen(const char *path);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4309,7 +4309,7 @@ zfs_save_arguments(int argc, char **argv, char *string, int len)
 {
 	int i;
 
-	(void) strlcpy(string, basename(argv[0]), len);
+	(void) strlcpy(string, zfs_basename(argv[0]), len);
 	for (i = 1; i < argc; i++) {
 		(void) strlcat(string, " ", len);
 		(void) strlcat(string, argv[i], len);

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -253,11 +253,13 @@
     <elf-symbol name='tpool_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='update_vdev_config_dev_strs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_append_partition' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_basename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_dev_flush' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_dev_is_dm' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_dev_is_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_device_get_devid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_device_get_physical' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_dirnamelen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_get_enclosure_sysfs_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_get_underlying_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_ioctl_fd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1747,22 +1749,32 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <typedef-decl name='size_t' type-id='type-id-26' id='type-id-123'/>
+    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_basename'>
+      <parameter type-id='type-id-16' name='path'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-5' id='type-id-123'/>
+    <typedef-decl name='ssize_t' type-id='type-id-123' id='type-id-124'/>
+    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dirnamelen'>
+      <parameter type-id='type-id-16' name='path'/>
+      <return type-id='type-id-124'/>
+    </function-decl>
+    <typedef-decl name='size_t' type-id='type-id-26' id='type-id-125'/>
     <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
       <parameter type-id='type-id-16' name='name'/>
       <parameter type-id='type-id-37' name='path'/>
-      <parameter type-id='type-id-123' name='len'/>
+      <parameter type-id='type-id-125' name='len'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='getenv' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-16'/>
       <return type-id='type-id-37'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-126'/>
     <function-decl name='strtok_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-37'/>
       <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-126'/>
       <return type-id='type-id-37'/>
     </function-decl>
     <function-decl name='access' visibility='default' binding='global' size-in-bits='64'>
@@ -1770,11 +1782,11 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-16' const='yes' id='type-id-125'/>
-    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-126'/>
+    <qualified-type-def type-id='type-id-16' const='yes' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
     <function-decl name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-38'/>
-      <return type-id='type-id-126'/>
+      <return type-id='type-id-128'/>
     </function-decl>
     <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
       <parameter type-id='type-id-16' name='name'/>
@@ -1795,11 +1807,11 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-129'/>
     <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
       <parameter type-id='type-id-1' name='fd'/>
       <parameter type-id='type-id-64' name='config'/>
-      <parameter type-id='type-id-127' name='num_labels'/>
+      <parameter type-id='type-id-129' name='num_labels'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='ioctl' visibility='default' binding='global' size-in-bits='64'>
@@ -1811,14 +1823,14 @@
     <function-decl name='spl_pagesize' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-26'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-130'/>
     <function-decl name='posix_memalign' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-128'/>
+      <parameter type-id='type-id-130'/>
       <parameter type-id='type-id-26'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='aiocb' size-in-bits='1344' is-struct='yes' visibility='default' id='type-id-129'>
+    <class-decl name='aiocb' size-in-bits='1344' is-struct='yes' visibility='default' id='type-id-131'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='aio_fildes' type-id='type-id-1' visibility='default'/>
       </data-member>
@@ -1829,16 +1841,16 @@
         <var-decl name='aio_reqprio' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='aio_buf' type-id='type-id-130' visibility='default'/>
+        <var-decl name='aio_buf' type-id='type-id-132' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='aio_nbytes' type-id='type-id-123' visibility='default'/>
+        <var-decl name='aio_nbytes' type-id='type-id-125' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='aio_sigevent' type-id='type-id-131' visibility='default'/>
+        <var-decl name='aio_sigevent' type-id='type-id-133' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='__next_prio' type-id='type-id-132' visibility='default'/>
+        <var-decl name='__next_prio' type-id='type-id-134' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
         <var-decl name='__abs_prio' type-id='type-id-1' visibility='default'/>
@@ -1850,20 +1862,20 @@
         <var-decl name='__error_code' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__return_value' type-id='type-id-133' visibility='default'/>
+        <var-decl name='__return_value' type-id='type-id-123' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='aio_offset' type-id='type-id-134' visibility='default'/>
+        <var-decl name='aio_offset' type-id='type-id-135' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='__glibc_reserved' type-id='type-id-135' visibility='default'/>
+        <var-decl name='__glibc_reserved' type-id='type-id-136' visibility='default'/>
       </data-member>
     </class-decl>
-    <qualified-type-def type-id='type-id-17' volatile='yes' id='type-id-136'/>
-    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-130'/>
-    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-131'>
+    <qualified-type-def type-id='type-id-17' volatile='yes' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-132'/>
+    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-133'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sigev_value' type-id='type-id-137' visibility='default'/>
+        <var-decl name='sigev_value' type-id='type-id-138' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='sigev_signo' type-id='type-id-1' visibility='default'/>
@@ -1872,10 +1884,10 @@
         <var-decl name='sigev_notify' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sigev_un' type-id='type-id-138' visibility='default'/>
+        <var-decl name='_sigev_un' type-id='type-id-139' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-139'>
+    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-140'>
       <data-member access='private'>
         <var-decl name='sival_int' type-id='type-id-1' visibility='default'/>
       </data-member>
@@ -1883,74 +1895,73 @@
         <var-decl name='sival_ptr' type-id='type-id-73' visibility='default'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='__sigval_t' type-id='type-id-139' id='type-id-137'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-138'>
+    <typedef-decl name='__sigval_t' type-id='type-id-140' id='type-id-138'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-139'>
       <data-member access='private'>
-        <var-decl name='_pad' type-id='type-id-140' visibility='default'/>
+        <var-decl name='_pad' type-id='type-id-141' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='_tid' type-id='type-id-141' visibility='default'/>
+        <var-decl name='_tid' type-id='type-id-142' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='_sigev_thread' type-id='type-id-142' visibility='default'/>
+        <var-decl name='_sigev_thread' type-id='type-id-143' visibility='default'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-140'>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-141'>
       <subrange length='12' type-id='type-id-12' id='type-id-103'/>
 
     </array-type-def>
-    <typedef-decl name='__pid_t' type-id='type-id-1' id='type-id-141'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-142'>
+    <typedef-decl name='__pid_t' type-id='type-id-1' id='type-id-142'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-143'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_function' type-id='type-id-143' visibility='default'/>
+        <var-decl name='_function' type-id='type-id-144' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_attribute' type-id='type-id-144' visibility='default'/>
+        <var-decl name='_attribute' type-id='type-id-145' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-143'/>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='type-id-146'>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-144'/>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='type-id-147'>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-147' visibility='default'/>
+        <var-decl name='__size' type-id='type-id-148' visibility='default'/>
       </data-member>
       <data-member access='private'>
         <var-decl name='__align' type-id='type-id-5' visibility='default'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='448' id='type-id-147'>
-      <subrange length='56' type-id='type-id-12' id='type-id-148'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='448' id='type-id-148'>
+      <subrange length='56' type-id='type-id-12' id='type-id-149'/>
 
     </array-type-def>
-    <typedef-decl name='pthread_attr_t' type-id='type-id-146' id='type-id-149'/>
-    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-144'/>
-    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-132'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-5' id='type-id-133'/>
-    <typedef-decl name='__off64_t' type-id='type-id-5' id='type-id-134'/>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-147' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-134'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' id='type-id-135'/>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='256' id='type-id-135'>
-      <subrange length='32' type-id='type-id-12' id='type-id-150'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='256' id='type-id-136'>
+      <subrange length='32' type-id='type-id-12' id='type-id-151'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-132' const='yes' id='type-id-151'/>
-    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-152'/>
-    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-153'/>
+    <qualified-type-def type-id='type-id-134' const='yes' id='type-id-152'/>
+    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-154'/>
     <function-decl name='lio_listio' mangled-name='lio_listio64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-152'/>
-      <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-154'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-129' const='yes' id='type-id-154'/>
-    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-155'/>
+    <qualified-type-def type-id='type-id-131' const='yes' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-156'/>
     <function-decl name='aio_error' mangled-name='aio_error64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-155'/>
+      <parameter type-id='type-id-156'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='aio_return' mangled-name='aio_return64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-134'/>
       <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='pread64' visibility='default' binding='global' size-in-bits='64'>
@@ -1960,24 +1971,24 @@
       <parameter type-id='type-id-5'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-156'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-158'/>
     <function-decl name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-35'/>
       <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-156'/>
       <parameter type-id='type-id-157'/>
+      <parameter type-id='type-id-158'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-35'/>
       <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-126'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-158'>
+    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-159'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='path' type-id='type-id-124' visibility='default'/>
+        <var-decl name='path' type-id='type-id-126' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='paths' type-id='type-id-1' visibility='default'/>
@@ -2001,27 +2012,27 @@
         <var-decl name='policy' type-id='type-id-29' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='importargs_t' type-id='type-id-158' id='type-id-159'/>
-    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-160'/>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-161'>
+    <typedef-decl name='importargs_t' type-id='type-id-159' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-161'/>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-162'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-162' visibility='default'/>
+        <var-decl name='pco_refresh_config' type-id='type-id-163' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-163' visibility='default'/>
+        <var-decl name='pco_pool_active' type-id='type-id-164' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-164' id='type-id-165'/>
-    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-162'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-166' id='type-id-167'/>
-    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-163'/>
-    <qualified-type-def type-id='type-id-161' const='yes' id='type-id-168'/>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-168' id='type-id-169'/>
-    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-171'/>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-165' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-163'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-167' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-164'/>
+    <qualified-type-def type-id='type-id-162' const='yes' id='type-id-169'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-169' id='type-id-170'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-172'/>
     <function-decl name='zpool_search_import' mangled-name='zpool_search_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
       <parameter type-id='type-id-73' name='hdl'/>
-      <parameter type-id='type-id-160' name='import'/>
-      <parameter type-id='type-id-171' name='pco'/>
+      <parameter type-id='type-id-161' name='import'/>
+      <parameter type-id='type-id-172' name='pco'/>
       <return type-id='type-id-29'/>
     </function-decl>
     <function-decl name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
@@ -2030,27 +2041,27 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-37'/>
     </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-172'>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-173'>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-173' visibility='default'/>
+        <var-decl name='__size' type-id='type-id-174' visibility='default'/>
       </data-member>
       <data-member access='private'>
         <var-decl name='__align' type-id='type-id-1' visibility='default'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32' id='type-id-173'>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32' id='type-id-174'>
       <subrange length='4' type-id='type-id-12' id='type-id-92'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-172' const='yes' id='type-id-174'/>
-    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
+    <qualified-type-def type-id='type-id-173' const='yes' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
     <function-decl name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-175'/>
+      <parameter type-id='type-id-176'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' id='type-id-176'>
+    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' id='type-id-177'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='lpc_printerr' type-id='type-id-41' visibility='default'/>
       </data-member>
@@ -2061,66 +2072,66 @@
         <var-decl name='lpc_desc_active' type-id='type-id-41' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lpc_desc' type-id='type-id-177' visibility='default'/>
+        <var-decl name='lpc_desc' type-id='type-id-178' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8320'>
-        <var-decl name='lpc_ops' type-id='type-id-171' visibility='default'/>
+        <var-decl name='lpc_ops' type-id='type-id-172' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8384'>
         <var-decl name='lpc_lib_handle' type-id='type-id-73' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8192' id='type-id-177'>
-      <subrange length='1024' type-id='type-id-12' id='type-id-178'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8192' id='type-id-178'>
+      <subrange length='1024' type-id='type-id-12' id='type-id-179'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-179'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-180'>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-180'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-181'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-181' visibility='default'/>
+        <var-decl name='avl_root' type-id='type-id-182' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-182' visibility='default'/>
+        <var-decl name='avl_compar' type-id='type-id-183' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-123' visibility='default'/>
+        <var-decl name='avl_offset' type-id='type-id-125' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-183' visibility='default'/>
+        <var-decl name='avl_numnodes' type-id='type-id-184' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-123' visibility='default'/>
+        <var-decl name='avl_size' type-id='type-id-125' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-184'>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-185'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-185' visibility='default'/>
+        <var-decl name='avl_child' type-id='type-id-186' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-186' visibility='default'/>
+        <var-decl name='avl_pcb' type-id='type-id-187' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-181'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-182'/>
 
-    <array-type-def dimensions='1' type-id='type-id-181' size-in-bits='128' id='type-id-185'>
+    <array-type-def dimensions='1' type-id='type-id-182' size-in-bits='128' id='type-id-186'>
       <subrange length='2' type-id='type-id-12' id='type-id-62'/>
 
     </array-type-def>
-    <typedef-decl name='uintptr_t' type-id='type-id-26' id='type-id-186'/>
-    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-182'/>
-    <typedef-decl name='ulong_t' type-id='type-id-26' id='type-id-183'/>
-    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-188'/>
-    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-189'/>
+    <typedef-decl name='uintptr_t' type-id='type-id-26' id='type-id-187'/>
+    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-183'/>
+    <typedef-decl name='ulong_t' type-id='type-id-26' id='type-id-184'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-190'/>
     <function-decl name='zpool_find_import_blkid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-179'/>
+      <parameter type-id='type-id-180'/>
       <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-190'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
-      <parameter type-id='type-id-182'/>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-183'/>
       <parameter type-id='type-id-26'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-17'/>
@@ -2166,8 +2177,8 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
-      <parameter type-id='type-id-128'/>
+      <parameter type-id='type-id-189'/>
+      <parameter type-id='type-id-130'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='nvlist_empty' visibility='default' binding='global' size-in-bits='64'>
@@ -2181,8 +2192,8 @@
       <parameter type-id='type-id-73' name='hdl'/>
       <parameter type-id='type-id-16' name='target'/>
       <parameter type-id='type-id-64' name='configp'/>
-      <parameter type-id='type-id-160' name='args'/>
-      <parameter type-id='type-id-171' name='pco'/>
+      <parameter type-id='type-id-161' name='args'/>
+      <parameter type-id='type-id-172' name='pco'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
@@ -2194,42 +2205,42 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-190'/>
-    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-191'/>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-191'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-192'/>
     <function-decl name='tpool_create' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
       <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-144'/>
-      <return type-id='type-id-191'/>
+      <parameter type-id='type-id-145'/>
+      <return type-id='type-id-192'/>
     </function-decl>
     <function-decl name='avl_first' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
+      <parameter type-id='type-id-189'/>
       <return type-id='type-id-73'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-193'/>
+    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-194'/>
     <function-decl name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-191'/>
-      <parameter type-id='type-id-193'/>
+      <parameter type-id='type-id-192'/>
+      <parameter type-id='type-id-194'/>
       <parameter type-id='type-id-73'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
+      <parameter type-id='type-id-189'/>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='tpool_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-191'/>
+      <parameter type-id='type-id-192'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='tpool_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-191'/>
+      <parameter type-id='type-id-192'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
+      <parameter type-id='type-id-189'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='nvlist_remove' visibility='default' binding='global' size-in-bits='64'>
@@ -2244,12 +2255,12 @@
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-194'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-195'/>
     <function-decl name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-35'/>
       <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-194'/>
-      <parameter type-id='type-id-157'/>
+      <parameter type-id='type-id-195'/>
+      <parameter type-id='type-id-158'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
@@ -2272,21 +2283,21 @@
       <parameter type-id='type-id-6'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='__dirstream' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-195'/>
-    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-196'/>
+    <class-decl name='__dirstream' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-196'/>
+    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
     <function-decl name='opendir' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-16'/>
-      <return type-id='type-id-196'/>
+      <return type-id='type-id-197'/>
     </function-decl>
-    <class-decl name='dirent64' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-197'>
+    <class-decl name='dirent64' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-198'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-198' visibility='default'/>
+        <var-decl name='d_ino' type-id='type-id-199' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-134' visibility='default'/>
+        <var-decl name='d_off' type-id='type-id-135' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-199' visibility='default'/>
+        <var-decl name='d_reclen' type-id='type-id-200' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
         <var-decl name='d_type' type-id='type-id-30' visibility='default'/>
@@ -2295,31 +2306,31 @@
         <var-decl name='d_name' type-id='type-id-43' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__ino64_t' type-id='type-id-26' id='type-id-198'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-199'/>
-    <pointer-type-def type-id='type-id-197' size-in-bits='64' id='type-id-200'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-26' id='type-id-199'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-200'/>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-201'/>
     <function-decl name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-196'/>
-      <return type-id='type-id-200'/>
+      <parameter type-id='type-id-197'/>
+      <return type-id='type-id-201'/>
     </function-decl>
     <function-decl name='closedir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-196'/>
+      <parameter type-id='type-id-197'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='asprintf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-126'/>
       <parameter type-id='type-id-16'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='avl_find' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
+      <parameter type-id='type-id-189'/>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-38'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='avl_insert' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-188'/>
+      <parameter type-id='type-id-189'/>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-17'/>
@@ -2328,28 +2339,28 @@
       <parameter type-id='type-id-35'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-166'>
+    <function-type size-in-bits='64' id='type-id-167'>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-16'/>
       <parameter type-id='type-id-23'/>
       <parameter type-id='type-id-118'/>
       <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-187'>
+    <function-type size-in-bits='64' id='type-id-188'>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-73'/>
       <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-164'>
+    <function-type size-in-bits='64' id='type-id-165'>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-29'/>
       <return type-id='type-id-29'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-145'>
-      <parameter type-id='type-id-137'/>
+    <function-type size-in-bits='64' id='type-id-146'>
+      <parameter type-id='type-id-138'/>
       <return type-id='type-id-17'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-192'>
+    <function-type size-in-bits='64' id='type-id-193'>
       <parameter type-id='type-id-73'/>
       <return type-id='type-id-17'/>
     </function-type>
@@ -2359,7 +2370,7 @@
       <parameter type-id='type-id-16' name='str'/>
       <return type-id='type-id-41'/>
     </function-decl>
-    <enum-decl name='zfs_nicenum_format' id='type-id-201'>
+    <enum-decl name='zfs_nicenum_format' id='type-id-202'>
       <underlying-type type-id='type-id-18'/>
       <enumerator name='ZFS_NICENUM_1024' value='0'/>
       <enumerator name='ZFS_NICENUM_BYTES' value='1'/>
@@ -2370,37 +2381,37 @@
     <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
       <parameter type-id='type-id-23' name='num'/>
       <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-123' name='buflen'/>
-      <parameter type-id='type-id-201' name='format'/>
+      <parameter type-id='type-id-125' name='buflen'/>
+      <parameter type-id='type-id-202' name='format'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
       <parameter type-id='type-id-23' name='num'/>
       <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
       <parameter type-id='type-id-23' name='num'/>
       <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
       <parameter type-id='type-id-23' name='num'/>
       <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
       <parameter type-id='type-id-23' name='num'/>
       <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-17'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-202'>
+    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-203'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='dds_blocks' type-id='type-id-23' visibility='default'/>
       </data-member>
@@ -2426,25 +2437,25 @@
         <var-decl name='dds_ref_dsize' type-id='type-id-23' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ddt_stat_t' type-id='type-id-202' id='type-id-203'/>
-    <qualified-type-def type-id='type-id-203' const='yes' id='type-id-204'/>
-    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
-    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' id='type-id-206'>
+    <typedef-decl name='ddt_stat_t' type-id='type-id-203' id='type-id-204'/>
+    <qualified-type-def type-id='type-id-204' const='yes' id='type-id-205'/>
+    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-206'/>
+    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' id='type-id-207'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddh_stat' type-id='type-id-207' visibility='default'/>
+        <var-decl name='ddh_stat' type-id='type-id-208' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-203' size-in-bits='32768' id='type-id-207'>
-      <subrange length='64' type-id='type-id-12' id='type-id-208'/>
+    <array-type-def dimensions='1' type-id='type-id-204' size-in-bits='32768' id='type-id-208'>
+      <subrange length='64' type-id='type-id-12' id='type-id-209'/>
 
     </array-type-def>
-    <typedef-decl name='ddt_histogram_t' type-id='type-id-206' id='type-id-209'/>
-    <qualified-type-def type-id='type-id-209' const='yes' id='type-id-210'/>
-    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-211'/>
+    <typedef-decl name='ddt_histogram_t' type-id='type-id-207' id='type-id-210'/>
+    <qualified-type-def type-id='type-id-210' const='yes' id='type-id-211'/>
+    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-212'/>
     <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
-      <parameter type-id='type-id-205' name='dds_total'/>
-      <parameter type-id='type-id-211' name='ddh'/>
+      <parameter type-id='type-id-206' name='dds_total'/>
+      <parameter type-id='type-id-212' name='ddh'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64'>
@@ -2459,21 +2470,21 @@
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-212'/>
-    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-213'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-213'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-214'/>
     <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
       <parameter type-id='type-id-37' name='buf'/>
       <parameter type-id='type-id-23' name='bytes_read'/>
       <parameter type-id='type-id-71' name='leftover'/>
-      <parameter type-id='type-id-212' name='records'/>
-      <parameter type-id='type-id-213' name='numrecords'/>
+      <parameter type-id='type-id-213' name='records'/>
+      <parameter type-id='type-id-214' name='numrecords'/>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
     <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
       <parameter type-id='type-id-37' name='path'/>
-      <parameter type-id='type-id-123' name='max_len'/>
+      <parameter type-id='type-id-125' name='max_len'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
@@ -2488,15 +2499,15 @@
       <parameter type-id='type-id-16' name='dev_name'/>
       <return type-id='type-id-37'/>
     </function-decl>
-    <class-decl name='dirent' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-214'>
+    <class-decl name='dirent' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-215'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-198' visibility='default'/>
+        <var-decl name='d_ino' type-id='type-id-199' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-134' visibility='default'/>
+        <var-decl name='d_off' type-id='type-id-135' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-199' visibility='default'/>
+        <var-decl name='d_reclen' type-id='type-id-200' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
         <var-decl name='d_type' type-id='type-id-30' visibility='default'/>
@@ -2505,10 +2516,10 @@
         <var-decl name='d_name' type-id='type-id-43' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-215'/>
+    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-216'/>
     <function-decl name='readdir' mangled-name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-196'/>
-      <return type-id='type-id-215'/>
+      <parameter type-id='type-id-197'/>
+      <return type-id='type-id-216'/>
     </function-decl>
     <function-decl name='readlink' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-16'/>
@@ -2524,7 +2535,7 @@
       <parameter type-id='type-id-16' name='dev_name'/>
       <return type-id='type-id-41'/>
     </function-decl>
-    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='type-id-216'>
+    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='type-id-217'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='efi_version' type-id='type-id-34' visibility='default'/>
       </data-member>
@@ -2538,16 +2549,16 @@
         <var-decl name='efi_lbasize' type-id='type-id-34' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='efi_last_lba' type-id='type-id-217' visibility='default'/>
+        <var-decl name='efi_last_lba' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='efi_first_u_lba' type-id='type-id-217' visibility='default'/>
+        <var-decl name='efi_first_u_lba' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='efi_last_u_lba' type-id='type-id-217' visibility='default'/>
+        <var-decl name='efi_last_u_lba' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='efi_disk_uguid' type-id='type-id-218' visibility='default'/>
+        <var-decl name='efi_disk_uguid' type-id='type-id-219' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='efi_flags' type-id='type-id-34' visibility='default'/>
@@ -2556,27 +2567,27 @@
         <var-decl name='efi_reserved1' type-id='type-id-34' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='efi_altern_lba' type-id='type-id-217' visibility='default'/>
+        <var-decl name='efi_altern_lba' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='efi_reserved' type-id='type-id-219' visibility='default'/>
+        <var-decl name='efi_reserved' type-id='type-id-220' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='efi_parts' type-id='type-id-220' visibility='default'/>
+        <var-decl name='efi_parts' type-id='type-id-221' visibility='default'/>
       </data-member>
     </class-decl>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-221'/>
-    <typedef-decl name='longlong_t' type-id='type-id-221' id='type-id-222'/>
-    <typedef-decl name='diskaddr_t' type-id='type-id-222' id='type-id-217'/>
-    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-218'>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-222'/>
+    <typedef-decl name='longlong_t' type-id='type-id-222' id='type-id-223'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-223' id='type-id-218'/>
+    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-219'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='time_low' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time_mid' type-id='type-id-223' visibility='default'/>
+        <var-decl name='time_mid' type-id='type-id-224' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='time_hi_and_version' type-id='type-id-223' visibility='default'/>
+        <var-decl name='time_hi_and_version' type-id='type-id-224' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-32' visibility='default'/>
@@ -2588,65 +2599,65 @@
         <var-decl name='node_addr' type-id='type-id-105' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__uint16_t' type-id='type-id-199' id='type-id-224'/>
-    <typedef-decl name='uint16_t' type-id='type-id-224' id='type-id-223'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-200' id='type-id-225'/>
+    <typedef-decl name='uint16_t' type-id='type-id-225' id='type-id-224'/>
 
-    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='384' id='type-id-219'>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='384' id='type-id-220'>
       <subrange length='12' type-id='type-id-12' id='type-id-103'/>
 
     </array-type-def>
-    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-225'>
+    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-226'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_start' type-id='type-id-217' visibility='default'/>
+        <var-decl name='p_start' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_size' type-id='type-id-217' visibility='default'/>
+        <var-decl name='p_size' type-id='type-id-218' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_guid' type-id='type-id-218' visibility='default'/>
+        <var-decl name='p_guid' type-id='type-id-219' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='p_tag' type-id='type-id-226' visibility='default'/>
+        <var-decl name='p_tag' type-id='type-id-227' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='p_flag' type-id='type-id-226' visibility='default'/>
+        <var-decl name='p_flag' type-id='type-id-227' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='p_name' type-id='type-id-227' visibility='default'/>
+        <var-decl name='p_name' type-id='type-id-228' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='p_uguid' type-id='type-id-218' visibility='default'/>
+        <var-decl name='p_uguid' type-id='type-id-219' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='p_resv' type-id='type-id-228' visibility='default'/>
+        <var-decl name='p_resv' type-id='type-id-229' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ushort_t' type-id='type-id-199' id='type-id-226'/>
+    <typedef-decl name='ushort_t' type-id='type-id-200' id='type-id-227'/>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='288' id='type-id-227'>
-      <subrange length='36' type-id='type-id-12' id='type-id-229'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='288' id='type-id-228'>
+      <subrange length='36' type-id='type-id-12' id='type-id-230'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='256' id='type-id-228'>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='256' id='type-id-229'>
       <subrange length='8' type-id='type-id-12' id='type-id-102'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-225' size-in-bits='960' id='type-id-220'>
-      <subrange length='1' type-id='type-id-12' id='type-id-230'/>
+    <array-type-def dimensions='1' type-id='type-id-226' size-in-bits='960' id='type-id-221'>
+      <subrange length='1' type-id='type-id-12' id='type-id-231'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-216' size-in-bits='64' id='type-id-231'/>
-    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-232'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-232'/>
+    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-233'/>
     <function-decl name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-232'/>
+      <parameter type-id='type-id-233'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
-      <parameter type-id='type-id-231'/>
+      <parameter type-id='type-id-232'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
@@ -2657,27 +2668,27 @@
       <parameter type-id='type-id-16' name='path'/>
       <return type-id='type-id-41'/>
     </function-decl>
-    <class-decl name='udev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-233'/>
-    <pointer-type-def type-id='type-id-233' size-in-bits='64' id='type-id-234'/>
+    <class-decl name='udev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-234'/>
+    <pointer-type-def type-id='type-id-234' size-in-bits='64' id='type-id-235'/>
     <function-decl name='udev_new' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-234'/>
+      <return type-id='type-id-235'/>
     </function-decl>
-    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-235'/>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
+    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-236'/>
+    <pointer-type-def type-id='type-id-236' size-in-bits='64' id='type-id-237'/>
     <function-decl name='udev_device_new_from_subsystem_sysname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-234'/>
+      <parameter type-id='type-id-235'/>
       <parameter type-id='type-id-16'/>
       <parameter type-id='type-id-16'/>
-      <return type-id='type-id-236'/>
+      <return type-id='type-id-237'/>
     </function-decl>
     <function-decl name='udev_device_get_property_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-237'/>
       <parameter type-id='type-id-16'/>
       <return type-id='type-id-16'/>
     </function-decl>
     <function-decl name='udev_device_unref' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-236'/>
-      <return type-id='type-id-236'/>
+      <parameter type-id='type-id-237'/>
+      <return type-id='type-id-237'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
@@ -2686,21 +2697,21 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zutil_strdup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-179'/>
+      <parameter type-id='type-id-180'/>
       <parameter type-id='type-id-16'/>
       <return type-id='type-id-37'/>
     </function-decl>
     <function-decl name='zpool_read_label' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='label_paths' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-179'/>
+      <parameter type-id='type-id-180'/>
       <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-124'/>
-      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-126'/>
+      <parameter type-id='type-id-126'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
@@ -2709,113 +2720,113 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zutil_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-179'/>
+      <parameter type-id='type-id-180'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-73'/>
     </function-decl>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-237'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-238'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-238' visibility='default'/>
+        <var-decl name='tv_sec' type-id='type-id-239' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-239' visibility='default'/>
+        <var-decl name='tv_nsec' type-id='type-id-240' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-5' id='type-id-238'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-5' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-240'/>
+    <typedef-decl name='__time_t' type-id='type-id-5' id='type-id-239'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-5' id='type-id-240'/>
+    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-241'/>
     <function-decl name='clock_gettime' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-240'/>
+      <parameter type-id='type-id-241'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='usleep' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-6'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='udev_list_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-241'/>
-    <pointer-type-def type-id='type-id-241' size-in-bits='64' id='type-id-242'/>
+    <class-decl name='udev_list_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-242'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
     <function-decl name='udev_device_get_devlinks_list_entry' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-236'/>
-      <return type-id='type-id-242'/>
+      <parameter type-id='type-id-237'/>
+      <return type-id='type-id-243'/>
     </function-decl>
     <function-decl name='udev_list_entry_get_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-242'/>
+      <parameter type-id='type-id-243'/>
       <return type-id='type-id-16'/>
     </function-decl>
     <function-decl name='udev_list_entry_get_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-242'/>
-      <return type-id='type-id-242'/>
+      <parameter type-id='type-id-243'/>
+      <return type-id='type-id-243'/>
     </function-decl>
     <function-decl name='udev_unref' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-234'/>
-      <return type-id='type-id-234'/>
+      <parameter type-id='type-id-235'/>
+      <return type-id='type-id-235'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-243'/>
+    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-244'/>
     <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
-      <parameter type-id='type-id-243' name='count'/>
-      <return type-id='type-id-126'/>
+      <parameter type-id='type-id-244' name='count'/>
+      <return type-id='type-id-128'/>
     </function-decl>
-    <class-decl name='blkid_struct_cache' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-244'/>
-    <pointer-type-def type-id='type-id-244' size-in-bits='64' id='type-id-245'/>
+    <class-decl name='blkid_struct_cache' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-245'/>
     <pointer-type-def type-id='type-id-245' size-in-bits='64' id='type-id-246'/>
+    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
     <function-decl name='blkid_get_cache' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-246'/>
+      <parameter type-id='type-id-247'/>
       <parameter type-id='type-id-16'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='blkid_probe_all_new' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-245'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='blkid_struct_dev_iterate' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-247'/>
-    <pointer-type-def type-id='type-id-247' size-in-bits='64' id='type-id-248'/>
+    <class-decl name='blkid_struct_dev_iterate' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-248'/>
+    <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-249'/>
     <function-decl name='blkid_dev_iterate_begin' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-245'/>
-      <return type-id='type-id-248'/>
+      <parameter type-id='type-id-246'/>
+      <return type-id='type-id-249'/>
     </function-decl>
     <function-decl name='blkid_dev_set_search' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-248'/>
+      <parameter type-id='type-id-249'/>
       <parameter type-id='type-id-16'/>
       <parameter type-id='type-id-16'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='blkid_dev_iterate_end' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-248'/>
+      <parameter type-id='type-id-249'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <class-decl name='blkid_struct_dev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <class-decl name='blkid_struct_dev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-250'/>
     <pointer-type-def type-id='type-id-250' size-in-bits='64' id='type-id-251'/>
+    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
     <function-decl name='blkid_dev_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-248'/>
-      <parameter type-id='type-id-251'/>
+      <parameter type-id='type-id-249'/>
+      <parameter type-id='type-id-252'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='blkid_put_cache' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-245'/>
+      <parameter type-id='type-id-246'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='blkid_dev_devname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-250'/>
+      <parameter type-id='type-id-251'/>
       <return type-id='type-id-16'/>
     </function-decl>
     <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
-      <parameter type-id='type-id-236' name='dev'/>
+      <parameter type-id='type-id-237' name='dev'/>
       <parameter type-id='type-id-37' name='bufptr'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='udev_device_get_parent_with_subsystem_devtype' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-236'/>
+      <parameter type-id='type-id-237'/>
       <parameter type-id='type-id-16'/>
       <parameter type-id='type-id-16'/>
-      <return type-id='type-id-236'/>
+      <return type-id='type-id-237'/>
     </function-decl>
     <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
-      <parameter type-id='type-id-236' name='dev'/>
+      <parameter type-id='type-id-237' name='dev'/>
       <parameter type-id='type-id-37' name='bufptr'/>
-      <parameter type-id='type-id-123' name='buflen'/>
+      <parameter type-id='type-id-125' name='buflen'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
@@ -2832,145 +2843,145 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-39' id='type-id-252'/>
-    <pointer-type-def type-id='type-id-252' size-in-bits='64' id='type-id-253'/>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-39' id='type-id-253'/>
+    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-254'/>
     <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
       <parameter type-id='type-id-1' name='fd'/>
       <parameter type-id='type-id-26' name='request'/>
-      <parameter type-id='type-id-253' name='zc'/>
+      <parameter type-id='type-id-254' name='zc'/>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libavl' language='LANG_C99'>
-    <typedef-decl name='avl_tree_t' type-id='type-id-180' id='type-id-254'/>
-    <pointer-type-def type-id='type-id-254' size-in-bits='64' id='type-id-255'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-181' id='type-id-255'/>
+    <pointer-type-def type-id='type-id-255' size-in-bits='64' id='type-id-256'/>
     <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='oldnode'/>
       <parameter type-id='type-id-1' name='left'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <return type-id='type-id-73'/>
     </function-decl>
-    <typedef-decl name='avl_index_t' type-id='type-id-186' id='type-id-256'/>
+    <typedef-decl name='avl_index_t' type-id='type-id-187' id='type-id-257'/>
     <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='type-id-255' name='tree'/>
-      <parameter type-id='type-id-256' name='where'/>
+      <parameter type-id='type-id-256' name='tree'/>
+      <parameter type-id='type-id-257' name='where'/>
       <parameter type-id='type-id-1' name='direction'/>
       <return type-id='type-id-73'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-257'/>
+    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-258'/>
     <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='value'/>
-      <parameter type-id='type-id-257' name='where'/>
+      <parameter type-id='type-id-258' name='where'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='new_data'/>
-      <parameter type-id='type-id-256' name='where'/>
+      <parameter type-id='type-id-257' name='where'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='new_data'/>
       <parameter type-id='type-id-73' name='here'/>
       <parameter type-id='type-id-1' name='direction'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='new_node'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <parameter type-id='type-id-73' name='data'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='type-id-255' name='t'/>
+      <parameter type-id='type-id-256' name='t'/>
       <parameter type-id='type-id-73' name='obj'/>
       <return type-id='type-id-41'/>
     </function-decl>
     <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='type-id-255' name='t'/>
+      <parameter type-id='type-id-256' name='t'/>
       <parameter type-id='type-id-73' name='obj'/>
       <return type-id='type-id-41'/>
     </function-decl>
     <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='type-id-255' name='t'/>
+      <parameter type-id='type-id-256' name='t'/>
       <parameter type-id='type-id-73' name='obj'/>
       <return type-id='type-id-41'/>
     </function-decl>
     <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='type-id-255' name='tree1'/>
-      <parameter type-id='type-id-255' name='tree2'/>
+      <parameter type-id='type-id-256' name='tree1'/>
+      <parameter type-id='type-id-256' name='tree2'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
-      <parameter type-id='type-id-255' name='tree'/>
-      <parameter type-id='type-id-182' name='compar'/>
-      <parameter type-id='type-id-123' name='size'/>
-      <parameter type-id='type-id-123' name='offset'/>
+      <parameter type-id='type-id-256' name='tree'/>
+      <parameter type-id='type-id-183' name='compar'/>
+      <parameter type-id='type-id-125' name='size'/>
+      <parameter type-id='type-id-125' name='offset'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
-      <parameter type-id='type-id-255' name='tree'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-256' name='tree'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
-      <parameter type-id='type-id-255' name='tree'/>
+      <parameter type-id='type-id-256' name='tree'/>
       <return type-id='type-id-41'/>
     </function-decl>
     <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
-      <parameter type-id='type-id-255' name='tree'/>
-      <parameter type-id='type-id-128' name='cookie'/>
+      <parameter type-id='type-id-256' name='tree'/>
+      <parameter type-id='type-id-130' name='cookie'/>
       <return type-id='type-id-73'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libtpool' language='LANG_C99'>
-    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-190'>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-191'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tp_forw' type-id='type-id-258' visibility='default'/>
+        <var-decl name='tp_forw' type-id='type-id-259' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tp_back' type-id='type-id-258' visibility='default'/>
+        <var-decl name='tp_back' type-id='type-id-259' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tp_mutex' type-id='type-id-259' visibility='default'/>
+        <var-decl name='tp_mutex' type-id='type-id-260' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tp_busycv' type-id='type-id-260' visibility='default'/>
+        <var-decl name='tp_busycv' type-id='type-id-261' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='tp_workcv' type-id='type-id-260' visibility='default'/>
+        <var-decl name='tp_workcv' type-id='type-id-261' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='tp_waitcv' type-id='type-id-260' visibility='default'/>
+        <var-decl name='tp_waitcv' type-id='type-id-261' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='tp_active' type-id='type-id-261' visibility='default'/>
+        <var-decl name='tp_active' type-id='type-id-262' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='tp_head' type-id='type-id-262' visibility='default'/>
+        <var-decl name='tp_head' type-id='type-id-263' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='tp_tail' type-id='type-id-262' visibility='default'/>
+        <var-decl name='tp_tail' type-id='type-id-263' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='tp_attr' type-id='type-id-149' visibility='default'/>
+        <var-decl name='tp_attr' type-id='type-id-150' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
         <var-decl name='tp_flags' type-id='type-id-1' visibility='default'/>
@@ -2994,39 +3005,39 @@
         <var-decl name='tp_idle' type-id='type-id-1' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_t' type-id='type-id-190' id='type-id-263'/>
-    <pointer-type-def type-id='type-id-263' size-in-bits='64' id='type-id-258'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-2' id='type-id-259'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-264'>
+    <typedef-decl name='tpool_t' type-id='type-id-191' id='type-id-264'/>
+    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-259'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-2' id='type-id-260'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-265'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-265' visibility='default'/>
+        <var-decl name='__data' type-id='type-id-266' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-266' visibility='default'/>
+        <var-decl name='__size' type-id='type-id-267' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-221' visibility='default'/>
+        <var-decl name='__align' type-id='type-id-222' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-265'>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-266'>
       <member-type access='public'>
-        <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-267'>
+        <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-268'>
           <data-member access='private'>
-            <var-decl name='__g1_start' type-id='type-id-268' visibility='default'/>
+            <var-decl name='__g1_start' type-id='type-id-269' visibility='default'/>
           </data-member>
           <data-member access='private'>
-            <var-decl name='__g1_start32' type-id='type-id-269' visibility='default'/>
+            <var-decl name='__g1_start32' type-id='type-id-270' visibility='default'/>
           </data-member>
         </union-decl>
       </member-type>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='' type-id='type-id-270' visibility='default'/>
+        <var-decl name='' type-id='type-id-271' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__g_refs' type-id='type-id-271' visibility='default'/>
+        <var-decl name='__g_refs' type-id='type-id-272' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__g_size' type-id='type-id-271' visibility='default'/>
+        <var-decl name='__g_size' type-id='type-id-272' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='__g1_orig_size' type-id='type-id-6' visibility='default'/>
@@ -3035,19 +3046,19 @@
         <var-decl name='__wrefs' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='__g_signals' type-id='type-id-271' visibility='default'/>
+        <var-decl name='__g_signals' type-id='type-id-272' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-270'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-271'>
       <data-member access='private'>
-        <var-decl name='__wseq' type-id='type-id-268' visibility='default'/>
+        <var-decl name='__wseq' type-id='type-id-269' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__wseq32' type-id='type-id-269' visibility='default'/>
+        <var-decl name='__wseq32' type-id='type-id-270' visibility='default'/>
       </data-member>
     </union-decl>
-    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-268'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-269'>
+    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-269'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-270'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__low' type-id='type-id-6' visibility='default'/>
       </data-member>
@@ -3056,212 +3067,212 @@
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='64' id='type-id-271'>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='64' id='type-id-272'>
       <subrange length='2' type-id='type-id-12' id='type-id-62'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='384' id='type-id-266'>
-      <subrange length='48' type-id='type-id-12' id='type-id-272'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='384' id='type-id-267'>
+      <subrange length='48' type-id='type-id-12' id='type-id-273'/>
 
     </array-type-def>
-    <typedef-decl name='pthread_cond_t' type-id='type-id-264' id='type-id-260'/>
-    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-273'>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-265' id='type-id-261'/>
+    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-274'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpa_next' type-id='type-id-261' visibility='default'/>
+        <var-decl name='tpa_next' type-id='type-id-262' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpa_tid' type-id='type-id-274' visibility='default'/>
+        <var-decl name='tpa_tid' type-id='type-id-275' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_active_t' type-id='type-id-273' id='type-id-275'/>
-    <pointer-type-def type-id='type-id-275' size-in-bits='64' id='type-id-261'/>
-    <typedef-decl name='pthread_t' type-id='type-id-26' id='type-id-274'/>
-    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-276'>
+    <typedef-decl name='tpool_active_t' type-id='type-id-274' id='type-id-276'/>
+    <pointer-type-def type-id='type-id-276' size-in-bits='64' id='type-id-262'/>
+    <typedef-decl name='pthread_t' type-id='type-id-26' id='type-id-275'/>
+    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-277'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpj_next' type-id='type-id-262' visibility='default'/>
+        <var-decl name='tpj_next' type-id='type-id-263' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpj_func' type-id='type-id-193' visibility='default'/>
+        <var-decl name='tpj_func' type-id='type-id-194' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='tpj_arg' type-id='type-id-73' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_job_t' type-id='type-id-276' id='type-id-277'/>
-    <pointer-type-def type-id='type-id-277' size-in-bits='64' id='type-id-262'/>
+    <typedef-decl name='tpool_job_t' type-id='type-id-277' id='type-id-278'/>
+    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-263'/>
     <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
       <parameter type-id='type-id-34' name='min_threads'/>
       <parameter type-id='type-id-34' name='max_threads'/>
       <parameter type-id='type-id-34' name='linger'/>
-      <parameter type-id='type-id-144' name='attr'/>
-      <return type-id='type-id-258'/>
+      <parameter type-id='type-id-145' name='attr'/>
+      <return type-id='type-id-259'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-146' const='yes' id='type-id-278'/>
-    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-279'/>
+    <qualified-type-def type-id='type-id-147' const='yes' id='type-id-279'/>
+    <pointer-type-def type-id='type-id-279' size-in-bits='64' id='type-id-280'/>
     <function-decl name='pthread_attr_getstack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-128'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-130'/>
       <parameter type-id='type-id-38'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-280'/>
+    <pointer-type-def type-id='type-id-265' size-in-bits='64' id='type-id-281'/>
     <function-decl name='pthread_cond_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-175'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-281'/>
-    <function-decl name='pthread_attr_init' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-176'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-282'>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-282'/>
+    <function-decl name='pthread_attr_init' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-282'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-283'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__bits' type-id='type-id-283' visibility='default'/>
+        <var-decl name='__bits' type-id='type-id-284' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__cpu_mask' type-id='type-id-26' id='type-id-284'/>
+    <typedef-decl name='__cpu_mask' type-id='type-id-26' id='type-id-285'/>
 
-    <array-type-def dimensions='1' type-id='type-id-284' size-in-bits='1024' id='type-id-283'>
+    <array-type-def dimensions='1' type-id='type-id-285' size-in-bits='1024' id='type-id-284'>
       <subrange length='16' type-id='type-id-12' id='type-id-104'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-282' size-in-bits='64' id='type-id-285'/>
+    <pointer-type-def type-id='type-id-283' size-in-bits='64' id='type-id-286'/>
     <function-decl name='pthread_attr_getaffinity_np' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
+      <parameter type-id='type-id-280'/>
       <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-285'/>
+      <parameter type-id='type-id-286'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-282' const='yes' id='type-id-286'/>
-    <pointer-type-def type-id='type-id-286' size-in-bits='64' id='type-id-287'/>
+    <qualified-type-def type-id='type-id-283' const='yes' id='type-id-287'/>
+    <pointer-type-def type-id='type-id-287' size-in-bits='64' id='type-id-288'/>
     <function-decl name='pthread_attr_setaffinity_np' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-287'/>
+      <parameter type-id='type-id-288'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_getdetachstate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setdetachstate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_getguardsize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
+      <parameter type-id='type-id-280'/>
       <parameter type-id='type-id-38'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setguardsize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_getinheritsched' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setinheritsched' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='sched_param' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-288'>
+    <class-decl name='sched_param' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-289'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='sched_priority' type-id='type-id-1' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-288' size-in-bits='64' id='type-id-289'/>
+    <pointer-type-def type-id='type-id-289' size-in-bits='64' id='type-id-290'/>
     <function-decl name='pthread_attr_getschedparam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-289'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-290'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-288' const='yes' id='type-id-290'/>
-    <pointer-type-def type-id='type-id-290' size-in-bits='64' id='type-id-291'/>
+    <qualified-type-def type-id='type-id-289' const='yes' id='type-id-291'/>
+    <pointer-type-def type-id='type-id-291' size-in-bits='64' id='type-id-292'/>
     <function-decl name='pthread_attr_setschedparam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <parameter type-id='type-id-291'/>
+      <parameter type-id='type-id-282'/>
+      <parameter type-id='type-id-292'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_getschedpolicy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setschedpolicy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_getscope' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setscope' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_setstack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <parameter type-id='type-id-73'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_attr_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
+      <parameter type-id='type-id-282'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
-      <parameter type-id='type-id-258' name='tpool'/>
-      <parameter type-id='type-id-193' name='func'/>
+      <parameter type-id='type-id-259' name='tpool'/>
+      <parameter type-id='type-id-194' name='func'/>
       <parameter type-id='type-id-73' name='arg'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_cond_signal' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-281'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-292'>
+    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-293'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__val' type-id='type-id-293' visibility='default'/>
+        <var-decl name='__val' type-id='type-id-294' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='1024' id='type-id-293'>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='1024' id='type-id-294'>
       <subrange length='16' type-id='type-id-12' id='type-id-104'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-292' const='yes' id='type-id-294'/>
-    <pointer-type-def type-id='type-id-292' size-in-bits='64' id='type-id-295'/>
+    <qualified-type-def type-id='type-id-293' const='yes' id='type-id-295'/>
+    <pointer-type-def type-id='type-id-293' size-in-bits='64' id='type-id-296'/>
     <function-decl name='pthread_sigmask' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-287'/>
-      <parameter type-id='type-id-295'/>
+      <parameter type-id='type-id-288'/>
+      <parameter type-id='type-id-296'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-296' size-in-bits='64' id='type-id-297'/>
+    <pointer-type-def type-id='type-id-297' size-in-bits='64' id='type-id-298'/>
     <function-decl name='pthread_create' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-38'/>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-297'/>
+      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-298'/>
       <parameter type-id='type-id-73'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='pthread_cond_broadcast' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-281'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_cancel' visibility='default' binding='global' size-in-bits='64'>
@@ -3269,56 +3280,56 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_cond_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-281'/>
       <parameter type-id='type-id-14'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='tpool_suspend' mangled-name='tpool_suspend' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='tpool_suspended' mangled-name='tpool_suspended' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='tpool_resume' mangled-name='tpool_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='tpool_member' mangled-name='tpool_member' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
-      <parameter type-id='type-id-258' name='tpool'/>
+      <parameter type-id='type-id-259' name='tpool'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_self' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-26'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-237' const='yes' id='type-id-298'/>
-    <pointer-type-def type-id='type-id-298' size-in-bits='64' id='type-id-299'/>
+    <qualified-type-def type-id='type-id-238' const='yes' id='type-id-299'/>
+    <pointer-type-def type-id='type-id-299' size-in-bits='64' id='type-id-300'/>
     <function-decl name='pthread_cond_timedwait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
+      <parameter type-id='type-id-281'/>
       <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-299'/>
+      <parameter type-id='type-id-300'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_setcanceltype' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='pthread_setcancelstate' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-129'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-296'>
+    <function-type size-in-bits='64' id='type-id-297'>
       <parameter type-id='type-id-73'/>
       <return type-id='type-id-73'/>
     </function-type>
@@ -3327,603 +3338,602 @@
     <var-decl name='libspl_assert_ok' type-id='type-id-1' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <qualified-type-def type-id='type-id-32' volatile='yes' id='type-id-300'/>
-    <pointer-type-def type-id='type-id-300' size-in-bits='64' id='type-id-301'/>
+    <qualified-type-def type-id='type-id-32' volatile='yes' id='type-id-301'/>
+    <pointer-type-def type-id='type-id-301' size-in-bits='64' id='type-id-302'/>
     <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <typedef-decl name='uchar_t' type-id='type-id-30' id='type-id-302'/>
-    <qualified-type-def type-id='type-id-302' volatile='yes' id='type-id-303'/>
-    <pointer-type-def type-id='type-id-303' size-in-bits='64' id='type-id-304'/>
+    <typedef-decl name='uchar_t' type-id='type-id-30' id='type-id-303'/>
+    <qualified-type-def type-id='type-id-303' volatile='yes' id='type-id-304'/>
+    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-305'/>
     <function-decl name='atomic_inc_uchar' mangled-name='atomic_inc_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
+      <parameter type-id='type-id-305' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-223' volatile='yes' id='type-id-305'/>
-    <pointer-type-def type-id='type-id-305' size-in-bits='64' id='type-id-306'/>
+    <qualified-type-def type-id='type-id-224' volatile='yes' id='type-id-306'/>
+    <pointer-type-def type-id='type-id-306' size-in-bits='64' id='type-id-307'/>
     <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-226' volatile='yes' id='type-id-307'/>
-    <pointer-type-def type-id='type-id-307' size-in-bits='64' id='type-id-308'/>
+    <qualified-type-def type-id='type-id-227' volatile='yes' id='type-id-308'/>
+    <pointer-type-def type-id='type-id-308' size-in-bits='64' id='type-id-309'/>
     <function-decl name='atomic_inc_ushort' mangled-name='atomic_inc_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-22' volatile='yes' id='type-id-309'/>
-    <pointer-type-def type-id='type-id-309' size-in-bits='64' id='type-id-310'/>
+    <qualified-type-def type-id='type-id-22' volatile='yes' id='type-id-310'/>
+    <pointer-type-def type-id='type-id-310' size-in-bits='64' id='type-id-311'/>
     <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-34' volatile='yes' id='type-id-311'/>
-    <pointer-type-def type-id='type-id-311' size-in-bits='64' id='type-id-312'/>
+    <qualified-type-def type-id='type-id-34' volatile='yes' id='type-id-312'/>
+    <pointer-type-def type-id='type-id-312' size-in-bits='64' id='type-id-313'/>
     <function-decl name='atomic_inc_uint' mangled-name='atomic_inc_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-183' volatile='yes' id='type-id-313'/>
-    <pointer-type-def type-id='type-id-313' size-in-bits='64' id='type-id-314'/>
+    <qualified-type-def type-id='type-id-184' volatile='yes' id='type-id-314'/>
+    <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-315'/>
     <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-23' volatile='yes' id='type-id-315'/>
-    <pointer-type-def type-id='type-id-315' size-in-bits='64' id='type-id-316'/>
+    <qualified-type-def type-id='type-id-23' volatile='yes' id='type-id-316'/>
+    <pointer-type-def type-id='type-id-316' size-in-bits='64' id='type-id-317'/>
     <function-decl name='atomic_inc_64' mangled-name='atomic_inc_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_uchar' mangled-name='atomic_dec_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
+      <parameter type-id='type-id-305' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_ushort' mangled-name='atomic_dec_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_uint' mangled-name='atomic_dec_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_dec_64' mangled-name='atomic_dec_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-317'/>
-    <typedef-decl name='__int8_t' type-id='type-id-317' id='type-id-318'/>
-    <typedef-decl name='int8_t' type-id='type-id-318' id='type-id-319'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-318'/>
+    <typedef-decl name='__int8_t' type-id='type-id-318' id='type-id-319'/>
+    <typedef-decl name='int8_t' type-id='type-id-319' id='type-id-320'/>
     <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
-      <parameter type-id='type-id-301' name='target'/>
-      <parameter type-id='type-id-319' name='bits'/>
+      <parameter type-id='type-id-302' name='target'/>
+      <parameter type-id='type-id-320' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_char' mangled-name='atomic_add_char' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-317' name='bits'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-318' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <parameter type-id='type-id-66' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_short' mangled-name='atomic_add_short' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <parameter type-id='type-id-7' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-21' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_int' mangled-name='atomic_add_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-1' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-5' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
-    <typedef-decl name='__int64_t' type-id='type-id-5' id='type-id-320'/>
-    <typedef-decl name='int64_t' type-id='type-id-320' id='type-id-321'/>
+    <typedef-decl name='__int64_t' type-id='type-id-5' id='type-id-321'/>
+    <typedef-decl name='int64_t' type-id='type-id-321' id='type-id-322'/>
     <function-decl name='atomic_add_64' mangled-name='atomic_add_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64'>
-      <parameter type-id='type-id-316' name='target'/>
-      <parameter type-id='type-id-321' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <typedef-decl name='ssize_t' type-id='type-id-133' id='type-id-322'/>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='type-id-130' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-322' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='type-id-132' name='target'/>
+      <parameter type-id='type-id-124' name='bits'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
     <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='type-id-301' name='target'/>
-      <parameter type-id='type-id-319' name='bits'/>
+      <parameter type-id='type-id-302' name='target'/>
+      <parameter type-id='type-id-320' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_char' mangled-name='atomic_sub_char' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-317' name='bits'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-318' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <parameter type-id='type-id-66' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_short' mangled-name='atomic_sub_short' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <parameter type-id='type-id-7' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-21' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_int' mangled-name='atomic_sub_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-1' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-5' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_sub_64' mangled-name='atomic_sub_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64'>
-      <parameter type-id='type-id-316' name='target'/>
-      <parameter type-id='type-id-321' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='type-id-130' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-322' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='type-id-132' name='target'/>
+      <parameter type-id='type-id-124' name='bits'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
     <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_uchar' mangled-name='atomic_or_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='bits'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='bits'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_ushort' mangled-name='atomic_or_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='bits'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_uint' mangled-name='atomic_or_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='bits'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_or_64' mangled-name='atomic_or_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_uchar' mangled-name='atomic_and_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='bits'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='bits'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_ushort' mangled-name='atomic_and_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='bits'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_uint' mangled-name='atomic_and_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='bits'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_and_64' mangled-name='atomic_and_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='bits'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_inc_uchar_nv' mangled-name='atomic_inc_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_inc_ushort_nv' mangled-name='atomic_inc_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort_nv'>
-      <parameter type-id='type-id-308' name='target'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_inc_uint_nv' mangled-name='atomic_inc_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='type-id-314' name='target'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_inc_64_nv' mangled-name='atomic_inc_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_dec_uchar_nv' mangled-name='atomic_dec_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_dec_ushort_nv' mangled-name='atomic_dec_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort_nv'>
-      <parameter type-id='type-id-308' name='target'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_dec_uint_nv' mangled-name='atomic_dec_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='type-id-314' name='target'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_dec_64_nv' mangled-name='atomic_dec_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
-      <parameter type-id='type-id-319' name='bits'/>
+      <parameter type-id='type-id-302' name='target'/>
+      <parameter type-id='type-id-320' name='bits'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_add_char_nv' mangled-name='atomic_add_char_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-317' name='bits'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-318' name='bits'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-223'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_add_short_nv' mangled-name='atomic_add_short_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short_nv'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-226'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-21' name='bits'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_add_int_nv' mangled-name='atomic_add_int_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-1' name='bits'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-183'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_add_64_nv' mangled-name='atomic_add_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
-      <parameter type-id='type-id-321' name='bits'/>
+      <parameter type-id='type-id-317' name='target'/>
+      <parameter type-id='type-id-322' name='bits'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='type-id-130' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
+      <parameter type-id='type-id-132' name='target'/>
+      <parameter type-id='type-id-124' name='bits'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
-      <parameter type-id='type-id-319' name='bits'/>
+      <parameter type-id='type-id-302' name='target'/>
+      <parameter type-id='type-id-320' name='bits'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_sub_char_nv' mangled-name='atomic_sub_char_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-317' name='bits'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-318' name='bits'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
+      <parameter type-id='type-id-307' name='target'/>
       <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-223'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_sub_short_nv' mangled-name='atomic_sub_short_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short_nv'>
-      <parameter type-id='type-id-308' name='target'/>
+      <parameter type-id='type-id-309' name='target'/>
       <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-226'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-21' name='bits'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_sub_int_nv' mangled-name='atomic_sub_int_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-1' name='bits'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-183'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_sub_64_nv' mangled-name='atomic_sub_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
-      <parameter type-id='type-id-321' name='bits'/>
+      <parameter type-id='type-id-317' name='target'/>
+      <parameter type-id='type-id-322' name='bits'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='type-id-130' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
+      <parameter type-id='type-id-132' name='target'/>
+      <parameter type-id='type-id-124' name='bits'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='bits'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_or_uchar_nv' mangled-name='atomic_or_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='bits'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='bits'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='bits'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='bits'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_or_ushort_nv' mangled-name='atomic_or_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort_nv'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='bits'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='bits'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='bits'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_or_uint_nv' mangled-name='atomic_or_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='bits'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='bits'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='bits'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_or_64_nv' mangled-name='atomic_or_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='bits'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='bits'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_and_uchar_nv' mangled-name='atomic_and_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar_nv'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='bits'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='bits'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='bits'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='bits'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_and_ushort_nv' mangled-name='atomic_and_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort_nv'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='bits'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='bits'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='bits'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_and_uint_nv' mangled-name='atomic_and_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint_nv'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='bits'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='bits'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='bits'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_and_64_nv' mangled-name='atomic_and_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64_nv'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='bits'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='exp'/>
       <parameter type-id='type-id-32' name='des'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_cas_uchar' mangled-name='atomic_cas_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='exp'/>
-      <parameter type-id='type-id-302' name='des'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='exp'/>
+      <parameter type-id='type-id-303' name='des'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='exp'/>
-      <parameter type-id='type-id-223' name='des'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='exp'/>
+      <parameter type-id='type-id-224' name='des'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_cas_ushort' mangled-name='atomic_cas_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='exp'/>
-      <parameter type-id='type-id-226' name='des'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='exp'/>
+      <parameter type-id='type-id-227' name='des'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='exp'/>
       <parameter type-id='type-id-22' name='des'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_cas_uint' mangled-name='atomic_cas_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='exp'/>
       <parameter type-id='type-id-34' name='des'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='exp'/>
-      <parameter type-id='type-id-183' name='des'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='exp'/>
+      <parameter type-id='type-id-184' name='des'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_cas_64' mangled-name='atomic_cas_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='exp'/>
       <parameter type-id='type-id-23' name='des'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='type-id-130' name='target'/>
+      <parameter type-id='type-id-132' name='target'/>
       <parameter type-id='type-id-73' name='exp'/>
       <parameter type-id='type-id-73' name='des'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
-      <parameter type-id='type-id-301' name='target'/>
+      <parameter type-id='type-id-302' name='target'/>
       <parameter type-id='type-id-32' name='bits'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='atomic_swap_uchar' mangled-name='atomic_swap_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uchar'>
-      <parameter type-id='type-id-304' name='target'/>
-      <parameter type-id='type-id-302' name='bits'/>
-      <return type-id='type-id-302'/>
+      <parameter type-id='type-id-305' name='target'/>
+      <parameter type-id='type-id-303' name='bits'/>
+      <return type-id='type-id-303'/>
     </function-decl>
     <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='type-id-306' name='target'/>
-      <parameter type-id='type-id-223' name='bits'/>
-      <return type-id='type-id-223'/>
+      <parameter type-id='type-id-307' name='target'/>
+      <parameter type-id='type-id-224' name='bits'/>
+      <return type-id='type-id-224'/>
     </function-decl>
     <function-decl name='atomic_swap_ushort' mangled-name='atomic_swap_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ushort'>
-      <parameter type-id='type-id-308' name='target'/>
-      <parameter type-id='type-id-226' name='bits'/>
-      <return type-id='type-id-226'/>
+      <parameter type-id='type-id-309' name='target'/>
+      <parameter type-id='type-id-227' name='bits'/>
+      <return type-id='type-id-227'/>
     </function-decl>
     <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='type-id-310' name='target'/>
+      <parameter type-id='type-id-311' name='target'/>
       <parameter type-id='type-id-22' name='bits'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='atomic_swap_uint' mangled-name='atomic_swap_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uint'>
-      <parameter type-id='type-id-312' name='target'/>
+      <parameter type-id='type-id-313' name='target'/>
       <parameter type-id='type-id-34' name='bits'/>
       <return type-id='type-id-34'/>
     </function-decl>
     <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='type-id-314' name='target'/>
-      <parameter type-id='type-id-183' name='bits'/>
-      <return type-id='type-id-183'/>
+      <parameter type-id='type-id-315' name='target'/>
+      <parameter type-id='type-id-184' name='bits'/>
+      <return type-id='type-id-184'/>
     </function-decl>
     <function-decl name='atomic_swap_64' mangled-name='atomic_swap_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_64'>
-      <parameter type-id='type-id-316' name='target'/>
+      <parameter type-id='type-id-317' name='target'/>
       <parameter type-id='type-id-23' name='bits'/>
       <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='type-id-130' name='target'/>
+      <parameter type-id='type-id-132' name='target'/>
       <parameter type-id='type-id-73' name='bits'/>
       <return type-id='type-id-73'/>
     </function-decl>
     <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-34' name='value'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='type-id-314' name='target'/>
+      <parameter type-id='type-id-315' name='target'/>
       <parameter type-id='type-id-34' name='value'/>
       <return type-id='type-id-1'/>
     </function-decl>
@@ -4006,16 +4016,16 @@
         <var-decl name='_old_offset' type-id='type-id-326' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-199' visibility='default'/>
+        <var-decl name='_cur_column' type-id='type-id-200' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-317' visibility='default'/>
+        <var-decl name='_vtable_offset' type-id='type-id-318' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
         <var-decl name='_shortbuf' type-id='type-id-327' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-134' visibility='default'/>
+        <var-decl name='_offset' type-id='type-id-135' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
         <var-decl name='_codecvt' type-id='type-id-328' visibility='default'/>
@@ -4030,7 +4040,7 @@
         <var-decl name='_freeres_buf' type-id='type-id-73' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-123' visibility='default'/>
+        <var-decl name='__pad5' type-id='type-id-125' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
         <var-decl name='_mode' type-id='type-id-1' visibility='default'/>
@@ -4045,7 +4055,7 @@
     <typedef-decl name='__off_t' type-id='type-id-5' id='type-id-326'/>
 
     <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8' id='type-id-327'>
-      <subrange length='1' type-id='type-id-12' id='type-id-230'/>
+      <subrange length='1' type-id='type-id-12' id='type-id-231'/>
 
     </array-type-def>
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-332'/>
@@ -4149,7 +4159,7 @@
         <var-decl name='st_dev' type-id='type-id-344' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-198' visibility='default'/>
+        <var-decl name='st_ino' type-id='type-id-199' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='st_nlink' type-id='type-id-345' visibility='default'/>
@@ -4179,13 +4189,13 @@
         <var-decl name='st_blocks' type-id='type-id-350' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-237' visibility='default'/>
+        <var-decl name='st_atim' type-id='type-id-238' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-237' visibility='default'/>
+        <var-decl name='st_mtim' type-id='type-id-238' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-237' visibility='default'/>
+        <var-decl name='st_ctim' type-id='type-id-238' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
         <var-decl name='__glibc_reserved' type-id='type-id-351' visibility='default'/>
@@ -4199,7 +4209,7 @@
     <typedef-decl name='__blksize_t' type-id='type-id-5' id='type-id-349'/>
     <typedef-decl name='__blkcnt64_t' type-id='type-id-5' id='type-id-350'/>
 
-    <array-type-def dimensions='1' type-id='type-id-239' size-in-bits='192' id='type-id-351'>
+    <array-type-def dimensions='1' type-id='type-id-240' size-in-bits='192' id='type-id-351'>
       <subrange length='3' type-id='type-id-12' id='type-id-59'/>
 
     </array-type-def>
@@ -4214,10 +4224,10 @@
   <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
     <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-353'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='list_size' type-id='type-id-123' visibility='default'/>
+        <var-decl name='list_size' type-id='type-id-125' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='list_offset' type-id='type-id-123' visibility='default'/>
+        <var-decl name='list_offset' type-id='type-id-125' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='list_head' type-id='type-id-354' visibility='default'/>
@@ -4236,8 +4246,8 @@
     <pointer-type-def type-id='type-id-356' size-in-bits='64' id='type-id-357'/>
     <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
       <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-123' name='size'/>
-      <parameter type-id='type-id-123' name='offset'/>
+      <parameter type-id='type-id-125' name='size'/>
+      <parameter type-id='type-id-125' name='offset'/>
       <return type-id='type-id-17'/>
     </function-decl>
     <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
@@ -4330,7 +4340,7 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='mbstowcs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-127'/>
+      <parameter type-id='type-id-129'/>
       <parameter type-id='type-id-16'/>
       <parameter type-id='type-id-26'/>
       <return type-id='type-id-26'/>
@@ -4351,23 +4361,23 @@
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
-      <return type-id='type-id-123'/>
+      <return type-id='type-id-125'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
       <parameter type-id='type-id-37' name='dst'/>
       <parameter type-id='type-id-16' name='src'/>
-      <parameter type-id='type-id-123' name='dstsize'/>
-      <return type-id='type-id-123'/>
+      <parameter type-id='type-id-125' name='dstsize'/>
+      <return type-id='type-id-125'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
       <parameter type-id='type-id-37' name='dst'/>
       <parameter type-id='type-id-16' name='src'/>
-      <parameter type-id='type-id-123' name='len'/>
-      <return type-id='type-id-123'/>
+      <parameter type-id='type-id-125' name='len'/>
+      <return type-id='type-id-125'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
@@ -4447,7 +4457,7 @@
     <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
       <parameter type-id='type-id-1' name='fd'/>
       <parameter type-id='type-id-22' name='nparts'/>
-      <parameter type-id='type-id-232' name='vtoc'/>
+      <parameter type-id='type-id-233' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='uuid_generate' visibility='default' binding='global' size-in-bits='64'>
@@ -4456,7 +4466,7 @@
     </function-decl>
     <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
       <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-232' name='vtoc'/>
+      <parameter type-id='type-id-233' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
@@ -4469,7 +4479,7 @@
     </function-decl>
     <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
       <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-231' name='vtoc'/>
+      <parameter type-id='type-id-232' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <qualified-type-def type-id='type-id-30' const='yes' id='type-id-371'/>
@@ -4505,7 +4515,7 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
-      <parameter type-id='type-id-231' name='vtoc'/>
+      <parameter type-id='type-id-232' name='vtoc'/>
       <return type-id='type-id-17'/>
     </function-decl>
   </abi-instr>

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libzutil.h>
 #include <sys/crypto/icp.h>
 #include <sys/processor.h>
 #include <sys/rrwlock.h>
@@ -571,19 +572,10 @@ void
 __dprintf(boolean_t dprint, const char *file, const char *func,
     int line, const char *fmt, ...)
 {
-	const char *newfile;
+	/* Get rid of annoying "../common/" prefix to filename. */
+	const char *newfile = zfs_basename(file);
+
 	va_list adx;
-
-	/*
-	 * Get rid of annoying "../common/" prefix to filename.
-	 */
-	newfile = strrchr(file, '/');
-	if (newfile != NULL) {
-		newfile = newfile + 1; /* Get rid of leading / */
-	} else {
-		newfile = file;
-	}
-
 	if (dprint) {
 		/* dprintf messages are printed immediately */
 
@@ -1070,7 +1062,7 @@ zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 
 	if (vn_dumpdir != NULL) {
 		char *dumppath = umem_zalloc(MAXPATHLEN, UMEM_NOFAIL);
-		char *inpath = basename((char *)(uintptr_t)path);
+		const char *inpath = zfs_basename(path);
 
 		(void) snprintf(dumppath, MAXPATHLEN,
 		    "%s/%s", vn_dumpdir, inpath);

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -168,7 +168,7 @@ out:
 	(void) close(fd);
 }
 
-static const char *
+static const char * const
 zpool_default_import_path[] = {
 	"/dev"
 };

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -74,7 +74,6 @@
 #endif
 #include <blkid/blkid.h>
 
-#define	DEFAULT_IMPORT_PATH_SIZE	9
 #define	DEV_BYID_PATH	"/dev/disk/by-id/"
 
 static boolean_t
@@ -255,8 +254,8 @@ zpool_open_func(void *arg)
 	}
 }
 
-static char *
-zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
+static const char * const
+zpool_default_import_path[] = {
 	"/dev/disk/by-vdev",	/* Custom rules, use first if they exist */
 	"/dev/mapper",		/* Use multipath devices before components */
 	"/dev/disk/by-partlabel", /* Single unique entry set by user */
@@ -271,8 +270,8 @@ zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
 const char * const *
 zpool_default_search_paths(size_t *count)
 {
-	*count = DEFAULT_IMPORT_PATH_SIZE;
-	return ((const char * const *)zpool_default_import_path);
+	*count = ARRAY_SIZE(zpool_default_import_path);
+	return (zpool_default_import_path);
 }
 
 /*
@@ -300,7 +299,7 @@ zfs_path_order(char *name, int *order)
 		}
 		free(envdup);
 	} else {
-		for (i = 0; i < DEFAULT_IMPORT_PATH_SIZE; i++) {
+		for (i = 0; i < ARRAY_SIZE(zpool_default_import_path); i++) {
 			if (strncmp(name, zpool_default_import_path[i],
 			    strlen(zpool_default_import_path[i])) == 0) {
 				*order = i;

--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -31,6 +31,22 @@
 
 #include <libzutil.h>
 
+/* Substring from after the last slash, or the string itself if none */
+const char *
+zfs_basename(const char *path)
+{
+	const char *bn = strrchr(path, '/');
+	return (bn ? bn + 1 : path);
+}
+
+/* Return index of last slash or -1 if none */
+ssize_t
+zfs_dirnamelen(const char *path)
+{
+	const char *end = strrchr(path, '/');
+	return (end ? end - path : -1);
+}
+
 /*
  * Given a shorthand device name check if a file by that name exists in any
  * of the 'zpool_default_import_path' or ZPOOL_IMPORT_PATH directories.  If

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -154,6 +154,17 @@ zutil_strdup(libpc_handle_t *hdl, const char *str)
 	return (ret);
 }
 
+static char *
+zutil_strndup(libpc_handle_t *hdl, const char *str, size_t n)
+{
+	char *ret;
+
+	if ((ret = strndup(str, n)) == NULL)
+		(void) zutil_no_memory(hdl);
+
+	return (ret);
+}
+
 /*
  * Intermediate structures used to gather configuration information.
  */
@@ -1272,20 +1283,22 @@ zpool_find_import_scan_path(libpc_handle_t *hdl, pthread_mutex_t *lock,
 {
 	int error = 0;
 	char path[MAXPATHLEN];
-	char *d, *b;
-	char *dpath, *name;
+	char *d = NULL;
+	ssize_t dl;
+	const char *dpath, *name;
 
 	/*
-	 * Separate the directory part and last part of the
-	 * path. We do this so that we can get the realpath of
+	 * Separate the directory and the basename.
+	 * We do this so that we can get the realpath of
 	 * the directory. We don't get the realpath on the
 	 * whole path because if it's a symlink, we want the
 	 * path of the symlink not where it points to.
 	 */
-	d = zutil_strdup(hdl, dir);
-	b = zutil_strdup(hdl, dir);
-	dpath = dirname(d);
-	name = basename(b);
+	name = zfs_basename(dir);
+	if ((dl = zfs_dirnamelen(dir)) == -1)
+		dpath = ".";
+	else
+		dpath = d = zutil_strndup(hdl, dir, dl);
 
 	if (realpath(dpath, path) == NULL) {
 		error = errno;
@@ -1303,7 +1316,6 @@ zpool_find_import_scan_path(libpc_handle_t *hdl, pthread_mutex_t *lock,
 	zpool_find_import_scan_add_slice(hdl, lock, cache, path, name, order);
 
 out:
-	free(b);
 	free(d);
 	return (error);
 }
@@ -1506,6 +1518,7 @@ discover_cached_paths(libpc_handle_t *hdl, nvlist_t *nv,
     avl_tree_t *cache, pthread_mutex_t *lock)
 {
 	char *path = NULL;
+	ssize_t dl;
 	uint_t children;
 	nvlist_t **child;
 
@@ -1521,8 +1534,12 @@ discover_cached_paths(libpc_handle_t *hdl, nvlist_t *nv,
 	 * our directory cache.
 	 */
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path) == 0) {
+		if ((dl = zfs_dirnamelen(path)) == -1)
+			path = ".";
+		else
+			path[dl] = '\0';
 		return (zpool_find_import_scan_dir(hdl, lock, cache,
-		    dirname(path), 0));
+		    path, 0));
 	}
 	return (0);
 }

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1243,9 +1243,20 @@ zpool_find_import_scan_dir(libpc_handle_t *hdl, pthread_mutex_t *lock,
 
 	while ((dp = readdir64(dirp)) != NULL) {
 		const char *name = dp->d_name;
-		if (name[0] == '.' &&
-		    (name[1] == 0 || (name[1] == '.' && name[2] == 0)))
+		if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
 			continue;
+
+		switch (dp->d_type) {
+		case DT_UNKNOWN:
+		case DT_BLK:
+#ifdef __FreeBSD__
+		case DT_CHR:
+#endif
+		case DT_REG:
+			break;
+		default:
+			continue;
+		}
 
 		zpool_find_import_scan_add_slice(hdl, lock, cache, path, name,
 		    order);

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -7,7 +7,7 @@ REF="HEAD"
 test_commit_bodylength()
 {
     length="72"
-    body=$(git log -n 1 --pretty=%b "$REF" | grep -Ev "http(s)*://" | grep -E -m 1 ".{$((length + 1))}")
+    body=$(git log --no-show-signature -n 1 --pretty=%b "$REF" | grep -Ev "http(s)*://" | grep -E -m 1 ".{$((length + 1))}")
     if [ -n "$body" ]; then
         echo "error: commit message body contains line over ${length} characters"
         return 1
@@ -20,7 +20,7 @@ test_commit_bodylength()
 check_tagged_line()
 {
     regex='^[[:space:]]*'"$1"':[[:space:]][[:print:]]+[[:space:]]<[[:graph:]]+>$'
-    foundline=$(git log -n 1 "$REF" | grep -E -m 1 "$regex")
+    foundline=$(git log --no-show-signature -n 1 "$REF" | grep -E -m 1 "$regex")
     if [ -z "$foundline" ]; then
         echo "error: missing \"$1\""
         return 1
@@ -35,7 +35,7 @@ new_change_commit()
     error=0
 
     # subject is not longer than 72 characters
-    long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{73}')
+    long_subject=$(git log --no-show-signature -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{73}')
     if [ -n "$long_subject" ]; then
         echo "error: commit subject over 72 characters"
         error=1
@@ -57,7 +57,7 @@ new_change_commit()
 is_coverity_fix()
 {
     # subject starts with Fix coverity defects means it's a coverity fix
-    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^Fix coverity defects')
+    subject=$(git log --no-show-signature -n 1 --pretty=%s "$REF" | grep -E -m 1 '^Fix coverity defects')
     if [ -n "$subject" ]; then
         return 0
     fi
@@ -70,7 +70,7 @@ coverity_fix_commit()
     error=0
 
     # subject starts with Fix coverity defects: CID dddd, dddd...
-    subject=$(git log -n 1 --pretty=%s "$REF" |
+    subject=$(git log --no-show-signature -n 1 --pretty=%s "$REF" |
         grep -E -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
     if [ -z "$subject" ]; then
         echo "error: Coverity defect fixes must have a subject line that starts with \"Fix coverity defects: CID dddd\""
@@ -86,7 +86,7 @@ coverity_fix_commit()
     OLDIFS=$IFS
     IFS='
 '
-    for line in $(git log -n 1 --pretty=%b "$REF" | grep -E '^CID'); do
+    for line in $(git log --no-show-signature -n 1 --pretty=%b "$REF" | grep -E '^CID'); do
         if ! echo "$line" | grep -qE '^CID [[:digit:]]+: ([[:graph:]]+|[[:space:]])+ \(([[:upper:]]|\_)+\)'; then
             echo "error: commit message has an improperly formatted CID defect line"
             error=1

--- a/tests/zfs-tests/tests/functional/ctime/Makefile.am
+++ b/tests/zfs-tests/tests/functional/ctime/Makefile.am
@@ -11,3 +11,5 @@ pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/ctime
 
 pkgexec_PROGRAMS = ctime
 ctime_SOURCES = ctime.c
+
+ctime_LDADD = $(abs_top_builddir)/lib/libzfs_core/libzfs_core.la

--- a/tests/zfs-tests/tests/functional/ctime/ctime.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime.c
@@ -37,6 +37,7 @@
 #include <utime.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <libzutil.h>
 #include <unistd.h>
 #include <strings.h>
 #include <errno.h>
@@ -149,22 +150,18 @@ static int
 do_link(const char *pfile)
 {
 	int ret = 0;
-	char link_file[BUFSIZ] = { 0 };
-	char pfile_copy[BUFSIZ] = { 0 };
-	char *dname;
+	char link_file[BUFSIZ + 16] = { 0 };
 
 	if (pfile == NULL) {
 		return (-1);
 	}
 
-	strncpy(pfile_copy, pfile, sizeof (pfile_copy)-1);
-	pfile_copy[sizeof (pfile_copy) - 1] = '\0';
 	/*
 	 * Figure out source file directory name, and create
 	 * the link file in the same directory.
 	 */
-	dname = dirname((char *)pfile_copy);
-	(void) snprintf(link_file, BUFSIZ, "%s/%s", dname, "link_file");
+	(void) snprintf(link_file, sizeof (link_file),
+	    "%.*s/%s", (int)zfs_dirnamelen(pfile), pfile, "link_file");
 
 	if (link(pfile, link_file) == -1) {
 		(void) fprintf(stderr, "link(%s, %s) failed with errno %d\n",
@@ -321,7 +318,7 @@ main(int argc, char *argv[])
 	(void) snprintf(tfile, sizeof (tfile), "%s/%s", penv[0], penv[1]);
 
 	/*
-	 * If the test file is exists, remove it first.
+	 * If the test file exists, remove it first.
 	 */
 	if (access(tfile, F_OK) == 0) {
 		(void) unlink(tfile);


### PR DESCRIPTION
### Description
The first three patches simplify and optimise import enumeration.

The rest prune the remaining {base,dir}name(3)s. Consult linux man-pages' basename(3) for the delight that is portability and usage of these (musl also has some (it might be slightly different? it's not immediately clear from the code) variant and uses it for variants). This is particularly fun for `zfs_save_arguments()` which has every right to raze argv[0], for example.

The top is a Fun Decluttering Exercise which gives more prominence to the generated files that *aren't* Makefiles, and removes 330+ lines of non-data since you always want that to match the filesystem anwyay.

Also: is there a reason FreeBSD is allowed to try to import chardevs?

### How Has This Been Tested?
Ran it, I guess?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none should apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
