### PR TITLE
Modernise and lint remaining manpages

### DIFF
--- a/man/man5/spl-module-parameters.5
+++ b/man/man5/spl-module-parameters.5
@@ -1,285 +1,196 @@
-'\" te
+.\"
+.\" The contents of this file are subject to the terms of the Common Development
+.\" and Distribution License (the "License").  You may not use this file except
+.\" in compliance with the License. You can obtain a copy of the license at
+.\" usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
+.\"
+.\" See the License for the specific language governing permissions and
+.\" limitations under the License. When distributing Covered Code, include this
+.\" CDDL HEADER in each file and include the License file at
+.\" usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this
+.\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
+.\" own identifying information:
+.\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
 .\" Copyright 2013 Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
 .\"
-.TH SPL-MODULE-PARAMETERS 5 "Aug 24, 2020" OpenZFS
-.SH NAME
-spl\-module\-parameters \- SPL module parameters
-.SH DESCRIPTION
-.sp
-.LP
-Description of the different parameters to the SPL module.
-
-.SS "Module parameters"
-.sp
-.LP
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_kmem_threads\fR (uint)
-.ad
-.RS 12n
-The number of threads created for the spl_kmem_cache task queue.  This task
-queue is responsible for allocating new slabs for use by the kmem caches.
+.Dd August 24, 2020
+.Dt SPL-MODULE-PARAMETERS 5
+.Os
+.
+.Sh NAME
+.Nm spl-module-parameters
+.Nd parameters of the SPL kernel module
+.
+.Sh DESCRIPTION
+.Bl -tag -width Ds
+.It Sy spl_kmem_cache_kmem_threads Ns = Ns Sy 4 Pq uint
+The number of threads created for the spl_kmem_cache task queue.
+This task queue is responsible for allocating new slabs
+for use by the kmem caches.
 For the majority of systems and workloads only a small number of threads are
 required.
-.sp
-Default value: \fB4\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_reclaim\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy spl_kmem_cache_reclaim Ns = Ns Sy 0 Pq uint
 When this is set it prevents Linux from being able to rapidly reclaim all the
-memory held by the kmem caches.  This may be useful in circumstances where
-it's preferable that Linux reclaim memory from some other subsystem first.
+memory held by the kmem caches.
+This may be useful in circumstances where it's preferable that Linux
+reclaim memory from some other subsystem first.
 Setting this will increase the likelihood out of memory events on a memory
 constrained system.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_obj_per_slab\fR (uint)
-.ad
-.RS 12n
-The preferred number of objects per slab in the cache.   In general, a larger
-value will increase the caches memory footprint while decreasing the time
-required to perform an allocation.  Conversely, a smaller value will minimize
-the footprint and improve cache reclaim time but individual allocations may
-take longer.
-.sp
-Default value: \fB8\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_max_size\fR (uint)
-.ad
-.RS 12n
-The maximum size of a kmem cache slab in MiB.  This effectively limits
-the maximum cache object size to \fBspl_kmem_cache_max_size\fR /
-\fBspl_kmem_cache_obj_per_slab\fR.  Caches may not be created with
+.
+.It Sy spl_kmem_cache_obj_per_slab Ns = Ns Sy 8 Pq uint
+The preferred number of objects per slab in the cache.
+In general, a larger value will increase the caches memory footprint
+while decreasing the time required to perform an allocation.
+Conversely, a smaller value will minimize the footprint
+and improve cache reclaim time but individual allocations may take longer.
+.
+.It Sy spl_kmem_cache_max_size Ns = Ns Sy 32 Po 64-bit Pc or Sy 4 Po 32-bit Pc Pq uint
+The maximum size of a kmem cache slab in MiB.
+This effectively limits the maximum cache object size to
+.Sy spl_kmem_cache_max_size Ns / Ns Sy spl_kmem_cache_obj_per_slab .
+.Pp
+Caches may not be created with
 object sized larger than this limit.
-.sp
-Default value: \fB32 (64-bit) or 4 (32-bit)\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_slab_limit\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy spl_kmem_cache_slab_limit Ns = Ns Sy 16384 Pq uint
 For small objects the Linux slab allocator should be used to make the most
-efficient use of the memory.  However, large objects are not supported by
-the Linux slab and therefore the SPL implementation is preferred.  This
-value is used to determine the cutoff between a small and large object.
-.sp
-Objects of \fBspl_kmem_cache_slab_limit\fR or smaller will be allocated
-using the Linux slab allocator, large objects use the SPL allocator.  A
-cutoff of 16K was determined to be optimal for architectures using 4K pages.
-.sp
-Default value: \fB16,384\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_alloc_warn\fR (uint)
-.ad
-.RS 12n
-As a general rule kmem_alloc() allocations should be small, preferably
-just a few pages since they must by physically contiguous.  Therefore, a
-rate limited warning will be printed to the console for any kmem_alloc()
+efficient use of the memory.
+However, large objects are not supported by
+the Linux slab and therefore the SPL implementation is preferred.
+This value is used to determine the cutoff between a small and large object.
+.Pp
+Objects of size
+.Sy spl_kmem_cache_slab_limit
+or smaller will be allocated using the Linux slab allocator,
+large objects use the SPL allocator.
+A cutoff of 16K was determined to be optimal for architectures using 4K pages.
+.
+.It Sy spl_kmem_alloc_warn Ns = Ns Sy 32768 Pq uint
+As a general rule
+.Fn kmem_alloc
+allocations should be small,
+preferably just a few pages, since they must by physically contiguous.
+Therefore, a rate limited warning will be printed to the console for any
+.Fn kmem_alloc
 which exceeds a reasonable threshold.
-.sp
+.Pp
 The default warning threshold is set to eight pages but capped at 32K to
-accommodate systems using large pages.  This value was selected to be small
-enough to ensure the largest allocations are quickly noticed and fixed.
+accommodate systems using large pages.
+This value was selected to be small enough to ensure
+the largest allocations are quickly noticed and fixed.
 But large enough to avoid logging any warnings when a allocation size is
-larger than optimal but not a serious concern.  Since this value is tunable,
-developers are encouraged to set it lower when testing so any new largish
-allocations are quickly caught.  These warnings may be disabled by setting
-the threshold to zero.
-.sp
-Default value: \fB32,768\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_alloc_max\fR (uint)
-.ad
-.RS 12n
-Large kmem_alloc() allocations will fail if they exceed KMALLOC_MAX_SIZE.
+larger than optimal but not a serious concern.
+Since this value is tunable, developers are encouraged to set it lower
+when testing so any new largish allocations are quickly caught.
+These warnings may be disabled by setting the threshold to zero.
+.
+.It Sy spl_kmem_alloc_max Ns = Ns Sy KMALLOC_MAX_SIZE Ns / Ns Sy 4 Pq uint
+Large
+.Fn kmem_alloc
+allocations will fail if they exceed
+.Sy KMALLOC_MAX_SIZE .
 Allocations which are marginally smaller than this limit may succeed but
 should still be avoided due to the expense of locating a contiguous range
-of free pages.  Therefore, a maximum kmem size with reasonable safely
-margin of 4x is set.  Kmem_alloc() allocations larger than this maximum
-will quickly fail.  Vmem_alloc() allocations less than or equal to this
-value will use kmalloc(), but shift to vmalloc() when exceeding this value.
-.sp
-Default value: \fBKMALLOC_MAX_SIZE/4\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_kmem_cache_magazine_size\fR (uint)
-.ad
-.RS 12n
+of free pages.
+Therefore, a maximum kmem size with reasonable safely margin of 4x is set.
+.Fn kmem_alloc
+allocations larger than this maximum will quickly fail.
+.Fn vmem_alloc
+allocations less than or equal to this value will use
+.Fn kmalloc ,
+but shift to
+.Fn vmalloc
+when exceeding this value.
+.
+.It Sy spl_kmem_cache_magazine_size Ns = Ns Sy 0 Pq uint
 Cache magazines are an optimization designed to minimize the cost of
-allocating memory.  They do this by keeping a per-cpu cache of recently
-freed objects, which can then be reallocated without taking a lock. This
-can improve performance on highly contended caches.  However, because
-objects in magazines will prevent otherwise empty slabs from being
-immediately released this may not be ideal for low memory machines.
-.sp
-For this reason \fBspl_kmem_cache_magazine_size\fR can be used to set a
-maximum magazine size.  When this value is set to 0 the magazine size will
-be automatically determined based on the object size.  Otherwise magazines
-will be limited to 2-256 objects per magazine (i.e per cpu).  Magazines
-may never be entirely disabled in this implementation.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_hostid\fR (ulong)
-.ad
-.RS 12n
+allocating memory.
+They do this by keeping a per-cpu cache of recently
+freed objects, which can then be reallocated without taking a lock.
+This can improve performance on highly contended caches.
+However, because objects in magazines will prevent otherwise empty slabs
+from being immediately released this may not be ideal for low memory machines.
+.Pp
+For this reason,
+.Sy spl_kmem_cache_magazine_size
+can be used to set a maximum magazine size.
+When this value is set to 0 the magazine size will
+be automatically determined based on the object size.
+Otherwise magazines will be limited to 2-256 objects per magazine (i.e per cpu).
+Magazines may never be entirely disabled in this implementation.
+.
+.It Sy spl_hostid Ns = Ns Sy 0 Pq ulong
 The system hostid, when set this can be used to uniquely identify a system.
 By default this value is set to zero which indicates the hostid is disabled.
 It can be explicitly enabled by placing a unique non-zero value in
-\fB/etc/hostid/\fR.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_hostid_path\fR (charp)
-.ad
-.RS 12n
-The expected path to locate the system hostid when specified.  This value
-may be overridden for non-standard configurations.
-.sp
-Default value: \fB/etc/hostid\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_panic_halt\fR (uint)
-.ad
-.RS 12n
-Cause a kernel panic on assertion failures. When not enabled, the thread is
-halted to facilitate further debugging.
-.sp
+.Pa /etc/hostid .
+.
+.It Sy spl_hostid_path Ns = Ns Pa /etc/hostid Pq charp
+The expected path to locate the system hostid when specified.
+This value may be overridden for non-standard configurations.
+.
+.It Sy spl_panic_halt Ns = Ns Sy 0 Pq uint
+Cause a kernel panic on assertion failures.
+When not enabled, the thread is halted to facilitate further debugging.
+.Pp
 Set to a non-zero value to enable.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_taskq_kick\fR (uint)
-.ad
-.RS 12n
-Kick stuck taskq to spawn threads. When writing a non-zero value to it, it will
-scan all the taskqs. If any of them have a pending task more than 5 seconds old,
-it will kick it to spawn more threads. This can be used if you find a rare
+.
+.It Sy spl_taskq_kick Ns = Ns Sy 0 Pq uint
+Kick stuck taskq to spawn threads.
+When writing a non-zero value to it, it will scan all the taskqs.
+If any of them have a pending task more than 5 seconds old,
+it will kick it to spawn more threads.
+This can be used if you find a rare
 deadlock occurs because one or more taskqs didn't spawn a thread when it should.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_taskq_thread_bind\fR (int)
-.ad
-.RS 12n
-Bind taskq threads to specific CPUs.  When enabled all taskq threads will
-be distributed evenly  over the available CPUs.  By default, this behavior
-is disabled to allow the Linux scheduler the maximum flexibility to determine
-where a thread should run.
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_taskq_thread_dynamic\fR (int)
-.ad
-.RS 12n
-Allow dynamic taskqs.  When enabled taskqs which set the TASKQ_DYNAMIC flag
-will by default create only a single thread.  New threads will be created on
-demand up to a maximum allowed number to facilitate the completion of
-outstanding tasks.  Threads which are no longer needed will be promptly
-destroyed.  By default this behavior is enabled but it can be disabled to
+.
+.It Sy spl_taskq_thread_bind Ns = Ns Sy 0 Pq int
+Bind taskq threads to specific CPUs.
+When enabled all taskq threads will be distributed evenly
+across the available CPUs.
+By default, this behavior is disabled to allow the Linux scheduler
+the maximum flexibility to determine where a thread should run.
+.
+.It Sy spl_taskq_thread_dynamic Ns = Ns Sy 1 Pq int
+Allow dynamic taskqs.
+When enabled taskqs which set the
+.Sy TASKQ_DYNAMIC
+flag will by default create only a single thread.
+New threads will be created on demand up to a maximum allowed number
+to facilitate the completion of outstanding tasks.
+Threads which are no longer needed will be promptly destroyed.
+By default this behavior is enabled but it can be disabled to
 aid performance analysis or troubleshooting.
-.sp
-Default value: \fB1\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_taskq_thread_priority\fR (int)
-.ad
-.RS 12n
+.
+.It Sy spl_taskq_thread_priority Ns = Ns Sy 1 Pq int
 Allow newly created taskq threads to set a non-default scheduler priority.
-When enabled the priority specified when a taskq is created will be applied
-to all threads created by that taskq.  When disabled all threads will use
-the default Linux kernel thread priority.  By default, this behavior is
-enabled.
-.sp
-Default value: \fB1\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_taskq_thread_sequential\fR (int)
-.ad
-.RS 12n
+When enabled, the priority specified when a taskq is created will be applied
+to all threads created by that taskq.
+When disabled all threads will use the default Linux kernel thread priority.
+By default, this behavior is enabled.
+.
+.It Sy spl_taskq_thread_sequential Ns = Ns Sy 4 Pq int
 The number of items a taskq worker thread must handle without interruption
-before requesting a new worker thread be spawned.  This is used to control
+before requesting a new worker thread be spawned.
+This is used to control
 how quickly taskqs ramp up the number of threads processing the queue.
 Because Linux thread creation and destruction are relatively inexpensive a
-small default value has been selected.  This means that normally threads will
-be created aggressively which is desirable.  Increasing this value will
+small default value has been selected.
+This means that normally threads will be created aggressively which is desirable.
+Increasing this value will
 result in a slower thread creation rate which may be preferable for some
 configurations.
-.sp
-Default value: \fB4\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBspl_max_show_tasks\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy spl_max_show_tasks Ns = Ns Sy 512 Pq uint
 The maximum number of tasks per pending list in each taskq shown in
-/proc/spl/{taskq,taskq-all}. Write 0 to turn off the limit. The proc file will
-walk the lists with lock held, reading it could cause a lock up if the list
-grow too large without limiting the output. "(truncated)" will be shown if the
-list is larger than the limit.
-.sp
-Default value: \fB512\fR
-.RE
+.Pa /proc/spl/taskq{,-all} .
+Write
+.Sy 0
+to turn off the limit.
+The proc file will walk the lists with lock held,
+reading it could cause a lock-up if the list grow too large
+without limiting the output.
+"(truncated)" will be shown if the list is larger than the limit.
+.
+.El

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1,4 +1,4 @@
-'\" te
+.\"
 .\" Copyright (c) 2013 by Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
 .\" Copyright (c) 2019, 2021 by Delphix. All rights reserved.
 .\" Copyright (c) 2019 Datto Inc.
@@ -14,1747 +14,959 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH ZFS-MODULE-PARAMETERS 5 "May 5, 2021" OpenZFS
-.SH NAME
-zfs\-module\-parameters \- ZFS module parameters
-.SH DESCRIPTION
-.sp
-.LP
-Description of the different parameters to the ZFS module.
-
-.SS "Module parameters"
-.sp
-.LP
-
-.sp
-.ne 2
-.na
-\fBdbuf_cache_max_bytes\fR (ulong)
-.ad
-.RS 12n
-Maximum size in bytes of the dbuf cache.  The target size is determined by the
-MIN versus \fB1/2^dbuf_cache_shift\fR (1/32) of the target ARC size.  The
-behavior of the dbuf cache and its associated settings can be observed via the
-\fB/proc/spl/kstat/zfs/dbufstats\fR kstat.
-.sp
-Default value: \fBULONG_MAX\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdbuf_metadata_cache_max_bytes\fR (ulong)
-.ad
-.RS 12n
-Maximum size in bytes of the metadata dbuf cache.  The target size is
-determined by the MIN versus \fB1/2^dbuf_metadata_cache_shift\fR (1/64) of the
-target ARC size.  The behavior of the metadata dbuf cache and its associated
-settings can be observed via the \fB/proc/spl/kstat/zfs/dbufstats\fR kstat.
-.sp
-Default value: \fBULONG_MAX\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdbuf_cache_hiwater_pct\fR (uint)
-.ad
-.RS 12n
-The percentage over \fBdbuf_cache_max_bytes\fR when dbufs must be evicted
-directly.
-.sp
-Default value: \fB10\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdbuf_cache_lowater_pct\fR (uint)
-.ad
-.RS 12n
-The percentage below \fBdbuf_cache_max_bytes\fR when the evict thread stops
-evicting dbufs.
-.sp
-Default value: \fB10\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdbuf_cache_shift\fR (int)
-.ad
-.RS 12n
-Set the size of the dbuf cache, \fBdbuf_cache_max_bytes\fR, to a log2 fraction
+.\"
+.Dd June 1, 2021
+.Dt ZFS-MODULE-PARAMETERS 5
+.Os
+.
+.Sh NAME
+.Nm zfs-module-parameters
+.Nd parameters of the ZFS kernel module
+.
+.Sh DESCRIPTION
+.Bl -tag -width Ds
+.It Sy dbuf_cache_max_bytes Ns = Ns Sy ULONG_MAX Ns B Pq ulong
+Maximum size in bytes of the dbuf cache.
+The target size is determined by the MIN versus
+.No 1/2^ Ns Sy dbuf_cache_shift Pq 1/32nd
 of the target ARC size.
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdbuf_metadata_cache_shift\fR (int)
-.ad
-.RS 12n
-Set the size of the dbuf metadata cache, \fBdbuf_metadata_cache_max_bytes\fR,
+The behavior of the dbuf cache and its associated settings
+can be observed via the
+.Pa /proc/spl/kstat/zfs/dbufstats
+kstat.
+.
+.It Sy dbuf_metadata_cache_max_bytes Ns = Ns Sy ULONG_MAX Ns B Pq ulong
+Maximum size in bytes of the metadata dbuf cache.
+The target size is determined by the MIN versus
+.No 1/2^ Ns Sy dbuf_metadata_cache_shift Pq 1/64th
+of the target ARC size.
+The behavior of the metadata dbuf cache and its associated settings
+can be observed via the
+.Pa /proc/spl/kstat/zfs/dbufstats
+kstat.
+.
+.It Sy dbuf_cache_hiwater_pct Ns = Ns Sy 10 Ns % Pq uint
+The percentage over
+.Sy dbuf_cache_max_bytes
+when dbufs must be evicted directly.
+.
+.It Sy dbuf_cache_lowater_pct Ns = Ns Sy 10 Ns % Pq uint
+The percentage below
+.Sy dbuf_cache_max_bytes
+when the evict thread stops evicting dbufs.
+.
+.It Sy dbuf_cache_shift Ns = Ns Sy 5 Pq int
+Set the size of the dbuf cache
+.Pq Sy dbuf_cache_max_bytes
 to a log2 fraction of the target ARC size.
-.sp
-Default value: \fB6\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdmu_object_alloc_chunk_shift\fR (int)
-.ad
-.RS 12n
-dnode slots allocated in a single operation as a power of 2. The default value
-minimizes lock contention for the bulk operation performed.
-.sp
-Default value: \fB7\fR (128).
-.RE
-
-.sp
-.ne 2
-.na
-\fBdmu_prefetch_max\fR (int)
-.ad
-.RS 12n
-Limit the amount we can prefetch with one call to this amount (in bytes).
+.
+.It Sy dbuf_metadata_cache_shift Ns = Ns Sy 6 Pq int
+Set the size of the dbuf metadata cache
+.Pq Sy dbuf_metadata_cache_max_bytes
+to a log2 fraction of the target ARC size.
+.
+.It Sy dmu_object_alloc_chunk_shift Ns = Ns Sy 7 Po 128 Pc Pq int
+dnode slots allocated in a single operation as a power of 2.
+The default value minimizes lock contention for the bulk operation performed.
+.
+.It Sy dmu_prefetch_max Ns = Ns Sy 134217728 Ns B Po 128MB Pc Pq int
+Limit the amount we can prefetch with one call to this amount in bytes.
 This helps to limit the amount of memory that can be used by prefetching.
