### PR TITLE
Corrected a case where we could read uninited ABD memory

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5682,17 +5682,20 @@ arc_read_done(zio_t *zio)
 		zio_crypt_decode_params_bp(bp, hdr->b_crypt_hdr.b_salt,
 		    hdr->b_crypt_hdr.b_iv);
 
-		if (BP_GET_TYPE(bp) == DMU_OT_INTENT_LOG) {
-			void *tmpbuf;
+		if (zio->io_error == 0) {
+			if (BP_GET_TYPE(bp) == DMU_OT_INTENT_LOG) {
+				void *tmpbuf;
 
-			tmpbuf = abd_borrow_buf_copy(zio->io_abd,
-			    sizeof (zil_chain_t));
-			zio_crypt_decode_mac_zil(tmpbuf,
-			    hdr->b_crypt_hdr.b_mac);
-			abd_return_buf(zio->io_abd, tmpbuf,
-			    sizeof (zil_chain_t));
-		} else {
-			zio_crypt_decode_mac_bp(bp, hdr->b_crypt_hdr.b_mac);
+				tmpbuf = abd_borrow_buf_copy(zio->io_abd,
+				    sizeof (zil_chain_t));
+				zio_crypt_decode_mac_zil(tmpbuf,
+				    hdr->b_crypt_hdr.b_mac);
+				abd_return_buf(zio->io_abd, tmpbuf,
+				    sizeof (zil_chain_t));
+			} else {
+				zio_crypt_decode_mac_bp(bp,
+				    hdr->b_crypt_hdr.b_mac);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Motivation and Context
For my sins, I started running valgrind over ztest to try and fix that pesky intermittent "zloop dies with malloc errors" problem.

This one seemed potentially exciting enough to merit cutting a PR for before the rest get polished for submission. (I should note that I have not observed this doing anything wrong in practice; fixing it did not appear to be sufficient to stop the occasional crashes in ztest I was observing.)

### Description
It seems to be the case that, in the encrypted case, unlike the unencrypted case, if we encountered an error, we can still call `abd_return_buf` on an uninitialized buffer, which winds up after a few steps in `abd_cmp_buf_off_cb`, which then calls `bcmp` on an uninitialized page, and we make a sad face.

So the first pass solution was to guard that segment of the code with a similar `if (zio->io_error == 0)` to what follows, and it seems to work and not fail any of the tests I've run.

(If sticking the entire `if (BP_IS_PROTECTED(bp)) {` block in the below if would be better, I'm happy to do it, I just touched the smallest block that seemed reasonable, as I'm not remotely familiar with this code.)

(The theory behind what's going awry and an idea for a first pass at fixing it, which seems to have worked, were @pcd1193182's; he hasn't seen this patch though, so don't blame him for any foolish choices I made. :) ) 

The complaint out of valgrind, for anyone curious:
[arcenc.log](https://github.com/openzfs/zfs/files/6627998/arcenc.log)

### How Has This Been Tested?
Ran ztest under valgrind a bunch, never saw the error with this patch, occasionally (~1 in 20 times?) saw it without; the GH actions test runners reported green when I pushed this to my fork branch.

(I did test this with a couple of other patches I'm in the process of cleaning up for submission, because otherwise valgrind spits out `==427756== More than 1000 different errors detected.  I'm not reporting any more.`, which is...not particularly useful.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
