### PR TITLE
[skip ci] spell check zfs-jail(8)

### DIFF
--- a/man/man8/zfs-jail.8
+++ b/man/man8/zfs-jail.8
@@ -92,7 +92,7 @@ to the jail identified by JID
 .Ar jailid .
 From now on this file system tree can be managed from within a jail if the
 .Sy jailed
-property has been set. To use this functuinality, the jail needs the
+property has been set. To use this functionality, the jail needs the
 .Va allow.mount
 and
 .Va allow.mount.zfs


### PR DESCRIPTION
### Motivation and Context
Fix man page spelling

### Description
Fix man page spelling

### How Has This Been Tested?
Viewed the man page

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
