### PR TITLE
channel program: test that encryption and encryptionroot properties are gettable

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -83,7 +83,7 @@ tests = ['case_all_values', 'norm_all_values', 'mixed_create_failure',
 tags = ['functional', 'casenorm']
 
 [tests/functional/channel_program/lua_core]
-tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists',
+tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists', 'tst.encryption',
     'tst.integer_illegal', 'tst.integer_overflow', 'tst.language_functions_neg',
     'tst.language_functions_pos', 'tst.large_prog', 'tst.libraries',
     'tst.memory_limit', 'tst.nested_neg', 'tst.nested_pos', 'tst.nvlist_to_lua',

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -64,7 +64,7 @@ tests = ['case_all_values', 'norm_all_values', 'sensitive_none_lookup',
 tags = ['functional', 'casenorm']
 
 [tests/functional/channel_program/lua_core]
-tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists',
+tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists', 'tst.encryption',
     'tst.integer_illegal', 'tst.integer_overflow', 'tst.language_functions_neg',
     'tst.language_functions_pos', 'tst.large_prog', 'tst.libraries',
     'tst.memory_limit', 'tst.nested_neg', 'tst.nested_pos', 'tst.nvlist_to_lua',

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/Makefile.am
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/Makefile.am
@@ -4,6 +4,7 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	tst.args_to_lua.ksh \
 	tst.divide_by_zero.ksh \
+	tst.encryption.ksh \
 	tst.exists.ksh \
 	tst.integer_illegal.ksh \
 	tst.integer_overflow.ksh \
@@ -30,6 +31,7 @@ dist_pkgdata_DATA = \
 	tst.divide_by_zero.err \
 	tst.divide_by_zero.zcp \
 	tst.exists.zcp \
+	tst.encryption.zcp \
 	tst.large_prog.out \
 	tst.large_prog.zcp \
 	tst.lib_base.lua \

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.encryption.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.encryption.ksh
@@ -1,0 +1,41 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2021 by Determinate Systems. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION:
+#       zfs.exists should accurately report whether a dataset exists, and
+#       report an error if a dataset is in another pool.
+
+verify_runnable "global"
+
+TESTDATASET="channelprogramencryption"
+
+passphrase="password"
+log_must eval "echo "$passphrase" | zfs create -o encryption=aes-256-ccm " \
+        "-o keyformat=passphrase $TESTPOOL/$TESTDATASET"
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTDATASET && \
+	    log_must zfs destroy -R $TESTPOOL/$TESTDATASET
+}
+
+log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.encryption.zcp \
+    $TESTPOOL/$TESTDATASET
+
+log_pass "zfs.get_prop(dataset, ...)  on \"encryption\" and \"encryptionroot\" gives correct results"

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.encryption.zcp
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.encryption.zcp
@@ -1,0 +1,22 @@
+--
+-- This file and its contents are supplied under the terms of the
+-- Common Development and Distribution License ("CDDL"), version 1.0.
+-- You may only use this file in accordance with the terms of version
+-- 1.0 of the CDDL.
+--
+-- A full copy of the text of the CDDL should have accompanied this
+-- source.  A copy of the CDDL is also available via the Internet at
+-- http://www.illumos.org/license/CDDL.
+--
+
+--
+-- Copyright (c) 2021 by Determinate Systems. All rights reserved.
+--
+
+-- ensure zfs.get_prop returns the correct values for "encryption"
+-- and "encryptionroot"
+
+args = ...
+argv = args['argv']
+assert(zfs.get_prop(argv[1], "encryption") == "aes-256-ccm")
+assert(zfs.get_prop(argv[1], "encryptionroot") == argv[1])


### PR DESCRIPTION
### Motivation and Context

Test zfs.get_prop on encryption and encryptionroot. These tests are novel because today they appear to always return "off" and null, respectively. Reported in https://github.com/openzfs/zfs/issues/12337

### Description
See above.

### How Has This Been Tested?
I'm hoping the GitHub CI will run them and verify they fail :grimacing: 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
