### PR TITLE
ZTS: Add zfs_clone_livelist_dedup.ksh to Makefile.am

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
@@ -4,6 +4,7 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zfs_clone_livelist_condense_and_disable.ksh \
 	zfs_clone_livelist_condense_races.ksh \
+	zfs_clone_livelist_dedup.ksh \
 	zfs_destroy_001_pos.ksh \
 	zfs_destroy_002_pos.ksh \
 	zfs_destroy_003_pos.ksh \


### PR DESCRIPTION
### Motivation and Context

Observed in the CI when running the test suite:

```
Warning: Test 'zfs_clone_livelist_dedup' removed from TestGroup
    '/usr/share/zfs/zfs-tests/tests/functional/cli_root/zfs_destroy' because it failed verification.
```

https://github.com/openzfs/zfs/pull/12222/checks?check_run_id=2797364462

### Description

Commit 86b5f4c12 added a new `zfs_clone_livelist_dedup.ksh` test case
but didn't include it in the `Makefile.am`.  This results in the test
not being included in the dist tarball so it's never run by the CI.

### How Has This Been Tested?

`make dist`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
