### PR TITLE
zstream: use -f flag when creating symlink

### DIFF
--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -17,4 +17,4 @@ zstream_LDADD = \
 include $(top_srcdir)/config/CppCheck.am
 
 install-exec-hook:
-	$(LN_S) zstream $(DESTDIR)$(sbindir)/zstreamdump
+	ln -sf zstream $(DESTDIR)$(sbindir)/zstreamdump


### PR DESCRIPTION
### Motivation and Context
I found that when running `make install` on a system that already have ZFS, it would fail:
```
gmake[4]: Entering directory '/usr/home/allan/zfs/cmd/zstream'
ln -s zstream /usr/local/sbin/zstreamdump
ln: /usr/local/sbin/zstreamdump: File exists
gmake[4]: *** [Makefile:1047: install-exec-hook] Error 1
```

The issue was introduced in dd00925e8de33ca490d29b7b30fc8d2a14ab4da3

### Description
Add the force flag to `ln` to ensure the symlink gets created if a file is in the way, or if the symlink already exists.

### How Has This Been Tested?
With the patch, running `make install` repeatedly doesn't error out

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
