### PR TITLE
Fix i386 build broken by the merge of ea400129c

### DIFF
--- a/lib/libspl/asm-i386/atomic.S
+++ b/lib/libspl/asm-i386/atomic.S
@@ -762,6 +762,7 @@
 	SET_SIZE(atomic_swap_32)
 
 	ENTRY(atomic_swap_64)
+	ALTENTRY(atomic_store_64)
 	pushl	%esi
 	pushl	%ebx
 	movl	12(%esp), %esi
@@ -776,7 +777,19 @@
 	popl	%ebx
 	popl	%esi
 	ret
+	SET_SIZE(atomic_store_64)
 	SET_SIZE(atomic_swap_64)
+
+	ENTRY(atomic_load_64)
+	pushl	%esi
+	movl	8(%esp), %esi
+	movl	%ebx, %eax
+	movl	%ecx, %edx
+	lock
+	cmpxchg8b (%esi)
+	popl	%esi
+	ret
+	SET_SIZE(atomic_load_64)
 
 	ENTRY(atomic_set_long_excl)
 	movl	4(%esp), %edx


### PR DESCRIPTION
### Motivation and Context
The changes in ea400129c376c958e32bd912ea29905107ebe0bb (More aggsum optimizations) expect the commit fef8bd41fc178d7212957b611c9bc81fe10cb63e (libspl: implement atomics in terms of atomics) to be landed.

Merge of ea400129c376c958e32bd912ea29905107ebe0bb without fef8bd41fc178d7212957b611c9bc81fe10cb63e broke the build on i386 (#12244)

### Description
Add missing bits to i386 assembler code.
As an alternative, fef8bd41fc178d7212957b611c9bc81fe10cb63e could be merged 

### How Has This Been Tested?
Already included as a (temporary) fix in FreeBSD 13-STABLE

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).