### PR TITLE
Rewrite mount.zfs(8) and touch up zfsprops(8) WRT nbmand and temp options

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -185,10 +185,11 @@ main(int argc, char **argv)
 			break;
 		case 'h':
 		case '?':
-			(void) fprintf(stderr, gettext("Invalid option '%c'\n"),
-			    optopt);
+			if (optopt)
+				(void) fprintf(stderr,
+				    gettext("Invalid option '%c'\n"), optopt);
 			(void) fprintf(stderr, gettext("Usage: mount.zfs "
-			    "[-sfnv] [-o options] <dataset> <mountpoint>\n"));
+			    "[-sfnvh] [-o options] <dataset> <mountpoint>\n"));
 			return (MOUNT_USAGE);
 		}
 	}

--- a/man/man8/mount.zfs.8
+++ b/man/man8/mount.zfs.8
@@ -22,123 +22,117 @@
 .\"
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
 .\"
-.TH MOUNT.ZFS 8 "Aug 24, 2020" OpenZFS
-
-.SH NAME
-mount.zfs \- mount a ZFS filesystem
-.SH SYNOPSIS
-.LP
-.BI "mount.zfs [\-sfnvh] [\-o " options "]" " dataset mountpoint
-
-.SH DESCRIPTION
-.BR mount.zfs
+.Dd May 24, 2021
+.Dt MOUNT.ZFS 8
+.Os
+.
+.Sh NAME
+.Nm mount.zfs
+.Nd mount a ZFS filesystem
+.Sh SYNOPSIS
+.Nm
+.Op Fl sfnvh
+.Op Fl o Ar options
+.Ar dataset
+.Ar mountpoint
+.
+.Sh DESCRIPTION
+.Nm
 is part of the zfsutils package for Linux. It is a helper program that
 is usually invoked by the
-.BR mount (8)
+.Xr mount 8
 or
-.BR zfs (8)
+.Xr zfs 8
 commands to mount a ZFS dataset.
-
+.Pp
 All
-.I options
+.Ar options
 are handled according to the FILESYSTEM INDEPENDENT MOUNT OPTIONS
 section in the
-.BR mount (8)
+.Xr mount 8
 manual, except for those described below.
-
+.Pp
 The
-.I dataset
+.Ar dataset
 parameter is a ZFS filesystem name, as output by the
-.B "zfs list -H -o name
+.Nm zfs Cm load-key Fl h Fl o Ar name
 command. This parameter never has a leading slash character and is
 not a device name.
-
+.Pp
 The
-.I mountpoint
+.Ar mountpoint
 parameter is the path name of a directory.
-
-
-.SH OPTIONS
-.TP
-.BI "\-s"
+.
+.Sh OPTIONS
+.Bl -tag -width "-o xa"
+.It Fl s
 Ignore bad or sloppy mount options.
-.TP
-.BI "\-f"
+.It Fl f
 Do a fake mount; do not perform the mount operation.
-.TP
-.BI "\-n"
+.It Fl n
 Do not update the /etc/mtab file.
-.TP
-.BI "\-v"
+.It Fl v
 Increase verbosity.
-.TP
-.BI "\-h"
+.It Fl h
 Print the usage message.
-.TP
-.BI "\-o context"
+.It Fl o Ar context
 This flag sets the SELinux context for all files in the filesystem
 under that mountpoint.
-.TP
-.BI "\-o fscontext"
+.It Fl o Ar fscontext
 This flag sets the SELinux context for the filesystem being mounted.
-.TP
-.BI "\-o defcontext"
+.It Fl o Ar defcontext
 This flag sets the SELinux context for unlabeled files.
-.TP
-.BI "\-o rootcontext"
+.It Fl o Ar rootcontext
 This flag sets the SELinux context for the root inode of the filesystem.
-.TP
-.BI "\-o legacy"
+.It Fl o Ar legacy
 This private flag indicates that the
-.I dataset
+.Ar dataset
 has an entry in the /etc/fstab file.
