### PR TITLE
Added another missed case to arc_summary3

### DIFF
--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -42,6 +42,7 @@ import os
 import subprocess
 import sys
 import time
+import errno
 
 # We can't use env -S portably, and we need python3 -u to handle pipes in
 # the shell abruptly closing the way we want to, so...
@@ -239,6 +240,11 @@ def handle_Exception(ex_cls, ex, tb):
         # It turns out that while sys.exit() triggers an exception
         # not handled message on Python 3.8+, os._exit() does not.
         os._exit(0)
+
+    if ex_cls is OSError:
+      if ex.errno == errno.ENOTCONN:
+        sys.exit()
+
     raise ex
 
 if hasattr(sys,'unraisablehook'): # Python 3.8+


### PR DESCRIPTION
### Motivation and Context
Noticed `arc_summary_001_pos` began sometimes failing on FBSD targets after #12037 went in.

### Description
It turns out that sometimes, evidently only when run inside the ZTS test runner (I tried to reproduce this with thousands of runs outside of it, using just pipes in the shell), `eval arc_summary3 | head > /dev/null` will die with ENOTCONN, and ruin the test run.

So I bolted a case for that onto the existing exception handler.

### How Has This Been Tested?
Ran `zfs-tests.sh -t tests/functional/cli_user/misc/arc_summary_001_pos` and `cmd/arc_summary/arc_summary3 | head > /dev/null` in a loop hundreds of times on FreeBSD 13-STABLE and Debian bullseye, both to make sure this was ameliorated and see if any other cases shook out.

(Before this change, it took me under 10 runs on FBSD to reproduce.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
