### PR TITLE
Fix minor shellcheck 0.7.2 warnings

### DIFF
--- a/cmd/zed/zed.d/all-syslog.sh
+++ b/cmd/zed/zed.d/all-syslog.sh
@@ -42,6 +42,7 @@ fi
     msg="${msg} delay=$((ZEVENT_ZIO_DELAY / 1000000))ms"
 
 # list the bookmark data together
+# shellcheck disable=SC2153
 [ -n "${ZEVENT_ZIO_OBJSET}" ] && \
     msg="${msg} bookmark=${ZEVENT_ZIO_OBJSET}:${ZEVENT_ZIO_OBJECT}:${ZEVENT_ZIO_LEVEL}:${ZEVENT_ZIO_BLKID}"
 

--- a/scripts/make_gitrev.sh
+++ b/scripts/make_gitrev.sh
@@ -50,7 +50,7 @@ esac
 ZFS_GITREV=$({ cd "${top_srcdir}" &&
 	git describe --always --long --dirty 2>/dev/null; } || :)
 
-if [ "x${ZFS_GITREV}" = x ]
+if [ -z "${ZFS_GITREV}" ]
 then
 	# If the source directory is not a git repository, check if the file
 	# already exists (in the source)

--- a/scripts/man-dates.sh
+++ b/scripts/man-dates.sh
@@ -7,6 +7,6 @@ set -eu
 
 find man -type f | while read -r i ; do
     git_date=$(git log -1 --date=short --format="%ad" -- "$i")
-    [ "x$git_date" = "x" ] && continue
+    [ -z "$git_date" ] && continue
     sed -i "s|^\.Dd.*|.Dd $(date -d "$git_date" "+%B %-d, %Y")|" "$i"
 done


### PR DESCRIPTION
### Motivation and Context

The `make checkstyle` target fails when using shellcheck 0.7.2 due to some minor warning.  That's no good, we want it to pass cleanly even on newer versions.

### Description

The failures were:

```
all-syslog.sh:46:47: warning: Possible misspelling: ZEVENT_ZIO_OBJECT may not be assigned, but ZEVENT_ZIO_OBJSET is. [SC2153]
make_gitrev.sh:53:6: note: Avoid x-prefix in comparisons as it no longer serves a purpose [SC2268]
man-dates.sh:10:7: note: Avoid x-prefix in comparisons as it no longer serves a purpose [SC2268]
```

The first warning of a misspelling is a false positive, so the patch annotates the script accordingly.

As for the `x-prefix` warnings I opted to update the code accordingly since it's my understanding the "x" prefix here really isn't needed any longer.

@nabijaczleweli this is pretty trivial but any thoughts you have on this would be welcome.

### How Has This Been Tested?

Manually ran the modified scripts and verified that `make checkstyle` now passes cleanly on version 0.7.2.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
