### PR TITLE
Backport 5.12 fixes for tmpiles and userns changes

### DIFF
--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -3,23 +3,43 @@ dnl # 3.11 API change
 dnl # Add support for i_op->tmpfile
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+	dnl #
+	dnl # 5.11 API change
+	dnl # add support for userns parameter to tmpfile
+	dnl #
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_userns], [
 		#include <linux/fs.h>
-		int tmpfile(struct inode *inode, struct dentry *dentry,
+		int tmpfile(struct user_namespace *userns,
+		    struct inode *inode, struct dentry *dentry,
 		    umode_t mode) { return 0; }
 		static struct inode_operations
 		    iops __attribute__ ((unused)) = {
 			.tmpfile = tmpfile,
 		};
 	],[])
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+			#include <linux/fs.h>
+			int tmpfile(struct inode *inode, struct dentry *dentry,
+			    umode_t mode) { return 0; }
+			static struct inode_operations
+			    iops __attribute__ ((unused)) = {
+				.tmpfile = tmpfile,
+			};
+	],[])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 	AC_MSG_CHECKING([whether i_op->tmpfile() exists])
-	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_userns], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+		AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
 	],[
-		AC_MSG_RESULT(no)
+		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+		],[
+			AC_MSG_RESULT(no)
+		])
 	])
 ])

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -63,7 +63,12 @@ extern int zpl_xattr_security_init(struct inode *ip, struct inode *dip,
     const struct qstr *qstr);
 #if defined(CONFIG_FS_POSIX_ACL)
 #if defined(HAVE_SET_ACL)
+#if defined(HAVE_SET_ACL_USERNS)
+extern int zpl_set_acl(struct user_namespace *userns, struct inode *ip,
+    struct posix_acl *acl, int type);
+#else
 extern int zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type);
+#endif /* HAVE_SET_ACL_USERNS */
 #endif /* HAVE_SET_ACL */
 extern struct posix_acl *zpl_get_acl(struct inode *ip, int type);
 extern int zpl_init_acl(struct inode *ip, struct inode *dir);

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -218,7 +218,12 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 
 #ifdef HAVE_TMPFILE
 static int
+#ifdef HAVE_TMPFILE_USERNS
+zpl_tmpfile(struct user_namespace *userns, struct inode *dir,
+    struct dentry *dentry, umode_t mode)
+#else
 zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
+#endif
 {
 	cred_t *cr = CRED();
 	struct inode *ip;


### PR DESCRIPTION
This backports the changes made in #12087 and #12093, which are necessary for proper 5.12 compat and are thus critical to have for a release that claims to be compatible with 5.12.