### PR TITLE
module/zfs: simplify ddt_stat_add() loop and fix LLVM's Polly build error

### DIFF
--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -423,8 +423,8 @@ ddt_stat_add(ddt_stat_t *dst, const ddt_stat_t *src, uint64_t neg)
 
 	ASSERT(neg == 0 || neg == -1ULL);	/* add or subtract */
 
-	while (d < d_end)
-		*d++ += (*s++ ^ neg) - neg;
+	for (int i = 0; i < d_end - d; i++)
+		d[i] += (s[i] ^ neg) - neg;
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
LLVM's Polly (ISL to be precise) is unhappy with the loop from `ddt_stat_add()`:

```
  CC [M]  fs/zfs/zfs/ddt.o
../lib/External/isl/isl_schedule_node.c:2470: cannot insert node
between set or sequence node and its filter children
```

(building with the custom patch which adds Polly support to Kbuild)

### Description

Full LLVM dump on this issue:

```
  CC [M]  fs/zfs/zfs/ddt.o
../lib/External/isl/isl_schedule_node.c:2470: cannot insert node between set or sequence node and its filter children
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: clang -Wp,-MMD,fs/zfs/zfs/.ddt.o.d -nostdinc -isystem /usr/lib/clang/12.0.0/include -I./arch/x86/include -I./arch/x86/include/generated -I./include -I./arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I./include/uapi -I./include/generated/uapi -include ./include/linux/compiler-version.h -include ./include/linux/kconfig.h -include ./include/linux/compiler_types.h -D__KERNEL__ -Qunused-arguments -fmacro-prefix-map=./= -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE -Werror=implicit-function-declaration -Werror=implicit-int -Werror=return-type -Wno-format-security -std=gnu89 -pipe -Werror=unknown-warning-option -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -fcf-protection=none -m64 -mno-80387 -mstack-alignment=8 -march=skylake -mno-red-zone -mcmodel=kernel -DCONFIG_X86_X32_ABI -Wno-sign-compare -fno-asynchronous-unwind-tables -mretpoline-external-thunk -fno-delete-null-pointer-checks -Wno-frame-address -Wno-address-of-packed-member -O3 -fplugin=LLVMPolly.so -mllvm -polly -mllvm -polly-ast-use-context -mllvm -polly-invariant-load-hoisting -mllvm -polly-opt-fusion=max -mllvm -polly-run-inliner -mllvm -polly-vectorizer=stripmine -mllvm -polly-run-dce -mllvm -inline-threshold=600 -mllvm -inlinehint-threshold=750 -Wframe-larger-than=1024 -fstack-protector-strong -Wno-format-invalid-specifier -Wno-gnu -mno-global-merge -Wno-unused-const-variable -fomit-frame-pointer -ftrivial-auto-var-init=pattern -fno-lto -flto -fvisibility=hidden -fsanitize=cfi -fsanitize-cfi-cross-dso -fno-sanitize-cfi-canonical-jump-tables -fno-sanitize-trap=cfi -fno-sanitize-blacklist -Wdeclaration-after-statement -Wvla -Wno-pointer-sign -Wno-array-bounds -fno-strict-overflow -fno-stack-check -Werror=date-time -Werror=incompatible-pointer-types -Wno-initializer-overrides -Wno-format -Wno-sign-compare -Wno-format-zero-length -Wno-pointer-to-enum-cast -Wno-tautological-constant-out-of-range-compare --param=ssp-buffer-size=4 -ftree-vectorize -std=gnu99 -Wno-declaration-after-statement -Wmissing-prototypes -Wno-format-zero-length -include ./include/zfs/zfs_config.h -I./include/zfs/os/linux/kernel -I./include/zfs/os/linux/spl -I./include/zfs/os/linux/zfs -I./include/zfs -D_KERNEL -UDEBUG -DNDEBUG -DMODULE -DKBUILD_BASENAME=\"ddt\" -DKBUILD_MODNAME=\"zfs\" -D__KBUILD_MODNAME=kmod_zfs -c -o fs/zfs/zfs/ddt.o fs/zfs/zfs/ddt.c
1.	<eof> parser at end of file
2.	Per-module optimization passes
3.	Running pass 'Function Pass Manager' on module 'fs/zfs/zfs/ddt.c'.
4.	Running pass 'Region Pass Manager' on function '@ddt_get_dedup_histogram'
5.	Running pass 'Polly - Optimize schedule of SCoP' on basic block '%9'
 #0 0x00007f4e437fd653 (/usr/bin/../lib/libLLVM-12.so+0xb48653)
 #1 0x00007f4e437fb1c4 llvm::sys::CleanupOnSignal(unsigned long) (/usr/bin/../lib/libLLVM-12.so+0xb461c4)
 #2 0x00007f4e4370c1f9 (/usr/bin/../lib/libLLVM-12.so+0xa571f9)
 #3 0x00007f4e4290fda0 __restore_rt (/usr/bin/../lib/libc.so.6+0x3cda0)
 #4 0x00007f4e4290fd22 raise (/usr/bin/../lib/libc.so.6+0x3cd22)
 #5 0x00007f4e428f9862 abort (/usr/bin/../lib/libc.so.6+0x26862)
 #6 0x00007f4e4052faf1 (/usr/bin/../lib/../lib/LLVMPolly.so+0x27faf1)
 #7 0x00007f4e405303fa (/usr/bin/../lib/../lib/LLVMPolly.so+0x2803fa)
 #8 0x00007f4e405f18ef (/usr/bin/../lib/../lib/LLVMPolly.so+0x3418ef)
 #9 0x00007f4e405f69c2 isl_schedule_node_insert_mark (/usr/bin/../lib/../lib/LLVMPolly.so+0x3469c2)
#10 0x00007f4e4046c480 ScheduleTreeOptimizer::prevectSchedBand(isl::noexceptions::schedule_node, unsigned int, int) (/usr/bin/../lib/../lib/LLVMPolly.so+0x1bc480)
#11 0x00007f4e4046cf9b ScheduleTreeOptimizer::standardBandOpts(isl::noexceptions::schedule_node, void*) (/usr/bin/../lib/../lib/LLVMPolly.so+0x1bcf9b)
#12 0x00007f4e40472207 ScheduleTreeOptimizer::optimizeBand(isl_schedule_node*, void*) (/usr/bin/../lib/../lib/LLVMPolly.so+0x1c2207)
#13 0x00007f4e405f3a5d (/usr/bin/../lib/../lib/LLVMPolly.so+0x343a5d)
#14 0x00007f4e405f3f15 isl_schedule_node_map_descendant_bottom_up (/usr/bin/../lib/../lib/LLVMPolly.so+0x343f15)
#15 0x00007f4e40472309 ScheduleTreeOptimizer::optimizeSchedule(isl::noexceptions::schedule, polly::OptimizerAdditionalInfoTy const*) (/usr/bin/../lib/../lib/LLVMPolly.so+0x1c2309)
#16 0x00007f4e4047290c (/usr/bin/../lib/../lib/LLVMPolly.so+0x1c290c)
#17 0x00007f4e404730b9 (/usr/bin/../lib/../lib/LLVMPolly.so+0x1c30b9)
#18 0x00007f4e44f53485 llvm::RGPassManager::runOnFunction(llvm::Function&) (/usr/bin/../lib/libLLVM-12.so+0x229e485)
#19 0x00007f4e43959790 llvm::FPPassManager::runOnFunction(llvm::Function&) (/usr/bin/../lib/libLLVM-12.so+0xca4790)
#20 0x00007f4e439598fc llvm::FPPassManager::runOnModule(llvm::Module&) (/usr/bin/../lib/libLLVM-12.so+0xca48fc)
#21 0x00007f4e4395b11a llvm::legacy::PassManagerImpl::run(llvm::Module&) (/usr/bin/../lib/libLLVM-12.so+0xca611a)
#22 0x00007f4e4a7e70f2 (/usr/bin/../lib/libclang-cpp.so.12+0x18980f2)
#23 0x00007f4e4a7e9035 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::DataLayout const&, llvm::Module*, clang::BackendAction, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream> >) (/usr/bin/../lib/libclang-cpp.so.12+0x189a035)
#24 0x00007f4e4ab665e2 (/usr/bin/../lib/libclang-cpp.so.12+0x1c175e2)
#25 0x00007f4e49886659 clang::ParseAST(clang::Sema&, bool, bool) (/usr/bin/../lib/libclang-cpp.so.12+0x937659)
#26 0x00007f4e4b2d1249 clang::FrontendAction::Execute() (/usr/bin/../lib/libclang-cpp.so.12+0x2382249)
#27 0x00007f4e4b26854e clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/usr/bin/../lib/libclang-cpp.so.12+0x231954e)
#28 0x00007f4e4b351929 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/usr/bin/../lib/libclang-cpp.so.12+0x2402929)
#29 0x000055e6e97ff8de cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/bin/clang-12+0x128de)
#30 0x000055e6e97fcee8 (/usr/bin/clang-12+0xfee8)
#31 0x00007f4e4af39fd5 (/usr/bin/../lib/libclang-cpp.so.12+0x1feafd5)
#32 0x00007f4e4370c303 llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/usr/bin/../lib/libLLVM-12.so+0xa57303)
#33 0x00007f4e4af3a380 (/usr/bin/../lib/libclang-cpp.so.12+0x1feb380)
#34 0x00007f4e4af0e298 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&) const (/usr/bin/../lib/libclang-cpp.so.12+0x1fbf298)
#35 0x00007f4e4af0ed29 clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*> >&) const (/usr/bin/../lib/libclang-cpp.so.12+0x1fbfd29)
#36 0x00007f4e4af1ec5a clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*> >&) (/usr/bin/../lib/libclang-cpp.so.12+0x1fcfc5a)
#37 0x000055e6e97fac13 main (/usr/bin/clang-12+0xdc13)
#38 0x00007f4e428fab25 __libc_start_main (/usr/bin/../lib/libc.so.6+0x27b25)
#39 0x000055e6e97fc86e _start (/usr/bin/clang-12+0xf86e)
clang-12: error: clang frontend command failed with exit code 134 (use -v to see invocation)
clang version 12.0.0
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
clang-12: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang-12: note: diagnostic msg: /tmp/ddt-562df1.c
clang-12: note: diagnostic msg: /tmp/ddt-562df1.sh
clang-12: note: diagnostic msg:

********************
```

Regarding that the entire Linux kernel and several OOT modules can be built with Polly without any (both compile-time and runtime) issues, I considered this more of ZFS than LLVM thing.
But I call @ClangBuiltLinux folks anyway: @kees @nathanchance @nickdesaulniers, just in case.

The loop itself can easily be simplified/converted to for-loop with determined index and bounds - please see the commit message for some details.

### How Has This Been Tested?
Compile-time and runtime test on the Linux 5.12.12 built for x86_64 with ClangLTO, ClangCFI and Polly.
Polly/ISL was failing on compiling the ZFS module prior to this change.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
