### PR TITLE
Quick fixes for two ZTS failures

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
@@ -50,6 +50,7 @@ listing=$(ls -i $init_data)
 set -A array $listing
 obj=${array[0]}
 log_note "file $init_data has object number $obj"
+sync_pool $TESTPOOL
 
 output=$(zdb -ddddddbbbbbb $TESTPOOL/$TESTFS $obj 2> /dev/null \
     |grep -m 1 "L0 DVA" |head -n1)

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
@@ -57,6 +57,7 @@ listing=$(ls -i $init_data)
 set -A array $listing
 obj=${array[0]}
 log_note "file $init_data has object number $obj"
+sync_pool $TESTPOOL
 
 output=$(zdb -d $TESTPOOL/$TESTFS)
 objset_id=$(echo $output | awk '{split($0,array,",")} END{print array[2]}' |


### PR DESCRIPTION
### Motivation and Context
On FreeBSD 14, these two tests started erroring out every time.

### Description
When you look at the bot log (in one case; the other test requires patching to not write stderr to /dev/null), the reason the tests are erroring is that zdb is spitting out `zdb: dmu_object_info() failed, errno 2` (2 is ENOENT), which is what I expect to happen if you try to use zdb on an object too fast after it's created, I hypothesized because they're not flushed out yet.

So I threw in a `zpool sync` before the first zdb use in each test.

Of course, that leaves the open question of what's changed? The same tests on the same git rev pass on 13-STABLE (examining all the failures of the last 20 on FreeBSD stable/13 amd64 (TEST), none of them report either of these tests)...

### How Has This Been Tested?
The tests failed every time I tried before these changes and passed every time I've tried after.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
