### PR TITLE
dracut: 90zfs: touchups

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -49,13 +49,16 @@ install() {
 		# On systems with gcc-config (Gentoo, Funtoo, etc.):
 		# Use the current profile to resolve the appropriate path
 		s="$(gcc-config -c)"
-		dracut_install "/usr/lib/gcc/${s%-*}/${s##*-}/libgcc_s.so.1"
-	elif ls /usr/lib/libgcc_s.so* >/dev/null 2>&1; then
+		dracut_install "/usr/lib/gcc/${s%-*}/${s##*-}/libgcc_s.so"*
+	elif [ "$(echo /usr/lib/libgcc_s.so*)" != "/usr/lib/libgcc_s.so*" ]; then
 		# Try a simple path first
 		dracut_install /usr/lib/libgcc_s.so*
+	elif [ "$(echo /lib*/libgcc_s.so*)" != "/lib*/libgcc_s.so*" ]; then
+		# SUSE
+		dracut_install /lib*/libgcc_s.so*
 	else
 		# Fallback: Guess the path and include all matches
-		dracut_install /usr/lib/gcc/*/*/libgcc_s.so*
+		dracut_install /usr/lib*/gcc/**/libgcc_s.so*
 	fi
 	# shellcheck disable=SC2050
 	if [ @LIBFETCH_DYNAMIC@ != 0 ]; then

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -58,7 +58,7 @@ ZFS_POOL="${ZFS_DATASET%%/*}"
 
 if import_pool "${ZFS_POOL}" ; then
 	# Load keys if we can or if we need to
-	if [ "$(zpool list -H -o feature@encryption "$(echo "${ZFS_POOL}" | awk -F/ '{print $1}')")" = 'active' ]; then
+	if [ "$(zpool list -H -o feature@encryption "${ZFS_POOL}")" = 'active' ]; then
 		# if the root dataset has encryption enabled
 		ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${ZFS_DATASET}")"
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -42,16 +42,32 @@ if [ "$(zpool list -H -o feature@encryption "${BOOTFS%%/*}")" = 'active' ]; then
         [ "$KEYSTATUS" = "unavailable" ] || exit 0
 
         KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
-        if ! [ "${KEYLOCATION}" = "prompt" ]; then
-            if ! [ "${KEYLOCATION#http}" = "${KEYLOCATION}" ]; then
+        case "${KEYLOCATION%%://*}" in
+            prompt)
+                for _ in 1 2 3; do
+                    systemd-ask-password "Encrypted ZFS password for ${BOOTFS}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
+                done
+                ;;
+            http*)
                 systemctl start network-online.target
-            fi
-            zfs load-key "${ENCRYPTIONROOT}"
-        else
-            # decrypt them
-            for _ in 1 2 3 4 5; do
-                systemd-ask-password "Encrypted ZFS password for ${BOOTFS}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
-            done
-        fi
+                zfs load-key "${ENCRYPTIONROOT}"
+                ;;
+            file)
+                KEYFILE="${KEYLOCATION#file://}"
+                [ -r "${KEYFILE}" ] || udevadm settle
+                [ -r "${KEYFILE}" ] || {
+                    info "Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
+                    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+                        sleep 0.5s
+                        [ -r "${KEYFILE}" ] && break
+                    done
+                }
+                [ -r "${KEYFILE}" ] || warn "Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
+                zfs load-key "${ENCRYPTIONROOT}"
+                ;;
+            *)
+                zfs load-key "${ENCRYPTIONROOT}"
+                ;;
+        esac
     fi
 fi

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -36,13 +36,12 @@ fi
 if [ "$(zpool list -H -o feature@encryption "$(echo "${BOOTFS}" | awk -F/ '{print $1}')")" = 'active' ]; then
     # if the root dataset has encryption enabled
     ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${BOOTFS}")"
-    # where the key is stored (in a file or loaded via prompt)
-    KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
         KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
         # continue only if the key needs to be loaded
         [ "$KEYSTATUS" = "unavailable" ] || exit 0
-        # if key is stored in a file, do not prompt
+
+        KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
         if ! [ "${KEYLOCATION}" = "prompt" ]; then
             if ! [ "${KEYLOCATION#http}" = "${KEYLOCATION}" ]; then
                 systemctl start network-online.target

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -33,7 +33,7 @@ else
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'
-if [ "$(zpool list -H -o feature@encryption "$(echo "${BOOTFS}" | awk -F/ '{print $1}')")" = 'active' ]; then
+if [ "$(zpool list -H -o feature@encryption "${BOOTFS%%/*}")" = 'active' ]; then
     # if the root dataset has encryption enabled
     ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${BOOTFS}")"
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -706,7 +706,8 @@ mountroot()
 
 	# ------------
 	# Look for the cache file (if any).
-	[ ! -f "${ZPOOL_CACHE}" ] && unset ZPOOL_CACHE
+	[ -f "${ZPOOL_CACHE}" ] || unset ZPOOL_CACHE
+	[ -s "${ZPOOL_CACHE}" ] || unset ZPOOL_CACHE
 
 	# ------------
 	# Compatibility: 'ROOT' is for Debian GNU/Linux (etc),

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -390,7 +390,7 @@ decrypt_fs()
 	fs="$1"
 
 	# If pool encryption is active and the zfs command understands '-o encryption'
-	if [ "$(zpool list -H -o feature@encryption "$(echo "${fs}" | awk -F/ '{print $1}')")" = 'active' ]; then
+	if [ "$(zpool list -H -o feature@encryption "${fs%%/*}")" = 'active' ]; then
 
 		# Determine dataset that holds key for root dataset
 		ENCRYPTIONROOT="$(get_fs_value "${fs}" encryptionroot)"


### PR DESCRIPTION
### Motivation and Context
#11750, #11800, #12065

### Description
See commit messages

### How Has This Been Tested?
I, uh, got the expressions to print the right thing on "OpenSUSE Tumbleweed 20210512", and the reordering is trivially correct. Wait loop is based off reporter's suggested solution.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
