### PR TITLE
Stop depending on libzfs_impl.h, format safety in libzfs

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -52,6 +52,8 @@
 #include <zone.h>
 #include <grp.h>
 #include <pwd.h>
+#include <umem.h>
+#include <pthread.h>
 #include <signal.h>
 #include <sys/list.h>
 #include <sys/mkdev.h>
@@ -78,7 +80,6 @@
 #include "zfs_iter.h"
 #include "zfs_util.h"
 #include "zfs_comutil.h"
-#include "libzfs_impl.h"
 #include "zfs_projectutil.h"
 
 libzfs_handle_t *g_zfs;
@@ -3315,7 +3316,7 @@ zfs_do_userspace(int argc, char **argv)
 	if ((zhp = zfs_path_to_zhandle(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_SNAPSHOT)) == NULL)
 		return (1);
-	if (zhp->zfs_head_type != ZFS_TYPE_FILESYSTEM) {
+	if (zfs_get_underlying_type(zhp) != ZFS_TYPE_FILESYSTEM) {
 		(void) fprintf(stderr, gettext("operation is only applicable "
 		    "to filesystems and their snapshots\n"));
 		zfs_close(zhp);

--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -71,7 +71,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <inttypes.h>
-#include <libzfs_impl.h>
+#include <libzfs.h>
 
 #define	POOL_MEASUREMENT	"zpool_stats"
 #define	SCAN_MEASUREMENT	"zpool_scan_stats"
@@ -101,9 +101,10 @@ typedef int (*stat_printer_f)(nvlist_t *, const char *, const char *);
  * caller is responsible for freeing result
  */
 static char *
-escape_string(char *s)
+escape_string(const char *s)
 {
-	char *c, *d;
+	const char *c;
+	char *d;
 	char *t = (char *)malloc(ZFS_MAX_DATASET_NAME_LEN * 2);
 	if (t == NULL) {
 		fprintf(stderr, "error: cannot allocate memory\n");
@@ -714,7 +715,7 @@ print_stats(zpool_handle_t *zhp, void *data)
 
 	/* if not this pool return quickly */
 	if (data &&
-	    strncmp(data, zhp->zpool_name, ZFS_MAX_DATASET_NAME_LEN) != 0) {
+	    strncmp(data, zpool_get_name(zhp), ZFS_MAX_DATASET_NAME_LEN) != 0) {
 		zpool_close(zhp);
 		return (0);
 	}
@@ -742,7 +743,7 @@ print_stats(zpool_handle_t *zhp, void *data)
 		return (3);
 	}
 
-	pool_name = escape_string(zhp->zpool_name);
+	pool_name = escape_string(zpool_get_name(zhp));
 	err = print_recursive_stats(print_summary_stats, nvroot,
 	    pool_name, NULL, 1);
 	/* if any of these return an error, skip the rest */

--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -22,7 +22,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <libzfs_impl.h>
 #include <libzfs.h>
 #include <libzutil.h>
 #include <stddef.h>

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -826,6 +826,7 @@ extern int zfs_mount(zfs_handle_t *, const char *, int);
 extern int zfs_mount_at(zfs_handle_t *, const char *, int, const char *);
 extern int zfs_unmount(zfs_handle_t *, const char *, int);
 extern int zfs_unmountall(zfs_handle_t *, int);
+extern int zfs_mount_delegation_check(void);
 
 #if defined(__linux__)
 extern int zfs_parse_mount_options(char *mntopts, unsigned long *mntflags,

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -468,6 +468,7 @@ extern zfs_handle_t *zfs_open(libzfs_handle_t *, const char *, int);
 extern zfs_handle_t *zfs_handle_dup(zfs_handle_t *);
 extern void zfs_close(zfs_handle_t *);
 extern zfs_type_t zfs_get_type(const zfs_handle_t *);
+extern zfs_type_t zfs_get_underlying_type(const zfs_handle_t *);
 extern const char *zfs_get_name(const zfs_handle_t *);
 extern zpool_handle_t *zfs_get_pool_handle(const zfs_handle_t *);
 extern const char *zfs_get_pool_name(const zfs_handle_t *);

--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -30,7 +30,6 @@
 #define	_LIBZFS_IMPL_H
 
 #include <sys/fs/zfs.h>
-#include <sys/spa.h>
 #include <sys/nvpair.h>
 #include <sys/dmu.h>
 #include <sys/zfs_ioctl.h>
@@ -243,7 +242,6 @@ extern proto_table_t proto_table[PROTO_END];
 extern int do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts,
     int flags);
 extern int do_unmount(const char *mntpt, int flags);
-extern int zfs_mount_delegation_check(void);
 extern int zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto);
 extern int unshare_one(libzfs_handle_t *hdl, const char *name,
     const char *mountpoint, zfs_share_proto_t proto);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1613,6 +1613,47 @@ typedef enum {
 #define	ZFS_EV_HIST_DSID	"history_dsid"
 #define	ZFS_EV_RESILVER_TYPE	"resilver_type"
 
+
+/*
+ * We currently support block sizes from 512 bytes to 16MB.
+ * The benefits of larger blocks, and thus larger IO, need to be weighed
+ * against the cost of COWing a giant block to modify one byte, and the
+ * large latency of reading or writing a large block.
+ *
+ * Note that although blocks up to 16MB are supported, the recordsize
+ * property can not be set larger than zfs_max_recordsize (default 1MB).
+ * See the comment near zfs_max_recordsize in dsl_dataset.c for details.
+ *
+ * Note that although the LSIZE field of the blkptr_t can store sizes up
+ * to 32MB, the dnode's dn_datablkszsec can only store sizes up to
+ * 32MB - 512 bytes.  Therefore, we limit SPA_MAXBLOCKSIZE to 16MB.
+ */
+#define	SPA_MINBLOCKSHIFT	9
+#define	SPA_OLD_MAXBLOCKSHIFT	17
+#define	SPA_MAXBLOCKSHIFT	24
+#define	SPA_MINBLOCKSIZE	(1ULL << SPA_MINBLOCKSHIFT)
+#define	SPA_OLD_MAXBLOCKSIZE	(1ULL << SPA_OLD_MAXBLOCKSHIFT)
+#define	SPA_MAXBLOCKSIZE	(1ULL << SPA_MAXBLOCKSHIFT)
+
+
+/* supported encryption algorithms */
+enum zio_encrypt {
+	ZIO_CRYPT_INHERIT = 0,
+	ZIO_CRYPT_ON,
+	ZIO_CRYPT_OFF,
+	ZIO_CRYPT_AES_128_CCM,
+	ZIO_CRYPT_AES_192_CCM,
+	ZIO_CRYPT_AES_256_CCM,
+	ZIO_CRYPT_AES_128_GCM,
+	ZIO_CRYPT_AES_192_GCM,
+	ZIO_CRYPT_AES_256_GCM,
+	ZIO_CRYPT_FUNCTIONS
+};
+
+#define	ZIO_CRYPT_ON_VALUE	ZIO_CRYPT_AES_256_GCM
+#define	ZIO_CRYPT_DEFAULT	ZIO_CRYPT_OFF
+
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -73,27 +73,6 @@ struct dsl_dataset;
 struct dsl_crypto_params;
 
 /*
- * We currently support block sizes from 512 bytes to 16MB.
- * The benefits of larger blocks, and thus larger IO, need to be weighed
- * against the cost of COWing a giant block to modify one byte, and the
- * large latency of reading or writing a large block.
- *
- * Note that although blocks up to 16MB are supported, the recordsize
- * property can not be set larger than zfs_max_recordsize (default 1MB).
- * See the comment near zfs_max_recordsize in dsl_dataset.c for details.
- *
- * Note that although the LSIZE field of the blkptr_t can store sizes up
- * to 32MB, the dnode's dn_datablkszsec can only store sizes up to
- * 32MB - 512 bytes.  Therefore, we limit SPA_MAXBLOCKSIZE to 16MB.
- */
-#define	SPA_MINBLOCKSHIFT	9
-#define	SPA_OLD_MAXBLOCKSHIFT	17
-#define	SPA_MAXBLOCKSHIFT	24
-#define	SPA_MINBLOCKSIZE	(1ULL << SPA_MINBLOCKSHIFT)
-#define	SPA_OLD_MAXBLOCKSIZE	(1ULL << SPA_OLD_MAXBLOCKSHIFT)
-#define	SPA_MAXBLOCKSIZE	(1ULL << SPA_MAXBLOCKSHIFT)
-
-/*
  * Alignment Shift (ashift) is an immutable, internal top-level vdev property
  * which can only be set at vdev creation time. Physical writes are always done
  * according to it, which makes 2^ashift the smallest possible IO on a vdev.

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -108,23 +108,6 @@ enum zio_checksum {
 
 #define	ZIO_DEDUPCHECKSUM	ZIO_CHECKSUM_SHA256
 
-/* supported encryption algorithms */
-enum zio_encrypt {
-	ZIO_CRYPT_INHERIT = 0,
-	ZIO_CRYPT_ON,
-	ZIO_CRYPT_OFF,
-	ZIO_CRYPT_AES_128_CCM,
-	ZIO_CRYPT_AES_192_CCM,
-	ZIO_CRYPT_AES_256_CCM,
-	ZIO_CRYPT_AES_128_GCM,
-	ZIO_CRYPT_AES_192_GCM,
-	ZIO_CRYPT_AES_256_GCM,
-	ZIO_CRYPT_FUNCTIONS
-};
-
-#define	ZIO_CRYPT_ON_VALUE	ZIO_CRYPT_AES_256_GCM
-#define	ZIO_CRYPT_DEFAULT	ZIO_CRYPT_OFF
-
 /* macros defining encryption lengths */
 #define	ZIO_OBJSET_MAC_LEN		32
 #define	ZIO_DATA_IV_LEN			12

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -153,6 +153,7 @@
     <elf-symbol name='zfs_get_pool_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_get_recvd_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_get_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_get_underlying_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_get_user_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_handle_dup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_hold' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -965,18 +966,18 @@
     <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-87'/>
     <qualified-type-def type-id='type-id-42' const='yes' id='type-id-88'/>
     <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-89'/>
-    <function-decl name='zfs_unmount' filepath='../../include/libzfs.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_unmount' filepath='../../include/libzfs.h' line='828' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' filepath='../../include/libzfs.h' line='853' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_unshare_smb' filepath='../../include/libzfs.h' line='855' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_commit_smb_shares' filepath='../../include/libzfs.h' line='862' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_commit_smb_shares' filepath='../../include/libzfs.h' line='864' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uu_avl_walk_end' filepath='../../include/libuutil.h' line='340' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -995,11 +996,11 @@
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' filepath='../../include/libzfs.h' line='850' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_share_smb' filepath='../../include/libzfs.h' line='852' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_refresh_properties' filepath='../../include/libzfs.h' line='810' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_refresh_properties' filepath='../../include/libzfs.h' line='811' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -1013,7 +1014,7 @@
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
     <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-91'/>
-    <function-decl name='zfs_prop_get' filepath='../../include/libzfs.h' line='494' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_get' filepath='../../include/libzfs.h' line='495' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-29'/>
@@ -1024,33 +1025,33 @@
       <parameter type-id='type-id-13'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_int' filepath='../../include/libzfs.h' line='511' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_get_int' filepath='../../include/libzfs.h' line='512' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-45'/>
     </function-decl>
     <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-92'/>
-    <function-decl name='zfs_is_mounted' filepath='../../include/libzfs.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_is_mounted' filepath='../../include/libzfs.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-92'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zfs_mount' filepath='../../include/libzfs.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_mount' filepath='../../include/libzfs.h' line='826' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_share_nfs' filepath='../../include/libzfs.h' line='849' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_nfs' filepath='../../include/libzfs.h' line='852' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_unshare_nfs' filepath='../../include/libzfs.h' line='854' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_commit_nfs_shares' filepath='../../include/libzfs.h' line='861' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_share_nfs' filepath='../../include/libzfs.h' line='851' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_commit_nfs_shares' filepath='../../include/libzfs.h' line='863' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='isa_child_of' mangled-name='isa_child_of' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_changelist.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='isa_child_of'>
@@ -1095,7 +1096,7 @@
       <parameter type-id='type-id-91'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='259' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_commit_proto' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-91'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -1167,20 +1168,20 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
-    <function-decl name='zfs_iter_dependents' filepath='../../include/libzfs.h' line='615' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_dependents' filepath='../../include/libzfs.h' line='616' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-13'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_iter_mounted' filepath='../../include/libzfs.h' line='623' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_mounted' filepath='../../include/libzfs.h' line='624' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' filepath='../../include/libzfs.h' line='614' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_children' filepath='../../include/libzfs.h' line='615' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
@@ -1188,7 +1189,7 @@
     </function-decl>
     <qualified-type-def type-id='type-id-22' const='yes' id='type-id-104'/>
     <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
-    <function-decl name='zfs_get_name' filepath='../../include/libzfs.h' line='471' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_get_name' filepath='../../include/libzfs.h' line='472' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-105'/>
       <return type-id='type-id-89'/>
     </function-decl>
@@ -1198,7 +1199,7 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-87'/>
     </function-decl>
-    <function-decl name='zfs_is_shared' filepath='../../include/libzfs.h' line='840' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_is_shared' filepath='../../include/libzfs.h' line='842' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-13'/>
     </function-decl>
@@ -1699,7 +1700,7 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-143'/>
-    <typedef-decl name='zfs_iter_f' type-id='type-id-143' filepath='../../include/libzfs.h' line='612' column='1' id='type-id-144'/>
+    <typedef-decl name='zfs_iter_f' type-id='type-id-143' filepath='../../include/libzfs.h' line='613' column='1' id='type-id-144'/>
     <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
       <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
       <parameter type-id='type-id-144' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_config.c' line='434' column='1'/>
@@ -1723,26 +1724,26 @@
     </function-type>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='962' column='1'/>
-      <parameter type-id='type-id-114' name='is_encroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='962' column='1'/>
-      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='963' column='1'/>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='965' column='1'/>
+      <parameter type-id='type-id-114' name='is_encroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='965' column='1'/>
+      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='966' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-145'/>
     <typedef-decl name='uint_t' type-id='type-id-19' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-146'/>
     <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-147'/>
-    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='993' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='993' column='1'/>
-      <parameter type-id='type-id-29' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='993' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='993' column='1'/>
-      <parameter type-id='type-id-28' name='pool_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='994' column='1'/>
-      <parameter type-id='type-id-6' name='stdin_available' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='994' column='1'/>
-      <parameter type-id='type-id-145' name='wkeydata_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='994' column='1'/>
-      <parameter type-id='type-id-147' name='wkeylen_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='995' column='1'/>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='996' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='996' column='1'/>
+      <parameter type-id='type-id-29' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='996' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='996' column='1'/>
+      <parameter type-id='type-id-28' name='pool_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='997' column='1'/>
+      <parameter type-id='type-id-6' name='stdin_available' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='997' column='1'/>
+      <parameter type-id='type-id-145' name='wkeydata_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='997' column='1'/>
+      <parameter type-id='type-id-147' name='wkeylen_out' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='998' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_prop_to_name' filepath='../../include/libzfs.h' line='491' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_to_name' filepath='../../include/libzfs.h' line='492' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-89'/>
     </function-decl>
@@ -1840,32 +1841,32 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1165' column='1'/>
-      <parameter type-id='type-id-98' name='origin_zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1165' column='1'/>
-      <parameter type-id='type-id-29' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1166' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1166' column='1'/>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1168' column='1'/>
+      <parameter type-id='type-id-98' name='origin_zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1168' column='1'/>
+      <parameter type-id='type-id-29' name='parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1169' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1169' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1231' column='1'/>
-      <parameter type-id='type-id-29' name='fsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1231' column='1'/>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1234' column='1'/>
+      <parameter type-id='type-id-29' name='fsname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1234' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfs_handle_dup' filepath='../../include/libzfs.h' line='468' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-87'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' filepath='../../include/libzfs.h' line='616' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_filesystems' filepath='../../include/libzfs.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1266' column='1'/>
-      <parameter type-id='type-id-6' name='noop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1266' column='1'/>
-      <parameter type-id='type-id-29' name='alt_keylocation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1266' column='1'/>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1269' column='1'/>
+      <parameter type-id='type-id-6' name='noop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1269' column='1'/>
+      <parameter type-id='type-id-29' name='alt_keylocation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1269' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_load_key' filepath='../../include/libzfs_core.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2022,21 +2023,21 @@
       <parameter type-id='type-id-78'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1434' column='1'/>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1437' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1437' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_unload_key' filepath='../../include/libzfs_core.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1570' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1570' column='1'/>
-      <parameter type-id='type-id-28' name='raw_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1570' column='1'/>
-      <parameter type-id='type-id-6' name='inheritkey' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1570' column='1'/>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1573' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1573' column='1'/>
+      <parameter type-id='type-id-28' name='raw_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1573' column='1'/>
+      <parameter type-id='type-id-6' name='inheritkey' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_crypto.c' line='1573' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' filepath='../../include/libzfs.h' line='814' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_parent_name' filepath='../../include/libzfs.h' line='815' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-29'/>
       <parameter type-id='type-id-45'/>
@@ -2049,7 +2050,7 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='zfs_valid_proplist' filepath='../../include/libzfs.h' line='488' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_valid_proplist' filepath='../../include/libzfs.h' line='489' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-81'/>
       <parameter type-id='type-id-112'/>
@@ -2513,7 +2514,7 @@
       <parameter type-id='type-id-1' name='types' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='683' column='1'/>
       <return type-id='type-id-98'/>
     </function-decl>
-    <function-decl name='zfs_iter_bookmarks' filepath='../../include/libzfs.h' line='622' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_bookmarks' filepath='../../include/libzfs.h' line='623' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
@@ -2710,7 +2711,7 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zfs_nicestrtonum' filepath='../../include/libzfs.h' line='866' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_nicestrtonum' filepath='../../include/libzfs.h' line='868' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-110'/>
@@ -2731,7 +2732,7 @@
       <parameter type-id='type-id-13'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' filepath='../../include/libzfs.h' line='564' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_prop_get_feature' filepath='../../include/libzfs.h' line='565' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-134'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-29'/>
@@ -2834,10 +2835,10 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
-      <parameter type-id='type-id-24' name='zph' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
-      <parameter type-id='type-id-32' name='volsize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5491' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5492' column='1'/>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='type-id-24' name='zph' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5497' column='1'/>
+      <parameter type-id='type-id-32' name='volsize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5497' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5498' column='1'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint64' filepath='../../include/sys/nvpair.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -2902,7 +2903,7 @@
       <parameter type-id='type-id-92' name='source' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='2038' column='1'/>
       <return type-id='type-id-32'/>
     </function-decl>
-    <function-decl name='zfs_prop_default_numeric' filepath='../../include/libzfs.h' line='484' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_default_numeric' filepath='../../include/libzfs.h' line='485' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-45'/>
     </function-decl>
@@ -3058,7 +3059,7 @@
       <parameter type-id='type-id-248'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_prop_default_string' filepath='../../include/libzfs.h' line='483' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_default_string' filepath='../../include/libzfs.h' line='484' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-89'/>
     </function-decl>
@@ -3166,36 +3167,40 @@
       <parameter type-id='type-id-256' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3331' column='1'/>
       <return type-id='type-id-26'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
-      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
-      <parameter type-id='type-id-38' name='buflen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3377' column='1'/>
+    <function-decl name='zfs_get_underlying_type' mangled-name='zfs_get_underlying_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_type'>
+      <parameter type-id='type-id-256' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3331' column='1'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3387' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3387' column='1'/>
+      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3387' column='1'/>
+      <parameter type-id='type-id-38' name='buflen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3387' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
-      <parameter type-id='type-id-26' name='types' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3472' column='1'/>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3482' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3482' column='1'/>
+      <parameter type-id='type-id-26' name='types' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3482' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
-      <parameter type-id='type-id-29' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
-      <parameter type-id='type-id-1' name='prefixlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3498' column='1'/>
+    <function-decl name='create_parents' mangled-name='create_parents' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='create_parents'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3508' column='1'/>
+      <parameter type-id='type-id-29' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3508' column='1'/>
+      <parameter type-id='type-id-1' name='prefixlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3508' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
-      <parameter type-id='type-id-26' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3609' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3610' column='1'/>
+    <function-decl name='zfs_create' mangled-name='zfs_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3619' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3619' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3619' column='1'/>
+      <parameter type-id='type-id-26' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3619' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3620' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_share' filepath='../../include/libzfs.h' line='841' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_share' filepath='../../include/libzfs.h' line='843' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_commit_all_shares' filepath='../../include/libzfs.h' line='863' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_commit_all_shares' filepath='../../include/libzfs.h' line='865' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='dataset_nestcheck' filepath='../../include/zfs_namecheck.h' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3208,7 +3213,7 @@
       <return type-id='type-id-134'/>
     </function-decl>
     <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-257'/>
-    <function-decl name='zfs_crypto_create' filepath='../../include/libzfs.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_crypto_create' filepath='../../include/libzfs.h' line='528' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-29'/>
       <parameter type-id='type-id-112'/>
@@ -3231,14 +3236,14 @@
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3572' column='1'/>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3582' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3582' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1'/>
-      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3784' column='1'/>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3794' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3794' column='1'/>
+      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3794' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_destroy_bookmarks' filepath='../../include/libzfs_core.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3263,16 +3268,16 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
-      <parameter type-id='type-id-29' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
-      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3852' column='1'/>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3862' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3862' column='1'/>
+      <parameter type-id='type-id-29' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3862' column='1'/>
+      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3862' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
-      <parameter type-id='type-id-28' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
-      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3876' column='1'/>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3886' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3886' column='1'/>
+      <parameter type-id='type-id-28' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3886' column='1'/>
+      <parameter type-id='type-id-6' name='defer' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3886' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_exists' filepath='../../include/libzfs_core.h' line='115' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3288,13 +3293,13 @@
       <parameter type-id='type-id-141'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
-      <parameter type-id='type-id-89' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3923' column='1'/>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3933' column='1'/>
+      <parameter type-id='type-id-89' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3933' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='3933' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_clone_check' filepath='../../include/libzfs.h' line='529' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_crypto_clone_check' filepath='../../include/libzfs.h' line='530' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-29'/>
@@ -3307,8 +3312,8 @@
       <parameter type-id='type-id-112'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4009' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4009' column='1'/>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4019' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_promote' filepath='../../include/libzfs_core.h' line='56' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3317,10 +3322,10 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
-      <parameter type-id='type-id-28' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4093' column='1'/>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4103' column='1'/>
+      <parameter type-id='type-id-28' name='snaps' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4103' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4103' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_snapshot' filepath='../../include/libzfs_core.h' line='52' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3329,20 +3334,20 @@
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
-      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4173' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4174' column='1'/>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4183' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4183' column='1'/>
+      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4183' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4184' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
-      <parameter type-id='type-id-98' name='snap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
-      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4274' column='1'/>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4284' column='1'/>
+      <parameter type-id='type-id-98' name='snap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4284' column='1'/>
+      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4284' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='617' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_snapshots' filepath='../../include/libzfs.h' line='618' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-13'/>
       <parameter type-id='type-id-103'/>
@@ -3356,22 +3361,22 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='650' column='1' id='type-id-259'>
+    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='651' column='1' id='type-id-259'>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='recursive' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='652' column='1'/>
+        <var-decl name='recursive' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='653' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='30'>
-        <var-decl name='nounmount' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='655' column='1'/>
+        <var-decl name='nounmount' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='656' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='forceunmount' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='658' column='1'/>
+        <var-decl name='forceunmount' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='659' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='renameflags_t' type-id='type-id-259' filepath='../../include/libzfs.h' line='659' column='1' id='type-id-260'/>
-    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
-      <parameter type-id='type-id-89' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
-      <parameter type-id='type-id-260' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4374' column='1'/>
+    <typedef-decl name='renameflags_t' type-id='type-id-259' filepath='../../include/libzfs.h' line='660' column='1' id='type-id-260'/>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4384' column='1'/>
+      <parameter type-id='type-id-89' name='target' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4384' column='1'/>
+      <parameter type-id='type-id-260' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4384' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='changelist_rename' filepath='../../include/libzfs_impl.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3380,50 +3385,50 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4576' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4576' column='1'/>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4586' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4586' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4582' column='1'/>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4592' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4592' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4591' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4576' column='1'/>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4601' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4586' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
-    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='536' column='1' id='type-id-261'>
+    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='537' column='1' id='type-id-261'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pl_prop' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='537' column='1'/>
+        <var-decl name='pl_prop' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pl_user_prop' type-id='type-id-29' visibility='default' filepath='../../include/libzfs.h' line='538' column='1'/>
+        <var-decl name='pl_user_prop' type-id='type-id-29' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pl_next' type-id='type-id-262' visibility='default' filepath='../../include/libzfs.h' line='539' column='1'/>
+        <var-decl name='pl_next' type-id='type-id-262' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pl_all' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='540' column='1'/>
+        <var-decl name='pl_all' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pl_width' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='541' column='1'/>
+        <var-decl name='pl_width' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pl_recvd_width' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='542' column='1'/>
+        <var-decl name='pl_recvd_width' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='543' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pl_fixed' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='543' column='1'/>
+        <var-decl name='pl_fixed' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='544' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-261' size-in-bits='64' id='type-id-262'/>
-    <typedef-decl name='zprop_list_t' type-id='type-id-261' filepath='../../include/libzfs.h' line='544' column='1' id='type-id-263'/>
+    <typedef-decl name='zprop_list_t' type-id='type-id-261' filepath='../../include/libzfs.h' line='545' column='1' id='type-id-263'/>
     <pointer-type-def type-id='type-id-263' size-in-bits='64' id='type-id-264'/>
     <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-265'/>
-    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
-      <parameter type-id='type-id-265' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
-      <parameter type-id='type-id-6' name='received' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4610' column='1'/>
-      <parameter type-id='type-id-6' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4611' column='1'/>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4620' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4620' column='1'/>
+      <parameter type-id='type-id-265' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4620' column='1'/>
+      <parameter type-id='type-id-6' name='received' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4620' column='1'/>
+      <parameter type-id='type-id-6' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4621' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-262' size-in-bits='64' id='type-id-266'/>
@@ -3433,9 +3438,9 @@
       <parameter type-id='type-id-81'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1'/>
-      <parameter type-id='type-id-30' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4707' column='1'/>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4717' column='1'/>
+      <parameter type-id='type-id-30' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4717' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='nvlist_remove' filepath='../../include/sys/nvpair.h' line='198' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3444,11 +3449,11 @@
       <parameter type-id='type-id-140'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
-      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
-      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
-      <parameter type-id='type-id-29' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4799' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4799' column='1'/>
+      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4799' column='1'/>
+      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4800' column='1'/>
+      <parameter type-id='type-id-29' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4800' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='ioctl' filepath='/usr/include/x86_64-linux-gnu/sys/ioctl.h' line='41' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3457,25 +3462,25 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4797' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
-      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4789' column='1'/>
-      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
-      <parameter type-id='type-id-29' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4790' column='1'/>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4799' column='1'/>
+      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4799' column='1'/>
+      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4800' column='1'/>
+      <parameter type-id='type-id-29' name='resource' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4800' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
-      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
-      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4805' column='1'/>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4815' column='1'/>
+      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4815' column='1'/>
+      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4815' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
-      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
-      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4812' column='1'/>
-      <parameter type-id='type-id-29' name='oldname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4813' column='1'/>
-      <parameter type-id='type-id-29' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4813' column='1'/>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4822' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4822' column='1'/>
+      <parameter type-id='type-id-29' name='dataset' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4822' column='1'/>
+      <parameter type-id='type-id-29' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4822' column='1'/>
+      <parameter type-id='type-id-29' name='oldname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4823' column='1'/>
+      <parameter type-id='type-id-29' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4823' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/sys/fs/zfs.h' line='192' column='1' id='type-id-267'>
@@ -3497,26 +3502,26 @@
     <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-267' filepath='../../include/sys/fs/zfs.h' line='206' column='1' id='type-id-268'/>
     <typedef-decl name='uid_t' type-id='type-id-197' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-269'/>
     <pointer-type-def type-id='type-id-270' size-in-bits='64' id='type-id-271'/>
-    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-271' filepath='../../include/libzfs.h' line='738' column='1' id='type-id-272'/>
-    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
-      <parameter type-id='type-id-268' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4820' column='1'/>
-      <parameter type-id='type-id-272' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4821' column='1'/>
-      <parameter type-id='type-id-21' name='arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4821' column='1'/>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-271' filepath='../../include/libzfs.h' line='739' column='1' id='type-id-272'/>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4830' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4830' column='1'/>
+      <parameter type-id='type-id-268' name='type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4830' column='1'/>
+      <parameter type-id='type-id-272' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4831' column='1'/>
+      <parameter type-id='type-id-21' name='arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4831' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
-      <parameter type-id='type-id-89' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
-      <parameter type-id='type-id-89' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4900' column='1'/>
-      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4901' column='1'/>
-      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4901' column='1'/>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4907' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4907' column='1'/>
+      <parameter type-id='type-id-89' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4907' column='1'/>
+      <parameter type-id='type-id-89' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4907' column='1'/>
+      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4908' column='1'/>
+      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4908' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
-      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
-      <parameter type-id='type-id-28' name='holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4932' column='1'/>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4939' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4939' column='1'/>
+      <parameter type-id='type-id-1' name='cleanup_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4939' column='1'/>
+      <parameter type-id='type-id-28' name='holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='4939' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_hold' filepath='../../include/libzfs_core.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3525,11 +3530,11 @@
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
-      <parameter type-id='type-id-89' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
-      <parameter type-id='type-id-89' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5031' column='1'/>
-      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5032' column='1'/>
+    <function-decl name='zfs_release' mangled-name='zfs_release' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5038' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5038' column='1'/>
+      <parameter type-id='type-id-89' name='snapname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5038' column='1'/>
+      <parameter type-id='type-id-89' name='tag' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5038' column='1'/>
+      <parameter type-id='type-id-6' name='recursive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5039' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_release' filepath='../../include/libzfs_core.h' line='74' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3548,9 +3553,9 @@
       <parameter type-id='type-id-112'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1'/>
-      <parameter type-id='type-id-113' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5112' column='1'/>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5119' column='1'/>
+      <parameter type-id='type-id-113' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5119' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_unpack' filepath='../../include/sys/nvpair.h' line='155' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3560,10 +3565,10 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
-      <parameter type-id='type-id-6' name='un' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
-      <parameter type-id='type-id-28' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5179' column='1'/>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5185' column='1'/>
+      <parameter type-id='type-id-6' name='un' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5185' column='1'/>
+      <parameter type-id='type-id-28' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5185' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_size' filepath='../../include/sys/nvpair.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3580,9 +3585,9 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1'/>
-      <parameter type-id='type-id-113' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5233' column='1'/>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5239' column='1'/>
+      <parameter type-id='type-id-113' name='nvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5239' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_get_config' filepath='../../include/libzfs.h' line='412' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3604,11 +3609,11 @@
       <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
     </enum-decl>
     <typedef-decl name='zfs_wait_activity_t' type-id='type-id-274' filepath='../../include/sys/fs/zfs.h' line='1442' column='1' id='type-id-275'/>
-    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
-      <parameter type-id='type-id-275' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5547' column='1'/>
-      <parameter type-id='type-id-114' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5548' column='1'/>
-      <parameter type-id='type-id-114' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5548' column='1'/>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5553' column='1'/>
+      <parameter type-id='type-id-275' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5553' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5554' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_dataset.c' line='5554' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_wait_fs' filepath='../../include/libzfs_core.h' line='136' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -3652,7 +3657,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-29'/>
     </function-decl>
-    <function-decl name='is_mounted' filepath='../../include/libzfs.h' line='823' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='is_mounted' filepath='../../include/libzfs.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-92'/>
@@ -3715,7 +3720,7 @@
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-276' size-in-bits='64' id='type-id-277'/>
-    <function-decl name='find_shares_object' filepath='../../include/libzfs_impl.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='find_shares_object' filepath='../../include/libzfs_impl.h' line='256' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-277'/>
       <return type-id='type-id-1'/>
     </function-decl>
@@ -3924,7 +3929,7 @@
       <parameter type-id='type-id-21' name='arg' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='384' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_dataset_exists' filepath='../../include/libzfs.h' line='815' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_dataset_exists' filepath='../../include/libzfs.h' line='816' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-81'/>
@@ -3943,7 +3948,7 @@
       <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_iter.c' line='544' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_get_clones_nvl' filepath='../../include/libzfs.h' line='518' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_get_clones_nvl' filepath='../../include/libzfs.h' line='519' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-112'/>
     </function-decl>
@@ -4027,20 +4032,20 @@
       <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='383' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='getprop_uint64' filepath='../../include/libzfs.h' line='510' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='getprop_uint64' filepath='../../include/libzfs.h' line='511' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-8'/>
       <parameter type-id='type-id-92'/>
       <return type-id='type-id-45'/>
     </function-decl>
     <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-305'/>
-    <function-decl name='zfs_crypto_get_encryption_root' filepath='../../include/libzfs.h' line='526' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_crypto_get_encryption_root' filepath='../../include/libzfs.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-305'/>
       <parameter type-id='type-id-29'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_load_key' filepath='../../include/libzfs.h' line='532' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_crypto_load_key' filepath='../../include/libzfs.h' line='533' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-13'/>
       <parameter type-id='type-id-29'/>
@@ -4173,21 +4178,21 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_spa_version' filepath='../../include/libzfs.h' line='817' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_spa_version' filepath='../../include/libzfs.h' line='818' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-231'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='612' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='612' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='612' column='1'/>
-      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='612' column='1'/>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='610' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='610' column='1'/>
+      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='610' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='931' column='1'/>
-      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='932' column='1'/>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_proto'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='929' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='929' column='1'/>
+      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='930' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='sa_commit_shares' filepath='../../lib/libspl/include/libshare.h' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4199,12 +4204,12 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='762' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='762' column='1'/>
-      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='762' column='1'/>
+    <function-decl name='zfs_share_proto' mangled-name='zfs_share_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='760' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_proto'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='760' column='1'/>
+      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='760' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='533' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_crypto_unload_key' filepath='../../include/libzfs.h' line='534' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-1'/>
     </function-decl>
@@ -4222,17 +4227,17 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-29'/>
     </function-decl>
-    <function-decl name='zfs_shareall' mangled-name='zfs_shareall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_shareall'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='922' column='1'/>
+    <function-decl name='zfs_shareall' mangled-name='zfs_shareall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='920' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_shareall'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='920' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='686' column='1'/>
-      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='686' column='1'/>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='684' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='684' column='1'/>
+      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='684' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='703' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='703' column='1'/>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='701' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs_impl.h' line='119' column='1' id='type-id-320'>
@@ -4242,22 +4247,22 @@
       <enumerator name='SHARED_SMB' value='4'/>
     </enum-decl>
     <typedef-decl name='zfs_share_type_t' type-id='type-id-320' filepath='../../include/libzfs_impl.h' line='123' column='1' id='type-id-321'/>
-    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='824' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='824' column='1'/>
-      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='824' column='1'/>
-      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='824' column='1'/>
+    <function-decl name='zfs_is_shared_proto' mangled-name='zfs_is_shared_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_proto'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1'/>
+      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1'/>
+      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='822' column='1'/>
       <return type-id='type-id-321'/>
     </function-decl>
-    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='722' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='722' column='1'/>
-      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='722' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='722' column='1'/>
-      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='723' column='1'/>
+    <function-decl name='unshare_one' mangled-name='unshare_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unshare_one'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='720' column='1'/>
+      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='720' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='720' column='1'/>
+      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='721' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='741' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='741' column='1'/>
-      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='741' column='1'/>
+    <function-decl name='is_shared' mangled-name='is_shared' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_shared'>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
+      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='739' column='1'/>
       <return type-id='type-id-321'/>
     </function-decl>
     <function-decl name='sa_enable_share' filepath='../../lib/libspl/include/libshare.h' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4267,12 +4272,12 @@
       <parameter type-id='type-id-29'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='922' column='1'/>
+    <function-decl name='zfs_share' mangled-name='zfs_share' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='805' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='920' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='814' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='814' column='1'/>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='812' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='812' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='changelist_unshare' filepath='../../include/libzfs_impl.h' line='188' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4280,23 +4285,23 @@
       <parameter type-id='type-id-305'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1012' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='814' column='1'/>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1010' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='812' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='846' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='846' column='1'/>
-      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='846' column='1'/>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='844' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='844' column='1'/>
+      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='844' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='853' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='846' column='1'/>
-      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='846' column='1'/>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='844' column='1'/>
+      <parameter type-id='type-id-92' name='where' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='844' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='866' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
-      <parameter type-id='type-id-29' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='866' column='1'/>
-      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='866' column='1'/>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='864' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_options'>
+      <parameter type-id='type-id-29' name='options' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='864' column='1'/>
+      <parameter type-id='type-id-94' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='864' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='sa_validate_shareopts' filepath='../../lib/libspl/include/libshare.h' line='84' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4304,76 +4309,76 @@
       <parameter type-id='type-id-29'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='872' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
-      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='872' column='1'/>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='870' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_proto'>
+      <parameter type-id='type-id-95' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='870' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='899' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
-      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='899' column='1'/>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='897' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='897' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='910' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='922' column='1'/>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='908' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='920' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='916' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='922' column='1'/>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='914' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='920' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='975' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='973' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1000' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='814' column='1'/>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='998' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='812' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1006' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='814' column='1'/>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='812' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1018' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='969' column='1'/>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1016' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='967' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1024' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1024' column='1'/>
-      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1024' column='1'/>
-      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1025' column='1'/>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1022' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1022' column='1'/>
+      <parameter type-id='type-id-89' name='mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1022' column='1'/>
+      <parameter type-id='type-id-89' name='proto' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1023' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1049' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1049' column='1'/>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1047' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='remove_mountpoint'>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1047' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='rmdir' filepath='/usr/include/unistd.h' line='834' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='625' column='1' id='type-id-322'>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='626' column='1' id='type-id-322'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_handles' type-id='type-id-323' visibility='default' filepath='../../include/libzfs.h' line='626' column='1'/>
+        <var-decl name='cb_handles' type-id='type-id-323' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cb_alloc' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='627' column='1'/>
+        <var-decl name='cb_alloc' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='628' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cb_used' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='628' column='1'/>
+        <var-decl name='cb_used' type-id='type-id-38' visibility='default' filepath='../../include/libzfs.h' line='629' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-323'/>
-    <typedef-decl name='get_all_cb_t' type-id='type-id-322' filepath='../../include/libzfs.h' line='629' column='1' id='type-id-324'/>
+    <typedef-decl name='get_all_cb_t' type-id='type-id-322' filepath='../../include/libzfs.h' line='630' column='1' id='type-id-324'/>
     <pointer-type-def type-id='type-id-324' size-in-bits='64' id='type-id-325'/>
-    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1075' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
-      <parameter type-id='type-id-325' name='cbp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1075' column='1'/>
-      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1075' column='1'/>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1073' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='type-id-325' name='cbp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1073' column='1'/>
+      <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1073' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='zfs_realloc' filepath='../../include/libzfs_impl.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4383,13 +4388,13 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-21'/>
     </function-decl>
-    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1397' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1397' column='1'/>
-      <parameter type-id='type-id-323' name='handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1397' column='1'/>
-      <parameter type-id='type-id-38' name='num_handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1398' column='1'/>
-      <parameter type-id='type-id-144' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1398' column='1'/>
-      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1398' column='1'/>
-      <parameter type-id='type-id-6' name='parallel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1398' column='1'/>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1395' column='1'/>
+      <parameter type-id='type-id-323' name='handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1395' column='1'/>
+      <parameter type-id='type-id-38' name='num_handles' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1396' column='1'/>
+      <parameter type-id='type-id-144' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1396' column='1'/>
+      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1396' column='1'/>
+      <parameter type-id='type-id-6' name='parallel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1396' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='qsort' filepath='/usr/include/stdlib.h' line='827' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4424,15 +4429,15 @@
       <parameter type-id='type-id-327'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1458' column='1'/>
-      <parameter type-id='type-id-89' name='mntopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1458' column='1'/>
-      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1458' column='1'/>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1456' column='1'/>
+      <parameter type-id='type-id-89' name='mntopts' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1456' column='1'/>
+      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1456' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1528' column='1'/>
-      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1528' column='1'/>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_unmount_datasets' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1526' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_unmount_datasets'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1526' column='1'/>
+      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_mount.c' line='1526' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-329'>
@@ -4441,7 +4446,7 @@
     </function-type>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='924' column='1' id='type-id-331'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='926' column='1' id='type-id-331'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
       <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
@@ -4449,12 +4454,12 @@
       <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
       <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_compat_status_t' type-id='type-id-331' filepath='../../include/libzfs.h' line='930' column='1' id='type-id-332'/>
-    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
-      <parameter type-id='type-id-89' name='compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-114' name='features' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-29' name='report' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4751' column='1'/>
-      <parameter type-id='type-id-38' name='rlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4752' column='1'/>
+    <typedef-decl name='zpool_compat_status_t' type-id='type-id-331' filepath='../../include/libzfs.h' line='932' column='1' id='type-id-332'/>
+    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4747' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
+      <parameter type-id='type-id-89' name='compat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4747' column='1'/>
+      <parameter type-id='type-id-114' name='features' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4747' column='1'/>
+      <parameter type-id='type-id-29' name='report' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4747' column='1'/>
+      <parameter type-id='type-id-38' name='rlen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4748' column='1'/>
       <return type-id='type-id-332'/>
     </function-decl>
     <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
@@ -4472,7 +4477,7 @@
       <parameter type-id='type-id-148'/>
       <return type-id='type-id-89'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_numeric' filepath='../../include/libzfs.h' line='567' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_prop_default_numeric' filepath='../../include/libzfs.h' line='568' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-148'/>
       <return type-id='type-id-45'/>
     </function-decl>
@@ -4577,8 +4582,8 @@
       <parameter type-id='type-id-340'/>
       <return type-id='type-id-338'/>
     </function-decl>
-    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1182' column='1'/>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1183' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
@@ -4600,18 +4605,18 @@
       <parameter type-id='type-id-247'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1172' column='1'/>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1173' column='1'/>
       <return type-id='type-id-89'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_string' filepath='../../include/libzfs.h' line='566' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_prop_default_string' filepath='../../include/libzfs.h' line='567' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-148'/>
       <return type-id='type-id-89'/>
     </function-decl>
-    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
-      <parameter type-id='type-id-89' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
-      <parameter type-id='type-id-89' name='propval' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='751' column='1'/>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='752' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='752' column='1'/>
+      <parameter type-id='type-id-89' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='752' column='1'/>
+      <parameter type-id='type-id-89' name='propval' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='752' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_standard_error' filepath='../../include/libzfs_impl.h' line='147' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4681,39 +4686,39 @@
       <parameter type-id='type-id-342'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
-      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1066' column='1'/>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1067' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1067' column='1'/>
+      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1067' column='1'/>
       <return type-id='type-id-24'/>
     </function-decl>
-    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1160' column='1'/>
+    <function-decl name='zpool_close' mangled-name='zpool_close' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1161' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='get_system_hostid' filepath='../../lib/libspl/include/sys/systeminfo.h' line='36' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-45'/>
     </function-decl>
-    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
-      <parameter type-id='type-id-265' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='807' column='1'/>
-      <parameter type-id='type-id-6' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
+      <parameter type-id='type-id-265' name='plp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='808' column='1'/>
+      <parameter type-id='type-id-6' name='literal' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='809' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' filepath='../../include/zfeature_common.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-89' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='905' column='1'/>
-      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
+      <parameter type-id='type-id-89' name='propname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
+      <parameter type-id='type-id-29' name='buf' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='906' column='1'/>
+      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='907' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
-      <parameter type-id='type-id-6' name='isopen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
-      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='967' column='1'/>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_valid'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='968' column='1'/>
+      <parameter type-id='type-id-6' name='isopen' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='968' column='1'/>
+      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='968' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='pool_namecheck' filepath='../../include/zfs_namecheck.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4728,27 +4733,27 @@
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-343'/>
-    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
-      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
-      <parameter type-id='type-id-343' name='ret' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1108' column='1'/>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1109' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_silent'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1109' column='1'/>
+      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1109' column='1'/>
+      <parameter type-id='type-id-343' name='ret' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1109' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
-      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1139' column='1'/>
+    <function-decl name='zpool_open' mangled-name='zpool_open' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1140' column='1'/>
+      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1140' column='1'/>
       <return type-id='type-id-24'/>
     </function-decl>
-    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
-      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1253' column='1'/>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1254' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1254' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1272' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
-      <parameter type-id='type-id-28' name='fsprops' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+    <function-decl name='zpool_create' mangled-name='zpool_create' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+      <parameter type-id='type-id-89' name='pool' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1273' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1274' column='1'/>
+      <parameter type-id='type-id-28' name='fsprops' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1274' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_add_uint8_array' filepath='../../include/sys/nvpair.h' line='184' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4758,36 +4763,36 @@
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
-      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1451' column='1'/>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1452' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1452' column='1'/>
+      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1452' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1'/>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1495' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint' filepath='../../include/libzfs_core.h' line='131' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1494' column='1'/>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1495' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint_discard' filepath='../../include/libzfs_core.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
-      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1537' column='1'/>
+    <function-decl name='zpool_add' mangled-name='zpool_add' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1538' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1538' column='1'/>
+      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1538' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
-      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
-      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1681' column='1'/>
+    <function-decl name='zpool_export' mangled-name='zpool_export' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
+      <parameter type-id='type-id-6' name='force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
+      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1680' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_standard_error_fmt' filepath='../../include/libzfs_impl.h' line='148' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4797,31 +4802,31 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
-      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1687' column='1'/>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1686' column='1'/>
+      <parameter type-id='type-id-89' name='log_str' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1686' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-1' name='reason' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
-      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1746' column='1'/>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1744' column='1'/>
+      <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1744' column='1'/>
+      <parameter type-id='type-id-1' name='reason' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1744' column='1'/>
+      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1745' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-89' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
-      <parameter type-id='type-id-29' name='altroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1833' column='1'/>
+    <function-decl name='zpool_import' mangled-name='zpool_import' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1831' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1831' column='1'/>
+      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1831' column='1'/>
+      <parameter type-id='type-id-89' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1831' column='1'/>
+      <parameter type-id='type-id-29' name='altroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1832' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-89' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
-      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1922' column='1'/>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1920' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1920' column='1'/>
+      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1920' column='1'/>
+      <parameter type-id='type-id-89' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1920' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
+      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1921' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../include/sys/fs/zfs.h' line='591' column='1' id='type-id-344'>
@@ -4844,8 +4849,8 @@
       <parameter type-id='type-id-345'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
-      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1890' column='1'/>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1889' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='type-id-28' name='config' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='1889' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64' filepath='../../include/sys/nvpair.h' line='327' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4853,11 +4858,11 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-45'/>
     </function-decl>
-    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-28' name='nv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
-      <parameter type-id='type-id-1' name='name_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4070' column='1'/>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4068' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4068' column='1'/>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4068' column='1'/>
+      <parameter type-id='type-id-28' name='nv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4068' column='1'/>
+      <parameter type-id='type-id-1' name='name_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4069' column='1'/>
       <return type-id='type-id-29'/>
     </function-decl>
     <enum-decl name='pool_initialize_func' filepath='../../include/sys/fs/zfs.h' line='1167' column='1' id='type-id-346'>
@@ -4868,10 +4873,10 @@
       <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
     </enum-decl>
     <typedef-decl name='pool_initialize_func_t' type-id='type-id-346' filepath='../../include/sys/fs/zfs.h' line='1172' column='1' id='type-id-347'/>
-    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
-      <parameter type-id='type-id-347' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
-      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2311' column='1'/>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2309' column='1'/>
+      <parameter type-id='type-id-347' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2309' column='1'/>
+      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_initialize' filepath='../../include/libzfs_core.h' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4904,10 +4909,10 @@
       <parameter type-id='type-id-305'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
-      <parameter type-id='type-id-347' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
-      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2311' column='1'/>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2309' column='1'/>
+      <parameter type-id='type-id-347' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2309' column='1'/>
+      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2310' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <enum-decl name='pool_trim_func' filepath='../../include/sys/fs/zfs.h' line='1177' column='1' id='type-id-349'>
@@ -4934,11 +4939,11 @@
     </class-decl>
     <typedef-decl name='trimflags_t' type-id='type-id-351' filepath='../../include/libzfs.h' line='279' column='1' id='type-id-352'/>
     <pointer-type-def type-id='type-id-352' size-in-bits='64' id='type-id-353'/>
-    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-350' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
-      <parameter type-id='type-id-353' name='trim_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2427' column='1'/>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2425' column='1'/>
+      <parameter type-id='type-id-350' name='cmd_type' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2425' column='1'/>
+      <parameter type-id='type-id-28' name='vds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2425' column='1'/>
+      <parameter type-id='type-id-353' name='trim_flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2426' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_trim' filepath='../../include/libzfs_core.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4956,12 +4961,12 @@
       <parameter type-id='type-id-59'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
-      <parameter type-id='type-id-114' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
-      <parameter type-id='type-id-114' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2809' column='1'/>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2807' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2807' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2807' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2807' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2808' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
     <enum-decl name='pool_scan_func' filepath='../../include/sys/fs/zfs.h' line='938' column='1' id='type-id-354'>
@@ -4979,18 +4984,18 @@
       <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
     </enum-decl>
     <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-356' filepath='../../include/sys/fs/zfs.h' line='952' column='1' id='type-id-357'/>
-    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
-      <parameter type-id='type-id-355' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
-      <parameter type-id='type-id-357' name='cmd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2482' column='1'/>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2481' column='1'/>
+      <parameter type-id='type-id-355' name='func' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2481' column='1'/>
+      <parameter type-id='type-id-357' name='cmd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2481' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
-      <parameter type-id='type-id-89' name='ppath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
-      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
-      <parameter type-id='type-id-114' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
-      <parameter type-id='type-id-114' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2758' column='1'/>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2756' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2756' column='1'/>
+      <parameter type-id='type-id-89' name='ppath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2756' column='1'/>
+      <parameter type-id='type-id-114' name='avail_spare' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-114' name='l2cache' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
+      <parameter type-id='type-id-114' name='log' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2757' column='1'/>
       <return type-id='type-id-28'/>
     </function-decl>
     <function-decl name='zfs_strcmp_pathname' filepath='../../include/libzutil.h' line='102' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -4999,23 +5004,23 @@
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
-      <parameter type-id='type-id-29' name='physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
-      <parameter type-id='type-id-38' name='phypath_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2981' column='1'/>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2980' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2980' column='1'/>
+      <parameter type-id='type-id-29' name='physpath' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2980' column='1'/>
+      <parameter type-id='type-id-38' name='phypath_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='2980' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3019' column='1'/>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3018' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3018' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3018' column='1'/>
       <return type-id='type-id-32'/>
     </function-decl>
     <pointer-type-def type-id='type-id-335' size-in-bits='64' id='type-id-358'/>
-    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
-      <parameter type-id='type-id-358' name='newstate' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3030' column='1'/>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3028' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3028' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3028' column='1'/>
+      <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3028' column='1'/>
+      <parameter type-id='type-id-358' name='newstate' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3029' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfs_resolve_shortname' filepath='../../include/libzutil.h' line='97' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5024,37 +5029,37 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='255' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_relabel_disk' filepath='../../include/libzfs_impl.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-99'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
-      <parameter type-id='type-id-6' name='istmp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3116' column='1'/>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3115' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3115' column='1'/>
+      <parameter type-id='type-id-6' name='istmp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3115' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
-      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
-      <parameter type-id='type-id-337' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3166' column='1'/>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3165' column='1'/>
+      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3165' column='1'/>
+      <parameter type-id='type-id-337' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3165' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
-      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
-      <parameter type-id='type-id-337' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3201' column='1'/>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3200' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3200' column='1'/>
+      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3200' column='1'/>
+      <parameter type-id='type-id-337' name='aux' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3200' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
-      <parameter type-id='type-id-89' name='old_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
-      <parameter type-id='type-id-89' name='new_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-1' name='replacing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
-      <parameter type-id='type-id-6' name='rebuild' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3256' column='1'/>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3254' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3254' column='1'/>
+      <parameter type-id='type-id-89' name='old_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3254' column='1'/>
+      <parameter type-id='type-id-89' name='new_disk' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-28' name='nvroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-1' name='replacing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
+      <parameter type-id='type-id-6' name='rebuild' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3255' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' filepath='../../include/zfeature_common.h' line='124' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5075,9 +5080,9 @@
       <parameter type-id='type-id-29'/>
       <return type-id='type-id-29'/>
     </function-decl>
-    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3428' column='1'/>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3427' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3427' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='258' column='1' id='type-id-359'>
@@ -5092,12 +5097,12 @@
       </data-member>
     </class-decl>
     <typedef-decl name='splitflags_t' type-id='type-id-359' filepath='../../include/libzfs.h' line='265' column='1' id='type-id-360'/>
-    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-29' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-113' name='newroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
-      <parameter type-id='type-id-360' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3526' column='1'/>
+    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3524' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3524' column='1'/>
+      <parameter type-id='type-id-29' name='newname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3524' column='1'/>
+      <parameter type-id='type-id-113' name='newroot' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3524' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
+      <parameter type-id='type-id-360' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3525' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist_array' filepath='../../include/sys/nvpair.h' line='192' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5107,39 +5112,39 @@
       <parameter type-id='type-id-19'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3769' column='1'/>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3768' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3768' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3768' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1'/>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3840' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3840' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
-      <parameter type-id='type-id-254' name='sizep' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3862' column='1'/>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3860' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3860' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3860' column='1'/>
+      <parameter type-id='type-id-254' name='sizep' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3861' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
-      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
-      <parameter type-id='type-id-28' name='rewindnvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3894' column='1'/>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3893' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3893' column='1'/>
+      <parameter type-id='type-id-89' name='path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3893' column='1'/>
+      <parameter type-id='type-id-28' name='rewindnvl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3893' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
-      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3970' column='1'/>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3969' column='1'/>
+      <parameter type-id='type-id-32' name='guid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3969' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3841' column='1'/>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3993' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='3840' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
-      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4014' column='1'/>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4013' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4013' column='1'/>
+      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4013' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_get_handle' filepath='../../include/libzfs.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5151,9 +5156,9 @@
       <parameter type-id='type-id-13'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
-      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4032' column='1'/>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4031' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4031' column='1'/>
+      <parameter type-id='type-id-21' name='data' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4031' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='fnvlist_add_boolean_value' filepath='../../include/sys/nvpair.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5168,33 +5173,33 @@
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
-      <parameter type-id='type-id-113' name='nverrlistp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4194' column='1'/>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4193' column='1'/>
+      <parameter type-id='type-id-113' name='nverrlistp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4193' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
-      <parameter type-id='type-id-32' name='new_version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4293' column='1'/>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4292' column='1'/>
+      <parameter type-id='type-id-32' name='new_version' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4292' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
-      <parameter type-id='type-id-1' name='argc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-92' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-29' name='string' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
-      <parameter type-id='type-id-1' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4309' column='1'/>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4308' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='type-id-1' name='argc' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4308' column='1'/>
+      <parameter type-id='type-id-92' name='argv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4308' column='1'/>
+      <parameter type-id='type-id-29' name='string' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4308' column='1'/>
+      <parameter type-id='type-id-1' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4308' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
-      <parameter type-id='type-id-89' name='message' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4321' column='1'/>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4320' column='1'/>
+      <parameter type-id='type-id-89' name='message' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4320' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-113' name='nvhisp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-254' name='off' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
-      <parameter type-id='type-id-114' name='eof' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4391' column='1'/>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4389' column='1'/>
+      <parameter type-id='type-id-113' name='nvhisp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4389' column='1'/>
+      <parameter type-id='type-id-254' name='off' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4389' column='1'/>
+      <parameter type-id='type-id-114' name='eof' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4390' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='zpool_history_unpack' filepath='../../include/libzutil.h' line='144' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5205,45 +5210,45 @@
       <parameter type-id='type-id-250'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
-      <parameter type-id='type-id-113' name='nvp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
-      <parameter type-id='type-id-231' name='dropped' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
-      <parameter type-id='type-id-19' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
-      <parameter type-id='type-id-1' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4461' column='1'/>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4459' column='1'/>
+      <parameter type-id='type-id-113' name='nvp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4459' column='1'/>
+      <parameter type-id='type-id-231' name='dropped' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-19' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
+      <parameter type-id='type-id-1' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4460' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
-      <parameter type-id='type-id-231' name='count' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4520' column='1'/>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4519' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4519' column='1'/>
+      <parameter type-id='type-id-231' name='count' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4519' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
-      <parameter type-id='type-id-32' name='eid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
-      <parameter type-id='type-id-1' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4543' column='1'/>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4539' column='1'/>
+      <parameter type-id='type-id-32' name='eid' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4539' column='1'/>
+      <parameter type-id='type-id-1' name='zevent_fd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4539' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-32' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-32' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-29' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4626' column='1'/>
-      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4626' column='1'/>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-32' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-32' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-29' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4622' column='1'/>
+      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4622' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-32' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-32' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4625' column='1'/>
-      <parameter type-id='type-id-29' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4626' column='1'/>
-      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4626' column='1'/>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-32' name='dsobj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-32' name='obj' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4621' column='1'/>
+      <parameter type-id='type-id-29' name='pathname' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4622' column='1'/>
+      <parameter type-id='type-id-38' name='len' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4622' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <typedef-decl name='zpool_wait_activity_t' type-id='type-id-348' filepath='../../include/sys/fs/zfs.h' line='1437' column='1' id='type-id-361'/>
-    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
-      <parameter type-id='type-id-361' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4641' column='1'/>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4637' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4637' column='1'/>
+      <parameter type-id='type-id-361' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4637' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_wait' filepath='../../include/libzfs_core.h' line='134' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5252,18 +5257,18 @@
       <parameter type-id='type-id-305'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
-      <parameter type-id='type-id-361' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4668' column='1'/>
-      <parameter type-id='type-id-114' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
-      <parameter type-id='type-id-114' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4669' column='1'/>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4664' column='1'/>
+      <parameter type-id='type-id-361' name='activity' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4664' column='1'/>
+      <parameter type-id='type-id-114' name='missing' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4665' column='1'/>
+      <parameter type-id='type-id-114' name='waited' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4665' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <qualified-type-def type-id='type-id-52' const='yes' id='type-id-362'/>
     <pointer-type-def type-id='type-id-362' size-in-bits='64' id='type-id-363'/>
-    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
-      <parameter type-id='type-id-363' name='envmap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4686' column='1'/>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4682' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4682' column='1'/>
+      <parameter type-id='type-id-363' name='envmap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4682' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <qualified-type-def type-id='type-id-46' const='yes' id='type-id-364'/>
@@ -5273,9 +5278,9 @@
       <parameter type-id='type-id-365'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
-      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
-      <parameter type-id='type-id-113' name='nvlp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4699' column='1'/>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4695' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='type-id-24' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4695' column='1'/>
+      <parameter type-id='type-id-113' name='nvlp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_pool.c' line='4695' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_get_bootenv' filepath='../../include/libzfs_core.h' line='139' column='1' visibility='default' binding='global' size-in-bits='64'>
@@ -5308,69 +5313,69 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_name_valid' filepath='../../include/libzfs.h' line='811' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_name_valid' filepath='../../include/libzfs.h' line='812' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-81'/>
       <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='663' column='1' id='type-id-366'>
+    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='664' column='1' id='type-id-366'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbosity' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='665' column='1'/>
+        <var-decl name='verbosity' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='666' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='replicate' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='668' column='1'/>
+        <var-decl name='replicate' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='669' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='skipmissing' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='671' column='1'/>
+        <var-decl name='skipmissing' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='672' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='doall' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='674' column='1'/>
+        <var-decl name='doall' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='675' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fromorigin' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='677' column='1'/>
+        <var-decl name='fromorigin' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='678' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pad' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='680' column='1'/>
+        <var-decl name='pad' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='681' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='props' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='683' column='1'/>
+        <var-decl name='props' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='684' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='686' column='1'/>
+        <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='687' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='parsable' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='689' column='1'/>
+        <var-decl name='parsable' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='690' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='progress' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='692' column='1'/>
+        <var-decl name='progress' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='693' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='largeblock' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='695' column='1'/>
+        <var-decl name='largeblock' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='696' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='embed_data' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='698' column='1'/>
+        <var-decl name='embed_data' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='699' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='compress' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='701' column='1'/>
+        <var-decl name='compress' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='702' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='raw' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='704' column='1'/>
+        <var-decl name='raw' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='705' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='backup' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='707' column='1'/>
+        <var-decl name='backup' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='708' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='holds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='710' column='1'/>
+        <var-decl name='holds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='711' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='saved' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='713' column='1'/>
+        <var-decl name='saved' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='714' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='sendflags_t' type-id='type-id-366' filepath='../../include/libzfs.h' line='714' column='1' id='type-id-367'/>
+    <typedef-decl name='sendflags_t' type-id='type-id-366' filepath='../../include/libzfs.h' line='715' column='1' id='type-id-367'/>
     <pointer-type-def type-id='type-id-367' size-in-bits='64' id='type-id-368'/>
-    <typedef-decl name='snapfilter_cb_t' type-id='type-id-369' filepath='../../include/libzfs.h' line='716' column='1' id='type-id-370'/>
+    <typedef-decl name='snapfilter_cb_t' type-id='type-id-369' filepath='../../include/libzfs.h' line='717' column='1' id='type-id-370'/>
     <pointer-type-def type-id='type-id-370' size-in-bits='64' id='type-id-371'/>
     <function-decl name='zfs_send' mangled-name='zfs_send' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
       <parameter type-id='type-id-98' name='zhp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='2120' column='1'/>
@@ -5456,19 +5461,15 @@
       <parameter type-id='type-id-89' name='resume_token' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='1869' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_get_pool_handle' filepath='../../include/libzfs.h' line='472' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_get_pool_handle' filepath='../../include/libzfs.h' line='473' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-105'/>
       <return type-id='type-id-134'/>
     </function-decl>
-    <function-decl name='zfs_hold_nvl' filepath='../../include/libzfs.h' line='732' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_hold_nvl' filepath='../../include/libzfs.h' line='733' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-112'/>
       <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_size' filepath='../../include/sys/nvpair.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-112'/>
-      <return type-id='type-id-45'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_native' filepath='../../include/zfs_fletcher.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-21'/>
@@ -5481,6 +5482,10 @@
       <parameter type-id='type-id-21'/>
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-59'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' filepath='../../include/sys/nvpair.h' line='278' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-45'/>
     </function-decl>
     <function-decl name='nvlist_lookup_boolean' filepath='../../include/sys/nvpair.h' line='202' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-112'/>
@@ -5527,60 +5532,60 @@
       <parameter type-id='type-id-244'/>
       <return type-id='type-id-242'/>
     </function-decl>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='747' column='1' id='type-id-376'>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='748' column='1' id='type-id-376'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbose' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='749' column='1'/>
+        <var-decl name='verbose' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='750' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='isprefix' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='752' column='1'/>
+        <var-decl name='isprefix' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='753' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='istail' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='758' column='1'/>
+        <var-decl name='istail' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='759' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='761' column='1'/>
+        <var-decl name='dryrun' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='762' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='force' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='764' column='1'/>
+        <var-decl name='force' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='765' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='canmountoff' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='767' column='1'/>
+        <var-decl name='canmountoff' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='768' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='resumable' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='773' column='1'/>
+        <var-decl name='resumable' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='774' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='byteswap' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='776' column='1'/>
+        <var-decl name='byteswap' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='777' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nomount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='779' column='1'/>
+        <var-decl name='nomount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='780' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='holds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='782' column='1'/>
+        <var-decl name='holds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='783' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='skipholds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='785' column='1'/>
+        <var-decl name='skipholds' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='786' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='domount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='788' column='1'/>
+        <var-decl name='domount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='789' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='forceunmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='791' column='1'/>
+        <var-decl name='forceunmount' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='792' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='recvflags_t' type-id='type-id-376' filepath='../../include/libzfs.h' line='792' column='1' id='type-id-377'/>
+    <typedef-decl name='recvflags_t' type-id='type-id-376' filepath='../../include/libzfs.h' line='793' column='1' id='type-id-377'/>
     <pointer-type-def type-id='type-id-377' size-in-bits='64' id='type-id-378'/>
     <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-379'/>
-    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
-      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5131' column='1'/>
-      <parameter type-id='type-id-89' name='tosnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5131' column='1'/>
-      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5131' column='1'/>
-      <parameter type-id='type-id-378' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5132' column='1'/>
-      <parameter type-id='type-id-1' name='infd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5132' column='1'/>
-      <parameter type-id='type-id-379' name='stream_avl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5132' column='1'/>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5128' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='type-id-23' name='hdl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5128' column='1'/>
+      <parameter type-id='type-id-89' name='tosnap' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5128' column='1'/>
+      <parameter type-id='type-id-28' name='props' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5128' column='1'/>
+      <parameter type-id='type-id-378' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5129' column='1'/>
+      <parameter type-id='type-id-1' name='infd' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5129' column='1'/>
+      <parameter type-id='type-id-379' name='stream_avl' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_sendrecv.c' line='5129' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='258' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='libzfs_set_pipe_max' filepath='../../include/libzfs_impl.h' line='257' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -5605,7 +5610,7 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-13'/>
     </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' filepath='../../include/libzfs.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_iter_snapshots_sorted' filepath='../../include/libzfs.h' line='620' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-21'/>
@@ -5613,7 +5618,7 @@
       <parameter type-id='type-id-45'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' filepath='../../include/libzfs.h' line='517' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_get_recvd_props' filepath='../../include/libzfs.h' line='518' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <return type-id='type-id-112'/>
     </function-decl>
@@ -6131,7 +6136,7 @@
       <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='zfs_prop_set' filepath='../../include/libzfs.h' line='492' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_prop_set' filepath='../../include/libzfs.h' line='493' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-87'/>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-89'/>
@@ -6158,7 +6163,7 @@
       <parameter type-id='type-id-414' name='errata' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_status.c' line='509' column='1'/>
       <return type-id='type-id-412'/>
     </function-decl>
-    <function-decl name='zpool_load_compat' filepath='../../include/libzfs.h' line='932' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zpool_load_compat' filepath='../../include/libzfs.h' line='934' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-305'/>
       <parameter type-id='type-id-29'/>
@@ -6303,6 +6308,9 @@
       <parameter type-id='type-id-1' name='flags' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='946' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
+    <function-decl name='fork' filepath='/usr/include/unistd.h' line='756' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
     <function-decl name='waitpid' filepath='/usr/include/x86_64-linux-gnu/sys/wait.h' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-1'/>
       <parameter type-id='type-id-231'/>
@@ -6316,23 +6324,23 @@
     </function-decl>
     <qualified-type-def type-id='type-id-29' const='yes' id='type-id-417'/>
     <pointer-type-def type-id='type-id-417' size-in-bits='64' id='type-id-418'/>
-    <function-decl name='execvp' filepath='/usr/include/unistd.h' line='578' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-89'/>
-      <parameter type-id='type-id-418'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
     <function-decl name='execv' filepath='/usr/include/unistd.h' line='563' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-418'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='execvpe' filepath='/usr/include/unistd.h' line='590' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='execvp' filepath='/usr/include/unistd.h' line='578' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-418'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='execve' filepath='/usr/include/unistd.h' line='551' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-418'/>
       <parameter type-id='type-id-418'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='execve' filepath='/usr/include/unistd.h' line='551' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='execvpe' filepath='/usr/include/unistd.h' line='590' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-89'/>
       <parameter type-id='type-id-418'/>
       <parameter type-id='type-id-418'/>
@@ -6372,7 +6380,7 @@
     <function-decl name='libzfs_init' mangled-name='libzfs_init' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1008' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
       <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='libzfs_load_module' filepath='../../include/libzfs_impl.h' line='253' column='1' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-420'/>
@@ -6655,33 +6663,33 @@
       <parameter type-id='type-id-113' name='nvlp' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1233' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='594' column='1' id='type-id-444'>
+    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' filepath='../../include/libzfs.h' line='595' column='1' id='type-id-444'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_sources' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='595' column='1'/>
+        <var-decl name='cb_sources' type-id='type-id-1' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cb_columns' type-id='type-id-445' visibility='default' filepath='../../include/libzfs.h' line='596' column='1'/>
+        <var-decl name='cb_columns' type-id='type-id-445' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cb_colwidths' type-id='type-id-446' visibility='default' filepath='../../include/libzfs.h' line='597' column='1'/>
+        <var-decl name='cb_colwidths' type-id='type-id-446' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cb_scripted' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='598' column='1'/>
+        <var-decl name='cb_scripted' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='599' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='cb_literal' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='599' column='1'/>
+        <var-decl name='cb_literal' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='600' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='cb_first' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='600' column='1'/>
+        <var-decl name='cb_first' type-id='type-id-6' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='cb_proplist' type-id='type-id-264' visibility='default' filepath='../../include/libzfs.h' line='601' column='1'/>
+        <var-decl name='cb_proplist' type-id='type-id-264' visibility='default' filepath='../../include/libzfs.h' line='602' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='cb_type' type-id='type-id-26' visibility='default' filepath='../../include/libzfs.h' line='602' column='1'/>
+        <var-decl name='cb_type' type-id='type-id-26' visibility='default' filepath='../../include/libzfs.h' line='603' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='582' column='1' id='type-id-447'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../include/libzfs.h' line='583' column='1' id='type-id-447'>
       <underlying-type type-id='type-id-7'/>
       <enumerator name='GET_COL_NONE' value='0'/>
       <enumerator name='GET_COL_NAME' value='1'/>
@@ -6690,7 +6698,7 @@
       <enumerator name='GET_COL_RECVD' value='4'/>
       <enumerator name='GET_COL_SOURCE' value='5'/>
     </enum-decl>
-    <typedef-decl name='zfs_get_column_t' type-id='type-id-447' filepath='../../include/libzfs.h' line='589' column='1' id='type-id-448'/>
+    <typedef-decl name='zfs_get_column_t' type-id='type-id-447' filepath='../../include/libzfs.h' line='590' column='1' id='type-id-448'/>
 
     <array-type-def dimensions='1' type-id='type-id-448' size-in-bits='160' alignment-in-bits='32' id='type-id-445'>
       <subrange length='5' type-id='type-id-43' id='type-id-398'/>
@@ -6701,7 +6709,7 @@
       <subrange length='6' type-id='type-id-43' id='type-id-407'/>
 
     </array-type-def>
-    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-444' filepath='../../include/libzfs.h' line='603' column='1' id='type-id-449'/>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-444' filepath='../../include/libzfs.h' line='604' column='1' id='type-id-449'/>
     <pointer-type-def type-id='type-id-449' size-in-bits='64' id='type-id-450'/>
     <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
       <parameter type-id='type-id-89' name='name' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1373' column='1'/>
@@ -6795,7 +6803,7 @@
     <function-decl name='zfs_version_print' mangled-name='zfs_version_print' filepath='/home/nabijaczleweli/store/code/zfs/lib/libzfs/libzfs_util.c' line='1978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_version_kernel' filepath='../../include/libzfs.h' line='889' column='1' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='zfs_version_kernel' filepath='../../include/libzfs.h' line='891' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-29'/>
       <parameter type-id='type-id-1'/>
       <return type-id='type-id-1'/>
@@ -7903,19 +7911,19 @@
       <parameter type-id='type-id-6' name='encrypted' filepath='../../module/zcommon/zfs_prop.c' line='931' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' filepath='../../module/zcommon/zfs_prop.c' line='954' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
+    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' filepath='../../module/zcommon/zfs_prop.c' line='956' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
       <parameter type-id='type-id-3' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1'/>
       <return type-id='type-id-89'/>
     </function-decl>
-    <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' filepath='../../module/zcommon/zfs_prop.c' line='965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
-      <parameter type-id='type-id-3' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='965' column='1'/>
+    <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' filepath='../../module/zcommon/zfs_prop.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
+      <parameter type-id='type-id-3' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='967' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' filepath='../../module/zcommon/zfs_prop.c' line='976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
+    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' filepath='../../module/zcommon/zfs_prop.c' line='978' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
       <parameter type-id='type-id-3' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='879' column='1'/>
       <return type-id='type-id-89'/>
     </function-decl>
-    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' filepath='../../module/zcommon/zfs_prop.c' line='986' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
+    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' filepath='../../module/zcommon/zfs_prop.c' line='988' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
       <parameter type-id='type-id-3' name='prop' filepath='../../module/zcommon/zfs_prop.c' line='851' column='1'/>
       <return type-id='type-id-6'/>
     </function-decl>

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1261,9 +1261,9 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			    intval > maxbs || !ISP2(intval))) {
 				zfs_nicebytes(maxbs, buf, sizeof (buf));
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "invalid '%s=%d' property: must be zero or "
-				    "a power of 2 from 512B to %s"), propname,
-				    intval, buf);
+				    "invalid '%s=%llu' property: must be zero "
+				    "or a power of 2 from 512B to %s"),
+				    propname, (unsigned long long)intval, buf);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -4835,8 +4835,6 @@ zfs_userspace(zfs_handle_t *zhp, zfs_userquota_prop_t type,
 
 		zc.zc_nvlist_dst_size = sizeof (buf);
 		if (zfs_ioctl(hdl, ZFS_IOC_USERSPACE_MANY, &zc) != 0) {
-			char errbuf[1024];
-
 			if ((errno == ENOTSUP &&
 			    (type == ZFS_PROP_USEROBJUSED ||
 			    type == ZFS_PROP_GROUPOBJUSED ||
@@ -4848,10 +4846,9 @@ zfs_userspace(zfs_handle_t *zhp, zfs_userquota_prop_t type,
 			    type == ZFS_PROP_PROJECTQUOTA)))
 				break;
 
-			(void) snprintf(errbuf, sizeof (errbuf),
+			return (zfs_standard_error_fmt(hdl, errno,
 			    dgettext(TEXT_DOMAIN,
-			    "cannot get used/quota for %s"), zc.zc_name);
-			return (zfs_standard_error_fmt(hdl, errno, errbuf));
+			    "cannot get used/quota for %s"), zc.zc_name));
 		}
 		if (zc.zc_nvlist_dst_size == 0)
 			break;
@@ -5080,7 +5077,7 @@ zfs_release(zfs_handle_t *zhp, const char *snapname, const char *tag,
 			(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		default:
-			(void) zfs_standard_error_fmt(hdl, errno, errbuf);
+			(void) zfs_standard_error(hdl, errno, errbuf);
 		}
 	}
 
@@ -5099,7 +5096,7 @@ zfs_release(zfs_handle_t *zhp, const char *snapname, const char *tag,
 			(void) zfs_error(hdl, EZFS_BADTYPE, errbuf);
 			break;
 		default:
-			(void) zfs_standard_error_fmt(hdl,
+			(void) zfs_standard_error(hdl,
 			    fnvpair_value_int32(elem), errbuf);
 		}
 	}
@@ -5156,17 +5153,16 @@ tryagain:
 			err = zfs_error(hdl, EZFS_NOENT, errbuf);
 			break;
 		default:
-			err = zfs_standard_error_fmt(hdl, errno, errbuf);
+			err = zfs_standard_error(hdl, errno, errbuf);
 			break;
 		}
 	} else {
 		/* success */
 		int rc = nvlist_unpack(nvbuf, zc.zc_nvlist_dst_size, nvl, 0);
 		if (rc) {
-			(void) snprintf(errbuf, sizeof (errbuf), dgettext(
+			err = zfs_standard_error_fmt(hdl, rc, dgettext(
 			    TEXT_DOMAIN, "cannot get permissions on '%s'"),
 			    zc.zc_name);
-			err = zfs_standard_error_fmt(hdl, rc, errbuf);
 		}
 	}
 
@@ -5219,7 +5215,7 @@ zfs_set_fsacl(zfs_handle_t *zhp, boolean_t un, nvlist_t *nvl)
 			err = zfs_error(hdl, EZFS_NOENT, errbuf);
 			break;
 		default:
-			err = zfs_standard_error_fmt(hdl, errno, errbuf);
+			err = zfs_standard_error(hdl, errno, errbuf);
 			break;
 		}
 	}
