### PR TITLE
Correct zfs-send(8) on readonly sends

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -317,7 +317,7 @@ get_usage(zfs_help_t idx)
 	case HELP_SEND:
 		return (gettext("\tsend [-DnPpRvLecwhb] [-[i|I] snapshot] "
 		    "<snapshot>\n"
-		    "\tsend [-nvPLecw] [-i snapshot|bookmark] "
+		    "\tsend [-DnvPLecw] [-i snapshot|bookmark] "
 		    "<filesystem|volume|snapshot>\n"
 		    "\tsend [-DnPpvLec] [-i bookmark|snapshot] "
 		    "--redact <bookmark> <snapshot>\n"

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -44,7 +44,7 @@
 .Ar snapshot
 .Nm zfs
 .Cm send
-.Op Fl DLPRcenpsvw
+.Op Fl DLPcensvw
 .Op Fl i Ar snapshot Ns | Ns Ar bookmark
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Nm zfs
@@ -285,7 +285,7 @@ You will be able to receive your streams on future versions of ZFS.
 .It Xo
 .Nm zfs
 .Cm send
-.Op Fl DLPRcenpvw
+.Op Fl DLPcenvw
 .Op Fl i Ar snapshot Ns | Ns Ar bookmark
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Xc
@@ -296,7 +296,11 @@ filesystem must not be mounted.
 When the stream generated from a filesystem or volume is received, the default
 snapshot name will be
 .Qq --head-- .
-.Bl -tag -width "-L"
+.Bl -tag -width "-D"
+.It Fl D , -dedup
+Deduplicated send is no longer supported.
+This flag is accepted for backwards compatibility, but a regular,
+non-deduplicated stream will be generated.
 .It Fl L , -large-block
 Generate a stream which may contain blocks larger than 128KB.
 This flag has no effect if the


### PR DESCRIPTION
### Motivation and Context
zfs-send(8) claimed you could use -pR when sending a readonly filesystem
or volume. You cannot. 

The usage output for `zfs send` already reflects this.

### Description
As above.

I suspect this never worked, but admit I have not tried firing up an old version or going source spelunking to verify this - I just got burned by this when helping someone send|recv from a readonly import during recovery, and wanted to at a minimum ensure nobody else is misled by the man page.

(I also noticed testing for other discrepancies between the man page and usage output for the r/o case that the usage didn't list -D even though it "works" fine. I know it's a noop, and going away Real Soon Now(tm), but it seemed better to list it (and eventually have it removed with the other instances) than either leaving the discrepancy or deleting it from the man page.)

### How Has This Been Tested?
Well, I ran mancheck, and looked at the man output.

If I broke something with the zfs_main.c edit, I will be quite impressed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