-.sp
-Default value: \fB134,217,728\fR (128MB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBignore_hole_birth\fR (int)
-.ad
-.RS 12n
-This is an alias for \fBsend_holes_without_birth_time\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_feed_again\fR (int)
-.ad
-.RS 12n
-Turbo L2ARC warm-up. When the L2ARC is cold the fill interval will be set as
-fast as possible.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_feed_min_ms\fR (ulong)
-.ad
-.RS 12n
-Min feed interval in milliseconds. Requires \fBl2arc_feed_again=1\fR and only
-applicable in related situations.
-.sp
-Default value: \fB200\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_feed_secs\fR (ulong)
-.ad
-.RS 12n
-Seconds between L2ARC writing
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_headroom\fR (ulong)
-.ad
-.RS 12n
-How far through the ARC lists to search for L2ARC cacheable content, expressed
-as a multiplier of \fBl2arc_write_max\fR.
-ARC persistence across reboots can be achieved with persistent L2ARC by setting
-this parameter to \fB0\fR allowing the full length of ARC lists to be searched
-for cacheable content.
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_headroom_boost\fR (ulong)
-.ad
-.RS 12n
-Scales \fBl2arc_headroom\fR by this percentage when L2ARC contents are being
-successfully compressed before writing. A value of \fB100\fR disables this
-feature.
-.sp
-Default value: \fB200\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_mfuonly\fR (int)
-.ad
-.RS 12n
+.
+.It Sy ignore_hole_birth Pq int
+Alias for
+.Sy send_holes_without_birth_time .
+.
+.It Sy l2arc_feed_again Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Turbo L2ARC warm-up.
+When the L2ARC is cold the fill interval will be set as fast as possible.
+.
+.It Sy l2arc_feed_min_ms Ns = Ns Sy 200 Pq ulong
+Min feed interval in milliseconds.
+Requires
+.Sy l2arc_feed_again Ns = Ns Ar 1
+and only applicable in related situations.
+.
+.It Sy l2arc_feed_secs Ns = Ns Sy 1 Pq ulong
+Seconds between L2ARC writing.
+.
+.It Sy l2arc_headroom Ns = Ns Sy 2 Pq ulong
+How far through the ARC lists to search for L2ARC cacheable content,
+expressed as a multiplier of
+.Sy l2arc_write_max .
+ARC persistence across reboots can be achieved with persistent L2ARC
+by setting this parameter to
+.Sy 0 ,
+allowing the full length of ARC lists to be searched for cacheable content.
+.
+.It Sy l2arc_headroom_boost Ns = Ns Sy 200 Ns % Pq ulong
+Scales
+.Sy l2arc_headroom
+by this percentage when L2ARC contents are being successfully compressed
+before writing.
+A value of
+.Sy 100
+disables this feature.
+.
+.It Sy l2arc_mfuonly Ns = Ns Sy 0 Ns | Ns 1 Pq  int
 Controls whether only MFU metadata and data are cached from ARC into L2ARC.
 This may be desired to avoid wasting space on L2ARC when reading/writing large
-amounts of data that are not expected to be accessed more than once. The
-default is \fB0\fR, meaning both MRU and MFU data and metadata are cached.
-When turning off (\fB0\fR) this feature some MRU buffers will still be present
-in ARC and eventually cached on L2ARC. If \fBl2arc_noprefetch\fR is set to 0,
+amounts of data that are not expected to be accessed more than once.
+.Pp
+The default is off,
+meaning both MRU and MFU data and metadata are cached.
+When turning off this feature, some MRU buffers will still be present
+in ARC and eventually cached on L2ARC.
+.No If Sy l2arc_noprefetch Ns = Ns Sy 0 ,
 some prefetched buffers will be cached to L2ARC, and those might later
-transition to MRU, in which case the \fBl2arc_mru_asize\fR arcstat will not
-be 0. Regardless of \fBl2arc_noprefetch\fR, some MFU buffers might be evicted
-from ARC, accessed later on as prefetches and transition to MRU as prefetches.
-If accessed again they are counted as MRU and the \fBl2arc_mru_asize\fR arcstat
-will not be 0. The ARC status of L2ARC buffers when they were first cached in
-L2ARC can be seen in the \fBl2arc_mru_asize\fR, \fBl2arc_mfu_asize\fR and
-\fBl2arc_prefetch_asize\fR arcstats when importing the pool or onlining a cache
-device if persistent L2ARC is enabled. The \fBevicted_l2_eligible_mru\fR
+transition to MRU, in which case the
+.Sy l2arc_mru_asize No arcstat will not be Sy 0 .
+.Pp
+Regardless of
+.Sy l2arc_noprefetch ,
+some MFU buffers might be evicted from ARC,
+accessed later on as prefetches and transition to MRU as prefetches.
+If accessed again they are counted as MRU and the
+.Sy l2arc_mru_asize No arcstat will not be Sy 0 .
+.Pp
+The ARC status of L2ARC buffers when they were first cached in
+L2ARC can be seen in the
+.Sy l2arc_mru_asize , Sy l2arc_mfu_asize , No and Sy l2arc_prefetch_asize
+arcstats when importing the pool or onlining a cache
+device if persistent L2ARC is enabled.
+.Pp
+The
+.Sy evict_l2_eligible_mru
 arcstat does not take into account if this option is enabled as the information
-provided by the evicted_l2_eligible_* arcstats can be used to decide if
-toggling this option is appropriate for the current workload.
-.sp
-Use \fB0\fR for no (default) and \fB1\fR for yes.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_meta_percent\fR (int)
-.ad
-.RS 12n
+provided by the
+.Sy evict_l2_eligible_m[rf]u
+arcstats can be used to decide if toggling this option is appropriate
+for the current workload.
+.
+.It Sy l2arc_meta_percent Ns = Ns Sy 33 Ns % Pq int
 Percent of ARC size allowed for L2ARC-only headers.
-Since L2ARC buffers are not evicted on memory pressure, too large amount of
-headers on system with irrationally large L2ARC can render it slow or unusable.
-This parameter limits L2ARC writes and rebuild to achieve it.
-.sp
-Default value: \fB33\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_trim_ahead\fR (ulong)
-.ad
-.RS 12n
-Trims ahead of the current write size (\fBl2arc_write_max\fR) on L2ARC devices
-by this percentage of write size if we have filled the device. If set to
-\fB100\fR we TRIM twice the space required to accommodate upcoming writes. A
-minimum of 64MB will be trimmed. It also enables TRIM of the whole L2ARC device
-upon creation or addition to an existing pool or if the header of the device is
-invalid upon importing a pool or onlining a cache device. A value of \fB0\fR
+Since L2ARC buffers are not evicted on memory pressure,
+too many headers on a system with an irrationally large L2ARC
+can render it slow or unusable.
+This parameter limits L2ARC writes and rebuilds to achieve the target.
+.
+.It Sy l2arc_trim_ahead Ns = Ns Sy 0 Ns % Pq ulong
+Trims ahead of the current write size
+.Pq Sy l2arc_write_max
+on L2ARC devices by this percentage of write size if we have filled the device.
+If set to
+.Sy 100
+we TRIM twice the space required to accommodate upcoming writes.
+A minimum of
+.Sy 64MB
+will be trimmed.
+It also enables TRIM of the whole L2ARC device upon creation
+or addition to an existing pool or if the header of the device is
+invalid upon importing a pool or onlining a cache device.
+A value of
+.Sy 0
 disables TRIM on L2ARC altogether and is the default as it can put significant
-stress on the underlying storage devices. This will vary depending of how well
-the specific device handles these commands.
-.sp
-Default value: \fB0\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_noprefetch\fR (int)
-.ad
-.RS 12n
+stress on the underlying storage devices.
+This will vary depending of how well the specific device handles these commands.
+.
+.It Sy l2arc_noprefetch Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Do not write buffers to L2ARC if they were prefetched but not used by
-applications. In case there are prefetched buffers in L2ARC and this option
-is later set to \fB1\fR, we do not read the prefetched buffers from L2ARC.
-Setting this option to \fB0\fR is useful for caching sequential reads from the
-disks to L2ARC and serve those reads from L2ARC later on. This may be beneficial
-in case the L2ARC device is significantly faster in sequential reads than the
-disks of the pool.
-.sp
-Use \fB1\fR to disable (default) and \fB0\fR to enable caching/reading
-prefetches to/from L2ARC..
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_norw\fR (int)
-.ad
-.RS 12n
+applications.
+In case there are prefetched buffers in L2ARC and this option
+is later set, we do not read the prefetched buffers from L2ARC.
+Unsetting this option is useful for caching sequential reads from the
+disks to L2ARC and serve those reads from L2ARC later on.
+This may be beneficial in case the L2ARC device is significantly faster
+in sequential reads than the disks of the pool.
+.Pp
+Use
+.Sy 1
+to disable and
+.Sy 0
+to enable caching/reading prefetches to/from L2ARC.
+.
+.It Sy l2arc_norw Ns = Ns Sy 0 Ns | Ns 1 Pq int
 No reads during writes.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_write_boost\fR (ulong)
-.ad
-.RS 12n
-Cold L2ARC devices will have \fBl2arc_write_max\fR increased by this amount
-while they remain cold.
-.sp
-Default value: \fB8,388,608\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_write_max\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy l2arc_write_boost Ns = Ns Sy 8388608 Ns B Po 8MB Pc Pq ulong
+Cold L2ARC devices will have
+.Sy l2arc_write_max
+increased by this amount while they remain cold.
+.
+.It Sy l2arc_write_max Ns = Ns Sy 8388608 Ns B Po 8MB Pc Pq ulong
 Max write bytes per interval.
-.sp
-Default value: \fB8,388,608\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_rebuild_enabled\fR (int)
-.ad
-.RS 12n
-Rebuild the L2ARC when importing a pool (persistent L2ARC). This can be
-disabled if there are problems importing a pool or attaching an L2ARC device
-(e.g. the L2ARC device is slow in reading stored log metadata, or the metadata
+.
+.It Sy l2arc_rebuild_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Rebuild the L2ARC when importing a pool (persistent L2ARC).
+This can be disabled if there are problems importing a pool
+or attaching an L2ARC device (e.g. the L2ARC device is slow
+in reading stored log metadata, or the metadata
 has become somehow fragmented/unusable).
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBl2arc_rebuild_blocks_min_l2size\fR (ulong)
-.ad
-.RS 12n
-Min size (in bytes) of an L2ARC device required in order to write log blocks
-in it. The log blocks are used upon importing the pool to rebuild
-the L2ARC (persistent L2ARC). Rationale: for L2ARC devices less than 1GB, the
-amount of data l2arc_evict() evicts is significant compared to the amount of
-restored L2ARC data. In this case do not write log blocks in L2ARC in order not
-to waste space.
-.sp
-Default value: \fB1,073,741,824\fR (1GB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_aliquot\fR (ulong)
-.ad
-.RS 12n
-Metaslab granularity, in bytes. This is roughly similar to what would be
-referred to as the "stripe size" in traditional RAID arrays. In normal
-operation, ZFS will try to write this amount of data to a top-level vdev
-before moving on to the next one.
-.sp
-Default value: \fB524,288\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_bias_enabled\fR (int)
-.ad
-.RS 12n
-Enable metaslab group biasing based on its vdev's over- or under-utilization
+.
+.It Sy l2arc_rebuild_blocks_min_l2size Ns = Ns Sy 1073741824 Ns B Po 1GB Pc Pq ulong
+Mininum size of an L2ARC device required in order to write log blocks in it.
+The log blocks are used upon importing the pool to rebuild the persistent L2ARC.
+.Pp
+For L2ARC devices less than 1GB, the amount of data
+.Fn l2arc_evict
+evicts is significant compared to the amount of restored L2ARC data.
+In this case, do not write log blocks in L2ARC in order not to waste space.
+.
+.It Sy metaslab_aliquot Ns = Ns Sy 524288 Ns B Po 512kB Pc Pq ulong
+Metaslab granularity, in bytes.
+This is roughly similar to what would be referred to as the "stripe size"
+in traditional RAID arrays.
+In normal operation, ZFS will try to write this amount of data
+to a top-level vdev before moving on to the next one.
+.
+.It Sy metaslab_bias_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Enable metaslab group biasing based on their vdevs' over- or under-utilization
 relative to the pool.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_force_ganging\fR (ulong)
-.ad
-.RS 12n
-Make some blocks above a certain size be gang blocks.  This option is used
-by the test suite to facilitate testing.
-.sp
-Default value: \fB16,777,217\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_history_output_max\fR (int)
-.ad
-.RS 12n
-When attempting to log the output nvlist of an ioctl in the on-disk history, the
-output will not be stored if it is larger than size (in bytes). This must be
-less than DMU_MAX_ACCESS (64MB). This applies primarily to
-zfs_ioc_channel_program().
-.sp
-Default value: \fB1MB\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_keep_log_spacemaps_at_export\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_force_ganging Ns = Ns Sy 16777217 Ns B Ns B Po 16MB + 1B Pc Pq ulong
+Make some blocks above a certain size be gang blocks.
+This option is used by the test suite to facilitate testing.
+.
+.It Sy zfs_history_output_max Ns = Ns Sy 1048576 Ns B Ns B Po 1MB Pc Pq int
+When attempting to log an output nvlist of an ioctl in the on-disk history,
+the output will not be stored if it is larger than this size (in bytes).
+This must be less than
+.Sy DMU_MAX_ACCESS Pq 64MB .
+This applies primarily to
+.Fn zfs_ioc_channel_program Pq cf. Xr zfs-program 8 .
+.
+.It Sy zfs_keep_log_spacemaps_at_export Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Prevent log spacemaps from being destroyed during pool exports and destroys.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_segment_weight_enabled\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_metaslab_segment_weight_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable/disable segment-based metaslab selection.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_switch_threshold\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_metaslab_switch_threshold Ns = Ns Sy 2 Pq int
 When using segment-based metaslab selection, continue allocating
-from the active metaslab until \fBzfs_metaslab_switch_threshold\fR
+from the active metaslab until this option's
 worth of buckets have been exhausted.
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_debug_load\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_debug_load Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Load all metaslabs during pool import.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_debug_unload\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_debug_unload Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Prevent metaslabs from being unloaded.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_fragmentation_factor_enabled\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_fragmentation_factor_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable use of the fragmentation metric in computing metaslab weights.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_df_max_search\fR (int)
-.ad
-.RS 12n
-Maximum distance to search forward from the last offset. Without this limit,
-fragmented pools can see >100,000 iterations and metaslab_block_picker()
+.
+.It Sy metaslab_df_max_search Ns = Ns Sy 16777216 Ns B Po 16MB Pc Pq int
+Maximum distance to search forward from the last offset.
+Without this limit, fragmented pools can see
+.Em >100`000
+iterations and
+.Fn metaslab_block_picker
 becomes the performance limiting factor on high-performance storage.
-
-With the default setting of 16MB, we typically see less than 500 iterations,
-even with very fragmented, ashift=9 pools. The maximum number of iterations
-possible is: \fBmetaslab_df_max_search / (2 * (1<<ashift))\fR.
-With the default setting of 16MB this is 16*1024 (with ashift=9) or 2048
-(with ashift=12).
-.sp
-Default value: \fB16,777,216\fR (16MB)
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_df_use_largest_segment\fR (int)
-.ad
-.RS 12n
-If we are not searching forward (due to metaslab_df_max_search,
-metaslab_df_free_pct, or metaslab_df_alloc_threshold), this tunable controls
-what segment is used.  If it is set, we will use the largest free segment.
-If it is not set, we will use a segment of exactly the requested size (or
-larger).
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_max_size_cache_sec\fR (ulong)
-.ad
-.RS 12n
-When we unload a metaslab, we cache the size of the largest free chunk. We use
-that cached size to determine whether or not to load a metaslab for a given
-allocation. As more frees accumulate in that metaslab while it's unloaded, the
-cached max size becomes less and less accurate. After a number of seconds
-controlled by this tunable, we stop considering the cached max size and start
+.Pp
+With the default setting of
+.Sy 16MB ,
+we typically see less than
+.Em 500
+iterations, even with very fragmented
+.Sy ashift Ns = Ns Sy 9
+pools.
+The maximum number of iterations possible is
+.Sy metaslab_df_max_search / 2^(ashift+1) .
+With the default setting of
+.Sy 16MB
+this is
+.Em 16*1024 Pq with Sy ashift Ns = Ns Sy 9
+or
+.Em 2*1024 Pq with Sy ashift Ns = Ns Sy 12 .
+.
+.It Sy metaslab_df_use_largest_segment Ns = Ns Sy 0 Ns | Ns 1 Pq int
+If not searching forward (due to
+.Sy metaslab_df_max_search , metaslab_df_free_pct ,
+.No or Sy metaslab_df_alloc_threshold ) ,
+this tunable controls which segment is used.
+If set, we will use the largest free segment.
+If unset, we will use a segment of at least the requested size.
+.
+.It Sy zfs_metaslab_max_size_cache_sec Ns = Ns Sy 3600 Ns s Po 1h Pc Pq ulong
+When we unload a metaslab, we cache the size of the largest free chunk.
+We use that cached size to determine whether or not to load a metaslab
+for a given allocation.
+As more frees accumulate in that metaslab while it's unloaded,
+the cached max size becomes less and less accurate.
+After a number of seconds controlled by this tunable,
+we stop considering the cached max size and start
 considering only the histogram instead.
-.sp
-Default value: \fB3600 seconds\fR (one hour)
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_mem_limit\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_metaslab_mem_limit Ns = Ns Sy 25 Ns % Pq int
 When we are loading a new metaslab, we check the amount of memory being used
-to store metaslab range trees. If it is over a threshold, we attempt to unload
-the least recently used metaslab to prevent the system from clogging all of
-its memory with range trees. This tunable sets the percentage of total system
-memory that is the threshold.
-.sp
-Default value: \fB25 percent\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_try_hard_before_gang\fR (int)
-.ad
-.RS 12n
-If not set (the default), we will first try normal allocation.
+to store metaslab range trees.
+If it is over a threshold, we attempt to unload the least recently used metaslab
+to prevent the system from clogging all of its memory with range trees.
+This tunable sets the percentage of total system memory that is the threshold.
+.
+.It Sy zfs_metaslab_try_hard_before_gang Ns = Ns Sy 0 Ns | Ns 1 Pq int
+.Bl -item -compact
+.It
+If unset, we will first try normal allocation.
+.It
 If that fails then we will do a gang allocation.
+.It
 If that fails then we will do a "try hard" gang allocation.
+.It
 If that fails then we will have a multi-layer gang block.
-.sp
+.El
+.Pp
+.Bl -item -compact
+.It
 If set, we will first try normal allocation.
+.It
 If that fails then we will do a "try hard" allocation.
+.It
 If that fails we will do a gang allocation.
+.It
 If that fails we will do a "try hard" gang allocation.
+.It
 If that fails then we will have a multi-layer gang block.
-.sp
-Default value: \fB0 (false)\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_find_max_tries\fR (int)
-.ad
-.RS 12n
+.El
+.
+.It Sy zfs_metaslab_find_max_tries Ns = Ns Sy 100 Pq int
 When not trying hard, we only consider this number of the best metaslabs.
 This improves performance, especially when there are many metaslabs per vdev
-and the allocation can't actually be satisfied (so we would otherwise iterate
-all the metaslabs).
-.sp
-Default value: \fB100\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_default_ms_count\fR (int)
-.ad
-.RS 12n
-When a vdev is added target this number of metaslabs per top-level vdev.
-.sp
-Default value: \fB200\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_default_ms_shift\fR (int)
-.ad
-.RS 12n
+and the allocation can't actually be satisfied
+(so we would otherwise iterate all metaslabs).
+.
+.It Sy zfs_vdev_default_ms_count Ns = Ns Sy 200 Pq int
+When a vdev is added, target this number of metaslabs per top-level vdev.
+.
+.It Sy zfs_vdev_default_ms_shift Ns = Ns Sy 29 Po 512MB Pc Pq int
 Default limit for metaslab size.
-.sp
-Default value: \fB29\fR [meaning (1 << 29) = 512MB].
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_max_auto_ashift\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_max_auto_ashift Ns = Ns Sy ASHIFT_MAX Po 16 Pc Pq ulong
 Maximum ashift used when optimizing for logical -> physical sector size on new
 top-level vdevs.
-.sp
-Default value: \fBASHIFT_MAX\fR (16).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_min_auto_ashift\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_min_auto_ashift Ns = Ns Sy ASHIFT_MIN Po 9 Pc Pq ulong
 Minimum ashift used when creating new top-level vdevs.
-.sp
-Default value: \fBASHIFT_MIN\fR (9).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_min_ms_count\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_min_ms_count Ns = Ns Sy 16 Pq int
 Minimum number of metaslabs to create in a top-level vdev.
-.sp
-Default value: \fB16\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBvdev_validate_skip\fR (int)
-.ad
-.RS 12n
-Skip label validation steps during pool import. Changing is not recommended
-unless you know what you are doing and are recovering a damaged label.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_ms_count_limit\fR (int)
-.ad
-.RS 12n
+.
+.It Sy vdev_validate_skip Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Skip label validation steps during pool import.
+Changing is not recommended unless you know what you're doing
+and are recovering a damaged label.
+.
+.It Sy zfs_vdev_ms_count_limit Ns = Ns Sy 131072 Po 128k Pc Pq int
 Practical upper limit of total metaslabs per top-level vdev.
-.sp
-Default value: \fB131,072\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_preload_enabled\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_preload_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable metaslab group preloading.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_lba_weighting_enabled\fR (int)
-.ad
-.RS 12n
-Give more weight to metaslabs with lower LBAs, assuming they have
-greater bandwidth as is typically the case on a modern constant
-angular velocity disk drive.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_unload_delay\fR (int)
-.ad
-.RS 12n
-After a metaslab is used, we keep it loaded for this many txgs, to attempt to
-reduce unnecessary reloading. Note that both this many txgs and
-\fBmetaslab_unload_delay_ms\fR milliseconds must pass before unloading will
-occur.
-.sp
-Default value: \fB32\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmetaslab_unload_delay_ms\fR (int)
-.ad
-.RS 12n
-After a metaslab is used, we keep it loaded for this many milliseconds, to
-attempt to reduce unnecessary reloading. Note that both this many
-milliseconds and \fBmetaslab_unload_delay\fR txgs must pass before unloading
-will occur.
-.sp
-Default value: \fB600000\fR (ten minutes).
-.RE
-
-.sp
-.ne 2
-.na
-\fBreference_history\fR (int)
-.ad
-.RS 12n
-Maximum reference holders being tracked when reference_tracking_enable is
-active.
-.sp
-Default value: \fB3\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBreference_tracking_enable\fR (int)
-.ad
-.RS 12n
-Track reference holders to refcount_t objects (debug builds only).
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBsend_holes_without_birth_time\fR (int)
-.ad
-.RS 12n
-When set, the hole_birth optimization will not be used, and all holes will
-always be sent on zfs send.  This is useful if you suspect your datasets are
-affected by a bug in hole_birth.
-.sp
-Use \fB1\fR for on (default) and \fB0\fR for off.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_config_path\fR (charp)
-.ad
-.RS 12n
-SPA config file
-.sp
-Default value: \fB/etc/zfs/zpool.cache\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_asize_inflation\fR (int)
-.ad
-.RS 12n
+.
+.It Sy metaslab_lba_weighting_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Give more weight to metaslabs with lower LBAs,
+assuming they have greater bandwidth,
+as is typically the case on a modern constant angular velocity disk drive.
+.
+.It Sy metaslab_unload_delay Ns = Ns Sy 32 Pq int
+After a metaslab is used, we keep it loaded for this many TXGs, to attempt to
+reduce unnecessary reloading.
+Note that both this many TXGs and
+.Sy metaslab_unload_delay_ms
+milliseconds must pass before unloading will occur.
+.
+.It Sy metaslab_unload_delay_ms Ns = Ns Sy 600000 Ns ms Po 10min Pc Pq int
+After a metaslab is used, we keep it loaded for this many milliseconds,
+to attempt to reduce unnecessary reloading.
+Note, that both this many milliseconds and
+.Sy metaslab_unload_delay
+TXGs must pass before unloading will occur.
+.
+.It Sy reference_history Ns = Ns Sy 3 Pq int
+Maximum reference holders being tracked when reference_tracking_enable is active.
+.
+.It Sy reference_tracking_enable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Track reference holders to
+.Sy refcount_t
+objects (debug builds only).
+.
+.It Sy send_holes_without_birth_time Ns = Ns Sy 1 Ns | Ns 0 Pq int
+When set, the
+.Sy hole_birth
+optimization will not be used, and all holes will always be sent during a
+.Nm zfs Cm send .
+This is useful if you suspect your datasets are affected by a bug in
+.Sy hole_birth .
+.
+.It Sy spa_config_path Ns = Ns Pa /etc/zfs/zpool.cache Pq charp
+SPA config file.
+.
+.It Sy spa_asize_inflation Ns = Ns Sy 24 Pq int
 Multiplication factor used to estimate actual disk consumption from the
-size of data being written. The default value is a worst case estimate,
-but lower values may be valid for a given pool depending on its
-configuration.  Pool administrators who understand the factors involved
-may wish to specify a more realistic inflation factor, particularly if
-they operate close to quota or capacity limits.
-.sp
-Default value: \fB24\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_load_print_vdev_tree\fR (int)
-.ad
-.RS 12n
+size of data being written.
+The default value is a worst case estimate,
+but lower values may be valid for a given pool depending on its configuration.
+Pool administrators who understand the factors involved
+may wish to specify a more realistic inflation factor,
+particularly if they operate close to quota or capacity limits.
+.
+.It Sy spa_load_print_vdev_tree Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Whether to print the vdev tree in the debugging message buffer during pool import.
-Use 0 to disable and 1 to enable.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_load_verify_data\fR (int)
-.ad
-.RS 12n
-Whether to traverse data blocks during an "extreme rewind" (\fB-X\fR)
-import.  Use 0 to disable and 1 to enable.
-
+.
+.It Sy spa_load_verify_data Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Whether to traverse data blocks during an "extreme rewind"
+.Pq Fl X
+import.
+.Pp
 An extreme rewind import normally performs a full traversal of all
-blocks in the pool for verification.  If this parameter is set to 0,
-the traversal skips non-metadata blocks.  It can be toggled once the
+blocks in the pool for verification.
+If this parameter is unset, the traversal skips non-metadata blocks.
+It can be toggled once the
 import has started to stop or start the traversal of non-metadata blocks.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_load_verify_metadata\fR (int)
-.ad
-.RS 12n
-Whether to traverse blocks during an "extreme rewind" (\fB-X\fR)
-pool import.  Use 0 to disable and 1 to enable.
-
+.
+.It Sy spa_load_verify_metadata  Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Whether to traverse blocks during an "extreme rewind"
+.Pq Fl X
+pool import.
+.Pp
 An extreme rewind import normally performs a full traversal of all
-blocks in the pool for verification.  If this parameter is set to 0,
-the traversal is not performed.  It can be toggled once the import has
-started to stop or start the traversal.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_load_verify_shift\fR (int)
-.ad
-.RS 12n
+blocks in the pool for verification.
+If this parameter is unset, the traversal is not performed.
+It can be toggled once the import has started to stop or start the traversal.
+.
+.It Sy spa_load_verify_shift Ns = Ns Sy 4 Po 1/16th Pc Pq int
 Sets the maximum number of bytes to consume during pool import to the log2
 fraction of the target ARC size.
-.sp
-Default value: \fB4\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspa_slop_shift\fR (int)
-.ad
-.RS 12n
-Normally, we don't allow the last 3.2% (1/(2^spa_slop_shift)) of space
-in the pool to be consumed.  This ensures that we don't run the pool
-completely out of space, due to unaccounted changes (e.g. to the MOS).
-It also limits the worst-case time to allocate space.  If we have
-less than this amount of free space, most ZPL operations (e.g. write,
-create) will return ENOSPC.
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBvdev_removal_max_span\fR (int)
-.ad
-.RS 12n
+.
+.It Sy spa_slop_shift Ns = Ns Sy 5 Po 1/32nd Pc Pq int
+Normally, we don't allow the last
+.Sy 3.2% Pq Sy 1/2^spa_slop_shift
+of space in the pool to be consumed.
+This ensures that we don't run the pool completely out of space,
+due to unaccounted changes (e.g. to the MOS).
+It also limits the worst-case time to allocate space.
+If we have less than this amount of free space,
+most ZPL operations (e.g. write, create) will return
+.Sy ENOSPC .
+.
+.It Sy vdev_removal_max_span Ns = Ns Sy 32768 Ns B Po 32kB Pc Pq int
 During top-level vdev removal, chunks of data are copied from the vdev
 which may include free space in order to trade bandwidth for IOPS.
-This parameter determines the maximum span of free space (in bytes)
+This parameter determines the maximum span of free space, in bytes,
 which will be included as "unnecessary" data in a chunk of copied data.
-
+.Pp
 The default value here was chosen to align with
-\fBzfs_vdev_read_gap_limit\fR, which is a similar concept when doing
+.Sy zfs_vdev_read_gap_limit ,
+which is a similar concept when doing
 regular reads (but there's no reason it has to be the same).
-.sp
-Default value: \fB32,768\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBvdev_file_logical_ashift\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy vdev_file_logical_ashift Ns = Ns Sy 9 Po 512B Pc Pq ulong
 Logical ashift for file-based devices.
-.sp
-Default value: \fB9\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBvdev_file_physical_ashift\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy vdev_file_physical_ashift Ns = Ns Sy 9 Po 512B Pc Pq ulong
 Physical ashift for file-based devices.
-.sp
-Default value: \fB9\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzap_iterate_prefetch\fR (int)
-.ad
-.RS 12n
-If this is set, when we start iterating over a ZAP object, zfs will prefetch
-the entire object (all leaf blocks).  However, this is limited by
-\fBdmu_prefetch_max\fR.
-.sp
-Use \fB1\fR for on (default) and \fB0\fR for off.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfetch_array_rd_sz\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zap_iterate_prefetch Ns = Ns Sy 1 Ns | Ns 0 Pq int
+If set, when we start iterating over a ZAP object,
+prefetch the entire object (all leaf blocks).
+However, this is limited by
+.Sy dmu_prefetch_max .
+.
+.It Sy zfetch_array_rd_sz Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq ulong
 If prefetching is enabled, disable prefetching for reads larger than this size.
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfetch_max_distance\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zfetch_max_distance Ns = Ns Sy 8388608 Ns B Po 8MB Pc Pq uint
 Max bytes to prefetch per stream.
-.sp
-Default value: \fB8,388,608\fR (8MB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfetch_max_idistance\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zfetch_max_idistance Ns = Ns Sy 67108864 Ns B Po 64MB Pc Pq uint
 Max bytes to prefetch indirects for per stream.
-.sp
-Default value: \fB67,108,864\fR (64MB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfetch_max_streams\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zfetch_max_streams Ns = Ns Sy 8 Pq uint
 Max number of streams per zfetch (prefetch streams per file).
-.sp
-Default value: \fB8\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfetch_min_sec_reap\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zfetch_min_sec_reap Ns = Ns Sy 2 Pq uint
 Min time before an active prefetch stream can be reclaimed
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_abd_scatter_enabled\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_abd_scatter_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enables ARC from using scatter/gather lists and forces all allocations to be
-linear in kernel memory. Disabling can improve performance in some code paths
+linear in kernel memory.
+Disabling can improve performance in some code paths
 at the expense of fragmented kernel memory.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_abd_scatter_max_order\fR (iunt)
-.ad
-.RS 12n
+.
+.It Sy zfs_abd_scatter_max_order Ns = Ns Sy MAX_ORDER-1 Pq uint
 Maximum number of consecutive memory pages allocated in a single block for
-scatter/gather lists. Default value is specified by the kernel itself.
-.sp
-Default value: \fB10\fR at the time of this writing.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_abd_scatter_min_size\fR (uint)
-.ad
-.RS 12n
-This is the minimum allocation size that will use scatter (page-based)
-ABD's.  Smaller allocations will use linear ABD's.
-.sp
-Default value: \fB1536\fR (512B and 1KB allocations will be linear).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_dnode_limit\fR (ulong)
-.ad
-.RS 12n
+scatter/gather lists.
+.Pp
+The value of
+.Sy MAX_ORDER
+depends on kernel configuration.
+.
+.It Sy zfs_abd_scatter_min_size Ns = Ns Sy 1536 Ns B Po 1.5kB Pc Pq uint
+This is the minimum allocation size that will use scatter (page-based) ABDs.
+Smaller allocations will use linear ABDs.
+.
+.It Sy zfs_arc_dnode_limit Ns = Ns Sy 0 Ns B Pq ulong
 When the number of bytes consumed by dnodes in the ARC exceeds this number of
-bytes, try to unpin some of it in response to demand for non-metadata. This
-value acts as a ceiling to the amount of dnode metadata, and defaults to 0 which
-indicates that a percent which is based on \fBzfs_arc_dnode_limit_percent\fR of
-the ARC meta buffers that may be used for dnodes.
-
-See also \fBzfs_arc_meta_prune\fR which serves a similar purpose but is used
-when the amount of metadata in the ARC exceeds \fBzfs_arc_meta_limit\fR rather
-than in response to overall demand for non-metadata.
-
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_dnode_limit_percent\fR (ulong)
-.ad
-.RS 12n
+bytes, try to unpin some of it in response to demand for non-metadata.
+This value acts as a ceiling to the amount of dnode metadata, and defaults to
+.Sy 0 ,
+which indicates that a percent which is based on
+.Sy zfs_arc_dnode_limit_percent
+of the ARC meta buffers that may be used for dnodes.
+.Pp
+Also see
+.Sy zfs_arc_meta_prune
+which serves a similar purpose but is used
+when the amount of metadata in the ARC exceeds
+.Sy zfs_arc_meta_limit
+rather than in response to overall demand for non-metadata.
+.
+.It Sy zfs_arc_dnode_limit_percent Ns = Ns Sy 10 Ns % Pq ulong
 Percentage that can be consumed by dnodes of ARC meta buffers.
-.sp
-See also \fBzfs_arc_dnode_limit\fR which serves a similar purpose but has a
-higher priority if set to nonzero value.
-.sp
-Default value: \fB10\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_dnode_reduce_percent\fR (ulong)
-.ad
-.RS 12n
+.Pp
+See also
+.Sy zfs_arc_dnode_limit ,
+which serves a similar purpose but has a higher priority if nonzero.
+.
+.It Sy zfs_arc_dnode_reduce_percent Ns = Ns Sy 10 Ns % Pq ulong
 Percentage of ARC dnodes to try to scan in response to demand for non-metadata
-when the number of bytes consumed by dnodes exceeds \fBzfs_arc_dnode_limit\fR.
-
-.sp
-Default value: \fB10\fR% of the number of dnodes in the ARC.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_average_blocksize\fR (int)
-.ad
-.RS 12n
+when the number of bytes consumed by dnodes exceeds
+.Sy zfs_arc_dnode_limit .
+.
+.It Sy zfs_arc_average_blocksize Ns = Ns Sy 8192 Ns B Po 8kB Pc Pq int
 The ARC's buffer hash table is sized based on the assumption of an average
-block size of \fBzfs_arc_average_blocksize\fR (default 8K).  This works out
-to roughly 1MB of hash table per 1GB of physical memory with 8-byte pointers.
-For configurations with a known larger average block size this value can be
-increased to reduce the memory footprint.
-
-.sp
-Default value: \fB8192\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_eviction_pct\fR (int)
-.ad
-.RS 12n
-When \fBarc_is_overflowing()\fR, \fBarc_get_data_impl()\fR waits for this
-percent of the requested amount of data to be evicted.  For example, by
-default for every 2KB that's evicted, 1KB of it may be "reused" by a new
-allocation. Since this is above 100%, it ensures that progress is made
-towards getting \fBarc_size\fR under \fBarc_c\fR.  Since this is finite, it
-ensures that allocations can still happen, even during the potentially long
-time that \fBarc_size\fR is more than \fBarc_c\fR.
-.sp
-Default value: \fB200\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_evict_batch_limit\fR (int)
-.ad
-.RS 12n
+block size of this value.
+This works out to roughly 1MB of hash table per 1GB of physical memory
+with 8-byte pointers.
+For configurations with a known larger average block size,
+this value can be increased to reduce the memory footprint.
+.
+.It Sy zfs_arc_eviction_pct Ns = Ns Sy 200 Ns % Pq int
+When
+.Fn arc_is_overflowing ,
+.Fn arc_get_data_impl
+waits for this percent of the requested amount of data to be evicted.
+For example, by default, for every
+.Em 2kB
+that's evicted,
+.Em 1kB
+of it may be "reused" by a new allocation.
+Since this is above
+.Sy 100 Ns % ,
+it ensures that progress is made towards getting
+.Sy arc_size No under Sy arc_c .
+Since this is finite, it ensures that allocations can still happen,
+even during the potentially long time that
+.Sy arc_size No is more than Sy arc_c .
+.
+.It Sy zfs_arc_evict_batch_limit Ns = Ns Sy 10 Pq int
 Number ARC headers to evict per sub-list before proceeding to another sub-list.
 This batch-style operation prevents entire sub-lists from being evicted at once
 but comes at a cost of additional unlocking and locking.
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_grow_retry\fR (int)
-.ad
-.RS 12n
-If set to a non zero value, it will replace the arc_grow_retry value with this value.
-The arc_grow_retry value (default 5) is the number of seconds the ARC will wait before
+.
+.It Sy zfs_arc_grow_retry Ns = Ns Sy 0 Ns s Pq int
+If set to a non zero value, it will replace the
+.Sy arc_grow_retry
+value with this value.
+The
+.Sy arc_grow_retry
+.No value Pq default Sy 5 Ns s
+is the number of seconds the ARC will wait before
 trying to resume growth after a memory pressure event.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_lotsfree_percent\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_arc_lotsfree_percent Ns = Ns Sy 10 Ns % Pq int
 Throttle I/O when free system memory drops below this percentage of total
-system memory.  Setting this value to 0 will disable the throttle.
-.sp
-Default value: \fB10\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_max\fR (ulong)
-.ad
-.RS 12n
-Max size of ARC in bytes.  If set to 0 then the max size of ARC is determined
-by the amount of system memory installed.  For Linux, 1/2 of system memory will
-be used as the limit.  For FreeBSD, the larger of all system memory - 1GB or
-5/8 of system memory will be used as the limit.  This value must be at least
-67108864 (64 megabytes).
-.sp
-This value can be changed dynamically with some caveats. It cannot be set back
-to 0 while running and reducing it below the current ARC size will not cause
+system memory.
+Setting this value to
+.Sy 0
+will disable the throttle.
+.
+.It Sy zfs_arc_max Ns = Ns Sy 0 Ns B Pq ulong
+Max size of ARC in bytes.
+If
+.Sy 0 ,
+then the max size of ARC is determined by the amount of system memory installed.
+Under Linux, half of system memory will be used as the limit.
+Under
+.Fx ,
+the larger of
+.Sy all_system_memory - 1GB No and Sy 5/8 * all_system_memory
+will be used as the limit.
+This value must be at least
+.Sy 67108864 Ns B Pq 64MB .
+.Pp
+This value can be changed dynamically, with some caveats.
+It cannot be set back to
+.Sy 0
+while running, and reducing it below the current ARC size will not cause
 the ARC to shrink without memory pressure to induce shrinking.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_adjust_restarts\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_arc_meta_adjust_restarts Ns = Ns Sy 4096 Pq ulong
 The number of restart passes to make while scanning the ARC attempting
-the free buffers in order to stay below the \fBzfs_arc_meta_limit\fR.
+the free buffers in order to stay below the
+.Sy fs_arc_meta_limit .
 This value should not need to be tuned but is available to facilitate
 performance analysis.
-.sp
-Default value: \fB4096\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_limit\fR (ulong)
-.ad
-.RS 12n
-The maximum allowed size in bytes that meta data buffers are allowed to
-consume in the ARC.  When this limit is reached meta data buffers will
-be reclaimed even if the overall arc_c_max has not been reached.  This
-value defaults to 0 which indicates that a percent which is based on
-\fBzfs_arc_meta_limit_percent\fR of the ARC may be used for meta data.
-.sp
-This value my be changed dynamically except that it cannot be set back to 0
-for a specific percent of the ARC; it must be set to an explicit value.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_limit_percent\fR (ulong)
-.ad
-.RS 12n
-Percentage of ARC buffers that can be used for meta data.
-
-See also \fBzfs_arc_meta_limit\fR which serves a similar purpose but has a
-higher priority if set to nonzero value.
-
-.sp
-Default value: \fB75\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_min\fR (ulong)
-.ad
-.RS 12n
-The minimum allowed size in bytes that meta data buffers may consume in
-the ARC.  This value defaults to 0 which disables a floor on the amount
-of the ARC devoted meta data.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_prune\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_arc_meta_limit Ns = Ns Sy 0 Ns B Pq ulong
+The maximum allowed size in bytes that metadata buffers are allowed to
+consume in the ARC.
+When this limit is reached, metadata buffers will be reclaimed,
+even if the overall
+.Sy arc_c_max
+has not been reached.
+It defaults to
+.Sy 0 ,
+which indicates that a percentage based on
+.Sy zfs_arc_meta_limit_percent
+of the ARC may be used for metadata.
+.Pp
+This value my be changed dynamically, except that must be set to an explicit value
+.Pq cannot be set back to Sy 0 .
+.
+.It Sy zfs_arc_meta_limit_percent Ns = Ns Sy 75 Ns % Pq ulong
+Percentage of ARC buffers that can be used for metadata.
+.Pp
+See also
+.Sy zfs_arc_meta_limit ,
+which serves a similar purpose but has a higher priority if nonzero.
+.
+.It Sy zfs_arc_meta_min Ns = Ns Sy 0 Ns B Pq ulong
+The minimum allowed size in bytes that metadata buffers may consume in
+the ARC.
+.
+.It Sy zfs_arc_meta_prune Ns = Ns Sy 10000 Pq int
 The number of dentries and inodes to be scanned looking for entries
-which can be dropped.  This may be required when the ARC reaches the
-\fBzfs_arc_meta_limit\fR because dentries and inodes can pin buffers
-in the ARC.  Increasing this value will cause to dentry and inode caches
-to be pruned more aggressively.  Setting this value to 0 will disable
-pruning the inode and dentry caches.
-.sp
-Default value: \fB10,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_meta_strategy\fR (int)
-.ad
-.RS 12n
-Define the strategy for ARC meta data buffer eviction (meta reclaim strategy).
-A value of 0 (META_ONLY) will evict only the ARC meta data buffers.
-A value of 1 (BALANCED) indicates that additional data buffers may be evicted if
-that is required to in order to evict the required number of meta data buffers.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_min\fR (ulong)
-.ad
-.RS 12n
-Min size of ARC in bytes. If set to 0 then arc_c_min will default to
-consuming the larger of 32M or 1/32 of total system memory.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_min_prefetch_ms\fR (int)
-.ad
-.RS 12n
-Minimum time prefetched blocks are locked in the ARC, specified in ms.
-A value of \fB0\fR will default to 1000 ms.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_min_prescient_prefetch_ms\fR (int)
-.ad
-.RS 12n
-Minimum time "prescient prefetched" blocks are locked in the ARC, specified
-in ms. These blocks are meant to be prefetched fairly aggressively ahead of
-the code that may use them. A value of \fB0\fR will default to 6000 ms.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_missing_tvds\fR (int)
-.ad
-.RS 12n
+which can be dropped.
+This may be required when the ARC reaches the
+.Sy zfs_arc_meta_limit
+because dentries and inodes can pin buffers in the ARC.
+Increasing this value will cause to dentry and inode caches
+to be pruned more aggressively.
+Setting this value to
+.Sy 0
+will disable pruning the inode and dentry caches.
+.
+.It Sy zfs_arc_meta_strategy Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Define the strategy for ARC metadata buffer eviction (meta reclaim strategy):
+.Bl -tag -compact -offset 4n -width "0 (META_ONLY)"
+.It Sy 0 Pq META_ONLY
+evict only the ARC metadata buffers
+.It Sy 1 Pq BALANCED
+additional data buffers may be evicted if required
+to evict the required number of metadata buffers.
+.El
+.
+.It Sy zfs_arc_min Ns = Ns Sy 0 Ns B Pq ulong
+Min size of ARC in bytes.
+.No If set to Sy 0 , arc_c_min
+will default to consuming the larger of
+.Sy 32MB No or Sy all_system_memory/32 .
+.
+.It Sy zfs_arc_min_prefetch_ms Ns = Ns Sy 0 Ns ms Ns Po Ns ≡ Ns 1s Pc Pq int
+Minimum time prefetched blocks are locked in the ARC.
+.
+.It Sy zfs_arc_min_prescient_prefetch_ms Ns = Ns Sy 0 Ns ms Ns Po Ns ≡ Ns 6s Pc Pq int
+Minimum time "prescient prefetched" blocks are locked in the ARC.
+These blocks are meant to be prefetched fairly aggressively ahead of
+the code that may use them.
+.
+.It Sy zfs_max_missing_tvds Ns = Ns Sy 0 Pq int
 Number of missing top-level vdevs which will be allowed during
 pool import (only in read-only mode).
-.sp
-Default value: \fB0\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_nvlist_src_size\fR (ulong)
-.ad
-.RS 12n
-Maximum size in bytes allowed to be passed as zc_nvlist_src_size for ioctls on
-/dev/zfs. This prevents a user from causing the kernel to allocate an excessive
-amount of memory. When the limit is exceeded, the ioctl fails with EINVAL and a
-description of the error is sent to the zfs-dbgmsg log. This parameter should
-not need to be touched under normal circumstances. On FreeBSD, the default is
-based on the system limit on user wired memory. On Linux, the default is
-\fB128MB\fR.
-.sp
-Default value: \fB0\fR (kernel decides)
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_multilist_num_sublists\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_max_nvlist_src_size Ns = Sy 0 Pq ulong
+Maximum size in bytes allowed to be passed as
+.Sy zc_nvlist_src_size
+for ioctls on
+.Pa /dev/zfs .
+This prevents a user from causing the kernel to allocate
+an excessive amount of memory.
+When the limit is exceeded, the ioctl fails with
+.Sy EINVAL
+and a description of the error is sent to the
+.Pa zfs-dbgmsg
+log.
+This parameter should not need to be touched under normal circumstances.
+If
+.Sy 0 ,
+equivalent to a quarter of the user-wired memory limit under
+.Fx
+and to
+.Sy 134217728 Ns B Pq 128MB
+under Linux.
+.
+.It Sy zfs_multilist_num_sublists Ns = Ns Sy 0 Pq int
 To allow more fine-grained locking, each ARC state contains a series
-of lists for both data and meta data objects.  Locking is performed at
-the level of these "sub-lists".  This parameters controls the number of
-sub-lists per ARC state, and also applies to other uses of the
-multilist data structure.
-.sp
-Default value: \fB4\fR or the number of online CPUs, whichever is greater
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_overflow_shift\fR (int)
-.ad
-.RS 12n
+of lists for both data and metadata objects.
+Locking is performed at the level of these "sub-lists".
+This parameters controls the number of sub-lists per ARC state,
+and also applies to other uses of the multilist data structure.
+.Pp
+If
+.Sy 0 ,
+equivalent to the greater of the number of online CPUs and
+.Sy 4 .
+.
+.It Sy zfs_arc_overflow_shift Ns = Ns Sy 8 Pq int
 The ARC size is considered to be overflowing if it exceeds the current
-ARC target size (arc_c) by a threshold determined by this parameter.
-The threshold is calculated as a fraction of arc_c using the formula
-"arc_c >> \fBzfs_arc_overflow_shift\fR".
-
-The default value of 8 causes the ARC to be considered to be overflowing
-if it exceeds the target size by 1/256th (0.3%) of the target size.
-
+ARC target size
+.Pq Sy arc_c
+by a threshold determined by this parameter.
+The threshold is calculated as a fraction of
+.Sy arc_c
+using the formula
+.Sy arc_c >> zfs_arc_overflow_shift .
+.Pp
+The default value of
+.Sy 8
+causes the ARC to be considered overflowing if it exceeds the target size by
+.Em 1/256th Pq Em 0.3%
+of the target size.
+.Pp
 When the ARC is overflowing, new buffer allocations are stalled until
 the reclaim thread catches up and the overflow condition no longer exists.
-.sp
-Default value: \fB8\fR.
-.RE
-
-.sp
-.ne 2
-.na
-
-\fBzfs_arc_p_min_shift\fR (int)
-.ad
-.RS 12n
-If set to a non zero value, this will update arc_p_min_shift (default 4)
+.
+.It Sy zfs_arc_p_min_shift Ns = Ns Sy 0 Pq int
+If nonzero, this will update
+.Sy arc_p_min_shift Pq default Sy 4
 with the new value.
-arc_p_min_shift is used to shift of arc_c for calculating both min and max
-max arc_p
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_p_dampener_disable\fR (int)
-.ad
-.RS 12n
-Disable arc_p adapt dampener
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_shrink_shift\fR (int)
-.ad
-.RS 12n
-If set to a non zero value, this will update arc_shrink_shift (default 7)
+.Sy arc_p_min_shift No is used as a shift of Sy arc_c
+when calculating the minumum
+.Sy arc_p No size.
+.
+.It Sy zfs_arc_p_dampener_disable Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Disable
+.Sy arc_p
+adapt dampener, which reduces the maximum single adjustment to
+.Sy arc_p .
+.
+.It Sy zfs_arc_shrink_shift Ns = Ns Sy 0 Pq int
+If nonzero, this will update
+.Sy arc_shrink_shift Pq default Sy 7
 with the new value.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_pc_percent\fR (uint)
-.ad
-.RS 12n
-Percent of pagecache to reclaim arc to
-
-This tunable allows ZFS arc to play more nicely with the kernel's LRU
-pagecache. It can guarantee that the ARC size won't collapse under scanning
-pressure on the pagecache, yet still allows arc to be reclaimed down to
-zfs_arc_min if necessary. This value is specified as percent of pagecache
-size (as measured by NR_FILE_PAGES) where that percent may exceed 100. This
+.
+.It Sy zfs_arc_pc_percent Ns = Ns Sy 0 Ns % Po off Pc Pq uint
+Percent of pagecache to reclaim ARC to.
+.Pp
+This tunable allows the ZFS ARC to play more nicely
+with the kernel's LRU pagecache.
+It can guarantee that the ARC size won't collapse under scanning
+pressure on the pagecache, yet still allows the ARC to be reclaimed down to
+.Sy zfs_arc_min
+if necessary.
+This value is specified as percent of pagecache size (as measured by
+.Sy NR_FILE_PAGES ) ,
+where that percent may exceed
+.Sy 100 .
+This
 only operates during memory pressure/reclaim.
-.sp
-Default value: \fB0\fR% (disabled).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_shrinker_limit\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_arc_shrinker_limit Ns = Ns Sy 10000 Pq int
 This is a limit on how many pages the ARC shrinker makes available for
-eviction in response to one page allocation attempt.  Note that in
-practice, the kernel's shrinker can ask us to evict up to about 4x this
-for one allocation attempt.
-.sp
-The default limit of 10,000 (in practice, 160MB per allocation attempt with
-4K pages) limits the amount of time spent attempting to reclaim ARC memory to
-less than 100ms per allocation attempt, even with a small average compressed
-block size of ~8KB.
-.sp
-The parameter can be set to 0 (zero) to disable the limit.
-.sp
-This parameter only applies on Linux.
-.sp
-Default value: \fB10,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_sys_free\fR (ulong)
-.ad
-.RS 12n
+eviction in response to one page allocation attempt.
+Note that in practice, the kernel's shrinker can ask us to evict
+up to about four times this for one allocation attempt.
+.Pp
+The default limit of
+.Sy 10000 Pq in practice, Em 160MB No per allocation attempt with 4kB pages
+limits the amount of time spent attempting to reclaim ARC memory to
+less than 100ms per allocation attempt,
+even with a small average compressed block size of ~8kB.
+.Pp
+The parameter can be set to 0 (zero) to disable the limit,
+and only applies on Linux.
+.
+.It Sy zfs_arc_sys_free Ns = Ns Sy 0 Ns B Pq ulong
 The target number of bytes the ARC should leave as free memory on the system.
-Defaults to the larger of 1/64 of physical memory or 512K.  Setting this
-option to a non-zero value will override the default.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_autoimport_disable\fR (int)
-.ad
-.RS 12n
-Disable pool import at module load by ignoring the cache file (typically \fB/etc/zfs/zpool.cache\fR).
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_checksum_events_per_second\fR (uint)
-.ad
-.RS 12n
-Rate limit checksum events to this many per second.  Note that this should
-not be set below the zed thresholds (currently 10 checksums over 10 sec)
-or else zed may not trigger any action.
-.sp
-Default value: 20
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_commit_timeout_pct\fR (int)
-.ad
-.RS 12n
+If zero, equivalent to the bigger of
+.Sy 512kB No and Sy all_system_memory/64 .
+.
+.It Sy zfs_autoimport_disable Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Disable pool import at module load by ignoring the cache file
+.Pq Sy spa_config_path .
+.
+.It Sy zfs_checksum_events_per_second Ns = Ns Sy 20 Ns /s Pq uint
+Rate limit checksum events to this many per second.
+Note that this should not be set below the ZED thresholds
+(currently 10 checksums over 10 seconds)
+or else the daemon may not trigger any action.
+.
+.It Sy zfs_commit_timeout_pct Ns = Ns Sy 5 Ns % Pq int
 This controls the amount of time that a ZIL block (lwb) will remain "open"
 when it isn't "full", and it has a thread waiting for it to be committed to
-stable storage.  The timeout is scaled based on a percentage of the last lwb
+stable storage.
+The timeout is scaled based on a percentage of the last lwb
 latency to avoid significantly impacting the latency of each individual
 transaction record (itx).
-.sp
-Default value: \fB5\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_condense_indirect_commit_entry_delay_ms\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_condense_indirect_commit_entry_delay_ms Ns = Ns Sy 0 Ns ms Pq int
 Vdev indirection layer (used for device removal) sleeps for this many
-milliseconds during mapping generation. Intended for use with the test suite
-to throttle vdev removal speed.
-.sp
-Default value: \fB0\fR (no throttle).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_condense_indirect_obsolete_pct\fR (int)
-.ad
-.RS 12n
-Minimum percent of obsolete bytes in vdev mapping required to attempt to
-condense (see \fBzfs_condense_indirect_vdevs_enable\fR). Intended for use
-with the test suite to facilitate triggering condensing as needed.
-.sp
-Default value: \fB25\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_condense_indirect_vdevs_enable\fR (int)
-.ad
-.RS 12n
-Enable condensing indirect vdev mappings.  When set to a non-zero value,
-attempt to condense indirect vdev mappings if the mapping uses more than
-\fBzfs_condense_min_mapping_bytes\fR bytes of memory and if the obsolete
-space map object uses more than \fBzfs_condense_max_obsolete_bytes\fR
-bytes on-disk.  The condensing process is an attempt to save memory by
-removing obsolete mappings.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_condense_max_obsolete_bytes\fR (ulong)
-.ad
-.RS 12n
+milliseconds during mapping generation.
+Intended for use with the test suite to throttle vdev removal speed.
+.
+.It Sy zfs_condense_indirect_obsolete_pct Ns = Ns Sy 25 Ns % Pq int
+Minimum percent of obsolete bytes in vdev mapping required to attempt to condense
+.Pq see Sy zfs_condense_indirect_vdevs_enable .
+Intended for use with the test suite
+to facilitate triggering condensing as needed.
+.
+.It Sy zfs_condense_indirect_vdevs_enable Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Enable condensing indirect vdev mappings.
+When set, attempt to condense indirect vdev mappings
+if the mapping uses more than
+.Sy zfs_condense_min_mapping_bytes
+bytes of memory and if the obsolete space map object uses more than
+.Sy zfs_condense_max_obsolete_bytes
+bytes on-disk.
+The condensing process is an attempt to save memory by removing obsolete mappings.
+.
+.It Sy zfs_condense_max_obsolete_bytes Ns = Ns Sy 1073741824 Ns B Po 1GB Pc Pq ulong
 Only attempt to condense indirect vdev mappings if the on-disk size
 of the obsolete space map object is greater than this number of bytes
-(see \fBfBzfs_condense_indirect_vdevs_enable\fR).
-.sp
-Default value: \fB1,073,741,824\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_condense_min_mapping_bytes\fR (ulong)
-.ad
-.RS 12n
-Minimum size vdev mapping to attempt to condense (see
-\fBzfs_condense_indirect_vdevs_enable\fR).
-.sp
-Default value: \fB131,072\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dbgmsg_enable\fR (int)
-.ad
-.RS 12n
-Internally ZFS keeps a small log to facilitate debugging.  By default the log
-is enabled, to disable it set this option to 0.  The contents of the log can
-be accessed by reading the /proc/spl/kstat/zfs/dbgmsg file.  Writing 0 to
-this proc file clears the log.
-.sp
-This setting does not influence debug prints due to \fBzfs_flags\fR
-settings.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dbgmsg_maxsize\fR (int)
-.ad
-.RS 12n
-The maximum size in bytes of the internal ZFS debug log.
-.sp
-Default value: \fB4M\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dbuf_state_index\fR (int)
-.ad
-.RS 12n
-This feature is currently unused. It is normally used for controlling what
-reporting is available under /proc/spl/kstat/zfs.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_deadman_enabled\fR (int)
-.ad
-.RS 12n
-When a pool sync operation takes longer than \fBzfs_deadman_synctime_ms\fR
-milliseconds, or when an individual I/O takes longer than
-\fBzfs_deadman_ziotime_ms\fR milliseconds, then the operation is considered to
-be "hung".  If \fBzfs_deadman_enabled\fR is set then the deadman behavior is
-invoked as described by the \fBzfs_deadman_failmode\fR module option.
-By default the deadman is enabled and configured to \fBwait\fR which results
-in "hung" I/Os only being logged.  The deadman is automatically disabled
-when a pool gets suspended.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_deadman_failmode\fR (charp)
-.ad
-.RS 12n
-Controls the failure behavior when the deadman detects a "hung" I/O.  Valid
-values are \fBwait\fR, \fBcontinue\fR, and \fBpanic\fR.
-.sp
-\fBwait\fR - Wait for a "hung" I/O to complete.  For each "hung" I/O a
-"deadman" event will be posted describing that I/O.
-.sp
-\fBcontinue\fR - Attempt to recover from a "hung" I/O by re-dispatching it
+.Pq see Sy zfs_condense_indirect_vdevs_enable .
+.
+.It Sy zfs_condense_min_mapping_bytes Ns = Ns Sy 131072 Ns B Po 128kB Pc Pq ulong
+Minimum size vdev mapping to attempt to condense
+.Pq see Sy zfs_condense_indirect_vdevs_enable .
+.
+.It Sy zfs_dbgmsg_enable Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Internally ZFS keeps a small log to facilitate debugging.
+The log is enabled by default, and can be disabled by unsetting this option.
+The contents of the log can be accessed by reading
+.Pa /proc/spl/kstat/zfs/dbgmsg .
+Writing
+.Sy 0
+to the file clears the log.
+.Pp
+This setting does not influence debug prints due to
+.Sy zfs_flags .
+.
+.It Sy zfs_dbgmsg_maxsize Ns = Ns Sy 4194304 Ns B Po 4MB Pc Pq int
+Maximum size of the internal ZFS debug log.
+.
+.It Sy zfs_dbuf_state_index Ns = Ns Sy 0 Pq int
+Historically used for controlling what reporting was available under
+.Pa /proc/spl/kstat/zfs .
+No effect.
+.
+.It Sy zfs_deadman_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+When a pool sync operation takes longer than
+.Sy zfs_deadman_synctime_ms ,
+or when an individual I/O operation takes longer than
+.Sy zfs_deadman_ziotime_ms ,
+then the operation is considered to be "hung".
+If
+.Sy zfs_deadman_enabled
+is set, then the deadman behavior is invoked as described by
+.Sy zfs_deadman_failmode .
+By default, the deadman is enabled and set to
+.Sy wait
+which results in "hung" I/Os only being logged.
+The deadman is automatically disabled when a pool gets suspended.
+.
+.It Sy zfs_deadman_failmode Ns = Ns Sy wait Pq charp
+Controls the failure behavior when the deadman detects a "hung" I/O operation.
+Valid values are:
+.Bl -tag -compact -offset 4n -width "continue"
+.It Sy wait
+Wait for a "hung" operation to complete.
+For each "hung" operation a "deadman" event will be posted
+describing that operation.
+.It Sy continue
+Attempt to recover from a "hung" operation by re-dispatching it
 to the I/O pipeline if possible.
-.sp
-\fBpanic\fR - Panic the system.  This can be used to facilitate an automatic
-fail-over to a properly configured fail-over partner.
-.sp
-Default value: \fBwait\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_deadman_checktime_ms\fR (int)
-.ad
-.RS 12n
-Check time in milliseconds. This defines the frequency at which we check
-for hung I/O and potentially invoke the \fBzfs_deadman_failmode\fR behavior.
-.sp
-Default value: \fB60,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_deadman_synctime_ms\fR (ulong)
-.ad
-.RS 12n
+.It Sy panic
+Panic the system.
+This can be used to facilitate automatic fail-over
+to a properly configured fail-over partner.
+.El
+.
+.It Sy zfs_deadman_checktime_ms Ns = Ns Sy 60000 Ns ms Po 1min Pc Pq int
+Check time in milliseconds.
+This defines the frequency at which we check for hung I/O requests
+and potentially invoke the
+.Sy zfs_deadman_failmode
+behavior.
+.
+.It Sy zfs_deadman_synctime_ms Ns = Ns Sy 600000 Ns ms Po 10min Pc Pq ulong
 Interval in milliseconds after which the deadman is triggered and also
 the interval after which a pool sync operation is considered to be "hung".
 Once this limit is exceeded the deadman will be invoked every
-\fBzfs_deadman_checktime_ms\fR milliseconds until the pool sync completes.
-.sp
-Default value: \fB600,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_deadman_ziotime_ms\fR (ulong)
-.ad
-.RS 12n
+.Sy zfs_deadman_checktime_ms
+milliseconds until the pool sync completes.
+.
+.It Sy zfs_deadman_ziotime_ms Ns = Ns Sy 300000 Ns ms Po 5min Pc Pq ulong
 Interval in milliseconds after which the deadman is triggered and an
-individual I/O operation is considered to be "hung".  As long as the I/O
-remains "hung" the deadman will be invoked every \fBzfs_deadman_checktime_ms\fR
-milliseconds until the I/O completes.
-.sp
-Default value: \fB300,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dedup_prefetch\fR (int)
-.ad
-.RS 12n
-Enable prefetching dedup-ed blks
-.sp
-Use \fB1\fR for yes and \fB0\fR to disable (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_delay_min_dirty_percent\fR (int)
-.ad
-.RS 12n
+individual I/O operation is considered to be "hung".
+As long as the operation remains "hung",
+the deadman will be invoked every
+.Sy zfs_deadman_checktime_ms
+milliseconds until the operation completes.
+.
+.It Sy zfs_dedup_prefetch Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Enable prefetching dedup-ed blocks which are going to be freed.
+.
+.It Sy zfs_delay_min_dirty_percent Ns = Ns Sy 60 Ns % Pq int
 Start to delay each transaction once there is this amount of dirty data,
-expressed as a percentage of \fBzfs_dirty_data_max\fR.
-This value should be >= zfs_vdev_async_write_active_max_dirty_percent.
-See the section "ZFS TRANSACTION DELAY".
-.sp
-Default value: \fB60\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_delay_scale\fR (int)
-.ad
-.RS 12n
+expressed as a percentage of
+.Sy zfs_dirty_data_max .
+This value should be at least
+.Sy zfs_vdev_async_write_active_max_dirty_percent .
+.No See Sx ZFS TRANSACTION DELAY .
+.
+.It Sy zfs_delay_scale Ns = Ns Sy 500000 Pq int
 This controls how quickly the transaction delay approaches infinity.
 Larger values cause longer delays for a given amount of dirty data.
-.sp
+.Pp
 For the smoothest delay, this value should be about 1 billion divided
-by the maximum number of operations per second.  This will smoothly
-handle between 10x and 1/10th this number.
-.sp
-See the section "ZFS TRANSACTION DELAY".
-.sp
-Note: \fBzfs_delay_scale\fR * \fBzfs_dirty_data_max\fR must be < 2^64.
-.sp
-Default value: \fB500,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_disable_ivset_guid_check\fR (int)
-.ad
-.RS 12n
-Disables requirement for IVset guids to be present and match when doing a raw
-receive of encrypted datasets. Intended for users whose pools were created with
+by the maximum number of operations per second.
+This will smoothly handle between ten times and a tenth of this number.
+.No See Sx ZFS TRANSACTION DELAY .
+.Pp
+.Sy zfs_delay_scale * zfs_dirty_data_max Em must be smaller than Sy 2^64 .
+.
+.It Sy zfs_disable_ivset_guid_check Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disables requirement for IVset GUIDs to be present and match when doing a raw
+receive of encrypted datasets.
+Intended for users whose pools were created with
 OpenZFS pre-release versions and now have compatibility issues.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_key_max_salt_uses\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_key_max_salt_uses Ns = Ns Sy 400000000 Po 4*10^8 Pc Pq ulong
 Maximum number of uses of a single salt value before generating a new one for
-encrypted datasets. The default value is also the maximum that will be
-accepted.
-.sp
-Default value: \fB400,000,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_object_mutex_size\fR (uint)
-.ad
-.RS 12n
+encrypted datasets.
+The default value is also the maximum.
+.
+.It Sy zfs_object_mutex_size Ns = Ns Sy 64 Pq uint
 Size of the znode hashtable used for holds.
-
+.Pp
 Due to the need to hold locks on objects that may not exist yet, kernel mutexes
 are not created per-object and instead a hashtable is used where collisions
 will result in objects waiting when there is not actually contention on the
 same object.
-.sp
-Default value: \fB64\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_slow_io_events_per_second\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_slow_io_events_per_second Ns = Ns Sy 20 Ns /s Pq int
 Rate limit delay and deadman zevents (which report slow I/Os) to this many per
 second.
-.sp
-Default value: 20
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unflushed_max_mem_amt\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_unflushed_max_mem_amt Ns = Ns Sy 1073741824 Ns B Po 1GB Pc Pq ulong
 Upper-bound limit for unflushed metadata changes to be held by the
-log spacemap in memory (in bytes).
-.sp
-Default value: \fB1,073,741,824\fR (1GB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unflushed_max_mem_ppm\fR (ulong)
-.ad
-.RS 12n
-Percentage of the overall system memory that ZFS allows to be used
-for unflushed metadata changes by the log spacemap.
-(value is calculated over 1000000 for finer granularity).
-.sp
-Default value: \fB1000\fR (which is divided by 1000000, resulting in
-the limit to be \fB0.1\fR% of memory)
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unflushed_log_block_max\fR (ulong)
-.ad
-.RS 12n
+log spacemap in memory, in bytes.
+.
+.It Sy zfs_unflushed_max_mem_ppm Ns = Ns Sy 1000 Ns ppm Po 0.1% Pc Pq ulong
+Part of overall system memory that ZFS allows to be used
+for unflushed metadata changes by the log spacemap, in millionths.
+.
+.It Sy zfs_unflushed_log_block_max Ns = Ns Sy 262144 Po 256k Pc Pq ulong
 Describes the maximum number of log spacemap blocks allowed for each pool.
-The default value of 262144 means that the space in all the log spacemaps
-can add up to no more than 262144 blocks (which means 32GB of logical
-space before compression and ditto blocks, assuming that blocksize is
-128k).
-.sp
+The default value means that the space in all the log spacemaps
+can add up to no more than
+.Sy 262144
+blocks (which means
+.Em 32GB
+of logical space before compression and ditto blocks,
+assuming that blocksize is
+.Em 128kB ) .
+.Pp
 This tunable is important because it involves a trade-off between import
 time after an unclean export and the frequency of flushing metaslabs.
 The higher this number is, the more log blocks we allow when the pool is
@@ -1763,2515 +975,1336 @@ the number of I/Os for spacemap updates per TXG.
 At the same time though, that means that in the event of an unclean export,
 there will be more log spacemap blocks for us to read, inducing overhead
 in the import time of the pool.
-The lower the number, the amount of flushing increases destroying log
+The lower the number, the amount of flushing increases, destroying log
 blocks quicker as they become obsolete faster, which leaves less blocks
 to be read during import time after a crash.
-.sp
+.Pp
 Each log spacemap block existing during pool import leads to approximately
 one extra logical I/O issued.
 This is the reason why this tunable is exposed in terms of blocks rather
 than space used.
-.sp
-Default value: \fB262144\fR (256K).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unflushed_log_block_min\fR (ulong)
-.ad
-.RS 12n
-If the number of metaslabs is small and our incoming rate is high, we
-could get into a situation that we are flushing all our metaslabs every
-TXG.
+.
+.It Sy zfs_unflushed_log_block_min Ns = Ns Sy 1000 Pq ulong
+If the number of metaslabs is small and our incoming rate is high,
+we could get into a situation that we are flushing all our metaslabs every TXG.
 Thus we always allow at least this many log blocks.
-.sp
-Default value: \fB1000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unflushed_log_block_pct\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_unflushed_log_block_pct Ns = Ns Sy 400 Ns % Pq ulong
 Tunable used to determine the number of blocks that can be used for
 the spacemap log, expressed as a percentage of the total number of
 metaslabs in the pool.
-.sp
-Default value: \fB400\fR (read as \fB400\fR% - meaning that the number
-of log spacemap blocks are capped at 4 times the number of
-metaslabs in the pool).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_unlink_suspend_progress\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zfs_unlink_suspend_progress Ns = Ns Sy 0 Ns | Ns 1 Pq uint
 When enabled, files will not be asynchronously removed from the list of pending
-unlinks and the space they consume will be leaked. Once this option has been
-disabled and the dataset is remounted, the pending unlinks will be processed
-and the freed space returned to the pool.
-This option is used by the test suite to facilitate testing.
-.sp
-Uses \fB0\fR (default) to allow progress and \fB1\fR to pause progress.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_delete_blocks\fR (ulong)
-.ad
-.RS 12n
-This is the used to define a large file for the purposes of delete.  Files
-containing more than \fBzfs_delete_blocks\fR will be deleted asynchronously
-while smaller files are deleted synchronously.  Decreasing this value will
-reduce the time spent in an unlink(2) system call at the expense of a longer
-delay before the freed space is available.
-.sp
-Default value: \fB20,480\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dirty_data_max\fR (int)
-.ad
-.RS 12n
-Determines the dirty space limit in bytes.  Once this limit is exceeded, new
-writes are halted until space frees up. This parameter takes precedence
-over \fBzfs_dirty_data_max_percent\fR.
-See the section "ZFS TRANSACTION DELAY".
-.sp
-Default value: \fB10\fR% of physical RAM, capped at \fBzfs_dirty_data_max_max\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dirty_data_max_max\fR (int)
-.ad
-.RS 12n
-Maximum allowable value of \fBzfs_dirty_data_max\fR, expressed in bytes.
+unlinks and the space they consume will be leaked.
+Once this option has been disabled and the dataset is remounted,
+the pending unlinks will be processed and the freed space returned to the pool.
+This option is used by the test suite.
+.
+.It Sy zfs_delete_blocks Ns = Ns Sy 20480 Pq ulong
+This is the used to define a large file for the purposes of deletion.
+Files containing more than
+.Sy zfs_delete_blocks
+will be deleted asynchronously, while smaller files are deleted synchronously.
+Decreasing this value will reduce the time spent in an
+.Xr unlink 2
+system call, at the expense of a longer delay before the freed space is available.
+.
+.It Sy zfs_dirty_data_max Ns = Pq int
+Determines the dirty space limit in bytes.
+Once this limit is exceeded, new writes are halted until space frees up.
+This parameter takes precedence over
+.Sy zfs_dirty_data_max_percent .
+.No See Sx ZFS TRANSACTION DELAY .
+.Pp
+Defaults to
+.Sy physical_ram/10 ,
+capped at
+.Sy zfs_dirty_data_max_max .
+.
+.It Sy zfs_dirty_data_max_max Ns = Pq int
+Maximum allowable value of
+.Sy zfs_dirty_data_max ,
+expressed in bytes.
 This limit is only enforced at module load time, and will be ignored if
-\fBzfs_dirty_data_max\fR is later changed.  This parameter takes
-precedence over \fBzfs_dirty_data_max_max_percent\fR. See the section
-"ZFS TRANSACTION DELAY".
-.sp
-Default value: \fB25\fR% of physical RAM.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dirty_data_max_max_percent\fR (int)
-.ad
-.RS 12n
-Maximum allowable value of \fBzfs_dirty_data_max\fR, expressed as a
-percentage of physical RAM.  This limit is only enforced at module load
-time, and will be ignored if \fBzfs_dirty_data_max\fR is later changed.
-The parameter \fBzfs_dirty_data_max_max\fR takes precedence over this
-one. See the section "ZFS TRANSACTION DELAY".
-.sp
-Default value: \fB25\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dirty_data_max_percent\fR (int)
-.ad
-.RS 12n
-Determines the dirty space limit, expressed as a percentage of all
-memory.  Once this limit is exceeded, new writes are halted until space frees
-up.  The parameter \fBzfs_dirty_data_max\fR takes precedence over this
-one.  See the section "ZFS TRANSACTION DELAY".
-.sp
-Default value: \fB10\fR%, subject to \fBzfs_dirty_data_max_max\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dirty_data_sync_percent\fR (int)
-.ad
-.RS 12n
+.Sy zfs_dirty_data_max
+is later changed.
+This parameter takes precedence over
+.Sy zfs_dirty_data_max_max_percent .
+.No See Sx ZFS TRANSACTION DELAY .
+.Pp
+Defaults to
+.Sy physical_ram/4 ,
+.
+.It Sy zfs_dirty_data_max_max_percent Ns = Ns Sy 25 Ns % Pq int
+Maximum allowable value of
+.Sy zfs_dirty_data_max ,
+expressed as a percentage of physical RAM.
+This limit is only enforced at module load time, and will be ignored if
+.Sy zfs_dirty_data_max
+is later changed.
+The parameter
+.Sy zfs_dirty_data_max_max
+takes precedence over this one.
+.No See Sx ZFS TRANSACTION DELAY .
+.
+.It Sy zfs_dirty_data_max_percent Ns = Ns Sy 10 Ns % Pq int
+Determines the dirty space limit, expressed as a percentage of all memory.
+Once this limit is exceeded, new writes are halted until space frees up.
+The parameter
+.Sy zfs_dirty_data_max
+takes precedence over this one.
+.No See Sx ZFS TRANSACTION DELAY .
+.Pp
+Subject to
+.Sy zfs_dirty_data_max_max .
+.
+.It Sy zfs_dirty_data_sync_percent Ns = Ns Sy 20 Ns % Pq int
 Start syncing out a transaction group if there's at least this much dirty data
-as a percentage of \fBzfs_dirty_data_max\fR.  This should be less than
-\fBzfs_vdev_async_write_active_min_dirty_percent\fR.
-.sp
-Default value: \fB20\fR% of \fBzfs_dirty_data_max\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_fallocate_reserve_percent\fR (uint)
-.ad
-.RS 12n
+.Pq as a percentage of Sy zfs_dirty_data_max .
+This should be less than
+.Sy zfs_vdev_async_write_active_min_dirty_percent .
+.
+.It Sy zfs_fallocate_reserve_percent Ns = Ns Sy 110 Ns % Pq uint
 Since ZFS is a copy-on-write filesystem with snapshots, blocks cannot be
 preallocated for a file in order to guarantee that later writes will not
-run out of space.  Instead, fallocate() space preallocation only checks
-that sufficient space is currently available in the pool or the user's
-project quota allocation, and then creates a sparse file of the requested
-size. The requested space is multiplied by \fBzfs_fallocate_reserve_percent\fR
+run out of space.
+Instead,
+.Xr fallocate 2
+space preallocation only checks that sufficient space is currently available
+in the pool or the user's project quota allocation,
+and then creates a sparse file of the requested size.
+The requested space is multiplied by
+.Sy zfs_fallocate_reserve_percent
 to allow additional space for indirect blocks and other internal metadata.
-Setting this value to 0 disables support for fallocate(2) and returns
-EOPNOTSUPP for fallocate() space preallocation again.
-.sp
-Default value: \fB110\fR%
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_fletcher_4_impl\fR (string)
-.ad
-.RS 12n
+Setting this to
+.Sy 0
+disables support for
+.Xr fallocate 2
+and causes it to return
+.Sy EOPNOTSUPP .
+.
+.It Sy zfs_fletcher_4_impl Ns = Ns Sy fastest Pq string
 Select a fletcher 4 implementation.
-.sp
-Supported selectors are: \fBfastest\fR, \fBscalar\fR, \fBsse2\fR, \fBssse3\fR,
-\fBavx2\fR, \fBavx512f\fR, \fBavx512bw\fR, and \fBaarch64_neon\fR.
-All of the selectors except \fBfastest\fR and \fBscalar\fR require instruction
-set extensions to be available and will only appear if ZFS detects that they are
-present at runtime. If multiple implementations of fletcher 4 are available,
-the \fBfastest\fR will be chosen using a micro benchmark. Selecting \fBscalar\fR
-results in the original, CPU based calculation, being used. Selecting any option
-other than \fBfastest\fR and \fBscalar\fR results in vector instructions from
-the respective CPU instruction set being used.
-.sp
-Default value: \fBfastest\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_free_bpobj_enabled\fR (int)
-.ad
-.RS 12n
+.Pp
+Supported selectors are:
+.Sy fastest , scalar , sse2 , ssse3 , avx2 , avx512f , avx512bw ,
+.No and Sy aarch64_neon .
+All except
+.Sy fastest No and Sy scalar
+require instruction set extensions to be available,
+and will only appear if ZFS detects that they are present at runtime.
+If multiple implementations of fletcher 4 are available, the
+.Sy fastest
+will be chosen using a micro benchmark.
+Selecting
+.Sy scalar
+results in the original CPU-based calculation being used.
+Selecting any option other than
+.Sy fastest No or Sy scalar
+results in vector instructions
+from the respective CPU instruction set being used.
+.
+.It Sy zfs_free_bpobj_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable/disable the processing of the free_bpobj object.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_async_block_max_blocks\fR (ulong)
-.ad
-.RS 12n
-Maximum number of blocks freed in a single txg.
-.sp
-Default value: \fBULONG_MAX\fR (unlimited).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_async_dedup_frees\fR (ulong)
-.ad
-.RS 12n
-Maximum number of dedup blocks freed in a single txg.
-.sp
-Default value: \fB100,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_override_estimate_recordsize\fR (ulong)
-.ad
-.RS 12n
-Record size calculation override for zfs send estimates.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_read_max_active\fR (int)
-.ad
-.RS 12n
-Maximum asynchronous read I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB3\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_read_min_active\fR (int)
-.ad
-.RS 12n
-Minimum asynchronous read I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_write_active_max_dirty_percent\fR (int)
-.ad
-.RS 12n
-When the pool has more than
-\fBzfs_vdev_async_write_active_max_dirty_percent\fR dirty data, use
-\fBzfs_vdev_async_write_max_active\fR to limit active async writes.  If
-the dirty data is between min and max, the active I/O limit is linearly
-interpolated. See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB60\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_write_active_min_dirty_percent\fR (int)
-.ad
-.RS 12n
-When the pool has less than
-\fBzfs_vdev_async_write_active_min_dirty_percent\fR dirty data, use
-\fBzfs_vdev_async_write_min_active\fR to limit active async writes.  If
-the dirty data is between min and max, the active I/O limit is linearly
-interpolated. See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB30\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_write_max_active\fR (int)
-.ad
-.RS 12n
-Maximum asynchronous write I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_async_write_min_active\fR (int)
-.ad
-.RS 12n
-Minimum asynchronous write I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
+.
+.It Sy zfs_async_block_max_blocks Ns = Ns Sy ULONG_MAX Po unlimited Pc Pq ulong
+Maximum number of blocks freed in a single TXG.
+.
+.It Sy zfs_max_async_dedup_frees Ns = Ns Sy 100000 Po 10^5 Pc Pq ulong
+Maximum number of dedup blocks freed in a single TXG.
+.
+.It Sy zfs_override_estimate_recordsize Ns = Ns Sy 0 Pq ulong
+If nonzer, override record size calculation for
+.Nm zfs Cm send
+estimates.
+.
+.It Sy zfs_vdev_async_read_max_active Ns = Ns Sy 3 Pq int
+Maximum asynchronous read I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_async_read_min_active Ns = Ns Sy 1 Pq int
+Minimum asynchronous read I/O operation active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_async_write_active_max_dirty_percent Ns = Ns Sy 60 Ns % Pq int
+When the pool has more than this much dirty data, use
+.Sy zfs_vdev_async_write_max_active
+to limit active async writes.
+If the dirty data is between the minimum and maximum,
+the active I/O limit is linearly interpolated.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_async_write_active_min_dirty_percent Ns = Ns Sy 30 Ns % Pq int
+When the pool has less than this much dirty data, use
+.Sy zfs_vdev_async_write_min_active
+to limit active async writes.
+If the dirty data is between the minimum and maximum,
+the active I/O limit is linearly
+interpolated.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_async_write_max_active Ns = Ns Sy 30 Pq int
+Maximum asynchronous write I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_async_write_min_active Ns = Ns Sy 2 Pq int
+Minimum asynchronous write I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.Pp
 Lower values are associated with better latency on rotational media but poorer
-resilver performance. The default value of 2 was chosen as a compromise. A
-value of 3 has been shown to improve resilver performance further at a cost of
+resilver performance.
+The default value of
+.Sy 2
+was chosen as a compromise.
+A value of
+.Sy 3
+has been shown to improve resilver performance further at a cost of
 further increasing latency.
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_initializing_max_active\fR (int)
-.ad
-.RS 12n
-Maximum initializing I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_initializing_min_active\fR (int)
-.ad
-.RS 12n
-Minimum initializing I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_max_active\fR (int)
-.ad
-.RS 12n
-The maximum number of I/Os active to each device.  Ideally, this will be >=
-the sum of each queue's max_active.  See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_rebuild_max_active\fR (int)
-.ad
-.RS 12n
-Maximum sequential resilver I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB3\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_rebuild_min_active\fR (int)
-.ad
-.RS 12n
-Minimum sequential resilver I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_removal_max_active\fR (int)
-.ad
-.RS 12n
-Maximum removal I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_removal_min_active\fR (int)
-.ad
-.RS 12n
-Minimum removal I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_scrub_max_active\fR (int)
-.ad
-.RS 12n
-Maximum scrub I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_scrub_min_active\fR (int)
-.ad
-.RS 12n
-Minimum scrub I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_sync_read_max_active\fR (int)
-.ad
-.RS 12n
-Maximum synchronous read I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_sync_read_min_active\fR (int)
-.ad
-.RS 12n
-Minimum synchronous read I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_sync_write_max_active\fR (int)
-.ad
-.RS 12n
-Maximum synchronous write I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_sync_write_min_active\fR (int)
-.ad
-.RS 12n
-Minimum synchronous write I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_trim_max_active\fR (int)
-.ad
-.RS 12n
-Maximum trim/discard I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_trim_min_active\fR (int)
-.ad
-.RS 12n
-Minimum trim/discard I/Os active to each device.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_nia_delay\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_initializing_max_active Ns = Ns Sy 1 Pq int
+Maximum initializing I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_initializing_min_active Ns = Ns Sy 1 Pq int
+Minimum initializing I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_max_active Ns = Ns Sy 1000 Pq int
+The maximum number of I/O operations active to each device.
+Ideally, this will be at least the sum of each queue's
+.Sy max_active .
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_rebuild_max_active Ns = Ns Sy 3 Pq int
+Maximum sequential resilver I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_rebuild_min_active Ns = Ns Sy 1 Pq int
+Minimum sequential resilver I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_removal_max_active Ns = Ns Sy 2 Pq int
+Maximum removal I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_removal_min_active Ns = Ns Sy 1 Pq int
+Minimum removal I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_scrub_max_active Ns = Ns Sy 2 Pq int
+Maximum scrub I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_scrub_min_active Ns = Ns Sy 1 Pq int
+Minimum scrub I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_sync_read_max_active Ns = Ns Sy 10 Pq int
+Maximum synchronous read I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_sync_read_min_active Ns = Ns Sy 10 Pq int
+Minimum synchronous read I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_sync_write_max_active Ns = Ns Sy 10 Pq int
+Maximum synchronous write I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_sync_write_min_active Ns = Ns Sy 10 Pq int
+Minimum synchronous write I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_trim_max_active Ns = Ns Sy 2 Pq int
+Maximum trim/discard I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_trim_min_active Ns = Ns Sy 1 Pq int
+Minimum trim/discard I/O operations active to each device.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_nia_delay Ns = Ns Sy 5 Pq int
 For non-interactive I/O (scrub, resilver, removal, initialize and rebuild),
-the number of concurrently-active I/O's is limited to *_min_active, unless
-the vdev is "idle".  When there are no interactive I/Os active (sync or
-async), and zfs_vdev_nia_delay I/Os have completed since the last
-interactive I/O, then the vdev is considered to be "idle", and the number
-of concurrently-active non-interactive I/O's is increased to *_max_active.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_nia_credit\fR (int)
-.ad
-.RS 12n
-Some HDDs tend to prioritize sequential I/O so high, that concurrent
-random I/O latency reaches several seconds.  On some HDDs it happens
-even if sequential I/Os are submitted one at a time, and so setting
-*_max_active to 1 does not help.  To prevent non-interactive I/Os, like
-scrub, from monopolizing the device no more than zfs_vdev_nia_credit
-I/Os can be sent while there are outstanding incomplete interactive
-I/Os.  This enforced wait ensures the HDD services the interactive I/O
+the number of concurrently-active I/O operations is limited to
+.Sy zfs_*_min_active ,
+unless the vdev is "idle".
+When there are no interactive I/O operatinons active (synchronous or otherwise),
+and
+.Sy zfs_vdev_nia_delay
+operations have completed since the last interactive operation,
+then the vdev is considered to be "idle",
+and the number of concurrently-active non-interactive operations is increased to
+.Sy zfs_*_max_active .
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_nia_credit Ns = Ns Sy 5 Pq int
+Some HDDs tend to prioritize sequential I/O so strongly, that concurrent
+random I/O latency reaches several seconds.
+On some HDDs this happens even if sequential I/O operations
+are submitted one at a time, and so setting
+.Sy zfs_*_max_active Ns = Sy 1
+does not help.
+To prevent non-interactive I/O, like scrub,
+from monopolizing the device, no more than
+.Sy zfs_vdev_nia_credit operations can be sent
+while there are outstanding incomplete interactive operations.
+This enforced wait ensures the HDD services the interactive I/O
 within a reasonable amount of time.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_queue_depth_pct\fR (int)
-.ad
-.RS 12n
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_queue_depth_pct Ns = Ns Sy 1000 Ns % Pq int
 Maximum number of queued allocations per top-level vdev expressed as
-a percentage of \fBzfs_vdev_async_write_max_active\fR which allows the
-system to detect devices that are more capable of handling allocations
-and to allocate more blocks to those devices.  It allows for dynamic
-allocation distribution when devices are imbalanced as fuller devices
-will tend to be slower than empty devices.
-
-See also \fBzio_dva_throttle_enabled\fR.
-.sp
-Default value: \fB1000\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_expire_snapshot\fR (int)
-.ad
-.RS 12n
-Seconds to expire .zfs/snapshot
-.sp
-Default value: \fB300\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_admin_snapshot\fR (int)
-.ad
-.RS 12n
-Allow the creation, removal, or renaming of entries in the .zfs/snapshot
+a percentage of
+.Sy zfs_vdev_async_write_max_active ,
+which allows the system to detect devices that are more capable
+of handling allocations and to allocate more blocks to those devices.
+This allows for dynamic allocation distribution when devices are imbalanced,
+as fuller devices will tend to be slower than empty devices.
+.Pp
+Also see
+.Sy zio_dva_throttle_enabled .
+.
+.It Sy zfs_expire_snapshot Ns = Ns Sy 300 Ns s Pq int
+Time before expiring
+.Pa .zfs/snapshot .
+.
+.It Sy zfs_admin_snapshot Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Allow the creation, removal, or renaming of entries in the
+.Sy .zfs/snapshot
 directory to cause the creation, destruction, or renaming of snapshots.
-When enabled this functionality works both locally and over NFS exports
-which have the 'no_root_squash' option set. This functionality is disabled
-by default.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_flags\fR (int)
-.ad
-.RS 12n
-Set additional debugging flags. The following flags may be bitwise-or'd
-together.
-.sp
+When enabled, this functionality works both locally and over NFS exports
+which have the
+.Em no_root_squash
+option set.
+.
+.It Sy zfs_flags Ns = Ns Sy 0 Pq int
+Set additional debugging flags.
+The following flags may be bitwise-ored together:
 .TS
 box;
-rB lB
-lB lB
-r l.
-Value	Symbolic Name
-	Description
+lbz r l l .
+	Value	Symbolic Name	Description
 _
-1	ZFS_DEBUG_DPRINTF
-	Enable dprintf entries in the debug log.
-_
-2	ZFS_DEBUG_DBUF_VERIFY *
-	Enable extra dbuf verifications.
-_
-4	ZFS_DEBUG_DNODE_VERIFY *
-	Enable extra dnode verifications.
-_
-8	ZFS_DEBUG_SNAPNAMES
-	Enable snapshot name verification.
-_
-16	ZFS_DEBUG_MODIFY
-	Check for illegally modified ARC buffers.
-_
-64	ZFS_DEBUG_ZIO_FREE
-	Enable verification of block frees.
-_
-128	ZFS_DEBUG_HISTOGRAM_VERIFY
-	Enable extra spacemap histogram verifications.
-_
-256	ZFS_DEBUG_METASLAB_VERIFY
-	Verify space accounting on disk matches in-core range_trees.
-_
-512	ZFS_DEBUG_SET_ERROR
-	Enable SET_ERROR and dprintf entries in the debug log.
-_
-1024	ZFS_DEBUG_INDIRECT_REMAP
-	Verify split blocks created by device removal.
-_
-2048	ZFS_DEBUG_TRIM
-	Verify TRIM ranges are always within the allocatable range tree.
-_
-4096	ZFS_DEBUG_LOG_SPACEMAP
-	Verify that the log summary is consistent with the spacemap log
-	and enable zfs_dbgmsgs for metaslab loading and flushing.
+	1	ZFS_DEBUG_DPRINTF	Enable dprintf entries in the debug log.
+*	2	ZFS_DEBUG_DBUF_VERIFY	Enable extra dbuf verifications.
+*	4	ZFS_DEBUG_DNODE_VERIFY	Enable extra dnode verifications.
+	8	ZFS_DEBUG_SNAPNAMES	Enable snapshot name verification.
+	16	ZFS_DEBUG_MODIFY	Check for illegally modified ARC buffers.
+	64	ZFS_DEBUG_ZIO_FREE	Enable verification of block frees.
+	128	ZFS_DEBUG_HISTOGRAM_VERIFY	Enable extra spacemap histogram verifications.
+	256	ZFS_DEBUG_METASLAB_VERIFY	Verify space accounting on disk matches in-memory \fBrange_trees\fP.
+	512	ZFS_DEBUG_SET_ERROR	Enable \fBSET_ERROR\fP and dprintf entries in the debug log.
+	1024	ZFS_DEBUG_INDIRECT_REMAP	Verify split blocks created by device removal.
+	2048	ZFS_DEBUG_TRIM	Verify TRIM ranges are always within the allocatable range tree.
+	4096	ZFS_DEBUG_LOG_SPACEMAP	Verify that the log summary is consistent with the spacemap log
+			       and enable \fBzfs_dbgmsgs\fP for metaslab loading and flushing.
 .TE
-.sp
-* Requires debug build.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_free_leak_on_eio\fR (int)
-.ad
-.RS 12n
-If destroy encounters an EIO while reading metadata (e.g. indirect
-blocks), space referenced by the missing metadata can not be freed.
-Normally this causes the background destroy to become "stalled", as
-it is unable to make forward progress.  While in this stalled state,
-all remaining space to free from the error-encountering filesystem is
-"temporarily leaked".  Set this flag to cause it to ignore the EIO,
+.Sy \& * No Requires debug build.
+.
+.It Sy zfs_free_leak_on_eio Ns = Ns Sy 0 Ns | Ns 1 Pq int
+If destroy encounters an
+.Sy EIO
+while reading metadata (e.g. indirect blocks),
+space referenced by the missing metadata can not be freed.
+Normally this causes the background destroy to become "stalled",
+as it is unable to make forward progress.
+While in this stalled state, all remaining space to free
+from the error-encountering filesystem is "temporarily leaked".
+Set this flag to cause it to ignore the
+.Sy EIO ,
 permanently leak the space from indirect blocks that can not be read,
 and continue to free everything else that it can.
-
-The default, "stalling" behavior is useful if the storage partially
-fails (i.e. some but not all i/os fail), and then later recovers.  In
-this case, we will be able to continue pool operations while it is
+.Pp
+The default "stalling" behavior is useful if the storage partially
+fails (i.e. some but not all I/O operations fail), and then later recovers.
+In this case, we will be able to continue pool operations while it is
 partially failed, and when it recovers, we can continue to free the
-space, with no leaks.  However, note that this case is actually
-fairly rare.
-
-Typically pools either (a) fail completely (but perhaps temporarily,
-e.g. a top-level vdev going offline), or (b) have localized,
-permanent errors (e.g. disk returns the wrong data due to bit flip or
-firmware bug).  In case (a), this setting does not matter because the
+space, with no leaks.
+Note, however, that this case is actually fairly rare.
+.Pp
+Typically pools either
+.Bl -enum -compact -offset 4n -width "1."
+.It
+fail completely (but perhaps temporarily,
+e.g. due to a top-level vdev going offline), or
+.It
+have localized, permanent errors (e.g. disk returns the wrong data
+due to bit flip or firmware bug).
+.El
+In the former case, this setting does not matter because the
 pool will be suspended and the sync thread will not be able to make
-forward progress regardless.  In case (b), because the error is
-permanent, the best we can do is leak the minimum amount of space,
-which is what setting this flag will do.  Therefore, it is reasonable
-for this flag to normally be set, but we chose the more conservative
-approach of not setting it, so that there is no possibility of
+forward progress regardless.
+In the latter, because the error is permanent, the best we can do
+is leak the minimum amount of space,
+which is what setting this flag will do.
+It is therefore reasonable for this flag to normally be set,
+but we chose the more conservative approach of not setting it,
+so that there is no possibility of
 leaking space in the "partial temporary" failure case.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_free_min_time_ms\fR (int)
-.ad
-.RS 12n
-During a \fBzfs destroy\fR operation using \fBfeature@async_destroy\fR a minimum
-of this much time will be spent working on freeing blocks per txg.
-.sp
-Default value: \fB1,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_obsolete_min_time_ms\fR (int)
-.ad
-.RS 12n
-Similar to \fBzfs_free_min_time_ms\fR but for cleanup of old indirection records
-for removed vdevs.
-.sp
-Default value: \fB500\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_immediate_write_sz\fR (long)
-.ad
-.RS 12n
-Largest data block to write to zil. Larger blocks will be treated as if the
-dataset being written to had the property setting \fBlogbias=throughput\fR.
-.sp
-Default value: \fB32,768\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_initialize_value\fR (ulong)
-.ad
-.RS 12n
-Pattern written to vdev free space by \fBzpool initialize\fR.
-.sp
-Default value: \fB16,045,690,984,833,335,022\fR (0xdeadbeefdeadbeee).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_initialize_chunk_size\fR (ulong)
-.ad
-.RS 12n
-Size of writes used by \fBzpool initialize\fR.
-This option is used by the test suite to facilitate testing.
-.sp
-Default value: \fB1,048,576\fR
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_max_entries\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_free_min_time_ms Ns = Ns Sy 1000 Ns ms Po 1s Pc Pq int
+During a
+.Nm zfs Cm destroy
+operation using the
+.Sy async_destroy
+feature,
+a minimum of this much time will be spent working on freeing blocks per TXG.
+.
+.It Sy zfs_obsolete_min_time_ms Ns = Ns Sy 500 Ns ms Pq int
+Similar to
+.Sy zfs_free_min_time_ms ,
+but for cleanup of old indirection records for removed vdevs.
+.
+.It Sy zfs_immediate_write_sz Ns = Ns Sy 32768 Ns B Po 32kB Pc Pq long
+Largest data block to write to the ZIL.
+Larger blocks will be treated as if the dataset being written to had the
+.Sy logbias Ns = Ns Sy throughput
+property set.
+.
+.It Sy zfs_initialize_value Ns = Ns Sy 16045690984833335022 Po 0xDEADBEEFDEADBEEE Pc Pq ulong
+Pattern written to vdev free space by
+.Xr zpool-initialize 8 .
+.
+.It Sy zfs_initialize_chunk_size Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq ulong
+Size of writes used by
+.Xr zpool-initialize 8 .
+This option is used by the test suite.
+.
+.It Sy zfs_livelist_max_entries Ns = Ns Sy 500000 Po 5*10^5 Pc Pq ulong
 The threshold size (in block pointers) at which we create a new sub-livelist.
 Larger sublists are more costly from a memory perspective but the fewer
 sublists there are, the lower the cost of insertion.
-.sp
-Default value: \fB500,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_min_percent_shared\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_livelist_min_percent_shared Ns = Ns Sy 75 Ns % Pq int
 If the amount of shared space between a snapshot and its clone drops below
-this threshold, the clone turns off the livelist and reverts to the old deletion
-method. This is in place because once a clone has been overwritten enough
-livelists no long give us a benefit.
-.sp
-Default value: \fB75\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_condense_new_alloc\fR (int)
-.ad
-.RS 12n
+this threshold, the clone turns off the livelist and reverts to the old
+deletion method.
+This is in place because livelists no long give us a benefit
+once a clone has been overwritten enough.
+.
+.It Sy zfs_livelist_condense_new_alloc Ns = Ns Sy 0 Pq int
 Incremented each time an extra ALLOC blkptr is added to a livelist entry while
 it is being condensed.
 This option is used by the test suite to track race conditions.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_condense_sync_cancel\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_livelist_condense_sync_cancel Ns = Ns Sy 0 Pq int
 Incremented each time livelist condensing is canceled while in
-spa_livelist_condense_sync.
+.Fn spa_livelist_condense_sync .
 This option is used by the test suite to track race conditions.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_condense_sync_pause\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_livelist_condense_sync_pause Ns = Ns Sy 0 Ns | Ns 1 Pq int
 When set, the livelist condense process pauses indefinitely before
-executing the synctask - spa_livelist_condense_sync.
+executing the synctask -
+.Fn spa_livelist_condense_sync .
 This option is used by the test suite to trigger race conditions.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_condense_zthr_cancel\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_livelist_condense_zthr_cancel Ns = Ns Sy 0 Pq int
 Incremented each time livelist condensing is canceled while in
-spa_livelist_condense_cb.
+.Fn spa_livelist_condense_cb .
 This option is used by the test suite to track race conditions.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_livelist_condense_zthr_pause\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_livelist_condense_zthr_pause Ns = Ns Sy 0 Ns | Ns 1 Pq int
 When set, the livelist condense process pauses indefinitely before
-executing the open context condensing work in spa_livelist_condense_cb.
+executing the open context condensing work in
+.Fn spa_livelist_condense_cb .
 This option is used by the test suite to trigger race conditions.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_lua_max_instrlimit\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_lua_max_instrlimit Ns = Ns Sy 100000000 Po 10^8 Pc Pq ulong
 The maximum execution time limit that can be set for a ZFS channel program,
 specified as a number of Lua instructions.
-.sp
-Default value: \fB100,000,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_lua_max_memlimit\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_lua_max_memlimit Ns = Ns Sy 104857600 Po 100MB Pc Pq ulong
 The maximum memory limit that can be set for a ZFS channel program, specified
 in bytes.
-.sp
-Default value: \fB104,857,600\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_dataset_nesting\fR (int)
-.ad
-.RS 12n
-The maximum depth of nested datasets.  This value can be tuned temporarily to
+.
+.It Sy zfs_max_dataset_nesting Ns = Ns Sy 50 Pq int
+The maximum depth of nested datasets.
+This value can be tuned temporarily to
 fix existing datasets that exceed the predefined limit.
-.sp
-Default value: \fB50\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_log_walking\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_max_log_walking Ns = Ns Sy 5 Pq ulong
 The number of past TXGs that the flushing algorithm of the log spacemap
 feature uses to estimate incoming log blocks.
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_logsm_summary_length\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_max_logsm_summary_length Ns = Ns Sy 10 Pq ulong
 Maximum number of rows allowed in the summary of the spacemap log.
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_max_recordsize\fR (int)
-.ad
-.RS 12n
-We currently support block sizes from 512 bytes to 16MB.  The benefits of
-larger blocks, and thus larger I/O, need to be weighed against the cost of
-COWing a giant block to modify one byte.  Additionally, very large blocks
-can have an impact on i/o latency, and also potentially on the memory
-allocator.  Therefore, we do not allow the recordsize to be set larger than
-zfs_max_recordsize (default 1MB).  Larger blocks can be created by changing
-this tunable, and pools with larger blocks can always be imported and used,
+.
+.It Sy zfs_max_recordsize Ns = Ns Sy 1048576 Po 1MB Pc Pq int
+We currently support block sizes from
+.Em 512B No to Em 16MB .
+The benefits of larger blocks, and thus larger I/O,
+need to be weighed against the cost of COWing a giant block to modify one byte.
+Additionally, very large blocks can have an impact on I/O latency,
+and also potentially on the memory allocator.
+Therefore, we do not allow the recordsize to be set larger than this tunable.
+Larger blocks can be created by changing it,
+and pools with larger blocks can always be imported and used,
 regardless of this setting.
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_allow_redacted_dataset_mount\fR (int)
-.ad
-.RS 12n
-Allow datasets received with redacted send/receive to be mounted. Normally
-disabled because these datasets may be missing key data.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_min_metaslabs_to_flush\fR (ulong)
-.ad
-.RS 12n
-Minimum number of metaslabs to flush per dirty TXG
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_metaslab_fragmentation_threshold\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_allow_redacted_dataset_mount Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Allow datasets received with redacted send/receive to be mounted.
+Normally disabled because these datasets may be missing key data.
+.
+.It Sy zfs_min_metaslabs_to_flush Ns = Ns Sy 1 Pq ulong
+Minimum number of metaslabs to flush per dirty TXG.
+.
+.It Sy zfs_metaslab_fragmentation_threshold Ns = Ns Sy 70 Ns % Pq int
 Allow metaslabs to keep their active state as long as their fragmentation
-percentage is less than or equal to this value. An active metaslab that
-exceeds this threshold will no longer keep its active status allowing
-better metaslabs to be selected.
-.sp
-Default value: \fB70\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_mg_fragmentation_threshold\fR (int)
-.ad
-.RS 12n
+percentage is no more than this value.
+An active metaslab that exceeds this threshold
+will no longer keep its active status allowing better metaslabs to be selected.
+.
+.It Sy zfs_mg_fragmentation_threshold Ns = Ns Sy 95 Ns % Pq int
 Metaslab groups are considered eligible for allocations if their
 fragmentation metric (measured as a percentage) is less than or equal to
-this value. If a metaslab group exceeds this threshold then it will be
+this value.
+If a metaslab group exceeds this threshold then it will be
 skipped unless all metaslab groups within the metaslab class have also
 crossed this threshold.
-.sp
-Default value: \fB95\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_mg_noalloc_threshold\fR (int)
-.ad
-.RS 12n
-Defines a threshold at which metaslab groups should be eligible for
-allocations.  The value is expressed as a percentage of free space
+.
+.It Sy zfs_mg_noalloc_threshold Ns = Ns Sy 0 Ns % Pq int
+Defines a threshold at which metaslab groups should be eligible for allocations.
+The value is expressed as a percentage of free space
 beyond which a metaslab group is always eligible for allocations.
 If a metaslab group's free space is less than or equal to the
 threshold, the allocator will avoid allocating to that group
-unless all groups in the pool have reached the threshold.  Once all
-groups have reached the threshold, all groups are allowed to accept
-allocations.  The default value of 0 disables the feature and causes
-all metaslab groups to be eligible for allocations.
-
+unless all groups in the pool have reached the threshold.
+Once all groups have reached the threshold, all groups are allowed to accept
+allocations.
+The default value of
+.Sy 0
+disables the feature and causes all metaslab groups to be eligible for allocations.
+.Pp
 This parameter allows one to deal with pools having heavily imbalanced
 vdevs such as would be the case when a new vdev has been added.
 Setting the threshold to a non-zero percentage will stop allocations
 from being made to vdevs that aren't filled to the specified percentage
 and allow lesser filled vdevs to acquire more allocations than they
-otherwise would under the old \fBzfs_mg_alloc_failures\fR facility.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_ddt_data_is_special\fR (int)
-.ad
-.RS 12n
+otherwise would under the old
+.Sy zfs_mg_alloc_failures
+facility.
+.
+.It Sy zfs_ddt_data_is_special Ns = Ns Sy 1 Ns | Ns 0 Pq int
 If enabled, ZFS will place DDT data into the special allocation class.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_user_indirect_is_special\fR (int)
-.ad
-.RS 12n
-If enabled, ZFS will place user data (both file and zvol) indirect blocks
+.
+.It Sy zfs_user_indirect_is_special Ns = Ns Sy 1 Ns | Ns 0 Pq int
+If enabled, ZFS will place user data indirect blocks
 into the special allocation class.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_multihost_history\fR (int)
-.ad
-.RS 12n
-Historical statistics for the last N multihost updates will be available in
-\fB/proc/spl/kstat/zfs/<pool>/multihost\fR
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_multihost_interval\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_multihost_history Ns = Ns Sy 0 Pq int
+Historical statistics for this many latest multihost updates will be available in
+.Pa /proc/spl/kstat/zfs/ Ns Ao Ar pool Ac Ns Pa /multihost .
+.
+.It Sy zfs_multihost_interval Ns = Ns Sy 1000 Ns ms Po 1s Pc Pq ulong
 Used to control the frequency of multihost writes which are performed when the
-\fBmultihost\fR pool property is on.  This is one factor used to determine the
+.Sy multihost
+pool property is on.
+This is one of the factors used to determine the
 length of the activity check during import.
-.sp
-The multihost write period is \fBzfs_multihost_interval / leaf-vdevs\fR
-milliseconds.  On average a multihost write will be issued for each leaf vdev
-every \fBzfs_multihost_interval\fR milliseconds.  In practice, the observed
-period can vary with the I/O load and this observed value is the delay which is
-stored in the uberblock.
-.sp
-Default value: \fB1000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_multihost_import_intervals\fR (uint)
-.ad
-.RS 12n
-Used to control the duration of the activity test on import.  Smaller values of
-\fBzfs_multihost_import_intervals\fR will reduce the import time but increase
-the risk of failing to detect an active pool.  The total activity check time is
-never allowed to drop below one second.
-.sp
+.Pp
+The multihost write period is
+.Sy zfs_multihost_interval / leaf-vdevs .
+On average a multihost write will be issued for each leaf vdev
+every
+.Sy zfs_multihost_interval
+milliseconds.
+In practice, the observed period can vary with the I/O load
+and this observed value is the delay which is stored in the uberblock.
+.
+.It Sy zfs_multihost_import_intervals Ns = Ns Sy 20 Pq uint
+Used to control the duration of the activity test on import.
+Smaller values of
+.Sy zfs_multihost_import_intervals
+will reduce the import time but increase
+the risk of failing to detect an active pool.
+The total activity check time is never allowed to drop below one second.
+.Pp
 On import the activity check waits a minimum amount of time determined by
-\fBzfs_multihost_interval * zfs_multihost_import_intervals\fR, or the same
-product computed on the host which last had the pool imported (whichever is
-greater).  The activity check time may be further extended if the value of mmp
+.Sy zfs_multihost_interval * zfs_multihost_import_intervals ,
+or the same product computed on the host which last had the pool imported,
+whichever is greater.
+The activity check time may be further extended if the value of MMP
 delay found in the best uberblock indicates actual multihost updates happened
-at longer intervals than \fBzfs_multihost_interval\fR.  A minimum value of
-\fB100ms\fR is enforced.
-.sp
-A value of 0 is ignored and treated as if it was set to 1.
-.sp
-Default value: \fB20\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_multihost_fail_intervals\fR (uint)
-.ad
-.RS 12n
+at longer intervals than
+.Sy zfs_multihost_interval .
+A minimum of
+.Em 100ms
+is enforced.
+.Pp
+.Sy 0 No is equivalent to Sy 1 .
+.
+.It Sy zfs_multihost_fail_intervals Ns = Ns Sy 10 Pq uint
 Controls the behavior of the pool when multihost write failures or delays are
 detected.
-.sp
-When \fBzfs_multihost_fail_intervals = 0\fR, multihost write failures or delays
-are ignored.  The failures will still be reported to the ZED which depending on
+.Pp
+When
+.Sy 0 ,
+multihost write failures or delays are ignored.
+The failures will still be reported to the ZED which depending on
 its configuration may take action such as suspending the pool or offlining a
 device.
-
-.sp
-When \fBzfs_multihost_fail_intervals > 0\fR, the pool will be suspended if
-\fBzfs_multihost_fail_intervals * zfs_multihost_interval\fR milliseconds pass
-without a successful mmp write.  This guarantees the activity test will see
-mmp writes if the pool is imported.  A value of 1 is ignored and treated as
-if it was set to 2.  This is necessary to prevent the pool from being suspended
+.Pp
+Otherwise, the pool will be suspended if
+.Sy zfs_multihost_fail_intervals * zfs_multihost_interval
+milliseconds pass without a successful MMP write.
+This guarantees the activity test will see MMP writes if the pool is imported.
+.Sy 1 No is equivalent to Sy 2 ;
+this is necessary to prevent the pool from being suspended
 due to normal, small I/O latency variations.
-
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_no_scrub_io\fR (int)
-.ad
-.RS 12n
-Set for no scrub I/O. This results in scrubs not actually scrubbing data and
+.
+.It Sy zfs_no_scrub_io Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Set to disable scrub I/O.
+This results in scrubs not actually scrubbing data and
 simply doing a metadata crawl of the pool instead.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_no_scrub_prefetch\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_no_scrub_prefetch Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Set to disable block prefetching for scrubs.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_nocacheflush\fR (int)
-.ad
-.RS 12n
-Disable cache flush operations on disks when writing.  Setting this will
-cause pool corruption on power loss if a volatile out-of-order write cache
-is enabled.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_nopwrite_enabled\fR (int)
-.ad
-.RS 12n
-Enable NOP writes
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_dmu_offset_next_sync\fR (int)
-.ad
-.RS 12n
-Enable forcing txg sync to find holes. When enabled forces ZFS to act
-like prior versions when SEEK_HOLE or SEEK_DATA flags are used, which
-when a dnode is dirty causes txg's to be synced so that this data can be
-found.
-.sp
-Use \fB1\fR for yes and \fB0\fR to disable (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_pd_bytes_max\fR (int)
-.ad
-.RS 12n
-The number of bytes which should be prefetched during a pool traversal
-(eg: \fBzfs send\fR or other data crawling operations)
-.sp
-Default value: \fB52,428,800\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_traverse_indirect_prefetch_limit\fR (int)
-.ad
-.RS 12n
-The number of blocks pointed by indirect (non-L0) block, which should be
-prefetched during a pool traversal (eg: \fBzfs send\fR or other data
-crawling operations)
-.sp
-Default value: \fB32\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_per_txg_dirty_frees_percent \fR (ulong)
-.ad
-.RS 12n
-Tunable to control percentage of dirtied indirect blocks from frees allowed
-into one TXG. After this threshold is crossed, additional frees will wait until
-the next TXG.
-A value of zero will disable this throttle.
-.sp
-Default value: \fB5\fR, set to \fB0\fR to disable.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_prefetch_disable\fR (int)
-.ad
-.RS 12n
-This tunable disables predictive prefetch.  Note that it leaves "prescient"
-prefetch (e.g. prefetch for zfs send) intact.  Unlike predictive prefetch,
-prescient prefetch never issues i/os that end up not being needed, so it
-can't hurt performance.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_qat_checksum_disable\fR (int)
-.ad
-.RS 12n
-This tunable disables qat hardware acceleration for sha256 checksums. It
-may be set after the zfs modules have been loaded to initialize the qat
-hardware as long as support is compiled in and the qat driver is present.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_qat_compress_disable\fR (int)
-.ad
-.RS 12n
-This tunable disables qat hardware acceleration for gzip compression. It
-may be set after the zfs modules have been loaded to initialize the qat
-hardware as long as support is compiled in and the qat driver is present.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_qat_encrypt_disable\fR (int)
-.ad
-.RS 12n
-This tunable disables qat hardware acceleration for AES-GCM encryption. It
-may be set after the zfs modules have been loaded to initialize the qat
-hardware as long as support is compiled in and the qat driver is present.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vnops_read_chunk_size\fR (long)
-.ad
-.RS 12n
-Bytes to read per chunk
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_read_history\fR (int)
-.ad
-.RS 12n
-Historical statistics for the last N reads will be available in
-\fB/proc/spl/kstat/zfs/<pool>/reads\fR
-.sp
-Default value: \fB0\fR (no data is kept).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_read_history_hits\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_nocacheflush Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable cache flush operations on disks when writing.
+Setting this will cause pool corruption on power loss
+if a volatile out-of-order write cache is enabled.
+.
+.It Sy zfs_nopwrite_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Allow no-operation writes.
+The occurrence of nopwrites will further depend on other pool properties
+.Pq i.a. the checksumming and compression algorithms .
+.
+.It Sy zfs_dmu_offset_next_sync Ns = Ns Sy 0 Ns | ns 1 Pq int
+Enable forcing TXG sync to find holes.
+When enabled forces ZFS to act like prior versions when
+.Sy SEEK_HOLE No or Sy SEEK_DATA
+flags are used, which, when a dnode is dirty,
+causes TXGs to be synced so that this data can be found.
+.
+.It Sy zfs_pd_bytes_max Ns = Ns Sy 52428800 Ns B Po 50MB Pc Pq int
+The number of bytes which should be prefetched during a pool traversal, like
+.Nm zfs Cm send
+or other data crawling operations.
+.
+.It Sy zfs_traverse_indirect_prefetch_limit Ns = Ns Sy 32 Pq int
+The number of blocks pointed by indirect (non-L0) block which should be
+prefetched during a pool traversal, like
+.Nm zfs Cm send
+or other data crawling operations.
+.
+.It Sy zfs_per_txg_dirty_frees_percent Ns = Ns Sy 5 Ns % Pq ulong
+Control percentage of dirtied indirect blocks from frees allowed into one TXG.
+After this threshold is crossed, additional frees will wait until the next TXG.
+.Sy 0 No disables this throttle.
+.
+.It Sy zfs_prefetch_disable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable predictive prefetch.
+Note that it leaves "prescient" prefetch (for. e.g.\&
+.Nm zfs Cm send )
+intact.
+Unlike predictive prefetch, prescient prefetch never issues I/O
+that ends up not being needed, so it can't hurt performance.
+.
+.It Sy zfs_qat_checksum_disable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable QAT hardware acceleration for SHA256 checksums.
+May be unset after the ZFS modules have been loaded to initialize the QAT
+hardware as long as support is compiled in and the QAT driver is present.
+.
+.It Sy zfs_qat_compress_disable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable QAT hardware acceleration for gzip compression.
+May be unset after the ZFS modules have been loaded to initialize the QAT
+hardware as long as support is compiled in and the QAT driver is present.
+.
+.It Sy zfs_qat_encrypt_disable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable QAT hardware acceleration for AES-GCM encryption.
+May be unset after the ZFS modules have been loaded to initialize the QAT
+hardware as long as support is compiled in and the QAT driver is present.
+.
+.It Sy zfs_vnops_read_chunk_size Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq long
+Bytes to read per chunk.
+.
+.It Sy zfs_read_history Ns = Ns Sy 0 Pq int
+Historical statistics for this many latest reads will be available in
+.Pa /proc/spl/kstat/zfs/ Ns Ao Ar pool Ac Ns Pa /reads .
+.
+.It Sy zfs_read_history_hits Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Include cache hits in read history
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_rebuild_max_segment\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_rebuild_max_segment Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq ulong
 Maximum read segment size to issue when sequentially resilvering a
 top-level vdev.
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_rebuild_scrub_enabled\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_rebuild_scrub_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Automatically start a pool scrub when the last active sequential resilver
 completes in order to verify the checksums of all blocks which have been
-resilvered. This option is enabled by default and is strongly recommended.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_rebuild_vdev_limit\fR (ulong)
-.ad
-.RS 12n
-Maximum amount of i/o that can be concurrently issued for a sequential
+resilvered.
+This is enabled by default and strongly recommended.
+.
+.It Sy zfs_rebuild_vdev_limit Ns = Ns Sy 33554432 Ns B Po 32MB Pc Pq ulong
+Maximum amount of I/O that can be concurrently issued for a sequential
 resilver per leaf device, given in bytes.
-.sp
-Default value: \fB33,554,432\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_reconstruct_indirect_combinations_max\fR (int)
-.ad
-.RS 12na
+.
+.It Sy zfs_reconstruct_indirect_combinations_max Ns = Ns Sy 4096 Pq int
 If an indirect split block contains more than this many possible unique
 combinations when being reconstructed, consider it too computationally
-expensive to check them all. Instead, try at most
-\fBzfs_reconstruct_indirect_combinations_max\fR randomly-selected
-combinations each time the block is accessed.  This allows all segment
-copies to participate fairly in the reconstruction when all combinations
+expensive to check them all.
+Instead, try at most this many randomly selected
+combinations each time the block is accessed.
+This allows all segment copies to participate fairly
+in the reconstruction when all combinations
 cannot be checked and prevents repeated use of one bad copy.
-.sp
-Default value: \fB4096\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_recover\fR (int)
-.ad
-.RS 12n
-Set to attempt to recover from fatal errors. This should only be used as a
-last resort, as it typically results in leaked space, or worse.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_removal_ignore_errors\fR (int)
-.ad
-.RS 12n
-.sp
-Ignore hard IO errors during device removal.  When set, if a device encounters
-a hard IO error during the removal process the removal will not be cancelled.
+.
+.It Sy zfs_recover Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Set to attempt to recover from fatal errors.
+This should only be used as a last resort,
+as it typically results in leaked space, or worse.
+.
+.It Sy zfs_removal_ignore_errors Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Ignore hard IO errors during device removal.
+When set, if a device encounters a hard IO error during the removal process
+the removal will not be cancelled.
 This can result in a normally recoverable block becoming permanently damaged
-and is not recommended.  This should only be used as a last resort when the
+and is hence not recommended.
+This should only be used as a last resort when the
 pool cannot be returned to a healthy state prior to removing the device.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_removal_suspend_progress\fR (int)
-.ad
-.RS 12n
-.sp
+.
+.It Sy zfs_removal_suspend_progress Ns = Ns Sy 0 Ns | Ns 1 Pq int
 This is used by the test suite so that it can ensure that certain actions
 happen while in the middle of a removal.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_remove_max_segment\fR (int)
-.ad
-.RS 12n
-.sp
+.
+.It Sy zfs_remove_max_segment Ns = Ns Sy 16777216 Ns B Po 16MB Pc Pq int
 The largest contiguous segment that we will attempt to allocate when removing
-a device.  This can be no larger than 16MB.  If there is a performance
-problem with attempting to allocate large blocks, consider decreasing this.
-.sp
-Default value: \fB16,777,216\fR (16MB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_resilver_disable_defer\fR (int)
-.ad
-.RS 12n
-Disables the \fBresilver_defer\fR feature, causing an operation that would
-start a resilver to restart one in progress immediately.
-.sp
-Default value: \fB0\fR (feature enabled).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_resilver_min_time_ms\fR (int)
-.ad
-.RS 12n
-Resilvers are processed by the sync thread. While resilvering it will spend
-at least this much time working on a resilver between txg flushes.
-.sp
-Default value: \fB3,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_ignore_errors\fR (int)
-.ad
-.RS 12n
-If set to a nonzero value, remove the DTL (dirty time list) upon
-completion of a pool scan (scrub) even if there were unrepairable
-errors.  It is intended to be used during pool repair or recovery to
+a device.
+If there is a performance problem with attempting to allocate large blocks,
+consider decreasing this.
+The default value is also the maximum.
+.
+.It Sy zfs_resilver_disable_defer Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Ignore the
+.Sy resilver_defer
+feature, causing an operation that would start a resilver to
+immediately restart the one in progress.
+.
+.It Sy zfs_resilver_min_time_ms Ns = Ns Sy 3000 Ns ms Po 3s Pc Pq int
+Resilvers are processed by the sync thread.
+While resilvering, it will spend at least this much time
+working on a resilver between TXG flushes.
+.
+.It Sy zfs_scan_ignore_errors Ns = Ns Sy 0 Ns | Ns 1 Pq int
+If set, remove the DTL (dirty time list) upon completion of a pool scan (scrub),
+even if there were unrepairable errors.
+Intended to be used during pool repair or recovery to
 stop resilvering when the pool is next imported.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scrub_min_time_ms\fR (int)
-.ad
-.RS 12n
-Scrubs are processed by the sync thread. While scrubbing it will spend
-at least this much time working on a scrub between txg flushes.
-.sp
-Default value: \fB1,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_checkpoint_intval\fR (int)
-.ad
-.RS 12n
-To preserve progress across reboots the sequential scan algorithm periodically
-needs to stop metadata scanning and issue all the verifications I/Os to disk.
-The frequency of this flushing is determined by the
-\fBzfs_scan_checkpoint_intval\fR tunable.
-.sp
-Default value: \fB7200\fR seconds (every 2 hours).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_fill_weight\fR (int)
-.ad
-.RS 12n
-This tunable affects how scrub and resilver I/O segments are ordered. A higher
-number indicates that we care more about how filled in a segment is, while a
-lower number indicates we care more about the size of the extent without
-considering the gaps within a segment. This value is only tunable upon module
-insertion. Changing the value afterwards will have no affect on scrub or
-resilver performance.
-.sp
-Default value: \fB3\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_issue_strategy\fR (int)
-.ad
-.RS 12n
-Determines the order that data will be verified while scrubbing or resilvering.
-If set to \fB1\fR, data will be verified as sequentially as possible, given the
-amount of memory reserved for scrubbing (see \fBzfs_scan_mem_lim_fact\fR). This
-may improve scrub performance if the pool's data is very fragmented. If set to
-\fB2\fR, the largest mostly-contiguous chunk of found data will be verified
-first. By deferring scrubbing of small segments, we may later find adjacent data
-to coalesce and increase the segment size. If set to \fB0\fR, zfs will use
-strategy \fB1\fR during normal verification and strategy \fB2\fR while taking a
-checkpoint.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_legacy\fR (int)
-.ad
-.RS 12n
-A value of 0 indicates that scrubs and resilvers will gather metadata in
-memory before issuing sequential I/O. A value of 1 indicates that the legacy
-algorithm will be used where I/O is initiated as soon as it is discovered.
-Changing this value to 0 will not affect scrubs or resilvers that are already
-in progress.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_max_ext_gap\fR (int)
-.ad
-.RS 12n
-Indicates the largest gap in bytes between scrub / resilver I/Os that will still
-be considered sequential for sorting purposes. Changing this value will not
+.
+.It Sy zfs_scrub_min_time_ms Ns = Ns Sy 1000 Ns ms Po 1s Pc Pq int
+Scrubs are processed by the sync thread.
+While scrubbing, it will spend at least this much time
+working on a scrub between TXG flushes.
+.
+.It Sy zfs_scan_checkpoint_intval Ns = Ns Sy 7200 Ns s Po 2h Pc Pq int
+To preserve progress across reboots, the sequential scan algorithm periodically
+needs to stop metadata scanning and issue all the verification I/O to disk.
+The frequency of this flushing is determined by this tunable.
+.
+.It Sy zfs_scan_fill_weight Ns = Ns Sy 3 Pq int
+This tunable affects how scrub and resilver I/O segments are ordered.
+A higher number indicates that we care more about how filled in a segment is,
+while a lower number indicates we care more about the size of the extent without
+considering the gaps within a segment.
+This value is only tunable upon module insertion.
+Changing the value afterwards will have no affect on scrub or resilver performance.
+.
+.It Sy zfs_scan_issue_strategy Ns = Ns Sy 0 Pq int
+Determines the order that data will be verified while scrubbing or resilvering:
+.Bl -tag -compact -offset 4n -width "a"
+.It Sy 1
+Data will be verified as sequentially as possible, given the
+amount of memory reserved for scrubbing
+.Pq see Sy zfs_scan_mem_lim_fact .
+This may improve scrub performance if the pool's data is very fragmented.
+.It Sy 2
+The largest mostly-contiguous chunk of found data will be verified first.
+By deferring scrubbing of small segments, we may later find adjacent data
+to coalesce and increase the segment size.
+.It Sy 0
+.No Use strategy Sy 1 No during normal verification
+.No and strategy Sy 2 No while taking a checkpoint.
+.El
+.
+.It Sy zfs_scan_legacy Ns = Ns Sy 0 Ns | Ns 1 Pq int
+If unset, indicates that scrubs and resilvers will gather metadata in
+memory before issuing sequential I/O.
+Otherwise indicates that the legacy algorithm will be used,
+where I/O is initiated as soon as it is discovered.
+Unsetting will not affect scrubs or resilvers that are already in progress.
+.
+.It Sy zfs_scan_max_ext_gap Ns = Ns Sy 2097152 Ns B Po 2MB Pc Pq int
+Sets the largest gap in bytes between scrub/resilver I/O operations
+that will still be considered sequential for sorting purposes.
+Changing this value will not
 affect scrubs or resilvers that are already in progress.
-.sp
-Default value: \fB2097152 (2 MB)\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_mem_lim_fact\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_scan_mem_lim_fact Ns = Ns Sy 20 Ns ^-1 Pq int
 Maximum fraction of RAM used for I/O sorting by sequential scan algorithm.
 This tunable determines the hard limit for I/O sorting memory usage.
 When the hard limit is reached we stop scanning metadata and start issuing
-data verification I/O. This is done until we get below the soft limit.
-.sp
-Default value: \fB20\fR which is 5% of RAM (1/20).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_mem_lim_soft_fact\fR (int)
-.ad
-.RS 12n
+data verification I/O.
+This is done until we get below the soft limit.
+.
+.It Sy zfs_scan_mem_lim_soft_fact Ns = Ns Sy 20 Ns ^-1 Pq int
 The fraction of the hard limit used to determined the soft limit for I/O sorting
-by the sequential scan algorithm. When we cross this limit from below no action
-is taken. When we cross this limit from above it is because we are issuing
-verification I/O. In this case (unless the metadata scan is done) we stop
-issuing verification I/O and start scanning metadata again until we get to the
-hard limit.
-.sp
-Default value: \fB20\fR which is 5% of the hard limit (1/20).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_strict_mem_lim\fR (int)
-.ad
-.RS 12n
-Enforces tight memory limits on pool scans when a sequential scan is in
-progress. When disabled the memory limit may be exceeded by fast disks.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_suspend_progress\fR (int)
-.ad
-.RS 12n
-Freezes a scrub/resilver in progress without actually pausing it. Intended for
-testing/debugging.
-.sp
-Default value: \fB0\fR.
-.RE
-
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_vdev_limit\fR (int)
-.ad
-.RS 12n
+by the sequential scan algorithm.
+When we cross this limit from below no action is taken.
+When we cross this limit from above it is because we are issuing verification I/O.
+In this case (unless the metadata scan is done) we stop issuing verification I/O
+and start scanning metadata again until we get to the hard limit.
+.
+.It Sy zfs_scan_strict_mem_lim Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Enforce tight memory limits on pool scans when a sequential scan is in progress.
+When disabled, the memory limit may be exceeded by fast disks.
+.
+.It Sy zfs_scan_suspend_progress Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Freezes a scrub/resilver in progress without actually pausing it.
+Intended for testing/debugging.
+.
+.It Sy zfs_scan_vdev_limit Ns = Ns Sy 4194304 Ns B Po 4MB Pc Pq int
 Maximum amount of data that can be concurrently issued at once for scrubs and
 resilvers per leaf device, given in bytes.
-.sp
-Default value: \fB4194304\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_corrupt_data\fR (int)
-.ad
-.RS 12n
-Allow sending of corrupt data (ignore read/checksum errors when sending data)
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_unmodified_spill_blocks\fR (int)
-.ad
-.RS 12n
-Include unmodified spill blocks in the send stream. Under certain circumstances
-previous versions of ZFS could incorrectly remove the spill block from an
-existing object.  Including unmodified copies of the spill blocks creates a
-backwards compatible stream which will recreate a spill block if it was
-incorrectly removed.
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR for no.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_no_prefetch_queue_ff\fR (int)
-.ad
-.RS 12n
-The fill fraction of the \fBzfs send\fR internal queues. The fill fraction
-controls the timing with which internal threads are woken up.
-.sp
-Default value: \fB20\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_no_prefetch_queue_length\fR (int)
-.ad
-.RS 12n
-The maximum number of bytes allowed in \fBzfs send\fR's internal queues.
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_queue_ff\fR (int)
-.ad
-.RS 12n
-The fill fraction of the \fBzfs send\fR prefetch queue. The fill fraction
-controls the timing with which internal threads are woken up.
-.sp
-Default value: \fB20\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_send_queue_length\fR (int)
-.ad
-.RS 12n
-The maximum number of bytes allowed that will be prefetched by \fBzfs send\fR.
+.
+.It Sy zfs_send_corrupt_data Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Allow sending of corrupt data (ignore read/checksum errors when sending).
+.
+.It Sy zfs_send_unmodified_spill_blocks Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Include unmodified spill blocks in the send stream.
+Under certain circumstances, previous versions of ZFS could incorrectly
+remove the spill block from an existing object.
+Including unmodified copies of the spill blocks creates a backwards-compatible
+stream which will recreate a spill block if it was incorrectly removed.
+.
+.It Sy zfs_send_no_prefetch_queue_ff Ns = Ns Sy 20 Ns ^-1 Pq int
+The fill fraction of the
+.Nm zfs Cm send
+internal queues.
+The fill fraction controls the timing with which internal threads are woken up.
+.
+.It Sy zfs_send_no_prefetch_queue_length Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq int
+The maximum number of bytes allowed in
+.Nm zfs Cm send Ns 's
+internal queues.
+.
+.It Sy zfs_send_queue_ff Ns = Ns Sy 20 Ns ^-1 Pq int
+The fill fraction of the
+.Nm zfs Cm send
+prefetch queue.
+The fill fraction controls the timing with which internal threads are woken up.
+.
+.It Sy zfs_send_queue_length Ns = Ns Sy 16777216 Ns B Po 16MB Pc Pq int
+The maximum number of bytes allowed that will be prefetched by
+.Nm zfs Cm send .
 This value must be at least twice the maximum block size in use.
-.sp
-Default value: \fB16,777,216\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_recv_queue_ff\fR (int)
-.ad
-.RS 12n
-The fill fraction of the \fBzfs receive\fR queue. The fill fraction
-controls the timing with which internal threads are woken up.
-.sp
-Default value: \fB20\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_recv_queue_length\fR (int)
-.ad
-.RS 12n
-The maximum number of bytes allowed in the \fBzfs receive\fR queue. This value
-must be at least twice the maximum block size in use.
-.sp
-Default value: \fB16,777,216\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_recv_write_batch_size\fR (int)
-.ad
-.RS 12n
-The maximum amount of data (in bytes) that \fBzfs receive\fR will write in
-one DMU transaction.  This is the uncompressed size, even when receiving a
-compressed send stream.  This setting will not reduce the write size below
-a single block. Capped at a maximum of 32MB
-.sp
-Default value: \fB1MB\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_override_estimate_recordsize\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_recv_queue_ff Ns = Ns Sy 20 Ns ^-1 Pq int
+The fill fraction of the
+.Nm zfs Cm receive
+queue.
+The fill fraction controls the timing with which internal threads are woken up.
+.
+.It Sy zfs_recv_queue_length Ns = Ns Sy 16777216 Ns B Po 16MB Pc Pq int
+The maximum number of bytes allowed in the
+.Nm zfs Cm receive
+queue.
+This value must be at least twice the maximum block size in use.
+.
+.It Sy zfs_recv_write_batch_size Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq int
+The maximum amount of data, in bytes, that
+.Nm zfs Cm receive
+will write in one DMU transaction.
+This is the uncompressed size, even when receiving a compressed send stream.
+This setting will not reduce the write size below a single block.
+Capped at a maximum of
+.Sy 32MB .
+.
+.It Sy zfs_override_estimate_recordsize Ns = Ns Sy 0 Ns | Ns 1 Pq ulong
 Setting this variable overrides the default logic for estimating block
-sizes when doing a zfs send. The default heuristic is that the average
-block size will be the current recordsize. Override this value if most data
-in your dataset is not of that size and you require accurate zfs send size
-estimates.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_sync_pass_deferred_free\fR (int)
-.ad
-.RS 12n
-Flushing of data to disk is done in passes. Defer frees starting in this pass
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_spa_discard_memory_limit\fR (int)
-.ad
-.RS 12n
+sizes when doing a
+.Nm zfs Cm send .
+The default heuristic is that the average block size
+will be the current recordsize.
+Override this value if most data in your dataset is not of that size
+and you require accurate zfs send size estimates.
+.
+.It Sy zfs_sync_pass_deferred_free Ns = Ns Sy 2 Pq int
+Flushing of data to disk is done in passes.
+Defer frees starting in this pass.
+.
+.It Sy zfs_spa_discard_memory_limit Ns = Ns Sy 16777216 Ns B Po 16MB Pc Pq int
 Maximum memory used for prefetching a checkpoint's space map on each
 vdev while discarding the checkpoint.
-.sp
-Default value: \fB16,777,216\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_special_class_metadata_reserve_pct\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_special_class_metadata_reserve_pct Ns = Ns Sy 25 Ns % Pq int
 Only allow small data blocks to be allocated on the special and dedup vdev
-types when the available free space percentage on these vdevs exceeds this
-value. This ensures reserved space is available for pool meta data as the
+types when the available free space percentage on these vdevs exceeds this value.
+This ensures reserved space is available for pool metadata as the
 special vdevs approach capacity.
-.sp
-Default value: \fB25\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_sync_pass_dont_compress\fR (int)
-.ad
-.RS 12n
-Starting in this sync pass, we disable compression (including of metadata).
+.
+.It Sy zfs_sync_pass_dont_compress Ns = Ns Sy 8 Pq int
+Starting in this sync pass, disable compression (including of metadata).
 With the default setting, in practice, we don't have this many sync passes,
 so this has no effect.
-.sp
+.Pp
 The original intent was that disabling compression would help the sync passes
-to converge. However, in practice disabling compression increases the average
-number of sync passes, because when we turn compression off, a lot of block's
-size will change and thus we have to re-allocate (not overwrite) them. It
-also increases the number of 128KB allocations (e.g. for indirect blocks and
-spacemaps) because these will not be compressed. The 128K allocations are
-especially detrimental to performance on highly fragmented systems, which may
-have very few free segments of this size, and may need to load new metaslabs
-to satisfy 128K allocations.
-.sp
-Default value: \fB8\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_sync_pass_rewrite\fR (int)
-.ad
-.RS 12n
-Rewrite new block pointers starting in this pass
-.sp
-Default value: \fB2\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_sync_taskq_batch_pct\fR (int)
-.ad
-.RS 12n
-This controls the number of threads used by the dp_sync_taskq.  The default
-value of 75% will create a maximum of one thread per cpu.
-.sp
-Default value: \fB75\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_trim_extent_bytes_max\fR (uint)
-.ad
-.RS 12n
-Maximum size of TRIM command.  Ranges larger than this will be split in to
-chunks no larger than \fBzfs_trim_extent_bytes_max\fR bytes before being
-issued to the device.
-.sp
-Default value: \fB134,217,728\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_trim_extent_bytes_min\fR (uint)
-.ad
-.RS 12n
-Minimum size of TRIM commands.  TRIM ranges smaller than this will be skipped
-unless they're part of a larger range which was broken in to chunks.  This is
-done because it's common for these small TRIMs to negatively impact overall
-performance.  This value can be set to 0 to TRIM all unallocated space.
-.sp
-Default value: \fB32,768\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_trim_metaslab_skip\fR (uint)
-.ad
-.RS 12n
-Skip uninitialized metaslabs during the TRIM process.  This option is useful
-for pools constructed from large thinly-provisioned devices where TRIM
-operations are slow.  As a pool ages an increasing fraction of the pools
-metaslabs will be initialized progressively degrading the usefulness of
-this option.  This setting is stored when starting a manual TRIM and will
+to converge.
+However, in practice, disabling compression increases
+the average number of sync passes; because when we turn compression off,
+many blocks' size will change, and thus we have to re-allocate
+(not overwrite) them.
+It also increases the number of
+.Em 128kB
+allocations (e.g. for indirect blocks and spacemaps)
+because these will not be compressed.
+The
+.Em 128kB
+allocations are especially detrimental to performance
+on highly fragmented systems, which may have very few free segments of this size,
+and may need to load new metaslabs to satisfy these allocations.
+.
+.It Sy zfs_sync_pass_rewrite Ns = Ns Sy 2 Pq int
+Rewrite new block pointers starting in this pass.
+.
+.It Sy zfs_sync_taskq_batch_pct Ns = Ns Sy 75 Ns % Pq int
+This controls the number of threads used by
+.Sy dp_sync_taskq .
+The default value of
+.Sy 75%
+will create a maximum of one thread per CPU.
+.
+.It Sy zfs_trim_extent_bytes_max Ns = Ns Sy 134217728 Ns B Po 128MB Pc Pq uint
+Maximum size of TRIM command.
+Larger ranges will be split into chunks no larger than this value before issuing.
+.
+.It Sy zfs_trim_extent_bytes_min Ns = Ns Sy 32768 Ns B Po 32kB Pc Pq uint
+Minimum size of TRIM commands.
+TRIM ranges smaller than this will be skipped,
+unless they're part of a larger range which was chunked.
+This is done because it's common for these small TRIMs
+to negatively impact overall performance.
+.
+.It Sy zfs_trim_metaslab_skip Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+Skip uninitialized metaslabs during the TRIM process.
+This option is useful for pools constructed from large thinly-provisioned devices
+where TRIM operations are slow.
+As a pool ages, an increasing fraction of the pool's metaslabs
+will be initialized, progressively degrading the usefulness of this option.
+This setting is stored when starting a manual TRIM and will
 persist for the duration of the requested TRIM.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_trim_queue_limit\fR (uint)
-.ad
-.RS 12n
-Maximum number of queued TRIMs outstanding per leaf vdev.  The number of
-concurrent TRIM commands issued to the device is controlled by the
-\fBzfs_vdev_trim_min_active\fR and \fBzfs_vdev_trim_max_active\fR module
-options.
-.sp
-Default value: \fB10\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_trim_txg_batch\fR (uint)
-.ad
-.RS 12n
-The number of transaction groups worth of frees which should be aggregated
-before TRIM operations are issued to the device.  This setting represents a
-trade-off between issuing larger, more efficient TRIM operations and the
-delay before the recently trimmed space is available for use by the device.
-.sp
+.
+.It Sy zfs_trim_queue_limit Ns = Ns Sy 10 Pq uint
+Maximum number of queued TRIMs outstanding per leaf vdev.
+The number of concurrent TRIM commands issued to the device is controlled by
+.Sy zfs_vdev_trim_min_active No and Sy zfs_vdev_trim_max_active .
+.
+.It Sy zfs_trim_txg_batch Ns = Ns Sy 32 Pq uint
+The number of transaction groups' worth of frees which should be aggregated
+before TRIM operations are issued to the device.
+This setting represents a trade-off between issuing larger,
+more efficient TRIM operations and the delay
+before the recently trimmed space is available for use by the device.
+.Pp
 Increasing this value will allow frees to be aggregated for a longer time.
-This will result is larger TRIM operations and potentially increased memory
-usage.  Decreasing this value will have the opposite effect.  The default
-value of 32 was determined to be a reasonable compromise.
-.sp
-Default value: \fB32\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_txg_history\fR (int)
-.ad
-.RS 12n
-Historical statistics for the last N txgs will be available in
-\fB/proc/spl/kstat/zfs/<pool>/txgs\fR
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_txg_timeout\fR (int)
-.ad
-.RS 12n
-Flush dirty data to disk at least every N seconds (maximum txg duration)
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_aggregate_trim\fR (int)
-.ad
-.RS 12n
-Allow TRIM I/Os to be aggregated.  This is normally not helpful because
-the extents to be trimmed will have been already been aggregated by the
-metaslab.  This option is provided for debugging and performance analysis.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_aggregation_limit\fR (int)
-.ad
-.RS 12n
-Max vdev I/O aggregation size
-.sp
-Default value: \fB1,048,576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_aggregation_limit_non_rotating\fR (int)
-.ad
-.RS 12n
-Max vdev I/O aggregation size for non-rotating media
-.sp
-Default value: \fB131,072\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_cache_bshift\fR (int)
-.ad
-.RS 12n
-Shift size to inflate reads too
-.sp
-Default value: \fB16\fR (effectively 65536).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_cache_max\fR (int)
-.ad
-.RS 12n
-Inflate reads smaller than this value to meet the \fBzfs_vdev_cache_bshift\fR
-size (default 64k).
-.sp
-Default value: \fB16384\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_cache_size\fR (int)
-.ad
-.RS 12n
+This will result is larger TRIM operations and potentially increased memory usage.
+Decreasing this value will have the opposite effect.
+The default of
+.Sy 32
+was determined to be a reasonable compromise.
+.
+.It Sy zfs_txg_history Ns = Ns Sy 0 Pq int
+Historical statistics for this many latest TXGs will be available in
+.Pa /proc/spl/kstat/zfs/ Ns Ao Ar pool Ac Ns Pa /TXGs .
+.
+.It Sy zfs_txg_timeout Ns = Ns Sy 5 Ns s Pq int
+Flush dirty data to disk at least every this many seconds (maximum TXG duration).
+.
+.It Sy zfs_vdev_aggregate_trim Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Allow TRIM I/Os to be aggregated.
+This is normally not helpful because the extents to be trimmed
+will have been already been aggregated by the metaslab.
+This option is provided for debugging and performance analysis.
+.
+.It Sy zfs_vdev_aggregation_limit Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq int
+Max vdev I/O aggregation size.
+.
+.It Sy zfs_vdev_aggregation_limit_non_rotating Ns = Ns Sy 131072 Ns B Po 128kB Pc Pq int
+Max vdev I/O aggregation size for non-rotating media.
+.
+.It Sy zfs_vdev_cache_bshift Ns = Ns Sy 16 Po 64kB Pc Pq int
+Shift size to inflate reads to.
+.
+.It Sy zfs_vdev_cache_max Ns = Ns Sy 16384 Ns B Po 16kB Pc Pq int
+Inflate reads smaller than this value to meet the
+.Sy zfs_vdev_cache_bshift
+size
+.Pq default Sy 64kB .
+.
+.It Sy zfs_vdev_cache_size Ns = Ns Sy 0 Pq int
 Total size of the per-disk cache in bytes.
-.sp
-Currently this feature is disabled as it has been found to not be helpful
+.Pp
+Currently this feature is disabled, as it has been found to not be helpful
 for performance and in some cases harmful.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_mirror_rotating_inc\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_mirror_rotating_inc Ns = Ns Sy 0 Pq int
 A number by which the balancing algorithm increments the load calculation for
-the purpose of selecting the least busy mirror member when an I/O immediately
-follows its predecessor on rotational vdevs for the purpose of making decisions
-based on load.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_mirror_rotating_seek_inc\fR (int)
-.ad
-.RS 12n
+the purpose of selecting the least busy mirror member when an I/O operation
+immediately follows its predecessor on rotational vdevs
+for the purpose of making decisions based on load.
+.
+.It Sy zfs_vdev_mirror_rotating_seek_inc Ns = Ns Sy 5 Pq int
 A number by which the balancing algorithm increments the load calculation for
-the purpose of selecting the least busy mirror member when an I/O lacks
-locality as defined by the zfs_vdev_mirror_rotating_seek_offset.  I/Os within
-this that are not immediately following the previous I/O are incremented by
-half.
-.sp
-Default value: \fB5\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_mirror_rotating_seek_offset\fR (int)
-.ad
-.RS 12n
-The maximum distance for the last queued I/O in which the balancing algorithm
-considers an I/O to have locality.
-See the section "ZFS I/O SCHEDULER".
-.sp
-Default value: \fB1048576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_mirror_non_rotating_inc\fR (int)
-.ad
-.RS 12n
+the purpose of selecting the least busy mirror member when an I/O operation
+lacks locality as defined by
+.Sy zfs_vdev_mirror_rotating_seek_offset .
+Operations within this that are not immediately following the previous operation
+are incremented by half.
+.
+.It Sy zfs_vdev_mirror_rotating_seek_offset Ns = Ns Sy 1048576 Ns B Po 1MB Pc Pq int
+The maximum distance for the last queued I/O operation in which
+the balancing algorithm considers an operation to have locality.
+.No See Sx ZFS I/O SCHEDULER .
+.
+.It Sy zfs_vdev_mirror_non_rotating_inc Ns = Ns Sy 0 Pq int
 A number by which the balancing algorithm increments the load calculation for
 the purpose of selecting the least busy mirror member on non-rotational vdevs
-when I/Os do not immediately follow one another.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_mirror_non_rotating_seek_inc\fR (int)
-.ad
-.RS 12n
+when I/O operations do not immediately follow one another.
+.
+.It Sy zfs_vdev_mirror_non_rotating_seek_inc Ns = Ns Sy 1 Pq int
 A number by which the balancing algorithm increments the load calculation for
-the purpose of selecting the least busy mirror member when an I/O lacks
-locality as defined by the zfs_vdev_mirror_rotating_seek_offset. I/Os within
-this that are not immediately following the previous I/O are incremented by
-half.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_read_gap_limit\fR (int)
-.ad
-.RS 12n
-Aggregate read I/O operations if the gap on-disk between them is within this
+the purpose of selecting the least busy mirror member when an I/O operation lacks
+locality as defined by the
+.Sy zfs_vdev_mirror_rotating_seek_offset .
+Operations within this that are not immediately following the previous operation
+are incremented by half.
+.
+.It Sy zfs_vdev_read_gap_limit Ns = Ns Sy 32768 Ns B Po 32kB Pc Pq int
+Aggregate read I/O operations if the on-disk gap between them is within this
 threshold.
-.sp
-Default value: \fB32,768\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_write_gap_limit\fR (int)
-.ad
-.RS 12n
-Aggregate write I/O over gap
-.sp
-Default value: \fB4,096\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_raidz_impl\fR (string)
-.ad
-.RS 12n
-Parameter for selecting raidz parity implementation to use.
-
-Options marked (always) below may be selected on module load as they are
-supported on all systems.
-The remaining options may only be set after the module is loaded, as they
-are available only if the implementations are compiled in and supported
-on the running system.
-
-Once the module is loaded, the content of
-/sys/module/zfs/parameters/zfs_vdev_raidz_impl will show available options
-with the currently selected one enclosed in [].
-Possible options are:
-  fastest  - (always) implementation selected using built-in benchmark
-  original - (always) original raidz implementation
-  scalar   - (always) scalar raidz implementation
-  sse2     - implementation using SSE2 instruction set (64bit x86 only)
-  ssse3    - implementation using SSSE3 instruction set (64bit x86 only)
-  avx2     - implementation using AVX2 instruction set (64bit x86 only)
-  avx512f  - implementation using AVX512F instruction set (64bit x86 only)
-  avx512bw - implementation using AVX512F & AVX512BW instruction sets (64bit x86 only)
-  aarch64_neon - implementation using NEON (Aarch64/64 bit ARMv8 only)
-  aarch64_neonx2 - implementation using NEON with more unrolling (Aarch64/64 bit ARMv8 only)
-  powerpc_altivec - implementation using Altivec (PowerPC only)
-.sp
-Default value: \fBfastest\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_vdev_scheduler\fR (charp)
-.ad
-.RS 12n
-\fBDEPRECATED\fR: This option exists for compatibility with older user
-configurations. It does nothing except print a warning to the kernel log if
-set.
-.sp
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_zevent_len_max\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_vdev_write_gap_limit Ns = Ns Sy 4096 Ns B Po 4kB Pc Pq int
+Aggregate write I/O operations if the on-disk gap between them is within this
+threshold.
+.
+.It Sy zfs_vdev_raidz_impl Ns = Ns Sy fastest Pq string
+Select the raidz parity implementation to use.
+.Pp
+Variants that don't depend on CPU-specific features
+may be selected on module load, as they are supported on all systems.
+The remaining options may only be set after the module is loaded,
+as they are available only if the implementations are compiled in
+and supported on the running system.
+.Pp
+Once the module is loaded,
+.Pa /sys/module/zfs/parameters/zfs_vdev_raidz_impl
+will show the available options,
+with the currently selected one enclosed in square brackets.
+.Pp
+.TS
+lb l l .
+fastest	selected by built-in benchmark
+original	original implementation
+scalar	scalar implementation
+sse2	SSE2 instruction set	64-bit x86
+ssse3	SSSE3 instruction set	64-bit x86
+avx2	AVX2 instruction set	64-bit x86
+avx512f	AVX512F instruction set	64-bit x86
+avx512bw	AVX512F & AVX512BW instruction sets	64-bit x86
+aarch64_neon	NEON	Aarch64/64-bit ARMv8
+aarch64_neonx2	NEON with more unrolling	Aarch64/64-bit ARMv8
+powerpc_altivec	Altivec	PowerPC
+.TE
+.
+.It Sy zfs_vdev_scheduler Pq charp
+.Sy DEPRECATED .
+Prints warning to kernel log for compatiblity.
+.
+.It Sy zfs_zevent_len_max Ns = Ns Sy 512 Pq int
 Max event queue length.
-Events in the queue can be viewed with the \fBzpool events\fR command.
-.sp
-Default value: \fB512\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_zevent_retain_max\fR (int)
-.ad
-.RS 12n
-Maximum recent zevent records to retain for duplicate checking.  Setting
-this value to zero disables duplicate detection.
-.sp
-Default value: \fB2000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_zevent_retain_expire_secs\fR (int)
-.ad
-.RS 12n
+Events in the queue can be viewed with
+.Xr zpool-events 8 .
+.
+.It Sy zfs_zevent_retain_max Ns = Ns Sy 2000 Pq int
+Maximum recent zevent records to retain for duplicate checking.
+Setting this to
+.Sy 0
+disables duplicate detection.
+.
+.It Sy zfs_zevent_retain_expire_secs Ns = Ns Sy 900 Ns s Po 15min Pc Pq int
 Lifespan for a recent ereport that was retained for duplicate checking.
-.sp
-Default value: \fB900\fR.
-.RE
-
-.na
-\fBzfs_zil_clean_taskq_maxalloc\fR (int)
-.ad
-.RS 12n
-The maximum number of taskq entries that are allowed to be cached.  When this
-limit is exceeded transaction records (itxs) will be cleaned synchronously.
-.sp
-Default value: \fB1048576\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_zil_clean_taskq_minalloc\fR (int)
-.ad
-.RS 12n
+.
+.It Sy zfs_zil_clean_taskq_maxalloc Ns = Ns Sy 1048576 Pq int
+The maximum number of taskq entries that are allowed to be cached.
+When this limit is exceeded transaction records (itxs)
+will be cleaned synchronously.
+.
+.It Sy zfs_zil_clean_taskq_minalloc Ns = Ns Sy 1024 Pq int
 The number of taskq entries that are pre-populated when the taskq is first
 created and are immediately available for use.
-.sp
-Default value: \fB1024\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_zil_clean_taskq_nthr_pct\fR (int)
-.ad
-.RS 12n
-This controls the number of threads used by the dp_zil_clean_taskq.  The default
-value of 100% will create a maximum of one thread per cpu.
-.sp
-Default value: \fB100\fR%.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzil_maxblocksize\fR (int)
-.ad
-.RS 12n
-This sets the maximum block size used by the ZIL.  On very fragmented pools,
-lowering this (typically to 36KB) can improve performance.
-.sp
-Default value: \fB131072\fR (128KB).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzil_nocacheflush\fR (int)
-.ad
-.RS 12n
-Disable the cache flush commands that are normally sent to the disk(s) by
-the ZIL after an LWB write has completed. Setting this will cause ZIL
-corruption on power loss if a volatile out-of-order write cache is enabled.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzil_replay_disable\fR (int)
-.ad
-.RS 12n
-Disable intent logging replay. Can be disabled for recovery from corrupted
-ZIL
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzil_slog_bulk\fR (ulong)
-.ad
-.RS 12n
+.
+.It Sy zfs_zil_clean_taskq_nthr_pct Ns = Ns Sy 100 Ns % Pq int
+This controls the number of threads used by
+.Sy dp_zil_clean_taskq .
+The default value of
+.Sy 100%
+will create a maximum of one thread per cpu.
+.
+.It Sy zil_maxblocksize Ns = Ns Sy 131072 Ns B Po 128kB Pc Pq int
+This sets the maximum block size used by the ZIL.
+On very fragmented pools, lowering this
+.Pq typically to Sy 36kB
+can improve performance.
+.
+.It Sy zil_nocacheflush Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable the cache flush commands that are normally sent to disk by
+the ZIL after an LWB write has completed.
+Setting this will cause ZIL corruption on power loss
+if a volatile out-of-order write cache is enabled.
+.
+.It Sy zil_replay_disable Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Disable intent logging replay.
+Can be disabled for recovery from corrupted ZIL.
+.
+.It Sy zil_slog_bulk Ns = Ns Sy 786432 Ns B Po 768kB Pc Pq ulong
 Limit SLOG write size per commit executed with synchronous priority.
 Any writes above that will be executed with lower (asynchronous) priority
 to limit potential SLOG device abuse by single active ZIL writer.
-.sp
-Default value: \fB786,432\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_embedded_slog_min_ms\fR (int)
-.ad
-.RS 12n
-Usually, one metaslab from each (normal-class) vdev is dedicated for use by
-the ZIL (to log synchronous writes).
-However, if there are fewer than zfs_embedded_slog_min_ms metaslabs in the
-vdev, this functionality is disabled.
-This ensures that we don't set aside an unreasonable amount of space for the
-ZIL.
-.sp
-Default value: \fB64\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_deadman_log_all\fR (int)
-.ad
-.RS 12n
-If non-zero, the zio deadman will produce debugging messages (see
-\fBzfs_dbgmsg_enable\fR) for all zios, rather than only for leaf
-zios possessing a vdev. This is meant to be used by developers to gain
+.
+.It Sy zfs_embedded_slog_min_ms Ns = Ns Sy 64  Pq int
+Usually, one metaslab from each normal-class vdev is dedicated for use by
+the ZIL to log synchronous writes.
+However, if there are fewer than
+.Sy zfs_embedded_slog_min_ms
+metaslabs in the vdev, this functionality is disabled.
+This ensures that we don't set aside an unreasonable amount of space for the ZIL.
+.
+.It Sy zio_deadman_log_all Ns = Ns Sy 0 Ns | Ns 1 Pq int
+If non-zero, the zio deadman will produce debugging messages
+.Pq see Sy zfs_dbgmsg_enable
+for all zios, rather than only for leaf zios possessing a vdev.
+This is meant to be used by developers to gain
 diagnostic information for hang conditions which don't involve a mutex
-or other locking primitive; typically conditions in which a thread in
+or other locking primitive: typically conditions in which a thread in
 the zio pipeline is looping indefinitely.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_slow_io_ms\fR (int)
-.ad
-.RS 12n
-When an I/O operation takes more than \fBzio_slow_io_ms\fR milliseconds to
-complete is marked as a slow I/O.  Each slow I/O causes a delay zevent.  Slow
-I/O counters can be seen with "zpool status -s".
-
-.sp
-Default value: \fB30,000\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_dva_throttle_enabled\fR (int)
-.ad
-.RS 12n
-Throttle block allocations in the I/O pipeline. This allows for
-dynamic allocation distribution when devices are imbalanced.
+.
+.It Sy zio_slow_io_ms Ns = Ns Sy 30000 Ns ms Po 30s Pc Pq int
+When an I/O operation takes more than this much time to complete,
+it's marked as slow.
+Each slow operation causes a delay zevent.
+Slow I/O counters can be seen with
+.Nm zpool Cm status Fl s .
+.
+.It Sy zio_dva_throttle_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Throttle block allocations in the I/O pipeline.
+This allows for dynamic allocation distribution when devices are imbalanced.
 When enabled, the maximum number of pending allocations per top-level vdev
-is limited by \fBzfs_vdev_queue_depth_pct\fR.
-.sp
-Default value: \fB1\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_requeue_io_start_cut_in_line\fR (int)
-.ad
-.RS 12n
-Prioritize requeued I/O
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_taskq_batch_pct\fR (uint)
-.ad
-.RS 12n
-Percentage of online CPUs (or CPU cores, etc) which will run a worker thread
-for I/O. These workers are responsible for I/O work such as compression and
-checksum calculations. Fractional number of CPUs will be rounded down.
-.sp
-The default value of 80 was chosen to avoid using all CPUs which can result in
-latency issues and inconsistent application performance, especially when slower
-compression and/or checksumming is enabled.
-.sp
-Default value: \fB80\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzio_taskq_batch_tpq\fR (uint)
-.ad
-.RS 12n
-Number of worker threads per taskq.  Lower value improves I/O ordering and
-CPU utilization, while higher reduces lock contention.
-.sp
-By default about 6 worker threads per taskq, depending on system size.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_inhibit_dev\fR (uint)
-.ad
-.RS 12n
-Do not create zvol device nodes. This may slightly improve startup time on
+is limited by
+.Sy zfs_vdev_queue_depth_pct .
+.
+.It Sy zio_requeue_io_start_cut_in_line Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Prioritize requeued I/O.
+.
+.It Sy zio_taskq_batch_pct Ns = Ns Sy 80 Ns % Pq uint
+Percentage of online CPUs which will run a worker thread for I/O.
+These workers are responsible for I/O work such as compression and
+checksum calculations.
+Fractional number of CPUs will be rounded down.
+.Pp
+The default value of
+.Sy 80%
+was chosen to avoid using all CPUs which can result in
+latency issues and inconsistent application performance,
+especially when slower compression and/or checksumming is enabled.
+.
+.It Sy zio_taskq_batch_tpq Ns = Ns Sy 0 Pq uint
+Number of worker threads per taskq.
+Lower values improve I/O ordering and CPU utilization,
+while higher reduces lock contention.
+.Pp
+If
+.Sy 0 ,
+generate a system-dependent value close to 6 threads per taskq.
+.
+.It Sy zvol_inhibit_dev Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+Do not create zvol device nodes.
+This may slightly improve startup time on
 systems with a very large number of zvols.
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_major\fR (uint)
-.ad
-.RS 12n
-Major number for zvol block devices
-.sp
-Default value: \fB230\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_max_discard_blocks\fR (ulong)
-.ad
-.RS 12n
-Discard (aka TRIM) operations done on zvols will be done in batches of this
-many blocks, where block size is determined by the \fBvolblocksize\fR property
-of a zvol.
-.sp
-Default value: \fB16,384\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_prefetch_bytes\fR (uint)
-.ad
-.RS 12n
-When adding a zvol to the system prefetch \fBzvol_prefetch_bytes\fR
-from the start and end of the volume.  Prefetching these regions
-of the volume is desirable because they are likely to be accessed
-immediately by \fBblkid(8)\fR or by the kernel scanning for a partition
-table.
-.sp
-Default value: \fB131,072\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_request_sync\fR (uint)
-.ad
-.RS 12n
-When processing I/O requests for a zvol submit them synchronously.  This
-effectively limits the queue depth to 1 for each I/O submitter.  When set
-to 0 requests are handled asynchronously by a thread pool.  The number of
-requests which can be handled concurrently is controller by \fBzvol_threads\fR.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_threads\fR (uint)
-.ad
-.RS 12n
+.
+.It Sy zvol_major Ns = Ns Sy 230 Pq uint
+Major number for zvol block devices.
+.
+.It Sy zvol_max_discard_blocks Ns = Ns Sy 16384 Pq ulong
+Discard (TRIM) operations done on zvols will be done in batches of this
+many blocks, where block size is determined by the
+.Sy volblocksize
+property of a zvol.
+.
+.It Sy zvol_prefetch_bytes Ns = Ns Sy 131072 Ns B Po 128kB Pc Pq uint
+When adding a zvol to the system, prefetch this many bytes
+from the start and end of the volume.
+Prefetching these regions of the volume is desirable,
+because they are likely to be accessed immediately by
+.Xr blkid 8
+or the kernel partitioner.
+.
+.It Sy zvol_request_sync Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+When processing I/O requests for a zvol, submit them synchronously.
+This effectively limits the queue depth to
+.Em 1
+for each I/O submitter.
+When unset, requests are handled asynchronously by a thread pool.
+The number of requests which can be handled concurrently is controlled by
+.Sy zvol_threads .
+.
+.It Sy zvol_threads Ns = Ns Sy 32 Pq uint
 Max number of threads which can handle zvol I/O requests concurrently.
-.sp
-Default value: \fB32\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzvol_volmode\fR (uint)
-.ad
-.RS 12n
-Defines zvol block devices behaviour when \fBvolmode\fR is set to \fBdefault\fR.
-Valid values are \fB1\fR (full), \fB2\fR (dev) and \fB3\fR (none).
-.sp
-Default value: \fB1\fR.
-.RE
-
-.SH ZFS I/O SCHEDULER
-ZFS issues I/O operations to leaf vdevs to satisfy and complete I/Os.
-The I/O scheduler determines when and in what order those operations are
-issued.  The I/O scheduler divides operations into five I/O classes
+.
+.It Sy zvol_volmode Ns = Ns Sy 1 Pq uint
+Defines zvol block devices behaviour when
+.Sy volmode Ns = Ns Sy default :
+.Bl -tag -compact -offset 4n -width "a"
+.It Sy 1
+.No equivalent to Sy full
+.It Sy 2
+.No equivalent to Sy dev
+.It Sy 3
+.No equivalent to Sy none
+.El
+.El
+.
+.Sh ZFS I/O SCHEDULER
+ZFS issues I/O operations to leaf vdevs to satisfy and complete I/O operations.
+The scheduler determines when and in what order those operations are issued.
+The scheduler divides operations into five I/O classes,
 prioritized in the following order: sync read, sync write, async read,
-async write, and scrub/resilver.  Each queue defines the minimum and
-maximum number of concurrent operations that may be issued to the
-device.  In addition, the device has an aggregate maximum,
-\fBzfs_vdev_max_active\fR. Note that the sum of the per-queue minimums
-must not exceed the aggregate maximum.  If the sum of the per-queue
-maximums exceeds the aggregate maximum, then the number of active I/Os
-may reach \fBzfs_vdev_max_active\fR, in which case no further I/Os will
-be issued regardless of whether all per-queue minimums have been met.
-.sp
+async write, and scrub/resilver.
+Each queue defines the minimum and maximum number of concurrent operations
+that may be issued to the device.
+In addition, the device has an aggregate maximum,
+.Sy zfs_vdev_max_active .
+Note that the sum of the per-queue minima must not exceed the aggregate maximum.
+If the sum of the per-queue maxima exceeds the aggregate maximum,
+then the number of active operations may reach
+.Sy zfs_vdev_max_active ,
+in which case no further operations will be issued,
+regardless of whether all per-queue minima have been met.
+.Pp
 For many physical devices, throughput increases with the number of
-concurrent operations, but latency typically suffers. Further, physical
-devices typically have a limit at which more concurrent operations have no
+concurrent operations, but latency typically suffers.
+Furthermore, physical devices typically have a limit
+at which more concurrent operations have no
 effect on throughput or can actually cause it to decrease.
-.sp
+.Pp
 The scheduler selects the next operation to issue by first looking for an
-I/O class whose minimum has not been satisfied. Once all are satisfied and
-the aggregate maximum has not been hit, the scheduler looks for classes
-whose maximum has not been satisfied. Iteration through the I/O classes is
-done in the order specified above. No further operations are issued if the
-aggregate maximum number of concurrent operations has been hit or if there
-are no operations queued for an I/O class that has not hit its maximum.
-Every time an I/O is queued or an operation completes, the I/O scheduler
-looks for new operations to issue.
-.sp
-In general, smaller max_active's will lead to lower latency of synchronous
-operations.  Larger max_active's may lead to higher overall throughput,
-depending on underlying storage.
-.sp
-The ratio of the queues' max_actives determines the balance of performance
-between reads, writes, and scrubs.  E.g., increasing
-\fBzfs_vdev_scrub_max_active\fR will cause the scrub or resilver to complete
-more quickly, but reads and writes to have higher latency and lower throughput.
-.sp
-All I/O classes have a fixed maximum number of outstanding operations
-except for the async write class. Asynchronous writes represent the data
-that is committed to stable storage during the syncing stage for
-transaction groups. Transaction groups enter the syncing state
-periodically so the number of queued async writes will quickly burst up
-and then bleed down to zero. Rather than servicing them as quickly as
-possible, the I/O scheduler changes the maximum number of active async
-write I/Os according to the amount of dirty data in the pool.  Since
-both throughput and latency typically increase with the number of
+I/O class whose minimum has not been satisfied.
+Once all are satisfied and the aggregate maximum has not been hit,
+the scheduler looks for classes whose maximum has not been satisfied.
+Iteration through the I/O classes is done in the order specified above.
+No further operations are issued
+if the aggregate maximum number of concurrent operations has been hit,
+or if there are no operations queued for an I/O class that has not hit its maximum.
+Every time an I/O operation is queued or an operation completes,
+the scheduler looks for new operations to issue.
+.Pp
+In general, smaller
+.Sy max_active Ns s
+will lead to lower latency of synchronous operations.
+Larger
+.Sy max_active Ns s
+may lead to higher overall throughput, depending on underlying storage.
+.Pp
+The ratio of the queues'
+.Sy max_active Ns s
+determines the balance of performance between reads, writes, and scrubs.
+For example, increasing
+.Sy zfs_vdev_scrub_max_active
+will cause the scrub or resilver to complete more quickly,
+but reads and writes to have higher latency and lower throughput.
+.Pp
+All I/O classes have a fixed maximum number of outstanding operations,
+except for the async write class.
+Asynchronous writes represent the data that is committed to stable storage
+during the syncing stage for transaction groups.
+Transaction groups enter the syncing state periodically,
+so the number of queued async writes will quickly burst up
+and then bleed down to zero.
+Rather than servicing them as quickly as possible,
+the I/O scheduler changes the maximum number of active async write operations
+according to the amount of dirty data in the pool.
+Since both throughput and latency typically increase with the number of
 concurrent operations issued to physical devices, reducing the
 burstiness in the number of concurrent operations also stabilizes the
-response time of operations from other -- and in particular synchronous
--- queues. In broad strokes, the I/O scheduler will issue more
-concurrent operations from the async write queue as there's more dirty
-data in the pool.
-.sp
-Async Writes
-.sp
+response time of operations from other – and in particular synchronous – queues.
+In broad strokes, the I/O scheduler will issue more concurrent operations
+from the async write queue as there's more dirty data in the pool.
+.
+.Ss Async Writes
 The number of concurrent operations issued for the async write I/O class
-follows a piece-wise linear function defined by a few adjustable points.
-.nf
-
-       |              o---------| <-- zfs_vdev_async_write_max_active
+follows a piece-wise linear function defined by a few adjustable points:
+.Bd -literal
+       |              o---------| <-- \fBzfs_vdev_async_write_max_active\fP
   ^    |             /^         |
   |    |            / |         |
 active |           /  |         |
  I/O   |          /   |         |
 count  |         /    |         |
        |        /     |         |
-       |-------o      |         | <-- zfs_vdev_async_write_min_active
+       |-------o      |         | <-- \fBzfs_vdev_async_write_min_active\fP
       0|_______^______|_________|
-       0%      |      |       100% of zfs_dirty_data_max
+       0%      |      |       100% of \fBzfs_dirty_data_max\fP
                |      |
-               |      `-- zfs_vdev_async_write_active_max_dirty_percent
-               `--------- zfs_vdev_async_write_active_min_dirty_percent
-
-.fi
+               |      `-- \fBzfs_vdev_async_write_active_max_dirty_percent\fP
+               `--------- \fBzfs_vdev_async_write_active_min_dirty_percent\fP
+.Ed
+.Pp
 Until the amount of dirty data exceeds a minimum percentage of the dirty
 data allowed in the pool, the I/O scheduler will limit the number of
-concurrent operations to the minimum. As that threshold is crossed, the
-number of concurrent operations issued increases linearly to the maximum at
-the specified maximum percentage of the dirty data allowed in the pool.
-.sp
+concurrent operations to the minimum.
+As that threshold is crossed, the number of concurrent operations issued
+increases linearly to the maximum at the specified maximum percentage
+of the dirty data allowed in the pool.
+.Pp
 Ideally, the amount of dirty data on a busy pool will stay in the sloped
-part of the function between \fBzfs_vdev_async_write_active_min_dirty_percent\fR
-and \fBzfs_vdev_async_write_active_max_dirty_percent\fR. If it exceeds the
-maximum percentage, this indicates that the rate of incoming data is
-greater than the rate that the backend storage can handle. In this case, we
-must further throttle incoming writes, as described in the next section.
-
-.SH ZFS TRANSACTION DELAY
+part of the function between
+.Sy zfs_vdev_async_write_active_min_dirty_percent
+and
+.Sy zfs_vdev_async_write_active_max_dirty_percent .
+If it exceeds the maximum percentage,
+this indicates that the rate of incoming data is
+greater than the rate that the backend storage can handle.
+In this case, we must further throttle incoming writes,
+as described in the next section.
+.
+.Sh ZFS TRANSACTION DELAY
 We delay transactions when we've determined that the backend storage
 isn't able to accommodate the rate of incoming writes.
-.sp
+.Pp
 If there is already a transaction waiting, we delay relative to when
-that transaction will finish waiting.  This way the calculated delay time
-is independent of the number of threads concurrently executing
-transactions.
-.sp
-If we are the only waiter, wait relative to when the transaction
-started, rather than the current time.  This credits the transaction for
-"time already served", e.g. reading indirect blocks.
-.sp
-The minimum time for a transaction to take is calculated as:
-.nf
-    min_time = zfs_delay_scale * (dirty - min) / (max - dirty)
-    min_time is then capped at 100 milliseconds.
-.fi
-.sp
-The delay has two degrees of freedom that can be adjusted via tunables.  The
-percentage of dirty data at which we start to delay is defined by
-\fBzfs_delay_min_dirty_percent\fR. This should typically be at or above
-\fBzfs_vdev_async_write_active_max_dirty_percent\fR so that we only start to
-delay after writing at full speed has failed to keep up with the incoming write
-rate. The scale of the curve is defined by \fBzfs_delay_scale\fR. Roughly speaking,
-this variable determines the amount of delay at the midpoint of the curve.
-.sp
-.nf
+that transaction will finish waiting.
+This way the calculated delay time
+is independent of the number of threads concurrently executing transactions.
+.Pp
+If we are the only waiter, wait relative to when the transaction started,
+rather than the current time.
+This credits the transaction for "time already served",
+e.g. reading indirect blocks.
+.Pp
+The minimum time for a transaction to take is calculated as
+.Dl min_time = min( Ns Sy zfs_delay_scale No * (dirty - min) / (max - dirty), 100ms)
+.Pp
+The delay has two degrees of freedom that can be adjusted via tunables.
+The percentage of dirty data at which we start to delay is defined by
+.Sy zfs_delay_min_dirty_percent .
+This should typically be at or above
+.Sy zfs_vdev_async_write_active_max_dirty_percent ,
+so that we only start to delay after writing at full speed
+has failed to keep up with the incoming write rate.
+The scale of the curve is defined by
+.Sy zfs_delay_scale .
+Roughly speaking, this variable determines the amount of delay at the midpoint of the curve.
+.Bd -literal
 delay
  10ms +-------------------------------------------------------------*+
       |                                                             *|
@@ -4292,22 +2325,25 @@ delay
   2ms +                                              (midpoint) *    +
       |                                                  |    **     |
   1ms +                                                  v ***       +
-      |             zfs_delay_scale ---------->     ********         |
+      |             \fBzfs_delay_scale\fP ---------->     ********         |
     0 +-------------------------------------*********----------------+
-      0%                    <- zfs_dirty_data_max ->               100%
-.fi
-.sp
-Note that since the delay is added to the outstanding time remaining on the
-most recent transaction, the delay is effectively the inverse of IOPS.
-Here the midpoint of 500us translates to 2000 IOPS. The shape of the curve
+      0%                    <- \fBzfs_dirty_data_max\fP ->               100%
+.Ed
+.Pp
+Note, that since the delay is added to the outstanding time remaining on the
+most recent transaction it's effectively the inverse of IOPS.
+Here, the midpoint of
+.Em 500us
+translates to
+.Em 2000 IOPS .
+The shape of the curve
 was chosen such that small changes in the amount of accumulated dirty data
-in the first 3/4 of the curve yield relatively small differences in the
-amount of delay.
-.sp
+in the first three quarters of the curve yield relatively small differences
+in the amount of delay.
+.Pp
 The effects can be easier to understand when the amount of delay is
-represented on a log scale:
-.sp
-.nf
+represented on a logarithmic scale:
+.Bd -literal
 delay
 100ms +-------------------------------------------------------------++
       +                                                              +
@@ -4318,7 +2354,7 @@ delay
       |                                              (midpoint)  **  |
       +                                                  |     **    +
   1ms +                                                  v ****      +
-      +             zfs_delay_scale ---------->        *****         +
+      +             \fBzfs_delay_scale\fP ---------->        *****         +
       |                                             ****             |
       +                                          ****                +
 100us +                                        **                    +
@@ -4330,12 +2366,14 @@ delay
       |                                                              |
       +                                                              +
       +--------------------------------------------------------------+
-      0%                    <- zfs_dirty_data_max ->               100%
-.fi
-.sp
+      0%                    <- \fBzfs_dirty_data_max\fP ->               100%
+.Ed
+.Pp
 Note here that only as the amount of dirty data approaches its limit does
-the delay start to increase rapidly. The goal of a properly tuned system
-should be to keep the amount of dirty data out of that range by first
-ensuring that the appropriate limits are set for the I/O scheduler to reach
-optimal throughput on the backend storage, and then by changing the value
-of \fBzfs_delay_scale\fR to increase the steepness of the curve.
+the delay start to increase rapidly.
+The goal of a properly tuned system should be to keep the amount of dirty data
+out of that range by first ensuring that the appropriate limits are set
+for the I/O scheduler to reach optimal throughput on the back-end storage,
+and then by changing the value of
+.Sy zfs_delay_scale
+to increase the steepness of the curve.

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -1,4 +1,4 @@
-'\" te
+.\"
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
 .\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
@@ -17,183 +17,195 @@
 .\" Copyright (c) 2019, Klara Inc.
 .\" Copyright (c) 2019, Allan Jude
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
-.TH ZPOOL-FEATURES 5 "Aug 24, 2020" OpenZFS
-.SH NAME
-zpool\-features \- ZFS pool feature descriptions
-.SH DESCRIPTION
-.sp
-.LP
-ZFS pool on\-disk format versions are specified via "features" which replace
-the old on\-disk format numbers (the last supported on\-disk format number is
-28). To enable a feature on a pool use the \fBupgrade\fR subcommand of the
-zpool(8) command, or set the \fBfeature@\fR\fIfeature_name\fR property
-to \fBenabled\fR. Please also see the \fB"Compatibility feature sets"\fR
+.\"
+.Dd May 31, 2021
+.Dt ZPOOL-FEATURES 5
+.Os
+.
+.Sh NAME
+.Nm zpool-features
+.Nd description of ZFS pool features
+.
+.Sh DESCRIPTION
+ZFS pool on-disk format versions are specified via "features" which replace
+the old on-disk format numbers (the last supported on-disk format number is 28).
+To enable a feature on a pool use the
+.Nm zpool Cm upgrade ,
+or set the
+.Sy feature Ns @ Ns Ar feature-name
+property to
+.Sy enabled .
+Please also see the
+.Sx Compatibility feature sets
 section for information on how sets of features may be enabled together.
-.sp
-.LP
+.Pp
 The pool format does not affect file system version compatibility or the ability
 to send file systems between pools.
-.sp
-.LP
-Since most features can be enabled independently of each other the on\-disk
+.Pp
+Since most features can be enabled independently of each other, the on-disk
 format of the pool is specified by the set of all features marked as
-\fBactive\fR on the pool. If the pool was created by another software version
+.Sy active
+on the pool.
+If the pool was created by another software version
 this set may include unsupported features.
-.SS "Identifying features"
-.sp
-.LP
-Every feature has a GUID of the form \fIcom.example:feature_name\fR. The
-reversed DNS name ensures that the feature's GUID is unique across all ZFS
-implementations. When unsupported features are encountered on a pool they will
-be identified by their GUIDs. Refer to the documentation for the ZFS
+.
+.Ss Identifying features
+Every feature has a GUID of the form
+.Ar com.example : Ns Ar feature-name .
+The reversed DNS name ensures that the feature's GUID is unique across all ZFS
+implementations.
+When unsupported features are encountered on a pool they will
+be identified by their GUIDs.
+Refer to the documentation for the ZFS
 implementation that created the pool for information about those features.
-.sp
-.LP
-Each supported feature also has a short name. By convention a feature's short
-name is the portion of its GUID which follows the ':' (e.g.
-\fIcom.example:feature_name\fR would have the short name \fIfeature_name\fR),
+.Pp
+Each supported feature also has a short name.
+By convention a feature's short name is the portion of its GUID which follows the
+.Sq \&:
+(i.e.
+.Ar com.example : Ns Ar feature-name
+would have the short name
+.Ar feature-name ) ,
 however a feature's short name may differ across ZFS implementations if
 following the convention would result in name conflicts.
-.SS "Feature states"
-.sp
-.LP
+.
+.Ss Feature states
 Features can be in one of three states:
-.sp
-.ne 2
-.na
-\fBactive\fR
-.ad
-.RS 12n
-This feature's on\-disk format changes are in effect on the pool. Support for
-this feature is required to import the pool in read\-write mode. If this
-feature is not read-only compatible, support is also required to import the pool
-in read\-only mode (see "Read\-only compatibility").
-.RE
-
-.sp
-.ne 2
-.na
-\fBenabled\fR
-.ad
-.RS 12n
+.Bl -tag -width "disabled"
+.It Sy active
+This feature's on-disk format changes are in effect on the pool.
+Support for this feature is required to import the pool in read-write mode.
+If this feature is not read-only compatible,
+support is also required to import the pool in read-only mode
+.Pq see Sx Read-only compatibility .
+.It Sy enabled
 An administrator has marked this feature as enabled on the pool, but the
-feature's on\-disk format changes have not been made yet. The pool can still be
-imported by software that does not support this feature, but changes may be made
-to the on\-disk format at any time which will move the feature to the
-\fBactive\fR state. Some features may support returning to the \fBenabled\fR
-state after becoming \fBactive\fR. See feature\-specific documentation for
-details.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdisabled\fR
-.ad
-.RS 12n
-This feature's on\-disk format changes have not been made and will not be made
-unless an administrator moves the feature to the \fBenabled\fR state. Features
-cannot be disabled once they have been enabled.
-.RE
-
-.sp
-.LP
+feature's on-disk format changes have not been made yet.
+The pool can still be imported by software that does not support this feature,
+but changes may be made to the on-disk format at any time
+which will move the feature to the
+.Sy active
+state.
+Some features may support returning to the
+.Sy enabled
+state after becoming
+.Sy active .
+See feature-specific documentation for details.
+.It Sy disabled
+This feature's on-disk format changes have not been made and will not be made
+unless an administrator moves the feature to the
+.Sy enabled
+state.
+Features cannot be disabled once they have been enabled.
+.El
+.Pp
 The state of supported features is exposed through pool properties of the form
-\fIfeature@short_name\fR.
-.SS "Read\-only compatibility"
-.sp
-.LP
-Some features may make on\-disk format changes that do not interfere with other
-software's ability to read from the pool. These features are referred to as
-"read\-only compatible". If all unsupported features on a pool are read\-only
-compatible, the pool can be imported in read\-only mode by setting the
-\fBreadonly\fR property during import (see zpool(8) for details on
-importing pools).
-.SS "Unsupported features"
-.sp
-.LP
-For each unsupported feature enabled on an imported pool a pool property
-named \fIunsupported@feature_name\fR will indicate why the import was allowed
-despite the unsupported feature. Possible values for this property are:
-
-.sp
-.ne 2
-.na
-\fBinactive\fR
-.ad
-.RS 12n
-The feature is in the \fBenabled\fR state and therefore the pool's on\-disk
+.Sy feature Ns @ Ns Ar short-name .
+.
+.Ss Read-only compatibility
+Some features may make on-disk format changes that do not interfere with other
+software's ability to read from the pool.
+These features are referred to as
+.Dq read-only compatible .
+If all unsupported features on a pool are read-only compatible,
+the pool can be imported in read-only mode by setting the
+.Sy readonly
+property during import (see
+.Xr zpool-import 8
+for details on importing pools).
+.
+.Ss Unsupported features
+For each unsupported feature enabled on an imported pool, a pool property
+named
+.Sy unsupported Ns @ Ns Ar feature-name
+will indicate why the import was allowed despite the unsupported feature.
+Possible values for this property are:
+.Bl -tag -width "readonly"
+.It Sy inactive
+The feature is in the
+.Sy enabled
+state and therefore the pool's on-disk
 format is still compatible with software that does not support this feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fBreadonly\fR
-.ad
-.RS 12n
-The feature is read\-only compatible and the pool has been imported in
-read\-only mode.
-.RE
-
-.SS "Feature dependencies"
-.sp
-.LP
-Some features depend on other features being enabled in order to function
-properly. Enabling a feature will automatically enable any features it
-depends on.
-
-.SS "Compatibility feature sets"
-.sp
-.LP
+.It Sy readonly
+The feature is read-only compatible and the pool has been imported in
+read-only mode.
+.El
+.
+.Ss Feature dependencies
+Some features depend on other features being enabled in order to function.
+Enabling a feature will automatically enable any features it depends on.
+.
+.Ss Compatibility feature sets
 It is sometimes necessary for a pool to maintain compatibility with a
-specific on\-disk format, by enabling and disabling particular features. The
-\fBcompatibility\fR feature facilitates this by allowing feature sets to
-be read from text files. When set to \fBoff\fR (the default); compatibility
-feature sets are disabled (ie: all features are enabled); when set to
-\fBlegacy\fR; no features are enabled. When set to a comma\-separated list
-of filenames (each filename may either be an absolute path, or relative to
-\fB/etc/zfs/compatibility.d\fR or \fB/usr/share/zfs/compatibility.d\fR)
-the lists of requested features are read from those files, separated by
-whitespace and/or commas. Only features present in all files are enabled.
-.LP
-Simple sanity checks are applied to the files; they must be between 1 and
-16,384 bytes in size, and must end with a newline character.
-.LP
+specific on-disk format, by enabling and disabling particular features.
+The
+.Sy compatibility
+feature facilitates this by allowing feature sets to be read from text files.
+When set to
+.Sy off
+(the default), compatibility feature sets are disabled
+(i.e. all features are enabled); when set to
+.Sy legacy ,
+no features are enabled.
+When set to a comma-separated list of filenames
+(each filename may either be an absolute path, or relative to
+.Pa /etc/zfs/compatibility.d
+or
+.Pa /usr/share/zfs/compatibility.d ) ,
+the lists of requested features are read from those files,
+separated by whitespace and/or commas.
+Only features present in all files are enabled.
+.Pp
+Simple sanity checks are applied to the files:
+they must be between 1B and 16kB in size, and must end with a newline character.
+.Pp
 The requested features are applied when a pool is created using
-\fBzpool create \-o compatibility=...\fR and controls which features are
-enabled when using \fBzpool upgrade\fR. \fBzpool status\fR
+.Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar …
+and controls which features are enabled when using
+.Nm zpool Cm upgrade .
+.Nm zpool Cm status
 will not show a warning about disabled features which are not part
 of the requested feature set.
-.LP
-The special value \fBlegacy\fR prevents any features from being enabled,
-either via \fBzpool upgrade\fR or via \fBzpool set feature@XX=enabled\fR.
-This setting also prevents pools from being upgraded to newer on-disk
-versions. This is a safety measure to prevent new features from being
+.Pp
+The special value
+.Sy legacy
+prevents any features from being enabled, either via
+.Nm zpool Cm upgrade
+or
+.Nm zpool Cm set Sy feature Ns @ Ns Ar feature-name Ns = Ns Sy enabled .
+This setting also prevents pools from being upgraded to newer on-disk versions.
+This is a safety measure to prevent new features from being
 accidentally enabled, breaking compatibility.
-.LP
-By convention, compatibility files in \fB/usr/share/zfs/compatibility.d\fR
-are provided by the distribution package, and include feature sets
+.Pp
+By convention, compatibility files in
+.Pa /usr/share/zfs/compatibility.d
+are provided by the distribution, and include feature sets
 supported by important versions of popular distributions, and feature
-sets commonly supported at the start of each year.  Compatibility files
-in \fB/etc/zfs/compatibility.d\fR, if present, will take precedence over
-files with the same name in \fB/usr/share/zfs/compatibility.d\fR.
-.LP
+sets commonly supported at the start of each year.
+Compatibility files in
+.Pa /etc/zfs/compatibility.d ,
+if present, will take precedence over files with the same name in
+.Pa /usr/share/zfs/compatibility.d .
+.Pp
 If an unrecognized feature is found in these files, an error message will
-be shown. If the unrecognized feature is in a file in
-\fB/etc/zfs/compatibility.d\fR, this is treated as an error and processing
-will stop. If the unrecognized feature is under
-\fB/usr/share/zfs/compatibility.d\fR, this is treated as a warning and
-processing will continue. This difference is to allow distributions to
-include features which might not be recognized by the currently-installed
-binaries.
-.LP
-Compatibility files may include comments; any text from \fB#\fR to the end
-of the line is ignored.
-.LP
-\fBExample:\fR
-.EX
-# \fBcat /usr/share/zfs/compatibility.d/grub2\fR
+be shown.
+If the unrecognized feature is in a file in
+.Pa /etc/zfs/compatibility.d ,
+this is treated as an error and processing will stop.
+If the unrecognized feature is under
+.Pa /usr/share/zfs/compatibility.d ,
+this is treated as a warning and processing will continue.
+This difference is to allow distributions to include features
+which might not be recognized by the currently-installed binaries.
+.Pp
+Compatibility files may include comments:
+any text from
+.Sq #
+to the end of the line is ignored.
+.Pp
+.Sy Example :
+.Bd -literal -compact -offset 4n
+.No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2
 # Features which are supported by GRUB2
 async_destroy
 bookmarks
@@ -207,871 +219,624 @@ large_blocks
 lz4_compress
 spacemap_histogram
 
-# \fBzpool create \-o compatibility=grub2 bootpool vdev\fR
-.EE
-.LP
-See \fBzpool\-create(8)\fR and \fBzpool\-upgrade(8)\fR for more information
-on how these commands are affected by feature sets.
-.SH FEATURES
-.sp
-.LP
+.No example# Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar grub2 Ar bootpool Ar vdev
+.Ed
+.Pp
+See
+.Xr zpool-create 8
+and
+.Xr zpool-upgrade 8
+for more information on how these commands are affected by feature sets.
+.
+.de feature
+.It Sy \\$2
+.Bl -tag -compact -width "READ-ONLY COMPATIBLE"
+.It GUID
+.Sy \\$1:\\$2
+.if !"\\$4"" \{\
+.It DEPENDENCIES
+\fB\\$4\fP\c
+.if !"\\$5"" , \fB\\$5\fP\c
+.if !"\\$6"" , \fB\\$6\fP\c
+.if !"\\$7"" , \fB\\$7\fP\c
+.if !"\\$8"" , \fB\\$8\fP\c
+.if !"\\$9"" , \fB\\$9\fP\c
+.\}
+.It READ-ONLY COMPATIBLE
+\\$3
+.El
+.Pp
+..
+.
+.ds instant-never \
+.No This feature becomes Sy active No as soon as it is enabled \
+and will never return to being Sy enabled .
+.
+.ds remount-upgrade \
+.No Each filesystem will be upgraded automatically when remounted, \
+or when a new file is created under that filesystem. \
+The upgrade can also be triggered on filesystems via \
+Nm zfs Cm set Sy version Ns = Ns Sy current Ar fs . \
+No The upgrade process runs in the background and may take a while to complete \
+for filesystems containing large amounts of files.
+.
+.de checksum-spiel
+When the
+.Sy \\$1
+feature is set to
+.Sy enabled ,
+the administrator can turn on the
+.Sy \\$1
+checksum on any dataset using
+.Nm zfs Cm set Sy checksum Ns = Ns Sy \\$1 Ar dset
+.Po see Xr zfs-set 8 Pc .
+This feature becomes
+.Sy active
+once a
+.Sy checksum
+property has been set to
+.Sy \\$1 ,
+and will return to being
+.Sy enabled
+once all filesystems that have ever had their checksum set to
+.Sy \\$1
+are destroyed.
+..
+.
+.Sh FEATURES
 The following features are supported on this system:
-
-.sp
-.ne 2
-.na
-\fBallocation_classes\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:allocation_classes
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
+.Bl -tag -width Ds
+.feature org.zfsonlinux allocation_classes yes
 This feature enables support for separate allocation classes.
-
-This feature becomes \fBactive\fR when a dedicated allocation class vdev
-(dedup or special) is created with the \fBzpool create\fR or \fBzpool add\fR
-subcommands. With device removal, it can be returned to the \fBenabled\fR
+.Pp
+This feature becomes
+.Sy active
+when a dedicated allocation class vdev (dedup or special) is created with the
+.Nm zpool Cm create No or Nm zpool Cm add No commands .
+With device removal, it can be returned to the
+.Sy enabled
 state if all the dedicated allocation class vdevs are removed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBasync_destroy\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:async_destroy
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
+.
+.feature com.delphix async_destroy yes
 Destroying a file system requires traversing all of its data in order to
-return its used space to the pool. Without \fBasync_destroy\fR the file system
-is not fully removed until all space has been reclaimed. If the destroy
-operation is interrupted by a reboot or power outage the next attempt to open
-the pool will need to complete the destroy operation synchronously.
-
-When \fBasync_destroy\fR is enabled the file system's data will be reclaimed
-by a background process, allowing the destroy operation to complete without
-traversing the entire file system. The background process is able to resume
+return its used space to the pool.
+Without
+.Sy async_destroy ,
+the file system is not fully removed until all space has been reclaimed.
+If the destroy operation is interrupted by a reboot or power outage,
+the next attempt to open the pool will need to complete the destroy
+operation synchronously.
+.Pp
+When
+.Sy async_destroy
+is enabled, the file system's data will be reclaimed by a background process,
+allowing the destroy operation to complete
+without traversing the entire file system.
+The background process is able to resume
 interrupted destroys after the pool has been opened, eliminating the need
-to finish interrupted destroys as part of the open operation. The amount
-of space remaining to be reclaimed by the background process is available
-through the \fBfreeing\fR property.
-
-This feature is only \fBactive\fR while \fBfreeing\fR is non\-zero.
-.RE
-
-.sp
-.ne 2
-.na
-\fBbookmarks\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:bookmarks
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature enables use of the \fBzfs bookmark\fR subcommand.
-
-This feature is \fBactive\fR while any bookmarks exist in the pool.
+to finish interrupted destroys as part of the open operation.
+The amount of space remaining to be reclaimed by the background process
+is available through the
+.Sy freeing
+property.
+.Pp
+This feature is only
+.Sy active
+while
+.Sy freeing
+is non-zero.
+.
+.feature com.delphix bookmarks yes extensible_dataset
+This feature enables use of the
+.Nm zfs Cm bookmark
+command.
+.Pp
+This feature is
+.Sy active
+while any bookmarks exist in the pool.
 All bookmarks in the pool can be listed by running
-\fBzfs list -t bookmark -r \fIpoolname\fR\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBbookmark_v2\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.datto:bookmark_v2
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmark, extensible_dataset
-.TE
-
+.Nm zfs Cm list Fl t Sy bookmark Fl r Ar poolname .
+.
+.feature com.datto bookmark_v2 no bookmark extensible_dataset
 This feature enables the creation and management of larger bookmarks which are
 needed for other features in ZFS.
-
-This feature becomes \fBactive\fR when a v2 bookmark is created and will be
-returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBbookmark_written\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:bookmark_written
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmark, extensible_dataset, bookmark_v2
-.TE
-
+.Pp
+This feature becomes
+.Sy active
+when a v2 bookmark is created and will be returned to the
+.Sy enabled
+state when all v2 bookmarks are destroyed.
+.
+.feature com.delphix bookmark_written no bookmark extensible_dataset bookmark_v2
 This feature enables additional bookmark accounting fields, enabling the
-written#<bookmark> property (space written since a bookmark) and estimates of
+.Sy written Ns # Ns Ar bookmark
+property (space written since a bookmark) and estimates of
 send stream sizes for incrementals from bookmarks.
-
-This feature becomes \fBactive\fR when a bookmark is created and will be
-returned to the \fBenabled\fR state when all bookmarks with these fields are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdevice_rebuild\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.openzfs:device_rebuild
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature enables the ability for the \fBzpool attach\fR and \fBzpool
-replace\fR subcommands to perform sequential reconstruction (instead of
-healing reconstruction) when resilvering.
-
+.Pp
+This feature becomes
+.Sy active
+when a bookmark is created and will be
+returned to the
+.Sy enabled
+state when all bookmarks with these fields are destroyed.
+.
+.feature org.openzfs device_rebuild yes
+This feature enables the ability for the
+.Nm zpool Cm attach
+and
+.Nm zpool Cm replace
+commands to perform sequential reconstruction
+(instead of healing reconstruction) when resilvering.
+.Pp
 Sequential reconstruction resilvers a device in LBA order without immediately
-verifying the checksums.  Once complete a scrub is started which then verifies
-the checksums.  This approach allows full redundancy to be restored to the pool
-in the minimum amount of time.  This two phase approach will take longer than a
-healing resilver when the time to verify the checksums is included.  However,
-unless there is additional pool damage no checksum errors should be reported
-by the scrub.  This feature is incompatible with raidz configurations.
-
-This feature becomes \fBactive\fR while a sequential resilver is in progress,
-and returns to \fBenabled\fR when the resilver completes.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdevice_removal\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:device_removal
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
-This feature enables the \fBzpool remove\fR subcommand to remove top-level
-vdevs, evacuating them to reduce the total size of the pool.
-
-This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is used
-on a top-level vdev, and will never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBdraid\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.openzfs:draid
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
-This feature enables use of the \fBdraid\fR vdev type.  dRAID is a variant
-of raidz which provides integrated distributed hot spares that allow faster
-resilvering while retaining the benefits of raidz.  Data, parity, and spare
-space are organized in redundancy groups and distributed evenly over all of
-the devices.
-
-This feature becomes \fBactive\fR when creating a pool which uses the
-\fBdraid\fR vdev type, or when adding a new \fBdraid\fR vdev to an
-existing pool.
-.RE
-
-.sp
-.ne 2
-.na
-\fBedonr\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.illumos:edonr
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
+verifying the checksums.
+Once complete, a scrub is started, which then verifies the checksums.
+This approach allows full redundancy to be restored to the pool
+in the minimum amount of time.
+This two-phase approach will take longer than a healing resilver
+when the time to verify the checksums is included.
+However, unless there is additional pool damage,
+no checksum errors should be reported by the scrub.
+This feature is incompatible with raidz configurations.
+.
+This feature becomes
+.Sy active
+while a sequential resilver is in progress, and returns to
+.Sy enabled
+when the resilver completes.
+.
+.feature com.delphix device_removal no
+This feature enables the
+.Nm zpool Cm remove
+command to remove top-level vdevs,
+evacuating them to reduce the total size of the pool.
+.Pp
+This feature becomes
+.Sy active
+when the
+.Nm zpool Cm remove
+command is used
+on a top-level vdev, and will never return to being
+.Sy enabled .
+.
+.feature org.openzfs draid no
+This feature enables use of the
+.Sy draid
+vdev type.
+dRAID is a variant of raidz which provides integrated distributed
+hot spares that allow faster resilvering while retaining the benefits of raidz.
+Data, parity, and spare space are organized in redundancy groups
+and distributed evenly over all of the devices.
+.Pp
+This feature becomes
+.Sy active
+when creating a pool which uses the
+.Sy draid
+vdev type, or when adding a new
+.Sy draid
+vdev to an existing pool.
+.
+.feature org.illumos edonr no extensible_dataset
 This feature enables the use of the Edon-R hash algorithm for checksum,
 including for nopwrite (if compression is also enabled, an overwrite of
 a block whose checksum matches the data being written will be ignored).
 In an abundance of caution, Edon-R requires verification when used with
-dedup: \fBzfs set dedup=edonr,verify\fR.  See \fBzfs\fR(8).
-
+dedup:
+.Nm zfs Cm set Sy dedup Ns = Ns Sy edonr , Ns Sy verify
+.Po see Xr zfs-set 8 Pc .
+.Pp
 Edon-R is a very high-performance hash algorithm that was part
-of the NIST SHA-3 competition. It provides extremely high hash
-performance (over 350% faster than SHA-256), but was not selected
-because of its unsuitability as a general purpose secure hash algorithm.
+of the NIST SHA-3 competition.
+It provides extremely high hash performance (over 350% faster than SHA-256),
+but was not selected because of its unsuitability
+as a general purpose secure hash algorithm.
 This implementation utilizes the new salted checksumming functionality
 in ZFS, which means that the checksum is pre-seeded with a secret
 256-bit random key (stored on the pool) before being fed the data block
-to be checksummed. Thus the produced checksums are unique to a given
-pool.
-
-When the \fBedonr\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBedonr\fR checksum on any dataset using the
-\fBzfs set checksum=edonr\fR. See zfs(8). This feature becomes
-\fBactive\fR once a \fBchecksum\fR property has been set to \fBedonr\fR,
-and will return to being \fBenabled\fR once all filesystems that have
-ever had their checksum set to \fBedonr\fR are destroyed.
-
-FreeBSD does not support the \fBedonr\fR feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fBembedded_data\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:embedded_data
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
+to be checksummed.
+Thus the produced checksums are unique to a given pool,
+preventing hash collision attacks on systems with dedup.
+.Pp
+.checksum-spiel edonr
+.Pp
+.Fx does not support the Sy edonr No feature.
+.
+.feature com.delphix embedded_data no
 This feature improves the performance and compression ratio of
-highly-compressible blocks.  Blocks whose contents can compress to 112 bytes
+highly-compressible blocks.
+Blocks whose contents can compress to 112 bytes
 or smaller can take advantage of this feature.
-
+.Pp
 When this feature is enabled, the contents of highly-compressible blocks are
 stored in the block "pointer" itself (a misnomer in this case, as it contains
-the compressed data, rather than a pointer to its location on disk).  Thus
-the space of the block (one sector, typically 512 bytes or 4KB) is saved,
-and no additional i/o is needed to read and write the data block.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBempty_bpobj\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:empty_bpobj
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
+the compressed data, rather than a pointer to its location on disk).
+Thus the space of the block (one sector, typically 512B or 4kB) is saved,
+and no additional I/O is needed to read and write the data block.
+.
+\*[instant-never]
+.
+.feature com.delphix empty_bpobj yes
 This feature increases the performance of creating and using a large
 number of snapshots of a single filesystem or volume, and also reduces
 the disk space required.
-
+.Pp
 When there are many snapshots, each snapshot uses many Block Pointer
-Objects (bpobj's) to track blocks associated with that snapshot.
-However, in common use cases, most of these bpobj's are empty.  This
-feature allows us to create each bpobj on-demand, thus eliminating the
-empty bpobjs.
-
-This feature is \fBactive\fR while there are any filesystems, volumes,
+Objects (bpobjs) to track blocks associated with that snapshot.
+However, in common use cases, most of these bpobjs are empty.
+This feature allows us to create each bpobj on-demand,
+thus eliminating the empty bpobjs.
+.Pp
+This feature is
+.Sy active
+while there are any filesystems, volumes,
 or snapshots which were created after enabling this feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fBenabled_txg\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:enabled_txg
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-Once this feature is enabled ZFS records the transaction group number
-in which new features are enabled. This has no user-visible impact,
-but other features may depend on this feature.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fB.
-.RE
-
-.sp
-.ne 2
-.na
-\fBencryption\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.datto:encryption
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmark_v2, extensible_dataset
-.TE
-
+.
+.feature com.delphix enabled_txg yes
+Once this feature is enabled, ZFS records the transaction group number
+in which new features are enabled.
+This has no user-visible impact, but other features may depend on this feature.
+.Pp
+This feature becomes
+.Sy active
+ as soon as it is enabled and will
+never return to being
+.Sy enabled .
+.
+.feature com.datto encryption no bookmark_v2 extensible_dataset
 This feature enables the creation and management of natively encrypted datasets.
-
-This feature becomes \fBactive\fR when an encrypted dataset is created and will
-be returned to the \fBenabled\fR state when all datasets that use this feature
-are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBextensible_dataset\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:extensible_dataset
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
+.Pp
+This feature becomes
+.Sy active
+when an encrypted dataset is created and will be returned to the
+.Sy enabled
+state when all datasets that use this feature are destroyed.
+.
+.feature com.delphix extensible_dataset no
 This feature allows more flexible use of internal ZFS data structures,
 and exists for other features to depend on.
-
-This feature will be \fBactive\fR when the first dependent feature uses it,
-and will be returned to the \fBenabled\fR state when all datasets that use
-this feature are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBfilesystem_limits\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.joyent:filesystem_limits
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature enables filesystem and snapshot limits. These limits can be used
-to control how many filesystems and/or snapshots can be created at the point in
-the tree on which the limits are set.
-
-This feature is \fBactive\fR once either of the limit properties has been
-set on a dataset. Once activated the feature is never deactivated.
-.RE
-
-.sp
-.ne 2
-.na
-\fBhole_birth\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:hole_birth
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	enabled_txg
-.TE
-
+.Pp
+This feature will be
+.Sy active
+when the first dependent feature uses it, and will be returned to the
+.Sy enabled
+state when all datasets that use this feature are destroyed.
+.
+.feature com.joyent filesystem_limits yes extensible_dataset
+This feature enables filesystem and snapshot limits.
+These limits can be used to control how many filesystems and/or snapshots
+can be created at the point in the tree on which the limits are set.
+.Pp
+This feature is
+.Sy active
+once either of the limit properties has been set on a dataset.
+Once activated the feature is never deactivated.
+.
+.feature com.delphix hole_birth no enabled_txg
 This feature has/had bugs, the result of which is that, if you do a
-\fBzfs send -i\fR (or \fB-R\fR, since it uses \fB-i\fR) from an affected
-dataset, the receiver will not see any checksum or other errors, but the
-resulting destination snapshot will not match the source.  Its use by
-\fBzfs send -i\fR has been disabled by default.  See the
-\fBsend_holes_without_birth_time\fR module parameter in
-zfs-module-parameters(5).
-
-This feature improves performance of incremental sends (\fBzfs send -i\fR)
-and receives for objects with many holes. The most common case of
-hole-filled objects is zvols.
-
-An incremental send stream from snapshot \fBA\fR to snapshot \fBB\fR
-contains information about every block that changed between \fBA\fR and
-\fBB\fR. Blocks which did not change between those snapshots can be
+.Nm zfs Cm send Fl i
+.Pq or Fl R , No since it uses Fl i
+from an affected dataset, the receiving party will not see any checksum
+or other errors, but the resulting destination snapshot
+will not match the source.
+Its use by
+.Nm zfs Cm send Fl i
+has been disabled by default
+.Pq see Sy send_holes_without_birth_time No in Xr zfs-module-parameters 5 .
+.Pp
+This feature improves performance of incremental sends
+.Pq Nm zfs Cm send Fl i
+and receives for objects with many holes.
+The most common case of hole-filled objects is zvols.
+.Pp
+An incremental send stream from snapshot
+.Sy A No to snapshot Sy B
+contains information about every block that changed between
+.Sy A No and Sy B .
+Blocks which did not change between those snapshots can be
 identified and omitted from the stream using a piece of metadata called
-the 'block birth time', but birth times are not recorded for holes (blocks
-filled only with zeroes). Since holes created after \fBA\fR cannot be
-distinguished from holes created before \fBA\fR, information about every
-hole in the entire filesystem or zvol is included in the send stream.
-
-For workloads where holes are rare this is not a problem. However, when
-incrementally replicating filesystems or zvols with many holes (for
-example a zvol formatted with another filesystem) a lot of time will
+the "block birth time", but birth times are not recorded for holes
+(blocks filled only with zeroes).
+Since holes created after
+.Sy A No cannot be distinguished from holes created before Sy A ,
+information about every hole in the entire filesystem or zvol
+is included in the send stream.
+.Pp
+For workloads where holes are rare this is not a problem.
+However, when incrementally replicating filesystems or zvols with many holes
+(for example a zvol formatted with another filesystem) a lot of time will
 be spent sending and receiving unnecessary information about holes that
 already exist on the receiving side.
-
-Once the \fBhole_birth\fR feature has been enabled the block birth times
-of all new holes will be recorded. Incremental sends between snapshots
-created after this feature is enabled will use this new metadata to avoid
-sending information about holes that already exist on the receiving side.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fB.
-.RE
-
-.sp
-.ne 2
-.na
-\fBlarge_blocks\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.open-zfs:large_blocks
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
-The \fBlarge_block\fR feature allows the record size on a dataset to be
-set larger than 128KB.
-
-This feature becomes \fBactive\fR once a dataset contains a file with
-a block size larger than 128KB, and will return to being \fBenabled\fR once all
-filesystems that have ever had their recordsize larger than 128KB are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBlarge_dnode\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:large_dnode
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
-The \fBlarge_dnode\fR feature allows the size of dnodes in a dataset to be
-set larger than 512B.
-
-This feature becomes \fBactive\fR once a dataset contains an object with
-a dnode larger than 512B, which occurs as a result of setting the
-\fBdnodesize\fR dataset property to a value other than \fBlegacy\fR. The
-feature will return to being \fBenabled\fR once all filesystems that
-have ever contained a dnode larger than 512B are destroyed. Large dnodes
-allow more data to be stored in the bonus buffer, thus potentially
-improving performance by avoiding the use of spill blocks.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlivelist\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:livelist
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
+.Pp
+Once the
+.Sy hole_birth
+feature has been enabled the block birth times
+of all new holes will be recorded.
+Incremental sends between snapshots created after this feature is enabled
+will use this new metadata to avoid sending information about holes that
+already exist on the receiving side.
+.Pp
+\*[instant-never]
+.
+.feature org.open-zfs large_blocks no extensible_dataset
+This feature allows the record size on a dataset to be set larger than 128kB.
+.Pp
+This feature becomes
+.Sy active
+once a dataset contains a file with a block size larger than 128kB,
+and will return to being
+.Sy enabled
+once all filesystems that have ever had their recordsize larger than 128kB
+are destroyed.
+.
+.feature org.zfsonlinux large_dnode no extensible_dataset
+This feature allows the size of dnodes in a dataset to be set larger than 512B.
+.
+This feature becomes
+.Sy active
+once a dataset contains an object with a dnode larger than 512B,
+which occurs as a result of setting the
+.Sy dnodesize
+dataset property to a value other than
+.Sy legacy .
+The feature will return to being
+.Sy enabled
+once all filesystems that have ever contained a dnode larger than 512B
+are destroyed.
+Large dnodes allow more data to be stored in the bonus buffer,
+thus potentially improving performance by avoiding the use of spill blocks.
+.
+.feature com.delphix livelist yes
 This feature allows clones to be deleted faster than the traditional method
 when a large number of random/sparse writes have been made to the clone.
 All blocks allocated and freed after a clone is created are tracked by the
 the clone's livelist which is referenced during the deletion of the clone.
-The feature is activated when a clone is created and remains active until all
-clones have been destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBlog_spacemap\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:log_spacemap
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	com.delphix:spacemap_v2
-.TE
-
+The feature is activated when a clone is created and remains
+.Sy active
+until all clones have been destroyed.
+.
+.feature com.delphix log_spacemap yes com.delphix:spacemap_v2
 This feature improves performance for heavily-fragmented pools,
-especially when workloads are heavy in random-writes. It does so by
-logging all the metaslab changes on a single spacemap every TXG
+especially when workloads are heavy in random-writes.
+It does so by logging all the metaslab changes on a single spacemap every TXG
 instead of scattering multiple writes to all the metaslab spacemaps.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will never
-return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBlz4_compress\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.illumos:lz4_compress
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
-\fBlz4\fR is a high-performance real-time compression algorithm that
+.Pp
+\*[instant-never]
+.
+.feature org.illumos lz4_compress no
+.Sy lz4
+is a high-performance real-time compression algorithm that
 features significantly faster compression and decompression as well as a
-higher compression ratio than the older \fBlzjb\fR compression.
-Typically, \fBlz4\fR compression is approximately 50% faster on
-compressible data and 200% faster on incompressible data than
-\fBlzjb\fR. It is also approximately 80% faster on decompression, while
-giving approximately 10% better compression ratio.
-
-When the \fBlz4_compress\fR feature is set to \fBenabled\fR, the
-administrator can turn on \fBlz4\fR compression on any dataset on the
-pool using the zfs(8) command. Please note that doing so will
-immediately activate the \fBlz4_compress\fR feature on the underlying
-pool using the zfs(8) command. Also, all newly written metadata
-will be compressed with \fBlz4\fR algorithm. Since this feature is not
-read-only compatible, this operation will render the pool unimportable
-on systems without support for the \fBlz4_compress\fR feature.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fB.
-.RE
-
-.sp
-.ne 2
-.na
-\fBmulti_vdev_crash_dump\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.joyent:multi_vdev_crash_dump
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
+higher compression ratio than the older
+.Sy lzjb
+compression.
+Typically,
+.Sy lz4
+compression is approximately 50% faster on compressible data and 200% faster
+on incompressible data than
+.Sy lzjb .
+It is also approximately 80% faster on decompression,
+while giving approximately a 10% better compression ratio.
+.Pp
+When the
+.Sy lz4_compress
+feature is set to
+.Sy enabled ,
+the administrator can turn on
+.Sy lz4
+compression on any dataset on the pool using the
+.Xr zfs-set 8
+command.
+All newly written metadata will be compressed with the
+.Sy lz4
+algorithm.
+.Pp
+\*[instant-never]
+.
+.feature com.joyent multi_vdev_crash_dump no
 This feature allows a dump device to be configured with a pool comprised
-of multiple vdevs.  Those vdevs may be arranged in any mirrored or raidz
-configuration.
-
-When the \fBmulti_vdev_crash_dump\fR feature is set to \fBenabled\fR,
-the administrator can use the \fBdumpadm\fR(1M) command to configure a
-dump device on a pool comprised of multiple vdevs.
-
-Under FreeBSD and Linux this feature is registered for compatibility but not
-used.  New pools created under FreeBSD and Linux will have the feature
-\fBenabled\fR but will never transition to \fB\fBactive\fR.  This functionality
-is not required in order to support crash dumps under FreeBSD and Linux.
-Existing pools where this feature is \fB\fBactive\fR can be imported.
-.RE
-
-.sp
-.ne 2
-.na
-\fBobsolete_counts\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:obsolete_counts
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	device_removal
-.TE
-
-This feature is an enhancement of device_removal, which will over time
-reduce the memory used to track removed devices.  When indirect blocks
-are freed or remapped, we note that their part of the indirect mapping
-is "obsolete", i.e. no longer needed.
-
-This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is
-used on a top-level vdev, and will never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBproject_quota\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:project_quota
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
+of multiple vdevs.
+Those vdevs may be arranged in any mirrored or raidz configuration.
+.Pp
+When the
+.Sy multi_vdev_crash_dump
+feature is set to
+.Sy enabled ,
+the administrator can use
+.Xr dumpadm 1M
+to configure a dump device on a pool comprised of multiple vdevs.
+.Pp
+Under
+.Fx
+and Linux this feature is unused, but registered for compatibility.
+New pools created on these systems will have the feature
+.Sy enabled
+but will never transition to
+.Sy active ,
+as this functionality is not required for crash dump support.
+Existing pools where this feature is
+.Sy active
+can be imported.
+.
+.feature com.delphix obsolete_counts yes device_removal
+This feature is an enhancement of
+.Sy device_removal ,
+which will over time reduce the memory used to track removed devices.
+When indirect blocks are freed or remapped,
+we note that their part of the indirect mapping is "obsolete" – no longer needed.
+.Pp
+This feature becomes
+.Sy active
+when the
+.Nm zpool Cm remove
+command is used on a top-level vdev, and will never return to being
+.Sy enabled .
+.
+.feature org.zfsonlinux project_quota yes extensible_dataset
 This feature allows administrators to account the spaces and objects usage
 information against the project identifier (ID).
-
-The project ID is new object-based attribute. When upgrading an existing
-filesystem, object without project ID attribute will be assigned a zero
-project ID. After this feature is enabled, newly created object will inherit
-its parent directory's project ID if the parent inherit flag is set (via
-\fBchattr +/-P\fR or \fBzfs project [-s|-C]\fR). Otherwise, the new object's
-project ID will be set as zero. An object's project ID can be changed at
-anytime by the owner (or privileged user) via \fBchattr -p $prjid\fR or
-\fBzfs project -p $prjid\fR.
-
-This feature will become \fBactive\fR as soon as it is enabled and will never
-return to being \fBdisabled\fR. Each filesystem will be upgraded automatically
-when remounted or when new file is created under that filesystem. The upgrade
-can also be triggered on filesystems via `zfs set version=current <pool/fs>`.
-The upgrade process runs in the background and may take a while to complete
-for the filesystems containing a large number of files.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBredaction_bookmarks\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:redaction_bookmarks
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmarks, extensible_dataset
-.TE
-
-This feature enables the use of the redacted zfs send.  Redacted \fBzfs send\fR
-creates redaction bookmarks, which store the list of blocks redacted by the
-send that created them.  For more information about redacted send,
-see \fBzfs\fR(8).
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBredacted_datasets\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:redacted_datasets
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature enables the receiving of redacted zfs send streams.  Redacted zfs
-send streams create redacted datasets when received.  These datasets are
-missing some of their blocks, and so cannot be safely mounted, and their
-contents cannot be safely read.  For more information about redacted receive,
-see \fBzfs\fR(8).
-.RE
-
-.sp
-.ne 2
-.na
-\fBresilver_defer\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.datto:resilver_defer
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature allows zfs to postpone new resilvers if an existing one is already
-in progress. Without this feature, any new resilvers will cause the currently
+.Pp
+The project ID is an object-based attribute.
+When upgrading an existing filesystem,
+objects without a project ID will be assigned a zero project ID.
+When this feature is enabled, newly created objects inherit
+their parent directories' project ID if the parent's inherit flag is set
+.Pq via Nm chattr Sy [+-]P No or Nm zfs Cm project Fl s Ns | Ns Fl C .
+Otherwise, the new object's project ID will be zero.
+An object's project ID can be changed at any time by the owner
+(or privileged user) via
+.Nm chattr Fl p Ar prjid
+or
+.Nm zfs Cm project Fl p Ar prjid .
+.Pp
+This feature will become
+.Sy active
+as soon as it is enabled and will never return to being
+.Sy disabled .
+\*[remount-upgrade]
+.
+.feature com.delphix redaction_bookmarks no bookmarks extensible_dataset
+This feature enables the use of redacted
+.Nm zfs Cm send Ns s ,
+which create redaction bookmarks storing the list of blocks
+redacted by the send that created them.
+For more information about redacted sends, see
+.Xr zfs-send 8 .
+.
+.feature com.delphix redacted_datasets no extensible_dataset
+This feature enables the receiving of redacted
+.Nm zfs Cm send Ns
+streams. which create redacted datasets when received.
+These datasets are missing some of their blocks,
+and so cannot be safely mounted, and their contents cannot be safely read.
+For more information about redacted receives, see
+.Xr zfs-send 8 .
+.
+.feature com.datto resilver_defer yes
+This feature allows ZFS to postpone new resilvers if an existing one is already
+in progress.
+Without this feature, any new resilvers will cause the currently
 running one to be immediately restarted from the beginning.
-
-This feature becomes \fBactive\fR once a resilver has been deferred, and
-returns to being \fBenabled\fR when the deferred resilver begins.
-.RE
-
-.sp
-.ne 2
-.na
-\fBsha512\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.illumos:sha512
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
+.Pp
+This feature becomes
+.Sy active
+once a resilver has been deferred, and returns to being
+.Sy enabled
+when the deferred resilver begins.
+.
+.feature org.illumos sha512 no extensible_dataset
 This feature enables the use of the SHA-512/256 truncated hash algorithm
-(FIPS 180-4) for checksum and dedup. The native 64-bit arithmetic of
-SHA-512 provides an approximate 50% performance boost over SHA-256 on
-64-bit hardware and is thus a good minimum-change replacement candidate
-for systems where hash performance is important, but these systems
-cannot for whatever reason utilize the faster \fBskein\fR and
-\fBedonr\fR algorithms.
-
-When the \fBsha512\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBsha512\fR checksum on any dataset using
-\fBzfs set checksum=sha512\fR. See zfs(8). This feature becomes
-\fBactive\fR once a \fBchecksum\fR property has been set to \fBsha512\fR,
-and will return to being \fBenabled\fR once all filesystems that have
-ever had their checksum set to \fBsha512\fR are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBskein\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.illumos:skein
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature enables the use of the Skein hash algorithm for checksum
-and dedup. Skein is a high-performance secure hash algorithm that was a
-finalist in the NIST SHA-3 competition. It provides a very high security
-margin and high performance on 64-bit hardware (80% faster than
-SHA-256). This implementation also utilizes the new salted checksumming
+(FIPS 180-4) for checksum and dedup.
+The native 64-bit arithmetic of SHA-512 provides an approximate 50%
+performance boost over SHA-256 on 64-bit hardware
+and is thus a good minimum-change replacement candidate
+for systems where hash performance is important,
+but these systems cannot for whatever reason utilize the faster
+.Sy skein No and Sy edonr
+algorithms.
+.Pp
+.checksum-spiel sha512
+.
+.feature org.illumos skein no extensible_dataset
+This feature enables the use of the Skein hash algorithm for checksum and dedup.
+Skein is a high-performance secure hash algorithm that was a
+finalist in the NIST SHA-3 competition.
+It provides a very high security margin and high performance on 64-bit hardware
+(80% faster than SHA-256).
+This implementation also utilizes the new salted checksumming
 functionality in ZFS, which means that the checksum is pre-seeded with a
 secret 256-bit random key (stored on the pool) before being fed the data
-block to be checksummed. Thus the produced checksums are unique to a
-given pool, preventing hash collision attacks on systems with dedup.
-
-When the \fBskein\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBskein\fR checksum on any dataset using
-\fBzfs set checksum=skein\fR. See zfs(8). This feature becomes
-\fBactive\fR once a \fBchecksum\fR property has been set to \fBskein\fR,
-and will return to being \fBenabled\fR once all filesystems that have
-ever had their checksum set to \fBskein\fR are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspacemap_histogram\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:spacemap_histogram
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
+block to be checksummed.
+Thus the produced checksums are unique to a given pool,
+preventing hash collision attacks on systems with dedup.
+.Pp
+.checksum-spiel skein
+.
+.feature com.delphix spacemap_histogram yes
 This features allows ZFS to maintain more information about how free space
-is organized within the pool. If this feature is \fBenabled\fR, ZFS will
-set this feature to \fBactive\fR when a new space map object is created or
-an existing space map is upgraded to the new format. Once the feature is
-\fBactive\fR, it will remain in that state until the pool is destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fBspacemap_v2\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:spacemap_v2
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
+is organized within the pool.
+If this feature is
+.Sy enabled ,
+it will be activated when a new space map object is created, or
+an existing space map is upgraded to the new format,
+and never returns back to being
+.Sy enabled .
+.
+.feature com.delphix spacemap_v2 yes
 This feature enables the use of the new space map encoding which
 consists of two words (instead of one) whenever it is advantageous.
 The new encoding allows space maps to represent large regions of
 space more efficiently on-disk while also increasing their maximum
 addressable offset.
-
-This feature becomes \fBactive\fR once it is \fBenabled\fR, and never
-returns back to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBuserobj_accounting\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:userobj_accounting
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
+.Pp
+This feature becomes
+.Sy active
+once it is
+.Sy enabled ,
+and never returns back to being
+.Sy enabled .
+.
+.feature org.zfsonlinux userobj_accounting yes extensible_dataset
 This feature allows administrators to account the object usage information
 by user and group.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will never
-return to being \fBenabled\fR. Each filesystem will be upgraded automatically
-when remounted, or when new files are created under that filesystem.
-The upgrade can also be started manually on filesystems by running
-`zfs set version=current <pool/fs>`. The upgrade process runs in the background
-and may take a while to complete for filesystems containing a large number of
-files.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzpool_checkpoint\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:zpool_checkpoint
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature enables the \fBzpool checkpoint\fR subcommand that can
-checkpoint the state of the pool at the time it was issued and later
-rewind back to it or discard it.
-
-This feature becomes \fBactive\fR when the \fBzpool checkpoint\fR subcommand
-is used to checkpoint the pool.
-The feature will only return back to being \fBenabled\fR when the pool
-is rewound or the checkpoint has been discarded.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzstd_compress\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.freebsd:zstd_compress
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
-.TE
-
-\fBzstd\fR is a high-performance compression algorithm that features a
-combination of high compression ratios and high speed. Compared to \fBgzip\fR,
-\fBzstd\fR offers slightly better compression at much higher speeds. Compared
-to \fBlz4\fR, \fBzstd\fR offers much better compression while being only
-modestly slower. Typically, \fBzstd\fR compression speed ranges from 250 to 500
-MB/s per thread and decompression speed is over 1 GB/s per thread.
-
-When the \fBzstd\fR feature is set to \fBenabled\fR, the administrator can turn
-on \fBzstd\fR compression of any dataset by running
-`zfs set compress=zstd <pool/fs>`.
-
-This feature becomes \fBactive\fR once a \fBcompress\fR property has been set to
-\fBzstd\fR, and will return to being \fBenabled\fR once all filesystems that
-have ever had their compress property set to \fBzstd\fR are destroyed.
-.RE
-
-.SH "SEE ALSO"
-zpool(8)
+.Pp
+\*[instant-never]
+\*[remount-upgrade]
+.
+.feature com.delphix zpool_checkpoint yes
+This feature enables the
+.Nm zpool Cm checkpoint
+command that can checkpoint the state of the pool
+at the time it was issued and later rewind back to it or discard it.
+.Pp
+This feature becomes
+.Sy active
+when the
+.Nm zpool Cm checkpoint
+command is used to checkpoint the pool.
+The feature will only return back to being
+.Sy enabled
+when the pool is rewound or the checkpoint has been discarded.
+.
+.feature org.freebsd zstd_compress no extensible_dataset
+.Sy zstd
+is a high-performance compression algorithm that features a
+combination of high compression ratios and high speed.
+Compared to
+.Sy gzip ,
+.Sy zstd
+offers slightly better compression at much higher speeds.
+Compared to
+.Sy lz4 ,
+.Sy zstd
+offers much better compression while being only modestly slower.
+Typically,
+.Sy zstd
+compression speed ranges from 250 to 500 MB/s per thread
+and decompression speed is over 1 GB/s per thread.
+.Pp
+When the
+.Sy zstd
+feature is set to
+.Sy enabled ,
+the administrator can turn on
+.Sy zstd
+compression of any dataset using
+.Nm zfs Cm set Sy compress Ns = Ns Sy zstd Ar dset
+.Po see Xr zfs-set 8 Pc .
+This feature becomes
+.Sy active
+once a
+.Sy compress
+property has been set to
+.Sy zstd ,
+and will return to being
+.Sy enabled
+once all filesystems that have ever had their
+.Sy compress
+property set to
+.Sy zstd
+are destroyed.
+.El
+.
+.Sh SEE ALSO
+.Xr zpool 8

--- a/man/man8/zfs-mount-generator.8.in
+++ b/man/man8/zfs-mount-generator.8.in
@@ -21,232 +21,172 @@
 .\" LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 .\" OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 .\" WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-.TH ZFS-MOUNT-GENERATOR 8 "Apr 19, 2021" OpenZFS
-
-.SH "NAME"
-zfs\-mount\-generator \- generates systemd mount units for ZFS
-.SH SYNOPSIS
-.B @systemdgeneratordir@/zfs\-mount\-generator
-.sp
-.SH DESCRIPTION
-zfs\-mount\-generator implements the \fBGenerators Specification\fP
-of
-.BR systemd (1),
-and is called during early boot to generate
-.BR systemd.mount (5)
-units for automatically mounted datasets. Mount ordering and dependencies
-are created for all tracked pools (see below).
-
-.SS ENCRYPTION KEYS
-If the dataset is an encryption root, a service that loads the associated key (either from file or through a
-.BR systemd\-ask\-password (1)
-prompt) will be created. This service
-. BR RequiresMountsFor
-the path of the key (if file-based) and also copies the mount unit's
-.BR After ,
-.BR Before
+.\"
+.Dd May 31, 2021
+.Dt ZFS-MOUNT-GENERATOR 8
+.Os
+.
+.Sh NAME
+.Nm zfs-mount-generator
+.Nd generate systemd mount units for ZFS filesystems
+.Sh SYNOPSIS
+.Pa @systemdgeneratordir@/zfs-mount-generator
+.
+.Sh DESCRIPTION
+.Nm
+is a
+.Xr systemd.generator 7
+that generates native
+.Xr systemd.mount 5
+units for configured ZFS datasets.
+.
+.Ss Properties
+.Bl -tag -compact -width "org.openzfs.systemd:required-by=unit[ unit]…"
+.It Sy mountpoint Ns =
+.No Skipped if Sy legacy No or Sy none .
+.
+.It Sy canmount Ns =
+.No Skipped if Sy off .
+.No Skipped if only Sy noauto
+datasets exist for a given mountpoint and there's more than one.
+.No Datasets with Sy yes No take precedence over ones with Sy noauto No for the same mountpoint.
+.No Sets logical Em noauto No flag if Sy noauto .
+Encryption roots always generate
+.Sy zfs-load-key@ Ns Ar root Ns Sy .service ,
+even if
+.Sy off .
+.
+.It Sy atime Ns = , Sy relatime Ns = , Sy devices Ns = , Sy exec Ns = , Sy readonly Ns = , Sy setuid Ns = , Sy nbmand Ns =
+Used to generate mount options equivalent to
+.Nm zfs Cm mount .
+.
+.It Sy encroot Ns = , Sy keylocation Ns =
+If the dataset is an encryption root, its mount unit will bind to
+.Sy zfs-load-key@ Ns Ar root Ns Sy .service ,
+with additional dependencies as follows:
+.Bl -tag -compact -offset Ds -width "keylocation=https://URL (et al.)"
+.It Sy keylocation Ns = Ns Sy prompt
+None, uses
+.Xr systemd-ask-password 1
+.It Sy keylocation Ns = Ns Sy https:// Ns Ar URL Pq et al.\&
+.Sy Wants Ns = , Sy After Ns = : Pa network-online.target
+.It Sy keylocation Ns = Ns Sy file:// Ns < Ns Ar path Ns >
+.Sy RequiresMountsFor Ns = Ns Ar path
+.El
+.
+The service also uses the same
+.Sy Wants Ns = ,
+.Sy After Ns = ,
+.Sy Requires Ns = , No and
+.Sy RequiresMountsFor Ns = ,
+as the mount unit.
+.
+.It Sy org.openzfs.systemd:requires Ns = Ns Pa path Ns Oo " " Ns Pa path Oc Ns …
+.No Sets Sy Requires Ns = for the mount- and key-loading unit.
+.
+.It Sy org.openzfs.systemd:requires-mounts-for Ns = Ns Pa path Ns Oo " " Ns Pa path Oc Ns …
+.No Sets Sy RequiresMountsFor Ns = for the mount- and key-loading unit.
+.
+.It Sy org.openzfs.systemd:before Ns = Ns Pa unit Ns Oo " " Ns Pa unit Oc Ns …
+.No Sets Sy Before Ns = for the mount unit.
+.
+.It Sy org.openzfs.systemd:after Ns = Ns Pa unit Ns Oo " " Ns Pa unit Oc Ns …
+.No Sets Sy After Ns = for the mount unit.
+.
+.It Sy org.openzfs.systemd:wanted-by Ns = Ns Pa unit Ns Oo " " Ns Pa unit Oc Ns …
+.No Sets logical Em noauto No flag (see below).
+.No If not Sy none , No sets Sy WantedBy Ns = for the mount unit.
+.It Sy org.openzfs.systemd:required-by Ns = Ns Pa unit Ns Oo " " Ns Pa unit Oc Ns …
+.No Sets logical Em noauto No flag (see below).
+.No If not Sy none , No sets Sy RequiredBy Ns = for the mount unit.
+.
+.It Sy org.openzfs.systemd:nofail Ns = Ns (unset) Ns | Ns Sy on Ns | Ns Sy off
+Waxes or wanes strength of default reverse dependencies of the mount unit, see below.
+.
+.It Sy org.openzfs.systemd:ignore Ns = Ns Sy on Ns | Ns Sy off
+.No Skip if Sy on .
+.No Defaults to Sy off .
+.El
+.
+.Ss Unit Ordering And Dependencies
+Additionally, unless the pool the dataset resides on
+is imported at generation time, both units gain
+.Sy Wants Ns = Ns Pa zfs-import.target
 and
-.BR Requires .
-All mount units of encrypted datasets add the key\-load service for their encryption root to their
-.BR Wants
-and
-.BR After .
-The service will not be
-.BR Want ed
-or
-.BR Require d
-by
-.BR local-fs.target
-directly, and so will only be started manually or as a dependency of a started mount unit.
-
-.SS UNIT ORDERING AND DEPENDENCIES
-mount unit's
-.BR Before
-\->
-key\-load service (if any)
-\->
-mount unit
-\->
-mount unit's
-.BR After
-
-It is worth nothing that when a mount unit is activated, it activates all available mount units for parent paths to its mountpoint, i.e. activating the mount unit for /tmp/foo/1/2/3 automatically activates all available mount units for /tmp, /tmp/foo, /tmp/foo/1, and /tmp/foo/1/2. This is true for any combination of mount units from any sources, not just ZFS.
-
-.SS CACHE FILE
+.Sy After Ns = Ns Pa zfs-import.target .
+.Pp
+Additionally, unless the logical
+.Em noauto
+flag is set, the mount unit gains a reverse-dependency for
+.Pa local-fs.target
+of strength
+.Bl -tag -compact -offset Ds -width "(unset)"
+.It (unset)
+.Sy WantedBy Ns = No + Sy Before Ns =
+.It Sy on
+.Sy WantedBy Ns =
+.It Sy off
+.Sy RequiredBy Ns = No + Sy Before Ns =
+.El
+.
+.Ss Cache File
 Because ZFS pools may not be available very early in the boot process,
-information on ZFS mountpoints must be stored separately. The output of the command
-.PP
-.RS 4
-zfs list -H -o name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid,nbmand,encroot,keylocation,org.openzfs.systemd:requires,org.openzfs.systemd:requires-mounts-for,org.openzfs.systemd:before,org.openzfs.systemd:after,org.openzfs.systemd:wanted-by,org.openzfs.systemd:required-by,org.openzfs.systemd:nofail,org.openzfs.systemd:ignore
-
-.RE
-.PP
-for datasets that should be mounted by systemd, should be kept
-separate from the pool at
-.RI @sysconfdir@/zfs/zfs-list.cache/ POOLNAME .
-.PP
-The cache file, if writeable, will be kept synchronized with the pool
-state by the
-.I history_event-zfs-list-cacher.sh
-ZEDLET.
-.PP
-.sp
-.SS PROPERTIES
-The behavior of the generator script can be influenced by the following dataset properties:
-.sp
-.TP 4
-.BR canmount = on | off | noauto
-If a dataset has
-.BR mountpoint
-set and
-.BR canmount
-is not
-.BR off ,
-a mount unit will be generated.
-Additionally, if
-.BR canmount
-is
-.BR on ,
-.BR local-fs.target
-will gain a dependency on the mount unit.
-
-This behavior is equal to the
-.BR auto
-and
-.BR noauto
-legacy mount options, see
-.BR systemd.mount (5).
-
-Encryption roots always generate a key-load service, even for
-.BR canmount=off .
-.TP 4
-.BR org.openzfs.systemd:requires\-mounts\-for = \fIpath\fR...
-Space\-separated list of mountpoints to require to be mounted for this mount unit
-.TP 4
-.BR org.openzfs.systemd:before = \fIunit\fR...
-The mount unit and associated key\-load service will be ordered before this space\-separated list of units.
-.TP 4
-.BR org.openzfs.systemd:after = \fIunit\fR...
-The mount unit and associated key\-load service will be ordered after this space\-separated list of units.
-.TP 4
-.BR org.openzfs.systemd:wanted\-by = \fIunit\fR...
-Space-separated list of units that will gain a
-.BR Wants
-dependency on this mount unit.
-Setting this property implies
-.BR noauto .
-.TP 4
-.BR org.openzfs.systemd:required\-by = \fIunit\fR...
-Space-separated list of units that will gain a
-.BR Requires
-dependency on this mount unit.
-Setting this property implies
-.BR noauto .
-.TP 4
-.BR org.openzfs.systemd:nofail = unset | on | off
-Toggles between a
-.BR Wants
-and
-.BR Requires
-type of dependency between the mount unit and
-.BR local-fs.target ,
-if
-.BR noauto
-isn't set or implied.
-
-.BR on :
-Mount will be
-.BR WantedBy
-local-fs.target
-
-.BR off :
-Mount will be
-.BR Before
-and
-.BR RequiredBy
-local-fs.target
-
-.BR unset :
-Mount will be
-.BR Before
-and
-.BR WantedBy
-local-fs.target
-.TP 4
-.BR org.openzfs.systemd:ignore = on | off
-If set to
-.BR on ,
-do not generate a mount unit for this dataset.
-
-See also
-.BR systemd.mount (5)
-
-.PP
-.SH ENVIRONMENT
+information on ZFS mountpoints must be stored separately.
+The output of
+.Dl Nm zfs Cm list Fl Ho Ar name , Ns Aq every property above in order
+for datasets that should be mounted by systemd should be kept at
+.Pa @sysconfdir@/zfs/zfs-list.cache/ Ns Ar poolname ,
+and, if writeable, will be kept synchronized for the entire pool by the
+.Pa history_event-zfs-list-cacher.sh
+ZEDLET, if enabled
+.Pq see Xr zed 8 .
+.
+.Sh ENVIRONMENT
 The
-.BR $ZFS_DEBUG
-environment variable, which can either be 0 (default),
-1 (print summary accounting information at the end),
-or at least 2 (print accounting information for each subprocess as it finishes).
-
-If not present, /proc/cmdline is additionally checked for
-.BR debug ,
-in which case the debug level is set to 2.
-
-.SH EXAMPLE
+.Sy ZFS_DEBUG
+environment variable can either be
+.Sy 0
+(default),
+.Sy 1
+(print summary accounting information at the end), or at least
+.Sy 2
+(print accounting information for each subprocess as it finishes).
+.
+If not present,
+.Pa /proc/cmdline
+is additionally checked for
+.Qq debug ,
+in which case the debug level is set to
+.Sy 2 .
+.
+.Sh EXAMPLES
 To begin, enable tracking for the pool:
-.PP
-.RS 4
-touch
-.RI @sysconfdir@/zfs/zfs-list.cache/ POOLNAME
-.RE
-.PP
-Then, enable the tracking ZEDLET:
-.PP
-.RS 4
-ln -s "@zfsexecdir@/zed.d/history_event-zfs-list-cacher.sh" "@sysconfdir@/zfs/zed.d"
-
-systemctl enable zfs-zed.service
-
-systemctl restart zfs-zed.service
-.RE
-.PP
-Force the running of the ZEDLET by setting a monitored property, e.g.
-.BR canmount ,
-for at least one dataset in the pool:
-.PP
-.RS 4
-zfs set canmount=on
-.I DATASET
-.RE
-.PP
-This forces an update to the stale cache file.
-
-To test the generator output, run
-.PP
-.RS 4
-@systemdgeneratordir@/zfs-mount-generator /tmp/zfs-mount-generator
-.RE
-.PP
-This will generate units and dependencies in
-.I /tmp/zfs-mount-generator
-for you to inspect them. The second and third argument are ignored.
-
-If you're satisfied with the generated units, instruct systemd to re-run all generators:
-.PP
-.RS 4
-systemctl daemon-reload
-.RE
-.PP
-
-.sp
-.SH SEE ALSO
-.BR zfs (5)
-.BR zfs-events (5)
-.BR zed (8)
-.BR zpool (5)
-.BR systemd (1)
-.BR systemd.target (5)
-.BR systemd.special (7)
-.BR systemd.mount (7)
+.Dl # Nm touch Pa @sysconfdir@/zfs/zfs-list.cache/ Ns Ar poolname
+Then enable the tracking ZEDLET:
+.Dl # Nm ln Fl s Pa @zfsexecdir@/zed.d/history_event-zfs-list-cacher.sh @sysconfdir@/zfs/zed.d
+.Dl # Nm systemctl Cm enable Pa zfs-zed.service
+.Dl # Nm systemctl Cm restart Pa zfs-zed.service
+.Pp
+If no history event is in the queue,
+inject one to ensure the ZEDLET runs to refresh the cache file
+by setting a monitored property somewhere on the pool:
+.Dl # Nm zfs Cm set Sy relatime Ns = Ns Sy off Ar poolname/dset
+.Dl # Nm zfs Cm inherit Sy relatime Ar poolname/dset
+.Pp
+To test the generator output:
+.Dl $ Nm mkdir Pa /tmp/zfs-mount-generator
+.Dl $ Nm @systemdgeneratordir@/zfs-mount-generator Pa /tmp/zfs-mount-generator
+.
+If the generated units are satisfactory, instruct
+.Nm systemd
+to re-run all generators:
+.Dl # Nm systemctl daemon-reload
+.
+.Sh SEE ALSO
+.Xr systemd.mount 5 ,
+.Xr systemd.target 5 ,
+.Xr zfs 5 ,
+.Xr zfs-events 5 ,
+.Xr systemd.generator 7 ,
+.Xr systemd.special 7 ,
+.Xr zed 8

--- a/man/man8/zfs-wait.8
+++ b/man/man8/zfs-wait.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -27,25 +26,20 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd May 31, 2021
 .Dt ZFS-WAIT 8
 .Os
+.
 .Sh NAME
 .Nm zfs-wait
-.Nd Wait for background activity to stop in a ZFS filesystem
+.Nd wait for activity in ZFS filesystem to stop
 .Sh SYNOPSIS
 .Nm zfs
 .Cm wait
-.Op Fl t Ar activity Ns Oo , Ns Ar activity Ns Oc Ns ...
-.Ar fs
+.Op Fl t Ar activity Ns Oo , Ns Ar activity Ns Oc Ns …
+.Ar filesystem
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zfs
-.Cm wait
-.Op Fl t Ar activity Ns Oo , Ns Ar activity Ns Oc Ns ...
-.Ar fs
-.Xc
 Waits until all background activity of the given types has ceased in the given
 filesystem.
 The activity could cease because it has completed or because the filesystem has
@@ -58,13 +52,14 @@ immediately.
 These are the possible values for
 .Ar activity ,
 along with what each one waits for:
-.Bd -literal
-        deleteq       The filesystem's internal delete queue to empty
-.Ed
+.Bl -tag -compact -offset Ds -width "deleteq"
+.It Sy deleteq
+The filesystem's internal delete queue to empty
+.El
 .Pp
 Note that the internal delete queue does not finish draining until
 all large files have had time to be fully destroyed and all open file
 handles to unlinked files are closed.
-.El
+.
 .Sh SEE ALSO
 .Xr lsof 8

--- a/man/man8/zpool-destroy.8
+++ b/man/man8/zpool-destroy.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -27,29 +26,23 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd May 31, 2021
 .Dt ZPOOL-DESTROY 8
 .Os
+.
 .Sh NAME
 .Nm zpool-destroy
-.Nd Destroys the given ZFS storage pool, freeing up any devices for other use
+.Nd destroy ZFS storage pool
 .Sh SYNOPSIS
 .Nm zpool
 .Cm destroy
 .Op Fl f
 .Ar pool
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zpool
-.Cm destroy
-.Op Fl f
-.Ar pool
-.Xc
 Destroys the given pool, freeing up any devices for other use.
 This command tries to unmount any active datasets before destroying the pool.
 .Bl -tag -width Ds
 .It Fl f
-Forces any active datasets contained within the pool to be unmounted.
-.El
+Forcefully unmount all active datasets.
 .El

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -30,24 +29,17 @@
 .Dd February 16, 2020
 .Dt ZPOOL-EXPORT 8
 .Os
+.
 .Sh NAME
 .Nm zpool-export
-.Nd Exports the given ZFS storage pools from the system
+.Nd export ZFS storage pools
 .Sh SYNOPSIS
 .Nm zpool
 .Cm export
-.Op Fl a
 .Op Fl f
-.Ar pool Ns ...
+.Fl a Ns | Ns Ar pool Ns …
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zpool
-.Cm export
-.Op Fl a
-.Op Fl f
-.Ar pool Ns ...
-.Xc
 Exports the given pools from the system.
 All devices are marked as exported, but are still considered in use by other
 subsystems.
@@ -69,15 +61,12 @@ the disks.
 .It Fl a
 Exports all pools imported on the system.
 .It Fl f
-Forcefully unmount all datasets, using the
-.Nm unmount Fl f
-command.
-This option is not supported on Linux.
+Forcefully unmount all datasets, and allow export of pools with active shared spares.
 .Pp
 This command will forcefully export the pool even if it has a shared spare that
 is currently being used.
 This may lead to potential data corruption.
 .El
-.El
+.
 .Sh SEE ALSO
 .Xr zpool-import 8

--- a/man/man8/zpool-history.8
+++ b/man/man8/zpool-history.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -30,22 +29,17 @@
 .Dd August 9, 2019
 .Dt ZPOOL-HISTORY 8
 .Os
+.
 .Sh NAME
 .Nm zpool-history
-.Nd Displays the command history of the specified ZFS storage pool(s)
+.Nd inspect command history of ZFS storage pools
 .Sh SYNOPSIS
 .Nm zpool
 .Cm history
 .Op Fl il
-.Oo Ar pool Oc Ns ...
+.Oo Ar pool Oc Ns …
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zpool
-.Cm history
-.Op Fl il
-.Oo Ar pool Oc Ns ...
-.Xc
 Displays the command history of the specified pool(s) or all pools if no pool is
 specified.
 .Bl -tag -width Ds
@@ -56,7 +50,7 @@ Displays log records in long format, which in addition to standard format
 includes, the user name, the hostname, and the zone in which the operation was
 performed.
 .El
-.El
+.
 .Sh SEE ALSO
 .Xr zpool-checkpoint 8 ,
 .Xr zpool-events 8 ,

--- a/man/man8/zpool-labelclear.8
+++ b/man/man8/zpool-labelclear.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -27,25 +26,20 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd May 31, 2021
 .Dt ZPOOL-LABELCLEAR 8
 .Os
+.
 .Sh NAME
 .Nm zpool-labelclear
-.Nd Removes ZFS label information from the specified physical device
+.Nd remove ZFS label information from device
 .Sh SYNOPSIS
 .Nm zpool
 .Cm labelclear
 .Op Fl f
 .Ar device
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zpool
-.Cm labelclear
-.Op Fl f
-.Ar device
-.Xc
 Removes ZFS label information from the specified
 .Ar device .
 If the
@@ -58,7 +52,7 @@ must not be part of an active pool configuration.
 .It Fl f
 Treat exported or foreign devices as inactive.
 .El
-.El
+.
 .Sh SEE ALSO
 .Xr zpool-destroy 8 ,
 .Xr zpool-detach 8 ,

--- a/man/man8/zpool-reguid.8
+++ b/man/man8/zpool-reguid.8
@@ -18,7 +18,6 @@
 .\"
 .\" CDDL HEADER END
 .\"
-.\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
@@ -27,27 +26,23 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd May 31, 2021
 .Dt ZPOOL-REGUID 8
 .Os
+.
 .Sh NAME
 .Nm zpool-reguid
-.Nd Generate a new unique identifier for a ZFS storage pool
+.Nd generate new unique identifier for ZFS storage pool
 .Sh SYNOPSIS
 .Nm zpool
 .Cm reguid
 .Ar pool
+.
 .Sh DESCRIPTION
-.Bl -tag -width Ds
-.It Xo
-.Nm zpool
-.Cm reguid
-.Ar pool
-.Xc
 Generates a new unique identifier for the pool.
 You must ensure that all devices in this pool are online and healthy before
 performing this action.
-.El
+.
 .Sh SEE ALSO
 .Xr zpool-export 8 ,
 .Xr zpool-import 8

--- a/scripts/mancheck.sh
+++ b/scripts/mancheck.sh
@@ -26,7 +26,7 @@ fi
 IFS="
 "
 
-files="$(find "$@" -type f -name '*[1-9]*' ! -name '*module-param*' ! -name 'zpool-features*' ! -name 'zfs-mount-generator*')" || exit 1
+files="$(find "$@" -type f -name '*[1-9]*')" || exit 1
 
 add_excl="$(awk '
     /^.\\" lint-ok:/ {


### PR DESCRIPTION
### Description
On top of #12129 and #12157

This is all manpages now. zfs-module-parameters.5 is sum -2000 alone lol.

The most obvious visual difference is that `zpool-features.5` no longer lists empty dependencies. This could trivially be reverted, since it's a macro now, but this reads better and the ordering makes more sense.

### How Has This Been Tested?
Looked at it.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
