### PR TITLE
Stop using "zstreamdump" in tests/

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -188,7 +188,6 @@ export ZFS_FILES='zdb
     zed
     zgenhostid
     zstream
-    zstreamdump
     zfs_ids_to_path
     zpool_influxdb'
 

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_embedded.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_embedded.ksh
@@ -65,7 +65,7 @@ for recsize in 512 1024 2048 4096 8192 16384; do
 	grep -q "EMBEDDED" $tmpdir/recv.zdb || \
 	    log_fail "Obj $recv_obj not embedded in $recvfs"
 
-	cat $stream | zstreamdump -v | log_must grep -q \
+	cat $stream | zstream dump -v | log_must grep -q \
 	    "WRITE_EMBEDDED object = $send_obj offset = 0"
 done
 
@@ -96,7 +96,7 @@ for recsize in 1024 4096 16384; do
 	grep -q "EMBEDDED" $tmpdir/recv.zdb || \
 	    log_fail "Obj $recv_obj not embedded in $recvfs"
 
-	cat $stream | zstreamdump -v | log_must grep -q \
+	cat $stream | zstream dump -v | log_must grep -q \
 	    "WRITE_EMBEDDED object = $send_obj offset = 0"
 done
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -584,13 +584,13 @@ function mess_send_file
 	# The random offset might truncate the send stream to be
 	# smaller than the DRR_BEGIN record. If this happens, then
 	# the receiving system won't have enough info to create the
-	# partial dataset at all. We use zstreamdump to check for
+	# partial dataset at all. We use zstream dump to check for
 	# this and retry in this case.
