### PR TITLE
Detect iSCSI in the zpool cmd vdev media script

### DIFF
--- a/cmd/zpool/zpool.d/media
+++ b/cmd/zpool/zpool.d/media
@@ -4,7 +4,7 @@
 #
 
 if [ "$1" = "-h" ] ; then
-	echo "Show whether a vdev is a file, hdd, or ssd."
+	echo "Show whether a vdev is a file, hdd, ssd, or iscsi."
 	exit
 fi
 
@@ -17,6 +17,13 @@ if [ -b "$VDEV_UPATH" ]; then
 
 	if [ "$val" = "1" ]; then
 		MEDIA="hdd"
+	fi
+
+	vpd_pg83="/sys/block/$device/device/vpd_pg83"
+	if [ -f "$vpd_pg83" ]; then
+		if grep -q --binary "iqn." "$vpd_pg83"; then
+			MEDIA="iscsi"
+		fi
 	fi
 else
 	if [ -f "$VDEV_UPATH" ]; then


### PR DESCRIPTION
### Motivation and Context
In the `zpool status` command, the `-c media` option shows whether a vdev is a file, hdd, or ssd.  It would be nice to also support iSCSI devices as a media type.

### Description
Added support to the `media` script to detect if a device is iSCSI.

### How Has This Been Tested?
manually tested with a pool comprised of iSCSI devices. Here are two example runs with the new detection:
```
$ zpool status -c media,vendor domain0
  pool: domain0
 state: ONLINE
config:

	NAME                                      STATE     READ WRITE CKSUM  media    vendor
	domain0                                   ONLINE       0     0     0
	  scsi-36f47acc1000000006b6b727300000281  ONLINE       0     0     0  iscsi  SolidFir
	  scsi-36f47acc1000000006b6b727300000282  ONLINE       0     0     0  iscsi  SolidFir

errors: No known data errors
```
```
$ zpool status -c media,vendor domain0
  pool: domain0
 state: ONLINE
config:

	NAME                                      STATE     READ WRITE CKSUM  media   vendor
	domain0                                   ONLINE       0     0     0
	  scsi-3600140535077b47cb424772bc8e6a4dd  ONLINE       0     0     0  iscsi  LIO-ORG
	  scsi-360014053d2ba41f557a4eb98e2f95041  ONLINE       0     0     0  iscsi  LIO-ORG
	  scsi-360014054498a6f3ff7a4f9988f3c6624  ONLINE       0     0     0  iscsi  LIO-ORG
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
