### PR TITLE
{zfs,spl}-module-parameters.5: fix nonexistent parameters

### DIFF
--- a/man/man5/spl-module-parameters.5
+++ b/man/man5/spl-module-parameters.5
@@ -17,33 +17,6 @@ Description of the different parameters to the SPL module.
 .sp
 .ne 2
 .na
-\fBspl_kmem_cache_expire\fR (uint)
-.ad
-.RS 12n
-Cache expiration is part of default Illumos cache behavior.  The idea is
-that objects in magazines which have not been recently accessed should be
-returned to the slabs periodically.  This is known as cache aging and
-when enabled objects will be typically returned after 15 seconds.
-.sp
-On the other hand Linux slabs are designed to never move objects back to
-the slabs unless there is memory pressure.  This is possible because under
-Linux the cache will be notified when memory is low and objects can be
-released.
-.sp
-By default only the Linux method is enabled.  It has been shown to improve
-responsiveness on low memory systems and not negatively impact the performance
-of systems with more memory.  This policy may be changed by setting the
-\fBspl_kmem_cache_expire\fR bit mask as follows, both policies may be enabled
-concurrently.
-.sp
-0x01 - Aging (Illumos), 0x02 - Low memory (Linux)
-.sp
-Default value: \fB0x02\fR
-.RE
-
-.sp
-.ne 2
-.na
 \fBspl_kmem_cache_kmem_threads\fR (uint)
 .ad
 .RS 12n
@@ -83,20 +56,6 @@ the footprint and improve cache reclaim time but individual allocations may
 take longer.
 .sp
 Default value: \fB8\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_obj_per_slab_min\fR (uint)
-.ad
-.RS 12n
-The minimum number of objects allowed per slab.  Normally slabs will contain
-\fBspl_kmem_cache_obj_per_slab\fR objects but for caches that contain very
-large objects it's desirable to only have a few, or even just one, object per
-slab.
-.sp
-Default value: \fB1\fR
 .RE
 
 .sp

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -2995,7 +2995,7 @@ Use \fB1\fR for yes and \fB0\fR for no (default).
 .sp
 .ne 2
 .na
-\fBzfs_read_chunk_size\fR (long)
+\fBzfs_vnops_read_chunk_size\fR (long)
 .ad
 .RS 12n
 Bytes to read per chunk
@@ -3994,19 +3994,6 @@ zios possessing a vdev. This is meant to be used by developers to gain
 diagnostic information for hang conditions which don't involve a mutex
 or other locking primitive; typically conditions in which a thread in
 the zio pipeline is looping indefinitely.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_decompress_fail_fraction\fR (int)
-.ad
-.RS 12n
-If non-zero, this value represents the denominator of the probability that zfs
-should induce a decompression failure. For instance, for a 5% decompression
-failure rate, this value should be set to 20.
 .sp
 Default value: \fB0\fR.
 .RE

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -527,9 +527,7 @@ spl_cache_flush(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flush)
  * Size a slab based on the size of each aligned object plus spl_kmem_obj_t.
  * When on-slab we want to target spl_kmem_cache_obj_per_slab.  However,
  * for very small objects we may end up with more than this so as not
- * to waste space in the minimal allocation of a single page.  Also for
- * very large objects we may use as few as spl_kmem_cache_obj_per_slab_min,
- * lower than this and we will fail.
+ * to waste space in the minimal allocation of a single page.
  */
 static int
 spl_slab_size(spl_kmem_cache_t *skc, uint32_t *objs, uint32_t *size)


### PR DESCRIPTION
### Motivation and Context
https://github.com/openzfs/zfs/pull/12125#issue-654114165, I hope for this to be pretty uncontroversial

### Description
Commit messages outline history for all of these

### How Has This Been Tested?
Looked at it, I guess? I made the selection through the very scientific process of getting all the names in the zfs-m-p page and contrasting that to a modinfo listing from zfs-2.0.3-6~bpo10+1, which yielded a list short enough for manual extraxion, like spl-m-p.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
