### PR TITLE
change dmu_read/dmu_write to take helper functions

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -833,6 +833,10 @@ int dmu_free_long_object(objset_t *os, uint64_t object);
 #define	DMU_READ_PREFETCH	0 /* prefetch */
 #define	DMU_READ_NO_PREFETCH	1 /* don't prefetch */
 #define	DMU_READ_NO_DECRYPT	2 /* don't decrypt */
+
+typedef size_t (*dmu_io_func)(const void *privptr, char *addr,
+    uint64_t offset, uint64_t logical_offset, size_t len);
+
 int dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	void *buf, uint32_t flags);
 int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
@@ -853,6 +857,10 @@ int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
 int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
+int dmu_read_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    void *privptr, dmu_io_func func, uint32_t flags);
+int dmu_write_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    const void *privptr, dmu_io_func func, dmu_tx_t *tx);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -994,11 +994,25 @@ dmu_free_range(objset_t *os, uint64_t object, uint64_t offset,
 	return (0);
 }
 
+inline static size_t dmu_read_default(const void *buf, char *addr,
+    uint64_t offset, uint64_t logical_offset, size_t len)
+{
+	/* Deal with odd block sizes */
+	if (addr == NULL) {
+		bzero((char *)buf, len);
+		return (len);
+	}
+
+	(void) memcpy((char *)buf + logical_offset, (char *)addr, len);
+	return (len);
+}
+
 static int
 dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
-    void *buf, uint32_t flags)
+    void *buf, dmu_io_func func, uint32_t flags)
 {
 	dmu_buf_t **dbp;
+	uint64_t logical_offset = 0ULL;
 	int numbufs, err = 0;
 
 	/*
@@ -1009,7 +1023,7 @@ dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
 	if (dn->dn_maxblkid == 0) {
 		uint64_t newsz = offset > dn->dn_datablksz ? 0 :
 		    MIN(size, dn->dn_datablksz - offset);
-		bzero((char *)buf + newsz, size - newsz);
+		(void) func((char *)buf + newsz, NULL, 0, 0, size - newsz);
 		size = newsz;
 	}
 
@@ -1036,11 +1050,17 @@ dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
 			bufoff = offset - db->db_offset;
 			tocpy = MIN(db->db_size - bufoff, size);
 
-			(void) memcpy(buf, (char *)db->db_data + bufoff, tocpy);
+			tocpy = func(buf, (char *)db->db_data + bufoff, offset,
+			    logical_offset, tocpy);
+
+			if (tocpy < 0) {
+				err = SET_ERROR(EIO);
+				break;
+			}
 
 			offset += tocpy;
 			size -= tocpy;
-			buf = (char *)buf + tocpy;
+			logical_offset += tocpy;
 		}
 		dmu_buf_rele_array(dbp, numbufs, FTAG);
 	}
@@ -1058,7 +1078,7 @@ dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	if (err != 0)
 		return (err);
 
-	err = dmu_read_impl(dn, offset, size, buf, flags);
+	err = dmu_read_impl(dn, offset, size, buf, dmu_read_default, flags);
 	dnode_rele(dn, FTAG);
 	return (err);
 }
@@ -1067,14 +1087,22 @@ int
 dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
     uint32_t flags)
 {
-	return (dmu_read_impl(dn, offset, size, buf, flags));
+	return (dmu_read_impl(dn, offset, size, buf, dmu_read_default, flags));
 }
 
-static void
+inline static size_t dmu_write_default(const void *buf, char *addr,
+    uint64_t offset, uint64_t logical_offset, size_t len)
+{
+	(void) memcpy((char *)addr, (char *)buf + logical_offset, len);
+	return (len);
+}
+
+static int
 dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
-    const void *buf, dmu_tx_t *tx)
+    const void *buf, dmu_io_func func, dmu_tx_t *tx)
 {
 	int i;
+	uint64_t logical_offset = 0ULL;
 
 	for (i = 0; i < numbufs; i++) {
 		uint64_t tocpy;
@@ -1093,15 +1121,20 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		else
 			dmu_buf_will_dirty(db, tx);
 
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
+		tocpy = func(buf, (char *)db->db_data + bufoff, offset,
+		    logical_offset, tocpy);
+
+		if (tocpy < 0)
+			return (SET_ERROR(EIO));
 
 		if (tocpy == db->db_size)
 			dmu_buf_fill_done(db, tx);
 
 		offset += tocpy;
 		size -= tocpy;
-		buf = (char *)buf + tocpy;
+		logical_offset += tocpy;
 	}
+	return (0);
 }
 
 void
@@ -1116,7 +1149,8 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 
 	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp));
-	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
+	(void) dmu_write_impl(dbp, numbufs, offset, size, buf,
+	    dmu_write_default, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
@@ -1135,7 +1169,8 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 
 	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
-	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
+	(void) dmu_write_impl(dbp, numbufs, offset, size, buf,
+	    dmu_write_default, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
@@ -1229,6 +1264,37 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size)
 	}
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 
+	return (err);
+}
+
+/*
+ * Issue IO with callout to function 'func'.
+ * int func(void *privptr, char *address, uint64_t offset, uint64_t len);
+ * return number of bytes processed (hopefully 'len' amount). negative
+ * return for failure abort.
+ */
+int
+dmu_read_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    void *privptr, dmu_io_func func, uint32_t flags)
+{
+	return (dmu_read_impl(dn, offset, size, privptr, func, flags));
+}
+
+int
+dmu_write_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    const void *privptr, dmu_io_func func, dmu_tx_t *tx)
+{
+	dmu_buf_t **dbp;
+	int numbufs;
+	int err = 0;
+
+	if (size == 0)
+		return (err);
+
+	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
+	err = dmu_write_impl(dbp, numbufs, offset, size, privptr, func, tx);
+	dmu_buf_rele_array(dbp, numbufs, FTAG);
 	return (err);
 }
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Change dmu_read/dmu_write to take helper functions. In the default case, these functions are calls to `memcpy()` as before. Export wrapper functions to allow specifying own callout functions.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

Instead of adding a dmu_read()/dmu_write() variant only for macOS, and increasing code-duplication, this PR tries to simply the existing dmu IO function to allow an IO call-out function to be used. In the normal (non-macOS situation) the dmu code will call `memcpy()` as before. 

Some minor changes in the logic; including not modifying `buf`, but rather passing along a `logical_offset` to achieve the same effect. (`buf + logical_offset`). This is required as macOS uses `buf` as a privptr to a C++ class (and it does not like the class pointer being incremented).

The macOS companion that uses this new interface is:

https://github.com/openzfsonosx/openzfs/blob/931a299570bd841620236564503d7c5427b8a33c/module/os/macos/zfs/zvolIO.cpp#L1152



### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
