### PR TITLE
Minor fix to configure on s390x

### DIFF
--- a/config/kernel-bdi.m4
+++ b/config/kernel-bdi.m4
@@ -8,7 +8,9 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BDI], [
 	], [
 		char *name = "bdi";
 		atomic_long_t zfs_bdi_seq;
-		int error __attribute__((unused)) =
+		int error __attribute__((unused));
+		atomic_long_set(&zfs_bdi_seq, 0);
+		error =
 		    super_setup_bdi_name(&sb, "%.28s-%ld", name,
 		    atomic_long_inc_return(&zfs_bdi_seq));
 	])


### PR DESCRIPTION
### Motivation and Context
configure on s390x on my testbed has a key check fail with a warning promoted to error about
a variable being used uninitialized. Specifically,
`/usr/src/linux-headers-4.19.0-16-common/arch/s390/include/asm/atomic_ops.h:101:27: error: 'zfs_bdi_seq' is used uninitialized in this function [-Werror=uninitialized]`

### Description
Just inserts an `atomic_long_set(X, 0);` to silence its complaints.

### How Has This Been Tested?
configure finished on Debian buster x86_64 and Debian buster s390x after this, while it failed on the latter before. (s390x also functions normally, albeit with a number of ZTS failures, after.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