-	nr_begins=$(head -c $offset $file | zstreamdump | \
+	nr_begins=$(head -c $offset $file | zstream dump | \
 	    grep DRR_BEGIN | awk '{ print $5 }')
 	while [ "$nr_begins" -eq 0 ]; do
 		offset=$(($RANDOM * $RANDOM % $filesize))
-		nr_begins=$(head -c $offset $file | zstreamdump | \
+		nr_begins=$(head -c $offset $file | zstream dump | \
 		    grep DRR_BEGIN | awk '{ print $5 }')
 	done
 
@@ -741,7 +741,7 @@ function stream_has_features
 	shift
 
 	[[ -f $file ]] || log_fail "Couldn't find file: $file"
-	typeset flags=$(cat $file | zstreamdump | \
+	typeset flags=$(cat $file | zstream dump | \
 	    awk '/features =/ {features = $3} END {print features}')
 	typeset -A feature
 	feature[dedup]="1"
@@ -774,7 +774,7 @@ function stream_has_features
 # comparing. This function does not currently handle incremental streams
 # that remove data.
 #
-# $1 The zstreamdump output file
+# $1 The zstream dump output file
 # $2 The dataset to compare against
 #    This can be a source of a send or recv target (fs, not snapshot)
 # $3 The percentage below which verification is deemed a failure
@@ -791,7 +791,7 @@ function verify_stream_size
 	[[ -f $stream ]] || log_fail "No such file: $stream"
 	datasetexists $ds || log_fail "No such dataset: $ds"
 
-	typeset stream_size=$(cat $stream | zstreamdump | sed -n \
+	typeset stream_size=$(cat $stream | zstream dump | sed -n \
 	    's/	Total payload size = \(.*\) (0x.*)/\1/p')
 
 	typeset inc_size=0

--- a/tests/zfs-tests/tests/functional/rsend/send-c_embedded_blocks.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_embedded_blocks.ksh
@@ -63,17 +63,17 @@ for recsize in "${recsize_prop_vals[@]}"; do
 	fi
 done
 
-# Generate the streams and zstreamdump output.
+# Generate the streams and zstream dump output.
 log_must zfs snapshot $sendfs@now
 log_must eval "zfs send -c $sendfs@now >$stream"
-log_must eval "zstreamdump -v <$stream >$dump"
+log_must eval "zstream dump -v <$stream >$dump"
 log_must eval "zfs recv -d $recvfs <$stream"
 cmp_ds_cont $sendfs $recvfs
 verify_stream_size $stream $sendfs
 log_mustnot stream_has_features $stream embed_data
 
 log_must eval "zfs send -c -e $sendfs@now >$stream2"
-log_must eval "zstreamdump -v <$stream2 >$dump2"
+log_must eval "zstream dump -v <$stream2 >$dump2"
 log_must eval "zfs recv -d $recvfs2 <$stream2"
 cmp_ds_cont $sendfs $recvfs2
 verify_stream_size $stream2 $sendfs
@@ -101,9 +101,9 @@ for recsize in "${recsize_prop_vals[@]}"; do
 	    log_fail "Obj $recv2_obj not embedded in $recvfs2"
 
 	grep -q "WRITE_EMBEDDED object = $send_obj offset = 0" $dump && \
-	    log_fail "Obj $obj embedded in zstreamdump output"
+	    log_fail "Obj $obj embedded in zstream dump output"
 	grep -q "WRITE_EMBEDDED object = $send_obj offset = 0" $dump2 || \
-	    log_fail "Obj $obj not embedded in zstreamdump output"
+	    log_fail "Obj $obj not embedded in zstream dump output"
 done
 
 log_pass "Compressed streams can contain embedded blocks."

--- a/tests/zfs-tests/tests/functional/rsend/send-c_zstreamdump.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_zstreamdump.ksh
@@ -21,12 +21,12 @@
 
 #
 # Description:
-# Verify compression features show up in zstreamdump
+# Verify compression features show up in zstream dump
 #
 # Strategy:
 # 1. Create a full compressed send stream
-# 2. Verify zstreamdump shows this stream has the relevant features
-# 3. Verify zstreamdump's accounting of logical and compressed size is correct
+# 2. Verify zstream dump shows this stream has the relevant features
+# 3. Verify zstream dump's accounting of logical and compressed size is correct
 # 4. Verify the toname from a resume token
 # 5. Verify it fails with corrupted resume token
 # 6. Verify it fails with missing resume token
@@ -34,7 +34,7 @@
 
 verify_runnable "both"
 
-log_assert "Verify zstreamdump correctly interprets compressed send streams."
+log_assert "Verify zstream dump correctly interprets compressed send streams."
 log_onexit cleanup_pool $POOL2
 
 typeset sendfs=$POOL2/fs
@@ -49,7 +49,7 @@ log_must zfs snapshot $sendfs@full
 
 log_must eval "zfs send -c $sendfs@full >$BACKDIR/full"
 log_must stream_has_features $BACKDIR/full lz4 compressed
-cat $BACKDIR/full | zstreamdump -v > $BACKDIR/dump.out
+cat $BACKDIR/full | zstream dump -v > $BACKDIR/dump.out
 
 lsize=$(awk '/^WRITE [^0]/ {lsize += $24} END {printf("%d", lsize)}' \
     $BACKDIR/dump.out)
@@ -72,4 +72,4 @@ bad_resume_token="1-1162e8285b-100789c6360"
 log_mustnot eval "zstream token $bad_resume_token 2>&1"
 log_mustnot eval "zstream token 2>&1"
 
-log_pass "zstreamdump correctly interprets compressed send streams."
+log_pass "zstream dump correctly interprets compressed send streams."

--- a/tests/zfs-tests/tests/functional/rsend/send-cpL_varied_recsize.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-cpL_varied_recsize.ksh
@@ -134,7 +134,7 @@ function check
 	[[ -f $stream ]] && log_must rm $stream
 	log_must eval "zfs send $flags $send_snap >$stream"
 	$verify eval "zfs recv $recv_ds <$stream"
-	typeset stream_size=$(cat $stream | zstreamdump | sed -n \
+	typeset stream_size=$(cat $stream | zstream dump | sed -n \
 	    's/	Total write size = \(.*\) (0x.*)/\1/p')
 
 	#


### PR DESCRIPTION
### Motivation and Context
When hacking on a patch to an existing change, I found ZTS failing because it wanted to use the `zstreamdump` symlink even though it wasn't creating it even if I nuked bin/.

I chose to remove the need to use it, rather than figure out why it wasn't generating it properly.

### Description
Removes the remaining uses of `zstreamdump` in tests/ in favor of `zstream dump` (except the test "send-c_zstreamdump.ksh", as it didn't seem especially useful to rename, and could confuse people's runfiles), including in commands.cfg.

### How Has This Been Tested?
Full run of ZTS passed with these changes with no errors, 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
