### PR TITLE
Fix inflated quiesce time caused by lwb_tx during zil_commit().

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1261,7 +1261,7 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 
 	mutex_enter(&zilog->zl_lwb_io_lock);
 	txg = lwb->lwb_issued_txg;
-	ASSERT(zilog->zl_lwb_inflight[txg & TXG_MASK] > 0);
+	ASSERT3U(zilog->zl_lwb_inflight[txg & TXG_MASK], >, 0);
 	zilog->zl_lwb_inflight[txg & TXG_MASK]--;
 	if (zilog->zl_lwb_inflight[txg & TXG_MASK] == 0)
 		cv_broadcast(&zilog->zl_lwb_io_cv);
@@ -1275,7 +1275,7 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 static void
 zil_lwb_flush_wait_all(zilog_t *zilog, uint64_t txg)
 {
-	ASSERT(txg == spa_syncing_txg(zilog->zl_spa));
+	ASSERT3U(txg, ==, spa_syncing_txg(zilog->zl_spa));
 
 	mutex_enter(&zilog->zl_lwb_io_lock);
 	while (zilog->zl_lwb_inflight[txg & TXG_MASK] > 0)

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -559,8 +559,8 @@ zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, boolean_t slog, uint64_t txg,
 	lwb->lwb_max_txg = txg;
 	lwb->lwb_write_zio = NULL;
 	lwb->lwb_root_zio = NULL;
-	lwb->lwb_tx = NULL;
 	lwb->lwb_issued_timestamp = 0;
+	lwb->lwb_issued_txg = 0;
 	if (BP_GET_CHECKSUM(bp) == ZIO_CHECKSUM_ZILOG2) {
 		lwb->lwb_nused = sizeof (zil_chain_t);
 		lwb->lwb_sz = BP_GET_LSIZE(bp);
@@ -1183,9 +1183,9 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 {
 	lwb_t *lwb = zio->io_private;
 	zilog_t *zilog = lwb->lwb_zilog;
-	dmu_tx_t *tx = lwb->lwb_tx;
 	zil_commit_waiter_t *zcw;
 	itx_t *itx;
+	uint64_t txg = lwb->lwb_issued_txg;
 
 	spa_config_exit(zilog->zl_spa, SCL_STATE, lwb);
 
@@ -1194,15 +1194,13 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 	mutex_enter(&zilog->zl_lock);
 
 	/*
-	 * Ensure the lwb buffer pointer is cleared before releasing the
-	 * txg. If we have had an allocation failure and the txg is
+	 * If we have had an allocation failure and the txg is
 	 * waiting to sync then we want zil_sync() to remove the lwb so
 	 * that it's not picked up as the next new one in
 	 * zil_process_commit_list(). zil_sync() will only remove the
 	 * lwb if lwb_buf is null.
 	 */
 	lwb->lwb_buf = NULL;
-	lwb->lwb_tx = NULL;
 
 	ASSERT3U(lwb->lwb_issued_timestamp, >, 0);
 	zilog->zl_last_lwb_latency = gethrtime() - lwb->lwb_issued_timestamp;
@@ -1261,12 +1259,44 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 
 	mutex_exit(&zilog->zl_lock);
 
-	/*
-	 * Now that we've written this log block, we have a stable pointer
-	 * to the next block in the chain, so it's OK to let the txg in
-	 * which we allocated the next block sync.
-	 */
-	dmu_tx_commit(tx);
+	mutex_enter(&zilog->zl_lwb_io_lock);
+	ASSERT(zilog->zl_lwb_inflight[txg & TXG_MASK] > 0);
+	zilog->zl_lwb_inflight[txg & TXG_MASK]--;
+	if (zilog->zl_lwb_inflight[txg & TXG_MASK] == 0)
+		cv_broadcast(&zilog->zl_lwb_io_cv);
+	mutex_exit(&zilog->zl_lwb_io_lock);
+}
+
+/*
+ * Wait for the completion of all issued write/flush of that txg provided.
+ * It guarantees zil_lwb_flush_vdevs_done() is called and returned.
+ */
+static void
+zil_lwb_flush_wait_all(zilog_t *zilog, uint64_t txg)
+{
+	ASSERT(txg == spa_syncing_txg(zilog->zl_spa));
+
+	mutex_enter(&zilog->zl_lwb_io_lock);
+	while (zilog->zl_lwb_inflight[txg & TXG_MASK] > 0)
+		cv_wait(&zilog->zl_lwb_io_cv, &zilog->zl_lwb_io_lock);
+	mutex_exit(&zilog->zl_lwb_io_lock);
+
+#ifdef ZFS_DEBUG
+	mutex_enter(&zilog->zl_lock);
+	lwb_t *lwb = list_head(&zilog->zl_lwb_list);
+	while (lwb != NULL && lwb->lwb_max_txg <= txg) {
+		if (lwb->lwb_issued_txg <= txg) {
+			ASSERT(lwb->lwb_state != LWB_STATE_ISSUED);
+			ASSERT(lwb->lwb_state != LWB_STATE_WRITE_DONE);
+			IMPLY(lwb->lwb_issued_txg > 0,
+			    lwb->lwb_state == LWB_STATE_FLUSH_DONE);
+		}
+		IMPLY(lwb->lwb_state == LWB_STATE_FLUSH_DONE,
+		    lwb->lwb_buf == NULL);
+		lwb = list_next(&zilog->zl_lwb_list, lwb);
+	}
+	mutex_exit(&zilog->zl_lock);
+#endif
 }
 
 /*
@@ -1581,8 +1611,12 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 
 	dsl_dataset_dirty(dmu_objset_ds(zilog->zl_os), tx);
 	txg = dmu_tx_get_txg(tx);
+	lwb->lwb_issued_txg = txg;
 
-	lwb->lwb_tx = tx;
+	mutex_enter(&zilog->zl_lwb_io_lock);
+	zilog->zl_lwb_inflight[txg & TXG_MASK]++;
+	zilog->zl_lwb_max_issued_txg = MAX(txg, zilog->zl_lwb_max_issued_txg);
+	mutex_exit(&zilog->zl_lwb_io_lock);
 
 	/*
 	 * Log blocks are pre-allocated. Here we select the size of the next
@@ -1656,6 +1690,8 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 
 	zio_nowait(lwb->lwb_root_zio);
 	zio_nowait(lwb->lwb_write_zio);
+
+	dmu_tx_commit(tx);
 
 	/*
 	 * If there was an allocation failure then nlwb will be null which
@@ -3124,6 +3160,8 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 	if (spa_sync_pass(spa) != 1)
 		return;
 
+	zil_lwb_flush_wait_all(zilog, txg);
+
 	mutex_enter(&zilog->zl_lock);
 
 	ASSERT(zilog->zl_stop_sync == 0);
@@ -3290,6 +3328,7 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 
 	mutex_init(&zilog->zl_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&zilog->zl_issuer_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&zilog->zl_lwb_io_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
 		mutex_init(&zilog->zl_itxg[i].itxg_lock, NULL,
@@ -3303,6 +3342,7 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 	    offsetof(itx_t, itx_node));
 
 	cv_init(&zilog->zl_cv_suspend, NULL, CV_DEFAULT, NULL);
+	cv_init(&zilog->zl_lwb_io_cv, NULL, CV_DEFAULT, NULL);
 
 	return (zilog);
 }
@@ -3338,8 +3378,10 @@ zil_free(zilog_t *zilog)
 
 	mutex_destroy(&zilog->zl_issuer_lock);
 	mutex_destroy(&zilog->zl_lock);
+	mutex_destroy(&zilog->zl_lwb_io_lock);
 
 	cv_destroy(&zilog->zl_cv_suspend);
+	cv_destroy(&zilog->zl_lwb_io_cv);
 
 	kmem_free(zilog, sizeof (zilog_t));
 }
@@ -3387,9 +3429,18 @@ zil_close(zilog_t *zilog)
 	mutex_exit(&zilog->zl_lock);
 
 	/*
-	 * We need to use txg_wait_synced() to wait long enough for the
-	 * ZIL to be clean, and to wait for all pending lwbs to be
-	 * written out.
+	 * zl_lwb_max_issued_txg may be larger than lwb_max_txg. It depends
+	 * on the time when the dmu_tx transaction is assigned in
+	 * zil_lwb_write_issue().
+	 */
+	mutex_enter(&zilog->zl_lwb_io_lock);
+	txg = MAX(zilog->zl_lwb_max_issued_txg, txg);
+	mutex_exit(&zilog->zl_lwb_io_lock);
+
+	/*
+	 * We need to use txg_wait_synced() to wait until that txg is synced.
+	 * zil_sync() will guarantee all lwbs up to that txg have been
+	 * written out, flushed, and cleaned.
 	 */
 	if (txg != 0)
 		txg_wait_synced(zilog->zl_dmu_pool, txg);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In current zil_commit() process, transaction lwb_tx is assigned in
zil_lwb_write_issue(), and is committed in zil_lwb_flush_vdevs_done().
Thus, during lwb write out process, the txg is held in open or quiesing
state, until zil_lwb_flush_vdevs_done() is called. If the zil's zio
latency is high, it will cause txg_sync_thread() to starve.

You can verify this quiesce-time degradation with sync=always on your dataset, and observe txg history.

### Description
<!--- Describe your changes in detail -->
The goal here is to defer waiting for zil_lwb_flush_vdevs_done to the 'syncing' txg state. That is, in zil_sync().

In this patch, it achieves the the goal without holding transaction.
A new function zil_lwb_flush_wait_all() is introduced. It waits for
the completion of all the zil_lwb_flush_vdevs_done() by given txg.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested with fio and zfs set sync=always
The improvement depends your slog device speed. The slower slog device is, the more improvement you will see.
After this patch there is no quiesce-time degradation visible after set sync=always.

Here is my test with spinning disk as slog, to show difference of the quiesce time.

with patch
```shell
txg      birth            state ndirty       nread        nwritten     reads    writes   otime        qtime        wtime        stime
722      3819311759383    C     0            3072         1033216      2        53       199546499    5026         88637        120417478
723      3819511305882    C     0            0            0            0        0        126672837    1683         17886        106016
724      3819637978719    C     0            1024         1025536      1        53       13947365     1288         36773        112106800
725      3819651926084    C     0            0            0            0        0        118113533    1597         10495        91106
726      3819770039617    C     0            1024         103424       1        38       5095744305   27835        145215       102824714
727      3824865783922    C     0            0            0            0        0        5120053917   4375         178995       417700
728      3829985837839    C     0            0            0            0        0        5119996727   4435         177865       469305
729      3835105834566    C     54018048     307200       139350528    9        858      1469141722   37584        28793        2172787838
730      3836574976288    C     89800704     2048         218882048    2        1276     2173390655   1138         31007        2134700931
731      3838748366943    C     133840896    1024         270976512    1        1463     2134744982   1139         6894         2932904532
732      3840883111925    C     142098432    1024         274039808    1        1414     2932928067   1547         32078        2641837091
733      3843816039992    C     131743744    1024         269938176    1        1447     2641883713   1305         15513        2774043735
734      3846457923705    C     146554880    2048         403771904    1        2571     2774076421   1547         17621        4987809631
735      3849232000126    C     255606784    1536         509530624    1        2865     4987836594   855          12714        8616763778
736      3854219836720    C     253771776    2048         509279232    1        2833     8616787556   986          19922        8308391114
737      3862836624276    C     253247488    1536         498496000    1        2783     8308421970   936          15241        8632259611
738      3871145046246    C     247087104    2048         510252544    1        2915     8632288585   1332         16683        8299059261
739      3879777334831    C     261898240    1024         508218880    1        2753     8299089281   1385         10823        6602355938
740      3888076424112    S     0            0            0            0        0        6602379488   1730         10614        0
741      3894678803600    O     0            0            0            0        0        0            0            0            0
```

without patch
```shell
txg      birth            state ndirty       nread        nwritten     reads    writes   otime        qtime        wtime        stime
789      4102835274754    C     0            2048         1057792      1        65       57904525     1450         37147        97630298
790      4102893179279    C     0            0            0            0        0        106901941    1476         12980        104187
791      4103000081220    C     0            0            1020928      0        49       12889766     857          10118        62213896
792      4103012970986    C     0            0            0            0        0        68551739     1607         36512        80945
793      4103081522725    C     2768896      0            1898496      0        85       4845745890   7530077      19759        196281535
794      4107927268615    C     53886976     192000       112074752    5        613      657526958    26952709     31097        1943359870
795      4108584795573    C     64897024     75776        134765568    4        717      1970413166   44824232     61839        1039096626
796      4110555208739    C     76955648     0            196256768    0        1171     1083993186   31569824     49449        2383267018
797      4111639201925    C     126631936    0            263712256    0        1406     2414895225   33835725     25244        2539729055
798      4114054097150    C     143278080    0            276193280    0        1468     2573601631   60943307     32181        2759894703
799      4116627698781    C     141180928    3072         320628736    1        1850     2820975839   36787516     30533        3222832141
800      4119448674620    C     185876480    0            440704512    0        2639     3259674596   31768175     45426        7350388640
801      4122708349216    C     261242880    4608         520176640    2        2878     7382218476   1369         16087        8646623611
802      4130090567692    C     260456448    0            495588864    0        2692     8646657587   1782         22131        5619056915
803      4138737225279    C     235945984    2560         502074368    1        2919     5619092136   1011         18622        8073224226
804      4144356317415    C     263733248    0            508206592    0        2835     8073272065   1444         31298        6019223002
805      4152429589480    C     244465664    2560         499199488    1        2818     6019264869   2831552      50281        8347371827
806      4158448854349    C     259670016    1536         493344768    1        2642     8350275168   1579         22592        6446452458
807      4166799129517    S     0            0            0            0        0        6446485932   1057         17744        0
808      4173245615449    O     0            0            0            0        0        0            0            0            0
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
