### PR TITLE
Consistent SPL module param 'spl_panic_halt' handling.

### DIFF
--- a/module/os/linux/spl/spl-err.c
+++ b/module/os/linux/spl/spl-err.c
@@ -101,6 +101,9 @@ vcmn_err(int ce, const char *fmt, va_list ap)
 		break;
 	case CE_PANIC:
 		printk(KERN_EMERG "PANIC: %s\n", msg);
+		if (spl_panic_halt)
+			panic("%s", msg);
+
 		spl_dumpstack();
 
 		/* Halt the thread to facilitate further debugging */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

SPL contains 2 places where the ZFS PANIC can be raised:

- `spl_panic()`
- `vcmn_err()`

Some time ago, functionality of PANIC handlers were extended by adding SPL module parameter `spl_panic_halt`:
[Module parameter to enable spl_panic() to panic the kernel ](https://github.com/openzfs/spl/commit/410f7ab5943684ef74be0e58ae17d3a0278ad0be#diff-040aa68bd13a5adb1a3abc8029a365fc24057552400dbe4bd19e8e1e4c4a3b87)

but above patch only adds support for `spl_panic_halt` to only one function: `spl_panic()`. 
In my scenario I also want to raise real Linux Kernel PANIC also from second function: `vcmn_err()`.

Working without this feature causes, escalation of problems on running system:
[Original issue on Proxmox forum](https://forum.proxmox.com/threads/panic-rpool-blkptr-at-dva-0-has-invalid-offset-18388167655883276288.88967/#post-392503)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] New feature (non-breaking change which adds functionality)

