### PR TITLE
Run arc_evict thread at higher priority

### DIFF
--- a/include/sys/zthr.h
+++ b/include/sys/zthr.h
@@ -28,7 +28,7 @@ extern zthr_t *zthr_create(const char *zthr_name,
     zthr_checkfunc_t checkfunc, zthr_func_t *func, void *arg);
 extern zthr_t *zthr_create_timer(const char *zthr_name,
     zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg,
-	hrtime_t nano_wait);
+	hrtime_t nano_wait, pri_t pri);
 extern void zthr_destroy(zthr_t *t);
 
 extern void zthr_wakeup(zthr_t *t);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7676,10 +7676,10 @@ arc_init(void)
 		kstat_install(arc_ksp);
 	}
 
-	arc_evict_zthr = zthr_create("arc_evict",
-	    arc_evict_cb_check, arc_evict_cb, NULL);
+	arc_evict_zthr = zthr_create_timer("arc_evict",
+	    arc_evict_cb_check, arc_evict_cb, NULL, (hrtime_t)0, maxclsyspri);
 	arc_reap_zthr = zthr_create_timer("arc_reap",
-	    arc_reap_cb_check, arc_reap_cb, NULL, SEC2NSEC(1));
+	    arc_reap_cb_check, arc_reap_cb, NULL, SEC2NSEC(1), minclsyspri);
 
 	arc_warm = B_FALSE;
 

--- a/module/zfs/zthr.c
+++ b/module/zfs/zthr.c
@@ -220,6 +220,9 @@ struct zthr {
 	 */
 	hrtime_t	zthr_sleep_timeout;
 
+	/* Thread priority */
+	pri_t		zthr_pri;
+
 	/* consumer-provided callbacks & data */
 	zthr_checkfunc_t	*zthr_checkfunc;
 	zthr_func_t	*zthr_func;
@@ -272,7 +275,7 @@ zthr_create(const char *zthr_name, zthr_checkfunc_t *checkfunc,
     zthr_func_t *func, void *arg)
 {
 	return (zthr_create_timer(zthr_name, checkfunc,
-	    func, arg, (hrtime_t)0));
+	    func, arg, (hrtime_t)0, minclsyspri));
 }
 
 /*
@@ -282,7 +285,7 @@ zthr_create(const char *zthr_name, zthr_checkfunc_t *checkfunc,
  */
 zthr_t *
 zthr_create_timer(const char *zthr_name, zthr_checkfunc_t *checkfunc,
-    zthr_func_t *func, void *arg, hrtime_t max_sleep)
+    zthr_func_t *func, void *arg, hrtime_t max_sleep, pri_t pri)
 {
 	zthr_t *t = kmem_zalloc(sizeof (*t), KM_SLEEP);
 	mutex_init(&t->zthr_state_lock, NULL, MUTEX_DEFAULT, NULL);
@@ -296,9 +299,10 @@ zthr_create_timer(const char *zthr_name, zthr_checkfunc_t *checkfunc,
 	t->zthr_arg = arg;
 	t->zthr_sleep_timeout = max_sleep;
 	t->zthr_name = zthr_name;
+	t->zthr_pri = pri;
 
 	t->zthr_thread = thread_create_named(zthr_name, NULL, 0,
-	    zthr_procedure, t, 0, &p0, TS_RUN, minclsyspri);
+	    zthr_procedure, t, 0, &p0, TS_RUN, pri);
 
 	mutex_exit(&t->zthr_state_lock);
 
@@ -423,7 +427,7 @@ zthr_resume(zthr_t *t)
 	 */
 	if (t->zthr_thread == NULL) {
 		t->zthr_thread = thread_create_named(t->zthr_name, NULL, 0,
-		    zthr_procedure, t, 0, &p0, TS_RUN, minclsyspri);
+		    zthr_procedure, t, 0, &p0, TS_RUN, t->zthr_pri);
 	}
 
 	mutex_exit(&t->zthr_state_lock);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running arc_evict thread at higher priority minimizes it getting
scheduled off CPU and can improve performance for workload with high
ARC evict activities.

On mixed read/write and sequential read workloads, I've seen between
10-20% better performance.

### Description
<!--- Describe your changes in detail -->
Extending zthr_create_timer() to take a new priority_t argument and
`arc_evict_zthr` is created with highest priority value, `maxclsyspri`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Manual tests with sequential reads and mixed read/writes with larger pool size.

ZFS performance test suite also show better though smaller gains for
sequential read and sequential writes, 8% and 3%, respectively.

Test setup:
- 8 vCPU
- 32 GB memory
- 4 x 100 SSD disks

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
