### PR TITLE
Don't direct to Freenode in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://lists.freebsd.org/mailman/listinfo/freebsd-fs
     about: Get community support for OpenZFS on FreeBSD
   - name: OpenZFS on IRC
-    url: https://webchat.freenode.net/#openzfs
+    url: https://kiwiirc.com/nextclient/irc.libera.chat/openzfs
     about: Use IRC to get community support for OpenZFS


### PR DESCRIPTION
While Libera doesn't yet have a webchat client, we should at least direct them to the right network. Once a webchat client is available, we can direct them to it.