### PR TITLE
zstream: force-install zstreamdump link

### DIFF
--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -17,4 +17,4 @@ zstream_LDADD = \
 include $(top_srcdir)/config/CppCheck.am
 
 install-exec-hook:
-	$(LN_S) zstream $(DESTDIR)$(sbindir)/zstreamdump
+	cd $(DESTDIR)$(sbindir) && $(LN_S) -f zstream zstreamdump


### PR DESCRIPTION
### Motivation and Context
What a blunder!

### Description
It didn't occur to me that that's a supported configuration; as seen in this CI log, for example: http://build.zfsonlinux.org/builders/FreeBSD%20stable%2F13%20amd64%20%28TEST%29/builds/1138/steps/shell_1/logs/install

### How Has This Been Tested?
Ran it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI should
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
