### PR TITLE
systemd: add weekly and monthly scrub timers

### DIFF
--- a/etc/systemd/system/.gitignore
+++ b/etc/systemd/system/.gitignore
@@ -1,3 +1,4 @@
 *.service
 *.target
 *.preset
+*.timer

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -12,7 +12,10 @@ systemdunit_DATA = \
 	zfs-volume-wait.service \
 	zfs-import.target \
 	zfs-volumes.target \
-	zfs.target
+	zfs.target \
+	zfs-scrub-monthly@.timer \
+	zfs-scrub-weekly@.timer \
+	zfs-scrub@.service
 
 SUBSTFILES += $(systemdpreset_DATA) $(systemdunit_DATA)
 

--- a/etc/systemd/system/zfs-scrub-monthly@.timer.in
+++ b/etc/systemd/system/zfs-scrub-monthly@.timer.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly zpool scrub timer for %i
+Documentation=man:zpool-scrub(8)
+
+[Timer]
+OnCalendar=monthly
+Persistent=true
+RandomizedDelaySec=1h
+Unit=zfs-scrub@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/zfs-scrub-weekly@.timer.in
+++ b/etc/systemd/system/zfs-scrub-weekly@.timer.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Weekly zpool scrub timer for %i
+Documentation=man:zpool-scrub(8)
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=1h
+Unit=zfs-scrub@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/zfs-scrub@.service.in
+++ b/etc/systemd/system/zfs-scrub@.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=zpool scrub on %i
+Documentation=man:zpool-scrub(8)
+Requires=zfs.target
+After=zfs.target
+ConditionACPower=true
+ConditionPathIsDirectory=/sys/module/zfs
+
+[Service]
+ExecStart=/bin/sh -c '\
+if @sbindir@/zpool status %i | grep "scrub in progress"; then\
+exec @sbindir@/zpool wait -t scrub %i;\
+else exec @sbindir@/zpool scrub -w %i; fi'
+ExecStop=-/bin/sh -c '@sbindir@/zpool scrub -p %i 2>/dev/null || true'

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -116,8 +116,29 @@ scanned at 100M/s, and 68.4M of that file data has been
 scrubbed sequentially at 10.0M/s.
 .El
 .El
+.Sh PERIODIC SCRUB
+On machines using systemd, scrub timers can be enabled on per-pool basis.
+.Nm weekly
+and
+.Nm monthly
+timer units are provided.
+.Bl -tag -width Ds
+.It Xo
+.Xc
+.Nm systemctl
+.Cm enable
+.Cm zfs-scrub-\fIweekly\fB@\fIrpool\fB.timer
+.Cm --now
+.It Xo
+.Xc
+.Nm systemctl
+.Cm enable
+.Cm zfs-scrub-\fImonthly\fB@\fIotherpool\fB.timer
+.Cm --now
+.El
 .
 .Sh SEE ALSO
+.Xr systemd.timer 5 ,
 .Xr zpool-iostat 8 ,
 .Xr zpool-resilver 8 ,
 .Xr zpool-status 8


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide 2 basic timers that leverage systemd scheduling tech.

### Description
<!--- Describe your changes in detail -->
provide 3 extra files for use with systemd:
```
zfs-scrub-weekly@.timer
zfs-scrub-monthly@.timer
zfs-scrub@.service
```
timers can be enabled as follows:
```bash
systemctl enable zfs-scrub-weekly@rpool.timer --now
systemctl enable zfs-scrub-monthly@datapool.timer --now
```

Each timer will pull in `zfs-scrub@${poolname}.service`, which is not
schedule-specific, but the `zfs-scrub` will receive pool argument from timer unit.

Configuration provided is generic and simple.

Users can tweak parameters by using `systemctl --edit <unitname>`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

```shell-session
 # systemctl enable zfs-scrub-weekly@zroot.timer --now
Created symlink /etc/systemd/system/timers.target.wants/zfs-scrub-weekly@zroot.timer → /usr/lib/systemd/system/zfs-scrub-weekly@.timer.

 # systemctl status zfs-scrub-weekly@zroot.timer 
● zfs-scrub-weekly@zroot.timer - Weekly zpool scrub timer for zroot
     Loaded: loaded (/usr/lib/systemd/system/zfs-scrub-weekly@.timer; enabled; vendor preset: disabled)
     Active: active (waiting) since Thu 2021-06-03 18:46:18 PDT; 11s ago
    Trigger: Mon 2021-06-07 00:00:00 PDT; 3 days left
   Triggers: ● zfs-scrub@zroot.service
       Docs: man:zpool-scrub(8)

Jun 03 18:46:18 cerberus systemd[1]: Started Weekly zpool scrub timer for zroot.

# systemctl status zfs-scrub@zroot.service
○ zfs-scrub@zroot.service - zpool scrub on zroot
     Loaded: loaded (/usr/lib/systemd/system/zfs-scrub@.service; static)
     Active: inactive (dead)
TriggeredBy: ● zfs-scrub-weekly@zroot.timer
       Docs: man:zpool-scrub(8)
```

in example above scrub for zroot pool will be triggered weekly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
