### PR TITLE
Restore FreeBSD sysctl processing for arc.min and arc.max

### DIFF
--- a/include/os/freebsd/spl/sys/mod_os.h
+++ b/include/os/freebsd/spl/sys/mod_os.h
@@ -62,6 +62,12 @@
 #define	param_set_arc_long_args(var) \
     CTLTYPE_ULONG, &var, 0, param_set_arc_long, "LU"
 
+#define	param_set_arc_min_args(var) \
+    CTLTYPE_ULONG, &var, 0, param_set_arc_min, "LU"
+
+#define	param_set_arc_max_args(var) \
+    CTLTYPE_ULONG, &var, 0, param_set_arc_max, "LU"
+
 #define	param_set_arc_int_args(var) \
     CTLTYPE_INT, &var, 0, param_set_arc_int, "I"
 

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -46,6 +46,13 @@ extern "C" {
  */
 #define	ARC_EVICT_ALL	UINT64_MAX
 
+/*
+ * ZFS gets very unhappy when the maximum ARC size is smaller than the maximum
+ * block size and a larger block is written.  To leave some safety margin, we
+ * limit the minimum for zfs_arc_max to the maximium transaction size.
+ */
+#define	MIN_ARC_MAX	DMU_MAX_ACCESS
+
 #define	HDR_SET_LSIZE(hdr, x) do { \
 	ASSERT(IS_P2ALIGNED(x, 1U << SPA_MINBLOCKSHIFT)); \
 	(hdr)->b_lsize = ((x) >> SPA_MINBLOCKSHIFT); \

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -1004,6 +1004,8 @@ extern void arc_unregister_hotplug(void);
 
 extern int param_set_arc_long(ZFS_MODULE_PARAM_ARGS);
 extern int param_set_arc_int(ZFS_MODULE_PARAM_ARGS);
+extern int param_set_arc_min(ZFS_MODULE_PARAM_ARGS);
+extern int param_set_arc_max(ZFS_MODULE_PARAM_ARGS);
 
 /* used in zdb.c */
 boolean_t l2arc_log_blkptr_valid(l2arc_dev_t *dev,

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -372,6 +372,18 @@ param_set_arc_long(const char *buf, zfs_kernel_param_t *kp)
 }
 
 int
+param_set_arc_min(const char *buf, zfs_kernel_param_t *kp)
+{
+	return (param_set_arc_long(buf, kp));
+}
+
+int
+param_set_arc_max(const char *buf, zfs_kernel_param_t *kp)
+{
+	return (param_set_arc_long(buf, kp));
+}
+
+int
 param_set_arc_int(const char *buf, zfs_kernel_param_t *kp)
 {
 	int error;


### PR DESCRIPTION
### Motivation and Context
Before OpenZFS 2.0, trying to set the FreeBSD sysctl vfs.zfs.arc_max
to a disallowed value would return an error.
Since the switch, it instead only generates WARN_IF_TUNING_IGNORED

Also lost, was the ability to set vfs.zfs.arc_max to a value less
than the default vfs.zfs.arc_min at boot time. Restore this as well.

### Description

### How Has This Been Tested?
#### BEFORE:
loader.conf:
```
vfs.zfs.arc.max=402653184
```

After boot, the values on the running system (notice c_max is higher than requested by the user):
```
vfs.zfs.arc.max: 402653184
vfs.zfs.arc.min: 0
kstat.zfs.misc.arcstats.c_max: 33122279424
kstat.zfs.misc.arcstats.c_min: 1068625664
```

Attempting to set the arc.max to less than arc.min:
`# sysctl vfs.zfs.arc.max=402653184`
```
vfs.zfs.arc.max: 402653184 -> 402653184
[on the console only] kernel: Solaris: WARNING: ignoring tunable zfs_arc_max (using 33122279424 instead)
```
Resulting values (again, notice that the users request was ignored, and outside of inspecting dmesg, they have no way of knowing):
```
vfs.zfs.arc.max: 402653184
kstat.zfs.misc.arcstats.c_max: 33122279424
```

#### AFTER:
loader.conf:
```
vfs.zfs.arc.max=402653184
```

After boot, the values on the running system:
```
vfs.zfs.arc.max: 402653184
vfs.zfs.arc.min: 0
kstat.zfs.misc.arcstats.c_max: 402653184
kstat.zfs.misc.arcstats.c_min: 201326592
```

Attempting to set the arc.max to less or equal to arc.min:
`# sysctl vfs.zfs.arc.max=201326592`
```
vfs.zfs.arc.max: 402653184
sysctl: vfs.zfs.arc.max=201326592: Invalid argument
```
Resulting values:
```
vfs.zfs.arc.max: 402653184
kstat.zfs.misc.arcstats.c_max: 402653184
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
