### PR TITLE
Timed-wait version of txg_wait_open() for vdev_autotrim_thread()

### DIFF
--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -101,6 +101,13 @@ extern boolean_t txg_wait_synced_sig(struct dsl_pool *dp, uint64_t txg);
  */
 extern void txg_wait_open(struct dsl_pool *dp, uint64_t txg,
     boolean_t should_quiesce);
+/*
+ * Wait as above with should_quiesce as false.
+ * Return true the wait was timed out.
+ */
+extern boolean_t txg_timedwait_open(struct dsl_pool *dp, uint64_t txg,
+    clock_t time);
+
 
 /*
  * Returns TRUE if we are "backed up" waiting for the syncing

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -1398,7 +1398,10 @@ vdev_autotrim_thread(void *arg)
 		 * zfs_trim_txg_batch txgs will occur before these metaslabs
 		 * are trimmed again.
 		 */
-		txg_wait_open(spa_get_dsl(spa), 0, issued_trim);
+		clock_t timeout = MSEC_TO_TICK(1000);
+		while (!vdev_autotrim_should_stop(vd) &&
+		    txg_timedwait_open(spa_get_dsl(spa), 0, timeout)) {
+		}
 
 		shift++;
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

vdev_autotrim_thread() has to call txg_wait_open() with
should_quiesce = false, to space out autotrim activities. It also
prevent quiescing a short-lived txg into the pipeline.
Why should_quiesce has to be false in vdev_autotrim_thread()? Please see detail here [PR#12162](https://github.com/openzfs/zfs/pull/12162)

However, the wait is not interruptible. Combining with big
zfs_txg_timeout value, it may cause big delay during "zpool export".

This commit add a new function txg_timedwait_open(). The caller can
call this function with reasonable "time" allowance. If the wait is
timed out before the txg is open, the caller can have choice either
to call this function again or to abort the waiting.

I also rewrite the original txg_wait_open().
In original code, tx_open_txg is often accessed without sufficient
lock. In 32bit system, accessing uint64_t may not be atomic.
Although it is still fine that txg will almost never grow beyond
32bit, I still think it is a good opportunity to fix this.


### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Run fio, observe txgs' history.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
