### PR TITLE
Force --enable-debug on FreeBSD if INVARIANTS is set

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -34,6 +34,9 @@ dnl # When debugging is enabled:
 dnl # - Enable all ASSERTs (-DDEBUG)
 dnl # - Promote all compiler warnings to errors (-Werror)
 dnl #
+dnl # (If INVARIANTS is detected, we need to force DEBUG, or strange panics
+dnl # can ensue.)
+dnl #
 AC_DEFUN([ZFS_AC_DEBUG], [
 	AC_MSG_CHECKING([whether assertion support will be enabled])
 	AC_ARG_ENABLE([debug],
@@ -48,6 +51,20 @@ AC_DEFUN([ZFS_AC_DEBUG], [
 		["xno"],
 		[ZFS_AC_DEBUG_DISABLE],
 		[AC_MSG_ERROR([Unknown option $enable_debug])])
+
+	AS_CASE(["x$enable_invariants"],
+		["xyes"],
+		[],
+		["xno"],
+		[],
+		[ZFS_AC_DEBUG_INVARIANTS_DETECT])
+
+	AS_CASE(["x$enable_invariants"],
+		["xyes"],
+		[ZFS_AC_DEBUG_ENABLE],
+		["xno"],
+		[],
+		[AC_MSG_ERROR([Unknown option $enable_invariants])])
 
 	AC_SUBST(DEBUG_CFLAGS)
 	AC_SUBST(DEBUG_CPPFLAGS)


### PR DESCRIPTION
### Motivation and Context
As illustrated in #12163, at least on 14-CURRENT, panics can result if built without --enable-debug when DEBUG and INVARIANTS are enabled. There is already logic present to force building with INVARIANTS if that's enabled, but that's not enough to resolve this problem.

### Description
Reshuffled the INVARIANTS check to happen before the --enable-debug check; set a new variable, FORCE_DEBUG, in the INVARIANTS check if it's true, then added if (FORCE_DEBUG) {enable debug} to the --enable-debug check.

### How Has This Been Tested?
Before the change, #12163 happened if built on the default GENERIC kernel (with DEBUG=-g and INVARIANTS) without an explicit --enable-debug. After the change, tried on a GENERIC kernel (it correctly forced --enable-debug and did not repro), and tried with a GENERIC-NODEBUG kernel (which explicitly does not have INVARIANTS) (it did not force --enable-debug).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
