### PR TITLE
Fix a number of small zvol-related udev error handling issues

### DIFF
--- a/cmd/zvol_id/zvol_id_main.c
+++ b/cmd/zvol_id/zvol_id_main.c
@@ -38,40 +38,39 @@
 static int
 ioctl_get_msg(char *var, int fd)
 {
-	int error = 0;
+	int ret;
 	char msg[ZFS_MAX_DATASET_NAME_LEN];
 
-	error = ioctl(fd, BLKZNAME, msg);
-	if (error < 0) {
-		return (error);
+	ret = ioctl(fd, BLKZNAME, msg);
+	if (ret < 0) {
+		return (ret);
 	}
 
 	snprintf(var, ZFS_MAX_DATASET_NAME_LEN, "%s", msg);
-	return (error);
+	return (ret);
 }
 
 int
 main(int argc, char **argv)
 {
-	int fd, error = 0;
+	int fd = -1, ret = 0, status = EXIT_FAILURE;
 	char zvol_name[ZFS_MAX_DATASET_NAME_LEN];
 	char *zvol_name_part = NULL;
 	char *dev_name;
 	struct stat64 statbuf;
 	int dev_minor, dev_part;
 	int i;
-	int rc;
 
 	if (argc < 2) {
 		fprintf(stderr, "Usage: %s /dev/zvol_device_node\n", argv[0]);
-		return (EINVAL);
+		goto fail;
 	}
 
 	dev_name = argv[1];
-	error = stat64(dev_name, &statbuf);
-	if (error != 0) {
+	ret = stat64(dev_name, &statbuf);
+	if (ret != 0) {
 		fprintf(stderr, "Unable to access device file: %s\n", dev_name);
-		return (errno);
+		goto fail;
 	}
 
 	dev_minor = minor(statbuf.st_rdev);
@@ -80,22 +79,22 @@ main(int argc, char **argv)
 	fd = open(dev_name, O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr, "Unable to open device file: %s\n", dev_name);
-		return (errno);
+		goto fail;
 	}
 
-	error = ioctl_get_msg(zvol_name, fd);
-	if (error < 0) {
+	ret = ioctl_get_msg(zvol_name, fd);
+	if (ret < 0) {
 		fprintf(stderr, "ioctl_get_msg failed: %s\n", strerror(errno));
-		return (errno);
+		goto fail;
 	}
 	if (dev_part > 0)
-		rc = asprintf(&zvol_name_part, "%s-part%d", zvol_name,
+		ret = asprintf(&zvol_name_part, "%s-part%d", zvol_name,
 		    dev_part);
 	else
-		rc = asprintf(&zvol_name_part, "%s", zvol_name);
+		ret = asprintf(&zvol_name_part, "%s", zvol_name);
 
-	if (rc == -1 || zvol_name_part == NULL)
-		goto error;
+	if (ret == -1 || zvol_name_part == NULL)
+		goto fail;
 
 	for (i = 0; i < strlen(zvol_name_part); i++) {
 		if (isblank(zvol_name_part[i]))
@@ -103,8 +102,13 @@ main(int argc, char **argv)
 	}
 
 	printf("%s\n", zvol_name_part);
-	free(zvol_name_part);
-error:
-	close(fd);
-	return (error);
+	status = EXIT_SUCCESS;
+
+fail:
+	if (zvol_name_part)
+		free(zvol_name_part);
+	if (fd >= 0)
+		close(fd);
+
+	return (status);
 }

--- a/cmd/zvol_id/zvol_id_main.c
+++ b/cmd/zvol_id/zvol_id_main.c
@@ -63,14 +63,14 @@ main(int argc, char **argv)
 	int rc;
 
 	if (argc < 2) {
-		printf("Usage: %s /dev/zvol_device_node\n", argv[0]);
+		fprintf(stderr, "Usage: %s /dev/zvol_device_node\n", argv[0]);
 		return (EINVAL);
 	}
 
 	dev_name = argv[1];
 	error = stat64(dev_name, &statbuf);
 	if (error != 0) {
-		printf("Unable to access device file: %s\n", dev_name);
+		fprintf(stderr, "Unable to access device file: %s\n", dev_name);
 		return (errno);
 	}
 
@@ -79,13 +79,13 @@ main(int argc, char **argv)
 
 	fd = open(dev_name, O_RDONLY);
 	if (fd < 0) {
-		printf("Unable to open device file: %s\n", dev_name);
+		fprintf(stderr, "Unable to open device file: %s\n", dev_name);
 		return (errno);
 	}
 
 	error = ioctl_get_msg(zvol_name, fd);
 	if (error < 0) {
-		printf("ioctl_get_msg failed:%s\n", strerror(errno));
+		fprintf(stderr, "ioctl_get_msg failed: %s\n", strerror(errno));
 		return (errno);
 	}
 	if (dev_part > 0)

--- a/udev/rules.d/60-zvol.rules.in
+++ b/udev/rules.d/60-zvol.rules.in
@@ -3,4 +3,4 @@
 # persistent disk links: /dev/zvol/dataset_name
 # also creates compatibility symlink of /dev/dataset_name
 
-KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM="@udevdir@/zvol_id $devnode", SYMLINK+="zvol/%c %c"
+KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM=="@udevdir@/zvol_id $devnode", SYMLINK+="zvol/%c %c"

--- a/udev/rules.d/60-zvol.rules.in
+++ b/udev/rules.d/60-zvol.rules.in
@@ -3,4 +3,4 @@
 # persistent disk links: /dev/zvol/dataset_name
 # also creates compatibility symlink of /dev/dataset_name
 
-KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM="@udevdir@/zvol_id $tempnode", SYMLINK+="zvol/%c %c"
+KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM="@udevdir@/zvol_id $devnode", SYMLINK+="zvol/%c %c"

--- a/udev/rules.d/60-zvol.rules.in
+++ b/udev/rules.d/60-zvol.rules.in
@@ -3,4 +3,4 @@
 # persistent disk links: /dev/zvol/dataset_name
 # also creates compatibility symlink of /dev/dataset_name
 
-KERNEL=="zd*" SUBSYSTEM=="block" ACTION=="add|change" PROGRAM="@udevdir@/zvol_id $tempnode" SYMLINK+="zvol/%c %c"
+KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM="@udevdir@/zvol_id $tempnode", SYMLINK+="zvol/%c %c"


### PR DESCRIPTION
I've come across a number of issues of general "crustiness" concerning the udev rules file for zvol dev nodes, as well as the udev helper binary `zvol_id`. This PR consists of a small stack of patches that address some of that crustiness.

Some of these are very much "1 character of code changed, with 1 long novel of commit message explanation accompanying it".

### Motivation and Context

As mentioned in #12301, I noticed that when `zvol_id` runs into actual problems (which is not a common thing as far as I know), the way that errors are actually handled is... well... not good. The udev rules file for zvols is ancient and uses deprecated syntax, and the `zvol_id` helper binary is also ancient and has a number of interesting quicks itself.

The core problem in #12301 isn't something I can solve myself, at least right now. But the ancillary stuff, regarding old crusty udev rules files and poor error handling that tends to result in tons of completely spurious symlinks being created... well, that's something I would probably write some local patches for myself anyway; so why not turn it into a day-long writing exercise and contribute it back. 😝

### Description

`60-zvol.rules.in`
- Fix deprecated syntax: no commas between key-value pairs
- Fix deprecated syntax: use `$devnode` rather than `$tempnode`
- Ensure that the `PROGRAM` key definitely uses the match (`==`) operator so that success/failure of the program is actually checked
  - I believe my suspicions here ended up being somewhat of a red herring: pretty sure that actually it was a circumstance of "program is returning 'nonzero' exit status 512, which gets modulo'd to 0"; but being more explicit and avoiding mushy udev policies about "auto-correcting" technically-wrong operators into correct ones isn't a bad thing

`zvol_id_main.c`
- Alleviate Dennis Ritchie continually rolling in his grave due to having literally invented `stderr`, only to have its existence be completely disregarded by this program 👻
- Make the overall exit status logic less stupid, less problematic, and just generally easier to follow

### How Has This Been Tested?

- [x] I've tested the udev rule changes myself already on my test system, with udev `log_level=debug` etc
- [ ] I'll be testing the `zvol_id` changes in a matter of minutes, most likely, once I give my system a reboot

Fortunately both the rules file and the helper program are pretty well isolated in their own corner with udev and friends, and they don't really have any super duper strong interactions with other stuff; at least not in the way that changes to e.g. parts of the kernel module might.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
  - Well... only insofar as the spurious creation of incorrect symlinks was making systemd-udevd take forever to finish device initialization because a bunch of different zvol devices would all try to claim ownership of symlinks `/dev/zvol/Unable` et al 😬
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Not sure if any tests are super-warranted here. I did do a cursory inspection to see if there were any preexisting tests for e.g. `vdev_id` or something similar like that which I could crib from; but didn't seem to find much. 🤷