### PR TITLE
vdev_autotrim_thread() should not force txg to be quiesced

### DIFF
--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -704,8 +704,9 @@ txg_wait_synced_impl(dsl_pool_t *dp, uint64_t txg, boolean_t wait_sig)
 		txg = tx->tx_open_txg + TXG_DEFER_SIZE;
 	if (tx->tx_sync_txg_waiting < txg)
 		tx->tx_sync_txg_waiting = txg;
-	dprintf("txg=%llu quiesce_txg=%llu sync_txg=%llu\n",
-	    txg, tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
+	dprintf("txg=%llu wait_sig=%s quiesce_txg=%llu sync_txg=%llu\n",
+	    txg, wait_sig ? "true" : "false",
+	    tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
 	while (tx->tx_synced_txg < txg) {
 		dprintf("broadcasting sync more "
 		    "tx_synced=%llu waiting=%llu dp=%px\n",
@@ -763,8 +764,9 @@ txg_wait_open(dsl_pool_t *dp, uint64_t txg, boolean_t should_quiesce)
 		txg = tx->tx_open_txg + 1;
 	if (tx->tx_quiesce_txg_waiting < txg && should_quiesce)
 		tx->tx_quiesce_txg_waiting = txg;
-	dprintf("txg=%llu quiesce_txg=%llu sync_txg=%llu\n",
-	    txg, tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
+	dprintf("txg=%llu should_quiesce=%s quiesce_txg=%llu sync_txg=%llu\n",
+	    txg, should_quiesce ? "true" : "false",
+	    tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
 	while (tx->tx_open_txg < txg) {
 		cv_broadcast(&tx->tx_quiesce_more_cv);
 		/*

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -1398,7 +1398,7 @@ vdev_autotrim_thread(void *arg)
 		 * zfs_trim_txg_batch txgs will occur before these metaslabs
 		 * are trimmed again.
 		 */
-		txg_wait_open(spa_get_dsl(spa), 0, issued_trim);
+		txg_wait_open(spa_get_dsl(spa), 0, B_FALSE);
 
 		shift++;
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
vdev_autotrim_thread() should not force to quiesce txg on txg_wait_open() call.

vdev_autotrim_thread() should spread out trim activity among normal txgs. If allow txg_wait_open() to quiesce txg immediately, which artificially inflates the number of txg, it defeats the purpose of "spread out trim activity". It also has negative effect on performance.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It prevents push a short-lived txg into quiescing stage. See test below.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Run fio with autotrim=on.
Before patch. You can see some short-lived txgs from time to time.
```shell
before patch
txg      birth            state ndirty       nread        nwritten     reads    writes   otime        qtime        wtime        stime
92134    73694635059462   C     250232832    0            249159680    0        787      4883598881   1579         26849        3758663047
92135    73699518658343   C     250626048    0            249552896    0        626      3758713008   1151         18343        3639043521
92136    73703277371351   C     245776384    0            244678656    0        681      3639079265   954          21673        3706403783
92137    73706916450616   C     249839616    8192         248791040    1        771      3706448584   1198         8125         3709219699
92138    73710622899200   C     249446400    0            248373248    0        624      3709253137   1235         21320        3727374806
92139    73714332152337   C     248004608    8192         246956032    1        676      3727413342   1023         12700        3627613484
92140    73718059565679   C     245907456    8192         245080064    1        754      3627649332   960          27284        3730101935
92141    73721687215011   C     251936768    16384        250961920    2        619      3730154425   1277         27167        3754965112
92142    73725417369436   C     247480320    0            246480896    0        684      3755011293   1287         11933        3609815629
92143    73729172380729   C     0            0            0            0        0        37526        1508         3609799774   276573
92144    73729172418255   C     245645312    0            244621312    0        629      3610086900   1090         11165        3647127753
92145    73732782505155   C     247480320    8192         246456320    1        511      3647159401   1066         12912        4618439259
92146    73736429664556   C     248922112    16384        247947264    1        584      4618465342   1447         8008         3669619393
92147    73741048129898   C     248659968    0            247611392    0        637      3669652856   1059         7118         4653668328
92148    73744717782754   C     244727808    0            243703808    0        599      4653699138   1270         18390        3629905658
92149    73749371481892   C     0            0            0            0        0        20772        751          3629915310   264492
92150    73749371502664   C     247480320    8192         246456320    1        659      3630189840   879          12212        4635145059
92151    73753001692504   C     246169600    8192         245121024    1        590      4635199295   995          24517        3747566866
92152    73757636891799   C     251281408    8192         250208256    1        615      3747607895   878          6667         3712266457
92153    73761384499694   C     249970688    8192         249118720    1        599      3712967799   1254         119235       3712932736
92154    73765097467493   C     251150336    0            250126336    0        616      3713560242   1655         80210        5203166993
92155    73768811027735   C     247873536    0            246800384    0        558      5203266201   1071         13665        4050393268
92156    73774014293936   C     247611392    0            246611968    0        607      4050423989   1300         18760        4687159079
92157    73778064717925   C     251019264    8192         249995264    1        590      4687199027   1354         31406        3751782189
92158    73782751916952   C     247218176    0            246169600    0        577      3751835263   1347         42675        4764230073
92159    73786503752215   C     246956032    8192         245907456    1        728      4764306023   1362         20641        3673905175
92160    73791268058238   C     246169600    0            245145600    0        656      3673950437   22788        20653        3654320448
92161    73794942008675   C     248004608    0            246980608    0        625      3654378245   1068         21995        4665942179
92162    73798596386920   C     0            0            0            0        0        24654        1236         4665956533   322819
92163    73798596411574   C     245776384    0            244752384    0        614      4666292493   1136         19474        3685443091
92164    73803262704067   C     247873536    0            246824960    0        597      3685477836   945          17277        3615710560
92165    73806948181903   C     245514240    0            244465664    0        640      3615743710   960          12798        4382622680
92166    73810563925613   C     248135680    0            247062528    0        573      4382651120   1035         10208        4658951036
92167    73814946576733   C     247480320    8192         246456320    1        589      4658985143   1272         12780        3772779637
92168    73819605561876   C     249708544    0            248668160    0        567      3772823570   45253        47165        4423907698
92169    73823378385446   C     246431744    0            245407744    0        645      4424043529   1054         12009        4380720124
92170    73827802428975   C     248135680    8192         247087104    1        635      4380766832   885          22385        4466037248
92171    73832183195807   C     247611392    16384        246636544    1        578      4466077279   1131         48186        5131832827
92172    73836649273086   C     249315328    8192         248266752    1        524      5131900761   1896         17986        4405673165
92173    73841781173847   C     247480320    8192         246505472    1        656      4405707377   1145         14287        4065964141
92174    73846186881224   C     247349248    0            246349824    0        698      4065992254   908          5106         3643702653
92175    73850252873478   C     245907456    0            244908032    0        603      3643726614   1343         11786        3650563761
92176    73853896600092   C     245907456    8192         244932608    1        625      3650589401   965          5171         3727668403
92177    73857547189493   C     249184256    0            248209408    0        576      3727693623   1333         21041        3649759586
92178    73861274883116   C     247611392    8192         246611968    1        570      3649794088   1197         5248         4434121841
92179    73864924677204   C     0            0            0            0        0        288691       605          4433855170   344103
92180    73864924965895   C     247611392    0            246636544    0        615      4434211554   1163         26112        4636287363
92181    73869359177449   C     249184256    8192         248258560    1        552      4636329702   963          21976        3991864777
92182    73873995507151   C     258097152    8192         257048576    1        649      3991898750   890          17978        4487721168
92183    73877987405901   C     248397824    8192         247373824    1        572      4487758701   1075         25627        4370958292
92184    73882475164602   C     248004608    0            246980608    0        654      4370997939   968          7354         4422642292
92185    73886846162541   C     246562816    0            245489664    0        642      4422665900   852          13752        4451753016
92186    73891268828441   C     248266752    0            247267328    0        566      4451810344   1001         23552        5262097104
92187    73895720638785   C     262422528    0            261423104    0        670      5262139961   1076         18180        4132835352
92188    73900982778746   C     248004608    8192         246956032    1        685      4132898676   988          17173        4661857351
92189    73905115677422   C     249446400    0            248446976    0        607      4661890709   901          27034        3743872407
92190    73909777568131   C     244596736    0            243597312    0        599      3743916133   897          25698        3626002005
92191    73913521484264   C     244596736    0            243548160    0        609      3626068779   1098         16819        3629157048
92192    73917147553043   C     245514240    8192         244539392    1        611      3629191799   1320         12376        3656728754
92193    73920776744842   C     244596736    8192         243646464    1        588      3656761421   1302         18569        3656742042
92194    73924433506263   C     248397824    0            247422976    0        572      3656778641   1421         14366        4397250803
92195    73928090284904   C     248266752    0            247275520    0        609      4397280618   1246         14017        4913705771
92196    73932487565522   C     249970688    0            248971264    0        612      4914137963   1396         60810        3655498430
92197    73937401703485   C     247218176    0            246415360    0        615      3655586786   1298         12065        4450631463
92198    73941057290271   C     247480320    0            246677504    0        571      4450665197   1224         15258        4415224007
92199    73945507955468   C     246824960    0            245891072    0        561      4415261980   1128         17692        4527441364
92200    73949923217448   C     247480320    0            246480896    0        571      4527476650   1128         19960        5141625255
92201    73954450694098   C     248791040    8192         247816192    1        597      5141667674   1002         10882        4780972579
92202    73959592361772   C     259538944    8192         258564096    1        746      4781003129   1497         12388        4134677555
92203    73964373364901   C     254427136    0            253427712    0        528      4134706674   1143         15141        3772549937
92204    73968508071575   C     0            0            0            0        0        23324        1071         3772560191   383571
92205    73968508094899   C     4472832      8192         4382720      1        55       3772957377   1117         33138        159378015
92206    73972281052276   C     0            0            0            0        0        159425322    1097         11105        93148
92207    73972440477598   C     0            0            0            0        0        116660       915          15755        139111
...
```

After patch
```shell
txg      birth            state ndirty       nread        nwritten     reads    writes   otime        qtime        wtime        stime
92405    74130098661274   C     0            81920        1228800      10       50       628231       1403         12657        147485139
92406    74130099289505   C     0            0            0            0        0        154017425    2029         29614        120247
92407    74130253306930   C     0            0            1130496      0        48       14068134     1706         54255        79727321
92408    74130267375064   C     0            0            0            0        0        94955535     1583         45057        82973
92409    74130362330599   C     0            0            647168       0        40       5103128059   4551         198985       82689587
92410    74135465458658   C     54149120     344064       53354496     7        222      2832235905   107878       24904        732909021
92411    74138297694563   C     244596736    0            243548160    0        559      733059331    1039         14021        4671808736
92412    74139030753894   C     252329984    0            251281408    0        625      4671839894   1539         14666        4438083158
92413    74143702593788   C     249184256    0            248135680    0        645      4438120751   1004         14013        3962469521
92414    74148140714539   C     244596736    0            243572736    0        614      3962495218   977          20152        4116347795
92415    74152103209757   C     250101760    8192         249077760    1        806      4116390988   1088         25042        4208905425
92416    74156219600745   C     246693888    0            245694464    0        595      4208954824   1243         25305        3703518331
92417    74160428555569   C     249315328    0            248315904    0        645      3703565474   1129         18660        3664458408
92418    74164132121043   C     248135680    8192         247111680    1        597      3664488795   1092         19831        3660814624
92419    74167796609838   C     246169600    8192         245170176    1        656      3660852003   1703         15105        4609181964
92420    74171457461841   C     258883584    0            257859584    0        530      4609215234   1175         21621        4470556953
92421    74176066677075   C     248004608    8192         246980608    1        613      4470595978   935          14520        3979900133
92422    74180537273053   C     244989952    0            243916800    0        578      3979943059   1718         26010        3622503831
92423    74184517216112   C     246693888    0            245669888    0        640      3622543453   1051         40737        4654559623
92424    74188139759565   C     249315328    16384        248365056    2        673      4654637968   132576       28883        4003560567
92425    74192794397533   C     256786432    0            255795200    0        687      4003738277   1159         13813        3794146036
92426    74196798135810   C     248397824    0            247422976    0        626      3794181100   1152         14586        3630420146
92427    74200592316910   C     245776384    8192         244752384    1        591      3630460765   1281         18370        3653193130
92428    74204222777675   C     248004608    0            246980608    0        645      3653223850   991          17700        4747392730
92429    74207876001525   C     255213568    24576        254263296    2        747      4747423065   1222         31332        3760476910
92430    74212623424590   C     249184256    0            248160256    0        621      3760533723   1591         25025        4736805907
92431    74216383958313   C     245776384    16384        244801536    1        688      4736848246   1073         14958        3862058483
92432    74221120806559   C     254427136    8192         253378560    1        665      3862131498   1114         33854        3726882872
92433    74224982938057   C     246956032    0            245932032    0        571      3726932702   1681         20545        3645113536
92434    74228709870759   C     247742464    0            246767616    0        722      3645146478   1088         13974        4796885476
92435    74232355017237   C     247611392    16384        246661120    2        627      4796910291   1092         9750         3698527869
92436    74237151927528   C     248135680    8192         247185408    1        500      3698568002   1503         28072        3664429210
92437    74240850495530   C     248659968    8192         247709696    1        645      3664475539   1232         32199        4611542338
92438    74244514971069   C     257703936    0            256704512    0        799      4618747625   1870         1379250      4121731857
92439    74249133718694   C     246562816    8192         245538816    1        633      4123126569   1083         18420        3669586301
92440    74253256845263   C     247873536    0            246849536    0        667      3669630311   1147         47222        4762003667
92441    74256926475574   C     248922112    0            247898112    0        684      4762065280   1369         19370        3649845025
92442    74261688540854   C     247742464    8192         246743040    1        671      3650370289   1986         30670        3667457488
92443    74265338911143   C     247873536    0            246849536    0        568      3667537663   1543         38837        3665533584
92444    74269006448806   C     246431744    0            245432320    0        603      3665596420   1477         18476        3725454749
92445    74272672045226   C     248791040    8192         247848960    1        584      3725490262   43683        11214        3654613092
92446    74276397535488   C     247611392    8192         246611968    1        666      3654693696   1403         17023        4706642339
92447    74280052229184   C     251281408    0            250232832    0        685      4706688848   1685         93012        3770371602
92448    74284758918032   C     250232832    16384        249233408    2        595      3770492368   1477         33401        3692141645
92449    74288529410400   C     248922112    8192         247848960    1        645      3692194503   992          24973        3652980697
92450    74292221604903   C     246300672    0            245227520    0        613      3653030115   1296         86922        3643561189
92451    74295874635018   C     245907456    0            244883456    0        626      3643677861   1200         13692        3716196807
92452    74299518312879   C     248922112    0            247898112    0        647      3716224949   1410         18119        3629003154
92453    74303234537828   C     245645312    8192         244670464    1        655      3629036871   1235         22495        3676111879
92454    74306863574699   C     247873536    8192         246874112    1        678      3676160936   1229         19066        3991244713
92455    74310539735635   C     259932160    8192         258908160    1        532      3991285580   1320         43670        4567820333
92456    74314531021215   C     247742464    8192         246767616    1        684      4567887723   1302         24227        5017855839
92457    74319098908938   C     258883584    8192         257835008    1        687      5017900486   1484         15045        3807306882
92458    74324116809424   C     246562816    8192         245563392    1        626      3807343888   1617         13552        3840021905
92459    74327924153312   C     256262144    0            255188992    0        382      3840055335   1504         20248        3748130941
92460    74331764208647   C     246562816    8192         245538816    1        755      3748262164   1708         41739        3660656409
92461    74335512470811   C     247873536    8192         246849536    1        568      3660713013   954          12832        4548503782
92462    74339173183824   C     251674624    8192         250626048    1        764      4548534339   123521       33654        3988088334
92463    74343721718163   C     245776384    0            244727808    0        639      3988283269   1152         15872        3657235645
92464    74347710001432   C     246300672    0            245252096    0        620      3657295368   52643        21346        4559404569
92465    74351367296800   C     247611392    8192         246611968    1        646      4559503934   1148         43314        3835482441
92466    74355926800734   C     253771776    0            252796928    0        431      3835552649   1937         30769        3719732059
92467    74359762353383   C     247611392    0            246611968    0        705      3719810305   72952        20140        3659703530
92468    74363482163688   C     245514240    0            244490240    0        666      3659814745   1677         16799        3672369541
92469    74367141978433   C     246956032    8192         246013952    1        572      3672416386   1331         44439        3640623688
92470    74370814394819   C     247611392    0            246562816    0        610      3640683861   1182         23494        4438552633
92471    74374455078680   C     249577472    8192         248553472    1        588      4438602588   1376         16214        5321208561
92472    74378893681268   C     256000000    16384        255025152    2        624      5321267495   1256         21677        4981813400
92473    74384214948763   C     263602176    8192         262602752    1        665      4981853486   1842         43660        4615395769
92474    74389196802249   C     248922112    0            247898112    0        570      4615462658   1165         28581        4391070918
92475    74393812264907   C     247480320    0            246407168    0        579      4391116583   1107         16668        4896891305
92476    74398203381490   C     249839616    0            248897536    0        661      4896948593   1048         30349        3647876080
92477    74403100330083   C     247611392    0            246669312    0        598      3647924943   1196         13858        3676706471
92478    74406748255026   C     244858880    0            243949568    0        616      3676751183   1260         33386        3689168174
92479    74410425006209   C     248135680    0            247087104    0        609      3689220631   1188         12127        3632944536
92480    74414114226840   C     247087104    0            246013952    0        572      3632987815   1460         13699        4389627719
92481    74417747214655   C     246693888    0            245645312    0        467      4389670605   1583         20458        4036606474
92482    74422136885260   C     243941376    0            242892800    0        586      4036650744   1219         39649        3609039242
92483    74426173536004   C     245907456    0            244834304    0        595      3609103285   1038         13309        3648302296
92484    74429782639289   C     245514240    8192         244514816    1        562      3648344012   1003         23587        4395440759
92485    74433430983301   C     249184256    8192         248184832    1        459      4395479364   1027         15816        4933602809
92486    74437826462665   C     27934720     16384        27516928     2        91       4933633525   1106         14978        447486371
92487    74442760096190   C     0            0            0            0        0        447525347    1621         34440        465778
92488    74443207621537   C     0            0            0            0        0        5090380588   4520         223235       852041
92489    74448298002125   C     0            0            0            0        0        1139656      4075         57680        279756
92490    74448299141781   C     0            0            0            0        0        411321       3654         91291        222915
92491    74448299553102   C     0            0            0            0        0        478055       3950         178585       202601
92492    74448300031157   C     0            0            0            0        0        12065246     3934         184386       29358989
92493    74448312096403   C     0            0            0            0        0        29712115     3500         135520       208435
92494    74448341808518   C     0            0            0            0        0        462150       4775         178295       205115
92495    74448342270668   O     0            0            0            0        0        0            0            0            0
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