@@ -5256,7 +5252,7 @@ zfs_get_holds(zfs_handle_t *zhp, nvlist_t **nvl)
 			err = zfs_error(hdl, EZFS_NOENT, errbuf);
 			break;
 		default:
-			err = zfs_standard_error_fmt(hdl, errno, errbuf);
+			err = zfs_standard_error(hdl, errno, errbuf);
 			break;
 		}
 	}

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3334,6 +3334,16 @@ zfs_get_type(const zfs_handle_t *zhp)
 }
 
 /*
+ * Returns the type of the given zfs handle,
+ * or, if a snapshot, the type of the snapshotted dataset.
+ */
+zfs_type_t
+zfs_get_underlying_type(const zfs_handle_t *zhp)
+{
+	return (zhp->zfs_head_type);
+}
+
+/*
  * Is one dataset name a child dataset of another?
  *
  * Needs to handle these cases:

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -732,7 +732,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	}
 
 	if (pipe2(pipefd, O_CLOEXEC)) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+		zfs_error_aux(zhp->zfs_hdl, "%s", strerror(errno));
 		teardown_differ_info(&di);
 		return (zfs_error(zhp->zfs_hdl, EZFS_PIPEFAILED, errbuf));
 	}
@@ -745,7 +745,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	di.datafd = pipefd[0];
 
 	if (pthread_create(&tid, NULL, differ, &di)) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+		zfs_error_aux(zhp->zfs_hdl, "%s", strerror(errno));
 		(void) close(pipefd[0]);
 		(void) close(pipefd[1]);
 		teardown_differ_info(&di);
@@ -771,14 +771,14 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
 			    "\n   Not an earlier snapshot from the same fs"));
 		} else if (errno != EPIPE || di.zerr == 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(errno));
 		}
 		(void) close(pipefd[1]);
 		(void) pthread_cancel(tid);
 		(void) pthread_join(tid, NULL);
 		teardown_differ_info(&di);
 		if (di.zerr != 0 && di.zerr != EPIPE) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(di.zerr));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(di.zerr));
 			return (zfs_error(zhp->zfs_hdl, EZFS_DIFF, di.errbuf));
 		} else {
 			return (zfs_error(zhp->zfs_hdl, EZFS_DIFFDATA, errbuf));
@@ -789,7 +789,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	(void) pthread_join(tid, NULL);
 
 	if (di.zerr != 0) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(di.zerr));
+		zfs_error_aux(zhp->zfs_hdl, "%s", strerror(di.zerr));
 		return (zfs_error(zhp->zfs_hdl, EZFS_DIFF, di.errbuf));
 	}
 	teardown_differ_info(&di);

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -538,19 +538,17 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "Insufficient privileges"));
 		} else if (rc == ENOTSUP) {
-			char buf[256];
 			int spa_version;
 
 			VERIFY(zfs_spa_version(zhp, &spa_version) == 0);
-			(void) snprintf(buf, sizeof (buf),
-			    dgettext(TEXT_DOMAIN, "Can't mount a version %lld "
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "Can't mount a version %llu "
 			    "file system on a version %d pool. Pool must be"
 			    " upgraded to mount this file system."),
 			    (u_longlong_t)zfs_prop_get_int(zhp,
 			    ZFS_PROP_VERSION), spa_version);
-			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, buf));
 		} else {
-			zfs_error_aux(hdl, strerror(rc));
+			zfs_error_aux(hdl, "%s", strerror(rc));
 		}
 		return (zfs_error_fmt(hdl, EZFS_MOUNTFAILED,
 		    dgettext(TEXT_DOMAIN, "cannot mount '%s'"),

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -563,8 +563,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (intval < version ||
 			    !SPA_VERSION_IS_SUPPORTED(intval)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' number %d is invalid."),
-				    propname, intval);
+				    "property '%s' number %llu is invalid."),
+				    propname, (unsigned long long)intval);
 				(void) zfs_error(hdl, EZFS_BADVERSION, errbuf);
 				goto error;
 			}
@@ -574,10 +574,11 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (intval != 0 &&
 			    (intval < ASHIFT_MIN || intval > ASHIFT_MAX)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' number %d is invalid, only "
-				    "values between %" PRId32 " and "
-				    "%" PRId32 " are allowed."),
-				    propname, intval, ASHIFT_MIN, ASHIFT_MAX);
+				    "property '%s' number %llu is invalid, "
+				    "only values between %" PRId32 " and %"
+				    PRId32 " are allowed."),
+				    propname, (unsigned long long)intval,
+				    ASHIFT_MIN, ASHIFT_MAX);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -685,7 +686,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			case ZPOOL_COMPATIBILITY_BADFILE:
 			case ZPOOL_COMPATIBILITY_BADTOKEN:
 			case ZPOOL_COMPATIBILITY_NOFILES:
-				zfs_error_aux(hdl, report);
+				zfs_error_aux(hdl, "%s", report);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
@@ -1648,10 +1649,6 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
     const char *log_str)
 {
 	zfs_cmd_t zc = {"\0"};
-	char msg[1024];
-
-	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "cannot export '%s'"), zhp->zpool_name);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_cookie = force;
@@ -1666,11 +1663,13 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 			    "'%s' has an active shared spare which could be"
 			    " used by other pools once '%s' is exported."),
 			    zhp->zpool_name, zhp->zpool_name);
-			return (zfs_error(zhp->zpool_hdl, EZFS_ACTIVE_SPARE,
-			    msg));
+			return (zfs_error_fmt(zhp->zpool_hdl, EZFS_ACTIVE_SPARE,
+			    dgettext(TEXT_DOMAIN, "cannot export '%s'"),
+			    zhp->zpool_name));
 		default:
 			return (zpool_standard_error_fmt(zhp->zpool_hdl, errno,
-			    msg));
+			    dgettext(TEXT_DOMAIN, "cannot export '%s'"),
+			    zhp->zpool_name));
 		}
 	}
 
@@ -2080,7 +2079,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 					    "the zgenhostid(8) command.\n"));
 				}
 
-				(void) zfs_error_aux(hdl, aux);
+				(void) zfs_error_aux(hdl, "%s", aux);
 			}
 			(void) zfs_error(hdl, EZFS_ACTIVE_POOL, desc);
 			break;
@@ -4520,13 +4519,10 @@ int
 zpool_events_clear(libzfs_handle_t *hdl, int *count)
 {
 	zfs_cmd_t zc = {"\0"};
-	char msg[1024];
-
-	(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
-	    "cannot clear events"));
 
 	if (zfs_ioctl(hdl, ZFS_IOC_EVENTS_CLEAR, &zc) != 0)
-		return (zpool_standard_error_fmt(hdl, errno, msg));
+		return (zpool_standard_error(hdl, errno,
+		    dgettext(TEXT_DOMAIN, "cannot clear events")));
 
 	if (count != NULL)
 		*count = (int)zc.zc_cookie; /* # of events cleared */

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -768,7 +768,7 @@ zfs_send_space(zfs_handle_t *zhp, const char *snapname, const char *from,
 		case EFAULT:
 		case EROFS:
 		case EINVAL:
-			zfs_error_aux(hdl, strerror(error));
+			zfs_error_aux(hdl, "%s", strerror(error));
 			return (zfs_error(hdl, EZFS_BADBACKUP, errbuf));
 
 		default:
@@ -849,7 +849,7 @@ dump_ioctl(zfs_handle_t *zhp, const char *fromsnap, uint64_t fromsnap_obj,
 		case ERANGE:
 		case EFAULT:
 		case EROFS:
-			zfs_error_aux(hdl, strerror(errno));
+			zfs_error_aux(hdl, "%s", strerror(errno));
 			return (zfs_error(hdl, EZFS_BADBACKUP, errbuf));
 
 		default:
@@ -1479,7 +1479,7 @@ estimate_size(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 		err = pthread_create(&ptid, NULL,
 		    send_progress_thread, &pa);
 		if (err != 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(errno));
 			return (zfs_error(zhp->zfs_hdl,
 			    EZFS_THREADCREATEFAILED, errbuf));
 		}
@@ -1505,7 +1505,7 @@ estimate_size(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 	}
 
 	if (err != 0) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(err));
+		zfs_error_aux(zhp->zfs_hdl, "%s", strerror(err));
 		return (zfs_error(zhp->zfs_hdl, EZFS_BADBACKUP,
 		    errbuf));
 	}
