### PR TITLE
FreeBSD: fix compilation of FreeBSD world after 29274c9f6

### DIFF
--- a/include/os/freebsd/spl/sys/random.h
+++ b/include/os/freebsd/spl/sys/random.h
@@ -51,7 +51,7 @@ random_get_pseudo_bytes(uint8_t *p, size_t s)
 static inline uint32_t
 random_in_range(uint32_t range)
 {
-#if  __FreeBSD_version >= 1300108
+#if defined(_KERNEL) && __FreeBSD_version >= 1300108
 	return (prng32_bounded(range));
 #else
 	uint32_t r;
@@ -61,7 +61,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 #endif

--- a/include/os/linux/spl/sys/random.h
+++ b/include/os/linux/spl/sys/random.h
@@ -46,7 +46,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 }

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -648,7 +648,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 }


### PR DESCRIPTION
### Motivation and Context
When compiling world on FreeBSD HEAD, clang 12 does complain about two issues:

1. prng32_bounded() is availabe to kernel only
2. When compiling zstd_event.cc it requires random_get_pseudo_bytes() to be called with (uint8_t *) instead of (void *)

### Description

- FreeBSD: Compile in prng32_bounded() only for kernel
- FreeBSD and Linux: do inline random_get_pseudo_bytes() with (uint8_t *). 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).