### PR TITLE
Update cache file when setting compatibility property

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -8730,12 +8730,16 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			spa->spa_comment = spa_strdup(strval);
 			/*
 			 * We need to dirty the configuration on all the vdevs
-			 * so that their labels get updated.  It's unnecessary
-			 * to do this for pool creation since the vdev's
-			 * configuration has already been dirtied.
+			 * so that their labels get updated.  We also need to
+			 * update the cache file to keep it in sync with the
+			 * MOS version. It's unnecessary to do this for pool
+			 * creation since the vdev's configuration has already
+			 * been dirtied.
 			 */
-			if (tx->tx_txg != TXG_INITIAL)
+			if (tx->tx_txg != TXG_INITIAL) {
 				vdev_config_dirty(spa->spa_root_vdev);
+				spa_async_request(spa, SPA_ASYNC_CONFIG_UPDATE);
+			}
 			spa_history_log_internal(spa, "set", tx,
 			    "%s=%s", nvpair_name(elem), strval);
 			break;
@@ -8747,8 +8751,11 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			/*
 			 * Dirty the configuration on vdevs as above.
 			 */
-			if (tx->tx_txg != TXG_INITIAL)
+			if (tx->tx_txg != TXG_INITIAL) {
 				vdev_config_dirty(spa->spa_root_vdev);
+				spa_async_request(spa, SPA_ASYNC_CONFIG_UPDATE);
+			}
+
 			spa_history_log_internal(spa, "set", tx,
 			    "%s=%s", nvpair_name(elem), strval);
 			break;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -351,7 +351,8 @@ tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
     'zpool_create_features_003_pos', 'zpool_create_features_004_neg',
     'zpool_create_features_005_pos', 'zpool_create_features_006_pos',
     'zpool_create_features_007_pos', 'zpool_create_features_008_pos',
-    'create-o_ashift', 'zpool_create_tempname', 'zpool_create_dryrun_output']
+    'zpool_create_features_009_pos', 'create-o_ashift',
+    'zpool_create_tempname', 'zpool_create_dryrun_output']
 tags = ['functional', 'cli_root', 'zpool_create']
 
 [tests/functional/cli_root/zpool_destroy]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
@@ -39,6 +39,7 @@ dist_pkgdata_SCRIPTS = \
 	zpool_create_features_006_pos.ksh \
 	zpool_create_features_007_pos.ksh \
 	zpool_create_features_008_pos.ksh \
+	zpool_create_features_009_pos.ksh \
 	create-o_ashift.ksh \
 	zpool_create_tempname.ksh \
 	zpool_create_dryrun_output.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_features_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_features_009_pos.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2021 Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	Verify '-o compatibility' property is updated in both the
+#	pool config MOS object and the cache file.
+#
+# STRATEGY:
+#	1. Create a pool with '-o compatibility=legacy', then verify
+#	   the property exists in the MOS config and cache file.
+#	2. Create a pool, set the 'compatibility=off' property, then
+#	   verify the property exists in the MOS config and cache file.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL && log_must zpool destroy $TESTPOOL
+	rm -f $CACHE_FILE
+}
+
+function check_config
+{
+	typeset propval=$1
+
+	poolval="$(zpool get -H -o value compatibility $TESTPOOL)"
+	if [ "$poolval" != "$propval" ]; then
+		log_fail "compatibility property set incorrectly $curval"
+	fi
+
+	if ! zdb -C -U $CACHE_FILE | grep "compatibility: '$propval'"; then
+		log_fail "compatibility property missing in cache file"
+	fi
+
+	if ! zdb -C -U $CACHE_FILE $TESTPOOL | grep "compatibility: '$propval'"; then
+		log_fail "compatibility property missing from MOS object"
+	fi
+}
+
+log_onexit cleanup
+
+log_assert "verify '-o compatibility' in MOS object and cache file"
+
+CACHE_FILE=$TEST_BASE_DIR/cachefile.$$
+
+# 1. Create a pool with '-o compatibility=legacy', then verify
+#    the property exists in the MOS config and cache file.
+log_must zpool create -f -o cachefile=$CACHE_FILE -o compatibility=legacy $TESTPOOL $DISKS
+log_must check_config legacy
+log_must zpool export -F $TESTPOOL
+log_must zpool import -c $CACHE_FILE $TESTPOOL
+log_must check_config legacy
+log_must zpool destroy -f $TESTPOOL
+
+# 2. Create a pool, set the 'compatibility=off' property, then
+#    verify the property exists in the MOS config and cache file.
+log_must zpool create -f -o cachefile=$CACHE_FILE $TESTPOOL $DISKS
+log_must zpool set compatibility=legacy $TESTPOOL
+log_must check_config legacy
+log_must zpool export -F $TESTPOOL
+log_must zpool import -c $CACHE_FILE $TESTPOOL
+log_must check_config legacy
+log_must zpool destroy -f $TESTPOOL
+
+log_pass "verify '-o compatibility' in MOS object and cache file"


### PR DESCRIPTION
### Motivation and Context

Issue #12261 observed the compatibility does not persist when
importing the pool using a cache file.  

### Description

Unlike most other properties the 'compatibility' property is stored
in the pool config object and not the DMU_OT_POOL_PROPS object.

This had the advantage that the compatibility information is available
without needing to fully import the pool (it can be read with zdb).
However, this means we need to make sure to update both the copy of
the config in the MOS and the cache file.  This wasn't being done.

This commit adds a call to spa_async_request() to ensure the copy of
the config in the cache file gets updated as well as the one stored
in the pool.  This same change is made for the 'comment' property
which suffers from the same inconsistency.

### How Has This Been Tested?

Added a new `zpool_create_features_009_pos.ksh` test case which
verifies the property is stored where it should be and is correctly
set when importing from a cache file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
