### PR TITLE
long options for ztest

### DIFF
--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -63,93 +63,113 @@ can re-use these files in your next \fBztest\fR run by using the -E
 option.
 .SH OPTIONS
 .HP
-.BI "\-?" ""
+.BR "\-h, -?, --help"
 .IP
 Print a help summary.
 .HP
-.BI "\-v" " vdevs" " (default: 5)
+.BR "\-v, --vdevs=" " (default: 5)
 .IP
 Number of vdevs.
 .HP
-.BI "\-s" " size_of_each_vdev" " (default: 64M)"
+.BR "\-s, --vdev-size=" " (default: 64M)"
 .IP
 Size of each vdev.
 .HP
-.BI "\-a" " alignment_shift" " (default: 9) (use 0 for random)"
+.BR "\-a, --alignment-shift=" " (default: 9) (use 0 for random)"
 .IP
-Used alignment in test.
+Alignment shift used in test.
 .HP
-.BI "\-m" " mirror_copies" " (default: 2)"
+.BR "\-m, --mirror-copies=" " (default: 2)"
 .IP
 Number of mirror copies.
 .HP
-.BI "\-r" " raidz_disks / draid_disks" " (default: 4 / 16)"
+.BR "\-r, --raid-disks=" " (default: 4 for raidz/ 16 for draid)"
 .IP
-Number of raidz disks.
+Number of raidz/draid disks.
 .HP
-.BI "\-R" " raid_parity" " (default: 1)"
+.BR "\-R, --raid-parity=" " (default: 1)"
 .IP
 Raid parity (raidz & draid).
 .HP
-.BI "\-K" " raid_kind" " (default: 'random') raidz|draid|random"
+.BR "\-K, --raid-kind=" " (default: 'random') raidz|draid|random"
 .IP
 The kind of RAID config to use. With 'random' the kind alternates between raidz and draid.
 .HP
-.BI "\-D" " draid_data" " (default: 4)"
+.BR "\-D, --draid-data=" " (default: 4)"
 .IP
 Number of data disks in a dRAID redundancy group.
 .HP
-.BI "\-S" " draid_spares" " (default: 1)"
+.BR "\-S, --draid-spares=" " (default: 1)"
 .IP
 Number of dRAID distributed spare disks.
 .HP
-.BI "\-C" " vdev_class_state" " (default: random)"
-.IP
-The vdev allocation class state: special=on|off|random.
-.HP
-.BI "\-d" " datasets" " (default: 7)"
+.BR "\-d, --datasets=" " (default: 7)"
 .IP
 Number of datasets.
 .HP
-.BI "\-t" " threads" " (default: 23)"
+.BR "\-t, --threads=" " (default: 23)"
 .IP
 Number of threads.
 .HP
-.BI "\-g" " gang_block_threshold" " (default: 32K)"
+.BR "\-g, --gang-block-threshold=" " (default: 32K)"
 .IP
 Gang block threshold.
 .HP
-.BI "\-i" " initialize_pool_i_times" " (default: 1)"
+.BR "\-i, --init-count=" " (default: 1)"
 .IP
-Number of pool initialisations.
+Number of pool initializations.
 .HP
-.BI "\-k" " kill_percentage" " (default: 70%)"
+.BR "\-k, --kill-percentage=" " (default: 70%)"
 .IP
 Kill percentage.
 .HP
-.BI "\-p" " pool_name" " (default: ztest)"
+.BR "\-p, --pool-name=" " (default: ztest)"
 .IP
 Pool name.
 .HP
-.BI "\-V(erbose)"
+.BR "\-f, --vdev-file-directory=" " (default: /tmp)"
 .IP
-Verbose (use multiple times for ever more blather).
+File directory for vdev files.
 .HP
-.BI "\-E(xisting)"
+.BR "\-M, --multi-host"
+.IP
+Multi-host; simulate pool imported on remote host.
+.HP
+.BR "\-E, --use-existing-pool"
 .IP
 Use existing pool (use existing pool instead of creating new one).
 .HP
-.BI "\-T" " time" " (default: 300 sec)"
+.BR "\-T, --run-time=" " (default: 300 sec)"
 .IP
 Total test run time.
 .HP
-.BI "\-z" " zil_failure_rate" " (default: fail every 2^5 allocs)
+.BR "\-P, --pass-time=" " (default: 60 sec)"
 .IP
-Injected failure rate.
+Time per pass.
 .HP
-.BI "\-G"
+.BR "\-F, --freeze-loops=" " (default: 50)"
 .IP
-Dump zfs_dbgmsg buffer before exiting.
+Max loops in spa_freeze().
+.HP
+.BR "\-B, --alt-ztest="
+.IP
+Alternate ztest path.
+.HP
+.BR "\-C, --vdev-class-state=on|off|random" " (default: random)"
+.IP
+The vdev allocation class state.
+.HP
+.BR "\-o, --option="
+.IP
+Set global variable to an unsigned 32-bit integer value.
+.HP
+.BR "\-G, --dump-debug"
+.IP
+Dump zfs_dbgmsg buffer before exiting due to an error.
+.HP
+.BR "\-V, --verbose"
+.IP
+Verbose (use multiple times for ever more verbosity).
 .SH "EXAMPLES"
 .LP
 To override /tmp as your location for block files, you can use the -f


### PR DESCRIPTION
Signed-off-by: Manoj Joseph <manoj.joseph@delphix.com>

<!--- Provide a general summary of your changes in the Title above -->
This change introduces long options for ztest.

### Motivation and Context
Today, ztest takes 27 different command line options. With most of the english alphabet taken, introducing new options involves associating alphabets with options in ways that are not very intuitive. Having long options would help in this regard.