@@ -1822,7 +1822,7 @@ zfs_send_resume_impl(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 		case ERANGE:
 		case EFAULT:
 		case EROFS:
-			zfs_error_aux(hdl, strerror(errno));
+			zfs_error_aux(hdl, "%s", strerror(errno));
 			return (zfs_error(hdl, EZFS_BADBACKUP, errbuf));
 
 		default:
@@ -2082,13 +2082,13 @@ send_prelim_records(zfs_handle_t *zhp, const char *from, int fd,
 		err = dump_record(&drr, packbuf, buflen, &zc, fd);
 		free(packbuf);
 		if (err != 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(err));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(err));
 			return (zfs_error(zhp->zfs_hdl, EZFS_BADBACKUP,
 			    errbuf));
 		}
 		err = send_conclusion_record(fd, &zc);
 		if (err != 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(err));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(err));
 			return (zfs_error(zhp->zfs_hdl, EZFS_BADBACKUP,
 			    errbuf));
 		}
@@ -2507,7 +2507,7 @@ zfs_send_one(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 		err = pthread_create(&ptid, NULL,
 		    send_progress_thread, &pa);
 		if (err != 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+			zfs_error_aux(zhp->zfs_hdl, "%s", strerror(errno));
 			return (zfs_error(zhp->zfs_hdl,
 			    EZFS_THREADCREATEFAILED, errbuf));
 		}
@@ -2522,13 +2522,10 @@ zfs_send_one(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 			(void) pthread_cancel(ptid);
 		(void) pthread_join(ptid, &status);
 		int error = (int)(uintptr_t)status;
-		if (error != 0 && status != PTHREAD_CANCELED) {
-			char errbuf[1024];
-			(void) snprintf(errbuf, sizeof (errbuf),
-			    dgettext(TEXT_DOMAIN, "progress thread exited "
-			    "nonzero"));
-			return (zfs_standard_error(hdl, error, errbuf));
-		}
+		if (error != 0 && status != PTHREAD_CANCELED)
+			return (zfs_standard_error_fmt(hdl, error,
+			    dgettext(TEXT_DOMAIN,
+			    "progress thread exited nonzero")));
 	}
 
 	if (flags->props || flags->holds || flags->backup) {
@@ -2576,7 +2573,7 @@ zfs_send_one(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 		case EPIPE:
 		case ERANGE:
 		case EROFS:
-			zfs_error_aux(hdl, strerror(errno));
+			zfs_error_aux(hdl, "%s", strerror(errno));
 			return (zfs_error(hdl, EZFS_BADBACKUP, errbuf));
 
 		default:
@@ -5078,8 +5075,8 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 	if (!DMU_STREAM_SUPPORTED(featureflags) ||
 	    (hdrtype != DMU_SUBSTREAM && hdrtype != DMU_COMPOUNDSTREAM)) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "stream has unsupported feature, feature flags = %lx"),
-		    featureflags);
+		    "stream has unsupported feature, feature flags = %llx"),
+		    (unsigned long long)featureflags);
 		return (zfs_error(hdl, EZFS_BADSTREAM, errbuf));
 	}
 

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -486,7 +486,7 @@ zfs_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 		zfs_verror(hdl, EZFS_BADPROP, fmt, ap);
 		break;
 	default:
-		zfs_error_aux(hdl, strerror(error));
+		zfs_error_aux(hdl, "%s", strerror(error));
 		zfs_verror(hdl, EZFS_UNKNOWN, fmt, ap);
 		break;
 	}
@@ -737,7 +737,7 @@ zpool_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 		zfs_verror(hdl, EZFS_IOC_NOTSUPPORTED, fmt, ap);
 		break;
 	default:
-		zfs_error_aux(hdl, strerror(error));
+		zfs_error_aux(hdl, "%s", strerror(error));
 		zfs_verror(hdl, EZFS_UNKNOWN, fmt, ap);
 	}
 


### PR DESCRIPTION
### Motivation and Context
#12048 but defanged

### Description
https://github.com/openzfs/zfs/pull/12048#issuecomment-847399449

### How Has This Been Tested?
Likewise

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand, probably
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
