### PR TITLE
Use deferred free mechanism for autotrim

### DIFF
--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -118,6 +118,8 @@ uint64_t metaslab_class_get_deferred(metaslab_class_t *);
 
 void metaslab_space_update(vdev_t *, metaslab_class_t *,
     int64_t, int64_t, int64_t);
+void metaslab_trimming_update(metaslab_t *, vdev_t *);
+void metaslab_trimmed_update(metaslab_t *, vdev_t *);
 
 metaslab_group_t *metaslab_group_create(metaslab_class_t *, vdev_t *, int);
 void metaslab_group_destroy(metaslab_group_t *);

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -423,6 +423,9 @@ struct metaslab {
 	 * facilitate efficient trimming.
 	 */
 	range_tree_t	*ms_trim;
+	range_tree_t	*ms_trimming;
+	range_tree_t	*ms_trimmed;
+	range_tree_t	*ms_trimmed_defer[TXG_DEFER_SIZE];
 
 	boolean_t	ms_condensing;	/* condensing? */
 	boolean_t	ms_condense_wanted;
@@ -483,6 +486,12 @@ struct metaslab {
 	 */
 	uint64_t	ms_synchist[SPACE_MAP_HISTOGRAM_SIZE];
 	uint64_t	ms_deferhist[TXG_DEFER_SIZE][SPACE_MAP_HISTOGRAM_SIZE];
+	uint64_t	ms_trim_hist[SPACE_MAP_HISTOGRAM_SIZE];
+	uint64_t	ms_notrim_hist[SPACE_MAP_HISTOGRAM_SIZE];
+	uint64_t	ms_trimming_hist[SPACE_MAP_HISTOGRAM_SIZE];
+	uint64_t	ms_trimmed_hist[SPACE_MAP_HISTOGRAM_SIZE];
+	uint64_t	ms_trimmed_deferhist
+			    [TXG_DEFER_SIZE][SPACE_MAP_HISTOGRAM_SIZE];
 
 	/*
 	 * Tracks the exact amount of allocated space of this metaslab
@@ -507,6 +516,7 @@ struct metaslab {
 	hrtime_t	ms_load_time;	/* time last loaded */
 	hrtime_t	ms_unload_time;	/* time last unloaded */
 	hrtime_t	ms_selected_time; /* time last allocated from */
+	hrtime_t	ms_hist_update_time; /* time histograms last updated */
 
 	uint64_t	ms_alloc_txg;	/* last successful alloc (debug only) */
 	uint64_t	ms_max_size;	/* maximum allocatable size	*/


### PR DESCRIPTION
**I will update related documentation and comments after a proper code review.**

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To improve the user's experience of autotrim.
Current autotrim causes short-lived txgs with txg_wait_synced().
Example: https://github.com/openzfs/zfs/discussions/12140#discussion-3385364

### Description
<!--- Describe your changes in detail -->
Current autotrim is implemented as following:
1. Select a metaslab that needs to be trimmed, and disable it.
2. Push the issued zio_trim() into txg sync pipline by calling
txg_wait_synced(). Wait for the txg (tx_open_txg + 2) to be synced.
3. Enable the metaslab.

In this patch, I added ms_trimming, ms_trimmed,
ms_trimmed_defer[2] to metaslab to track autotrim process.
Here are the steps after the patch:
1. Select a metaslab that needs to be trimmed, only grab the ms_lock.
2. Move all the trimming ranges from ms_allocatable to ms_trimming,
so that these trimming ranges will not be allocated. Then release
ms_lock.
3. After issuing all the zio_trim(), moving all the trimming ranges
from ms_trimming to ms_trimmed.
4. The trimmed ranges will go through ms_trimmed_defer[2], then
will be released back to ms_allocatable.

Benefits:
No metaslab_disable(), no txg_wait_synced().
txg_wait_synced() cause short-lived txgs, and fragmentation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Still testing.
I do not have the resources to do the fully test. I need the help of the community.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
