### PR TITLE
RPM: Explicitly set the required min/max kernel version for the DKMS

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -26,7 +26,7 @@ BuildArch:      noarch
 Requires:       dkms >= 2.2.0.3
 Requires:       gcc, make, perl, diffutils
 %if 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}
-Requires:       kernel-devel
+Requires:       kernel-devel >= @ZFS_META_KVER_MIN@, kernel-devel <= @ZFS_META_KVER_MAX@.999
 Obsoletes:      spl-dkms
 %endif
 Provides:       %{module}-kmod = %{version}


### PR DESCRIPTION
Motivation, context and description as in: #12124

@tonyhutter: I would appreciate if we could include this patch in the stable releases as well. This should do the trick for the 2.0.x series, I am not sure though how to get this into the 2.1.0 release as there is no staging branch.