### Description
This change introduces long options for ztest. It builds the usage message as well as the long_options array from a single table. It also adds #defines for the default values.

### How Has This Been Tested?
```
delphix@mj-ztest:~$ ztest --help
Usage: ztest [OPTIONS...]
    -v --vdevs=INTEGER                    Number of vdevs (default: 5)
    -s --vdev-size=INTEGER                Size of each vdev (default: 256M)
    -a --alignment-shift=INTEGER          Alignment shift; use 0 for random (default: 9)
    -m --mirror-copies=INTEGER            Number of mirror copies (default: 2)
    -r --raid-disks=INTEGER               Number of raidz/draid disks (default: 4)
    -R --raid-parity=INTEGER              Raid parity (default: 1)
    -K --raid-kind=raidz|draid|random     Raid kind (default: random)
    -D --draid-data=INTEGER               Number of draid data drives (default: 4)
    -S --draid-spares=INTEGER             Number of draid spares (default: 1)
    -d --datasets=INTEGER                 Number of datasets (default: 7)
    -t --threads=INTEGER                  Number of ztest threads (default: 23)
    -g --gang-block-threshold=INTEGER     Metaslab gang block threshold (default: 64K)
    -i --init-count=INTEGER               Number of times to initialize pool (default: 1)
    -k --kill-percentage=INTEGER          Kill percentage (default: 70%)
    -p --pool-name=STRING                 Pool name (default: ztest)
    -f --vdev-file-directory=PATH         File directory for vdev files (default: /tmp)
    -M --multi-host                       Multi-host; simulate pool imported on remote host
    -E --use-existing-pool                Use existing pool instead of creating new one
    -T --run-time=INTEGER                 Total run time (default: 300 sec)
    -P --pass-time=INTEGER                Time per pass (default: 60 sec)
    -F --freeze-loops=INTEGER             Max loops in spa_freeze() (default: 50)
    -B --alt-ztest=PATH                   Alternate ztest path
    -C --vdev-class-state=on|off|random   vdev class state (default: random)
    -o --option="OPTION=INTEGER"          Set global variable to an unsigned 32-bit integer value
    -G --dump-debug-msg                   Dump zfs_dbgmsg buffer before exiting due to an error
    -V --verbose                          Verbose (use multiple times for ever more verbosity)
    -h --help                             Show this help
delphix@mj-ztest:~$ 
delphix@mj-ztest:~$ ztest --verbose
1 vdevs, 7 datasets, 23 threads,16 draid disks, 300 seconds...

verifying concrete vdev 0, metaslab 11 of 12 ...
loading concrete vdev 0, metaslab 11 of 12 ...
verifying concrete vdev 0, metaslab 11 of 12 ...
loading concrete vdev 0, metaslab 11 of 12 ...
Pass   1,  SIGKILL,   0 ENOSPC,  6.7% of 3.00G used,  17% done,    4m08s to go
verifying concrete vdev 0, metaslab 11 of 12 ...
loading concrete vdev 0, metaslab 11 of 12 ...
verifying vdev 0, space map entry 0 of 1200 ...ning: 0hr 00min 01sec        
verifying vdev 0 of 1, metaslab 11 of 12 .....
Pass   2, Complete,   0 ENOSPC,  6.7% of 3.75G used,  44% done,    2m46s to go
verifying concrete vdev 0, metaslab 14 of 15 ...
loading concrete vdev 0, metaslab 14 of 15 ...
 246M completed (  48MB/s) estimated time remaining: 0hr 00min 00sec        Pass   3, Complete,   0 ENOSPC,  9.6% of 3.75G used,  75% done,    1m15s to go
verifying concrete vdev 1, metaslab 11 of 12 ...
loading concrete vdev 1, metaslab 11 of 12 ...
verifying vdev 1, space map entry 0 of 6 ......ning: 0hr 00min 00sec        
verifying vdev 1 of 2, metaslab 11 of 12 .....
Pass   4,  SIGKILL,   0 ENOSPC, 10.1% of 3.75G used,  84% done,      47s to go
verifying concrete vdev 1, metaslab 11 of 12 ...
loading concrete vdev 1, metaslab 11 of 12 ...
verifying vdev 1, space map entry 0 of 6 ......ning: 0hr 00min 01sec        
verifying vdev 1 of 2, metaslab 11 of 12 .....
Pass   5,  SIGKILL,   0 ENOSPC, 10.1% of 3.75G used,  89% done,      32s to go
verifying concrete vdev 1, metaslab 11 of 12 ...
loading concrete vdev 1, metaslab 11 of 12 ...
verifying vdev 1, space map entry 0 of 6 ......ning: 0hr 00min 01sec        
verifying vdev 1 of 2, metaslab 11 of 12 .....
Pass   6,  SIGKILL,   0 ENOSPC, 10.1% of 3.75G used,  94% done,      17s to go
verifying concrete vdev 1, metaslab 11 of 12 ...
loading concrete vdev 1, metaslab 11 of 12 ...
verifying vdev 1, space map entry 0 of 6 ......ning: 0hr 00min 01sec        
verifying vdev 1 of 2, metaslab 11 of 12 .....
Pass   7, Complete,   0 ENOSPC, 10.1% of 3.75G used, 100% done,       0s to go
verifying concrete vdev 1, metaslab 11 of 12 ...
loading concrete vdev 1, metaslab 11 of 12 ...
verifying vdev 1, space map entry 0 of 6 ......ning: 0hr 00min 01sec        
verifying vdev 1 of 2, metaslab 11 of 12 .....
4 killed, 3 completed, 57% kill rate
delphix@mj-ztest:~$ 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