-.TP
-.BI "\-o noxattr"
+.It Fl o Ar noxattr
 This private flag disables extended attributes.
-.TP
-.BI "\-o xattr
+.It Fl o Ar xattr
 This private flag enables directory-based extended attributes and, if
 appropriate, adds a ZFS context to the selinux system policy.
-.TP
-.BI "\-o saxattr
+.It Fl o Ar saxattr
 This private flag enables system attributed-based extended attributes and, if
 appropriate, adds a ZFS context to the selinux system policy.
-.TP
-.BI "\-o dirxattr
+.It Fl o Ar dirxattr
 Equivalent to
-.BR xattr .
-.TP
-.BI "\-o zfsutil"
+.Ar xattr .
+.It Fl o Ar zfsutil
 This private flag indicates that
-.BR mount (8)
+.Xr mount 8
 is being called by the
-.BR zfs (8)
+.Xr zfs 8
 command.
-
-.SH NOTES
+.El
+.
+.Sh NOTES
 ZFS conventionally requires that the
-.I mountpoint
+.Ar mountpoint
 be an empty directory, but the Linux implementation inconsistently
 enforces the requirement.
-
+.Pp
 The
-.BR mount.zfs
+.Nm
 helper does not mount the contents of zvols.
-
-.SH FILES
-.TP 18n
-.I /etc/fstab
+.
+.Sh FILES
+.Bl -tag -width "/etc/fstab"
+.It Pa /etc/fstab
 The static filesystem table.
-.TP
-.I /etc/mtab
+.It Pa /etc/mtab
 The mounted filesystem table.
-.SH "AUTHORS"
+.El
+.
+.Sh AUTHORS
 The primary author of
-.BR mount.zfs
+.Nm
 is Brian Behlendorf <behlendorf1@llnl.gov>.
-
+.Pp
 This man page was written by Darik Horn <dajhorn@vanadac.com>.
-.SH "SEE ALSO"
-.BR fstab (5),
-.BR mount (8),
-.BR zfs (8)
+.
+.Sh SEE ALSO
+.Xr fstab 5 ,
+.Xr mount 8 ,
+.Xr zfs 8

--- a/man/man8/mount.zfs.8
+++ b/man/man8/mount.zfs.8
@@ -1,4 +1,3 @@
-'\" t
 .\"
 .\" CDDL HEADER START
 .\"
@@ -19,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
 .\"
 .Dd May 24, 2021
@@ -37,68 +35,49 @@
 .Ar mountpoint
 .
 .Sh DESCRIPTION
+The
 .Nm
-is part of the zfsutils package for Linux. It is a helper program that
-is usually invoked by the
+helper is used by
+.Xr mount 8
+to mount filesystem snapshots and
+.Sy mountpoint= Ns Ar legacy
+ZFS filesystems, as well as by
+.Xr zfs 8
+when the
+.Ev Em $ZFS_MOUNT_HELPER
+environment variable is not set.
+Users should should invoke either
 .Xr mount 8
 or
 .Xr zfs 8
-commands to mount a ZFS dataset.
+in most cases.
 .Pp
-All
 .Ar options
-are handled according to the FILESYSTEM INDEPENDENT MOUNT OPTIONS
-section in the
-.Xr mount 8
-manual, except for those described below.
+are handled according to the
+.Em Temporary Mount Point Properties
+section in
+.Xr zfsprops 8 ,
+except for those described below.
 .Pp
-The
-.Ar dataset
-parameter is a ZFS filesystem name, as output by the
-.Nm zfs Cm load-key Fl h Fl o Ar name
-command. This parameter never has a leading slash character and is
-not a device name.
-.Pp
-The
-.Ar mountpoint
-parameter is the path name of a directory.
+If
+.Pa /etc/mtab
+is a regular file and
+.Fl n
+was not specified, it will be updated via libmount.
 .
 .Sh OPTIONS
 .Bl -tag -width "-o xa"
 .It Fl s
-Ignore bad or sloppy mount options.
+Ignore unknown (sloppy) mount options.
 .It Fl f
