### PR TITLE
Added uncompress+file checks

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -32,6 +32,13 @@ Obsoletes:      spl-dkms
 Provides:       %{module}-kmod = %{version}
 AutoReqProv:    no
 
+%if 0%{?rhel}%{?fedora}%{?suse_version}
+# We don't directly use it, but if this isn't installed, rpmbuild as root can
+# crash+corrupt rpmdb
+# See issue #12071
+BuildRequires:  ncompress
+%endif
+
 %description
 This package contains the dkms ZFS kernel modules.
 

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -57,6 +57,13 @@ BuildRequires:  gcc, make
 BuildRequires:  elfutils-libelf-devel
 %endif
 
+%if 0%{?rhel}%{?fedora}%{?suse_version}
+# We don't directly use it, but if this isn't installed, rpmbuild as root can
+# crash+corrupt rpmdb
+# See issue #12071
+BuildRequires:  ncompress
+%endif
+
 # The developments headers will conflict with the dkms packages.
 Conflicts:      %{module}-dkms
 

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -140,9 +140,14 @@ BuildRequires:  libblkid-devel
 BuildRequires:  libudev-devel
 BuildRequires:  libattr-devel
 BuildRequires:  openssl-devel
+# We don't directly use it, but if this isn't installed, rpmbuild as root can
+# crash+corrupt rpmdb
+# See issue #12071
+BuildRequires:  ncompress
 %if 0%{?fedora} >= 28 || 0%{?rhel} >= 8 || 0%{?centos} >= 8
 BuildRequires:  libtirpc-devel
 %endif
+
 Requires:       openssl
 %if 0%{?_systemd}
 BuildRequires: systemd


### PR DESCRIPTION
(Once this gets signoff from people as a reasonable idea, I'll go make a PR for the build docs and bb-dependencies.sh to add the "ncompress" package for RPM distro instructions. At this rate, I'll soon have just added * to the install command...)

### Motivation and Context
Having an old enough version of "file" and no "uncompress" program installed can cause rpmbuild as root to crash and mangle rpmdb, including on latest CentOS 8. "Oops."

As a brief summary of places this does or doesn't occur:
* 5.37 is the first release of upstream file that has this fixed (though, amusingly, it was not patched because of incorrectness, but for performance reasons)
* Debian-alikes ship "uncompress" as a copy of "gunzip" (Debian hardlinks it; Ubuntu just copies it), so this never comes up even though buster has an old enough version  (5.35) of file.
* CentOS 7 has an ancient version of file (5.11), but this never happened in >50 runs when it usually takes 10 or fewer on vulnerable platforms; I'm going to conclude that it's because there was nontrivial churn and restructuring in the guilty function (uncompressbuf in compress.c)
* CentOS 8 has a vulnerable version (5.33), and does crash and burn sometimes.
* Fedora 29 has a vulnerable version (5.34) and crashes and burns
* Fedora 30 had a vulnerable version (5.36) but shipped a patched version
* Fedora 34 is too new (5.39)
* FreeBSD never cares, since it's not calling rpmbuild

(See also: #12071 and #12168)

### Description
Added checks for file's version and uncompress's existence, then something that checks if file's major version is 5 and minor is less than 37; if so, and uncompress is absent, error out if attempting to build any rpm targets.

I also added checks to the RPM specfiles to require ncompress (a package which provides an uncompress on RPM distros) if on an EL distro <= 8 or a Fedora distro <= 30, to catch the odd case where someone runs ./configure and then uninstalls uncompress.

(If/when CentOS 8 ships a patched version of file, this could be revised to instead require >= patched version of file for each of Fedora and EL distros, but A) that hasn't happened yet and B) I have no idea how long it takes patched versions to propagate among EL derivatives)

### How Has This Been Tested?
Built rpm-{kmod,utils} on:
* CentOS 7, with and without ncompress (it naturally refused with the latter)
* CentOS 8, with and without ncompress (same)
* Fedora 29, with and without ncompress (and again)
* Fedora 34, with and without ncompress (both work)
* Debian buster, with and without uncompress (the former works; the latter by renaming it out of the way; it fails)
* Debian bullseye, with uncompress (works)

Also a non-RPM build on FreeBSD 14-CURRENT x86_64 worked fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
