### PR TITLE
Remove "compatibility" zvol symlinks (the /dev/dataset_name ones, as opposed to the /dev/zvol/dataset_name ones)

### DIFF
--- a/udev/rules.d/60-zvol.rules.in
+++ b/udev/rules.d/60-zvol.rules.in
@@ -1,6 +1,11 @@
 # Persistent links for zvol
 #
 # persistent disk links: /dev/zvol/dataset_name
-# also creates compatibility symlink of /dev/dataset_name
+#
+# NOTE: We used to also create an additional tree of zvol symlinks located at
+#       /dev/dataset_name (i.e. without the 'zvol' path component) for
+#       compatibility reasons. These are no longer created anymore, and should
+#       not be relied upon.
+#       
 
-KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM=="@udevdir@/zvol_id $devnode", SYMLINK+="zvol/%c %c"
+KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM=="@udevdir@/zvol_id $devnode", SYMLINK+="zvol/%c"


### PR DESCRIPTION
I don't have a super good sense for whether this is a good idea or a terrible idea. But I figured I'd put it forward anyway, and let people better-equipped than me figure that out.

~~(This PR/branch has a version of the commit that applies cleanly on master. See comment below for another branch with a different version of the commit that applies cleanly on top of PR #12302.)~~

### Motivation and Context

Getting rid of old junk that's ancient and that nobody should be using. (At least in theory.)

### Description

This modifies the `60-zvol.rules.in` file such that, while it still creates the symlink tree `/dev/zvol/dataset_name`, it no longer creates the "compatibility" symlink tree `/dev/dataset_name`.

### How Has This Been Tested?

Testing isn't particularly relevant here. The relevance mainly pertains to whether or not this is a good idea, which in turn probably mostly depends on to what extent we think people are relying on the old device node symlink layout.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
  - To a very small extent, less symlinks means udev will chug a bit less, particularly on systems with many zvols and/or with heavily-snapshotted zvols that have `snapdev=visible`.
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
  - Arguably. I mean, it cleans up my `/dev` directory, for what that's worth.
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - Depending on what users are expecting. This is kinda the crux of the matter.
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
  - Hmmmmm, this might be a good thing to look into, come to think of it. Not the easiest thing to grep ever, though.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

This is a really simple technical change, with a big fat question mark hanging over it that I can't answer, which is "does the old zvol tree still need to exist?" It seems like it ought to be fine to get rid of it, but then there may well be reasons I haven't thought of or don't have good insight into.