-Do a fake mount; do not perform the mount operation.
+Do everything except actually executing the system call.
 .It Fl n
-Do not update the /etc/mtab file.
+Never update
+.Pa /etc/mtab .
 .It Fl v
-Increase verbosity.
+Print resolved mount options and parser state.
 .It Fl h
 Print the usage message.
-.It Fl o Ar context
-This flag sets the SELinux context for all files in the filesystem
-under that mountpoint.
-.It Fl o Ar fscontext
-This flag sets the SELinux context for the filesystem being mounted.
-.It Fl o Ar defcontext
-This flag sets the SELinux context for unlabeled files.
-.It Fl o Ar rootcontext
-This flag sets the SELinux context for the root inode of the filesystem.
-.It Fl o Ar legacy
-This private flag indicates that the
-.Ar dataset
-has an entry in the /etc/fstab file.
-.It Fl o Ar noxattr
-This private flag disables extended attributes.
-.It Fl o Ar xattr
-This private flag enables directory-based extended attributes and, if
-appropriate, adds a ZFS context to the selinux system policy.
-.It Fl o Ar saxattr
-This private flag enables system attributed-based extended attributes and, if
-appropriate, adds a ZFS context to the selinux system policy.
-.It Fl o Ar dirxattr
-Equivalent to
-.Ar xattr .
 .It Fl o Ar zfsutil
 This private flag indicates that
 .Xr mount 8
@@ -107,32 +86,7 @@ is being called by the
 command.
 .El
 .
-.Sh NOTES
-ZFS conventionally requires that the
-.Ar mountpoint
-be an empty directory, but the Linux implementation inconsistently
-enforces the requirement.
-.Pp
-The
-.Nm
-helper does not mount the contents of zvols.
-.
-.Sh FILES
-.Bl -tag -width "/etc/fstab"
-.It Pa /etc/fstab
-The static filesystem table.
-.It Pa /etc/mtab
-The mounted filesystem table.
-.El
-.
-.Sh AUTHORS
-The primary author of
-.Nm
-is Brian Behlendorf <behlendorf1@llnl.gov>.
-.Pp
-This man page was written by Darik Horn <dajhorn@vanadac.com>.
-.
 .Sh SEE ALSO
 .Xr fstab 5 ,
 .Xr mount 8 ,
-.Xr zfs 8
+.Xr zfs-mount 8

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -38,7 +38,7 @@
 .\" Copyright 2019 Joyent, Inc.
 .\" Copyright (c) 2019, Kjeld Schouten-Lebbing
 .\"
-.Dd May 5, 2021
+.Dd May 24, 2021
 .Dt ZFSPROPS 8
 .Os
 .Sh NAME
@@ -1212,15 +1212,10 @@ location.
 .It Sy nbmand Ns = Ns Sy on Ns | Ns Sy off
 Controls whether the file system should be mounted with
 .Sy nbmand
-.Pq Non Blocking mandatory locks .
+.Pq Non-blocking mandatory locks .
 This is used for SMB clients.
 Changes to this property only take effect when the file system is umounted and
-remounted.
-See
-.Xr mount 8
-for more information on
-.Sy nbmand
-mounts. This property is not used on Linux.
+remounted. Support for these locks is scarce and not described by POSIX.
 .It Sy overlay Ns = Ns Sy on Ns | Ns Sy off
 Allow mounting on a busy directory or a directory which already contains
 files or directories.

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -1947,6 +1947,11 @@ The correlation between properties and mount options is as follows:
     relatime                relatime/norelatime
     setuid                  suid/nosuid
     xattr                   xattr/noxattr
+    nbmand                  mand/nomand
+    context                 context=
+    fscontext               fscontext=
+    defcontext              defcontext=
+    rootcontext             rootcontext=
 .Ed
 .Pp
 In addition, these options can be set on a per-mount basis using the


### PR DESCRIPTION
### Motivation and Context
nbmand was a mystery to me; no longer.

### Description
See individual commit messages.

### How Has This Been Tested?
Looked at it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
