### PR TITLE
Move comment and compatibility properties to the props object.

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1065,6 +1065,7 @@ extern spa_t *spa_by_guid(uint64_t pool_guid, uint64_t device_guid);
 extern boolean_t spa_guid_exists(uint64_t pool_guid, uint64_t device_guid);
 extern char *spa_strdup(const char *);
 extern void spa_strfree(char *);
+extern char *spa_stralloc(size_t);
 extern uint64_t spa_generate_guid(spa_t *spa);
 extern void snprintf_blkptr(char *buf, size_t buflen, const blkptr_t *bp);
 extern void spa_freeze(spa_t *spa);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1494,6 +1494,15 @@ spa_strfree(char *s)
 	kmem_free(s, strlen(s) + 1);
 }
 
+char *
+spa_stralloc(size_t len)
+{
+	char *new;
+	new = kmem_alloc(len + 1, KM_SLEEP);
+	new[0] = '\0';
+	return (new);
+}
+
 uint64_t
 spa_generate_guid(spa_t *spa)
 {
@@ -2877,6 +2886,7 @@ EXPORT_SYMBOL(spa_maxdnodesize);
 EXPORT_SYMBOL(spa_guid_exists);
 EXPORT_SYMBOL(spa_strdup);
 EXPORT_SYMBOL(spa_strfree);
+EXPORT_SYMBOL(spa_stralloc);
 EXPORT_SYMBOL(spa_generate_guid);
 EXPORT_SYMBOL(snprintf_blkptr);
 EXPORT_SYMBOL(spa_freeze);


### PR DESCRIPTION
### Motivation and Context
As discussed in #12261, the `comment` and `compatibility` properties are stored in the pool config object rather than the properties object. This PR changes the logic to store and load them from the `DMU_OT_POOL_PROPS` object.

It would also be desirable to detect the legacy configuration and allow migration to the new location [WIP].

### Description
In `spa_ld_get_props()` we load the string values from the props ZAP into the `spa_comment` and `spa_compatibility` variables. A couple of helper functions, `spa_prop_fstr()` and `spa_stralloc()` have been written to facilitate this.

In `spa_ld_parse_config()` we no longer look for the `ZPOOL_PROP_COMMENT` and `ZPOOL_PROP_COMPATIBILITY` config entries.

In `spa_sync_props()` we move the handling of these properties from the config section to the props section.

In order to migrate from the old format to the new, there are a few possibilities:
  * Silently (or with a warning) delete the entries from the config and add them to props.
    * My concern is that this would lead to this pool then being incorrectly imported on older versions (these properties would be lost, or discarded on import)
  * Allow both to exist indefinitely, preferring the props version where both are present.
    * Danger: old software versions would see the config version while new would see the props version, which might be a problem if they differ.
  * Output a warning, allowing the user to take action to remediate the issue.

Honestly, none of these are great options. The third is probably the safest as well as the easiest to implement.

I'm on the fence about this: on the one hand, it would be cleanest to actually have all the configurable pool properties stored in the props object, and there would be fewer special cases to deal with. On the other hand (especially given that both of these properties are just hints to userland rather than influencing kernel behavior), there's no real harm in having them in the config object, and a possible small benefit in having them visible in the cachefile before import.

Thoughts?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
