### PR TITLE
zpool: status: exit(amount of problematic pools) with -x

### DIFF
--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 15, 2020
+.Dd May 22, 2021
 .Dt ZPOOL-STATUS 8
 .Os
 .Sh NAME
@@ -126,6 +126,7 @@ data errors since the last complete pool scrub.
 Only display status for pools that are exhibiting errors or are otherwise
 unavailable.
 Warnings about pools not using the latest on-disk format will not be included.
+The exit code will be equal to the amount of pools that match these criteria.
 .El
 .El
 .Sh SEE ALSO


### PR DESCRIPTION
### Motivation and Context
#12100, so I don't forget, but I don't think that this is the right approach

### Description
It's what it says on the tin.

### How Has This Been Tested?
Ran it on various combination of okay and errored pools.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – I don't think any apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
