### PR TITLE
Allow cmd/zfs mount unmount of snapshots

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -685,6 +685,7 @@ _LIBZFS_H int zfs_snapshot(libzfs_handle_t *, const char *, boolean_t,
 _LIBZFS_H int zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps,
     nvlist_t *props);
 _LIBZFS_H int zfs_rollback(zfs_handle_t *, zfs_handle_t *, boolean_t);
+_LIBZFS_H int zfs_rollback_os(zfs_handle_t *);
 
 typedef struct renameflags {
 	/* recursive rename */
@@ -868,6 +869,8 @@ _LIBZFS_H int zfs_mount_at(zfs_handle_t *, const char *, int, const char *);
 _LIBZFS_H int zfs_unmount(zfs_handle_t *, const char *, int);
 _LIBZFS_H int zfs_unmountall(zfs_handle_t *, int);
 _LIBZFS_H int zfs_mount_delegation_check(void);
+_LIBZFS_H int zfs_snapshot_mount_os(zfs_handle_t *, const char *, int);
+_LIBZFS_H int zfs_snapshot_unmount_os(zfs_handle_t *, int);
 
 #if defined(__linux__) || defined(__APPLE__)
 _LIBZFS_H int zfs_parse_mount_options(char *mntopts, unsigned long *mntflags,

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -10,6 +10,7 @@
     <dependency name='libm.so.6'/>
     <dependency name='libcrypto.so.1.1'/>
     <dependency name='libz.so.1'/>
+    <dependency name='libdl.so.2'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
@@ -409,6 +410,7 @@
     <elf-symbol name='zfs_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_resolve_shortname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_rollback' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_rollback_os' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_save_arguments' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_send' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_send_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -427,7 +429,9 @@
     <elf-symbol name='zfs_smb_acl_remove' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_smb_acl_rename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_snapshot' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_snapshot_mount_os' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_snapshot_nvl' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_snapshot_unmount_os' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_spa_version' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_spa_version_map' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_special_devs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -907,7 +911,7 @@
   </abi-instr>
   <abi-instr address-size='64' path='assert.c' language='LANG_C99'>
     <function-decl name='libspl_set_assert_ok' mangled-name='libspl_set_assert_ok' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_set_assert_ok'>
-      <parameter type-id='f58c8277' name='val'/>
+      <parameter type-id='c19b74c3' name='val'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
@@ -970,6 +974,11 @@
       <parameter type-id='64698d33' name='target'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
       <parameter type-id='aa323ea4' name='target'/>
       <parameter type-id='ee31ee44' name='bits'/>
@@ -990,7 +999,7 @@
       <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
       <parameter type-id='fe09dd29' name='target'/>
       <parameter type-id='79a0948f' name='bits'/>
       <return type-id='48b5725f'/>
@@ -1013,11 +1022,6 @@
     <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
       <parameter type-id='64698d33' name='target'/>
       <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
@@ -1092,6 +1096,11 @@
       <parameter type-id='64698d33' name='target'/>
       <return type-id='ee1f298e'/>
     </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
     <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
       <parameter type-id='aa323ea4' name='target'/>
       <parameter type-id='ee31ee44' name='bits'/>
@@ -1112,7 +1121,7 @@
       <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='ee1f298e'/>
     </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
       <parameter type-id='fe09dd29' name='target'/>
       <parameter type-id='79a0948f' name='bits'/>
       <return type-id='eaa32e2f'/>
@@ -1136,11 +1145,6 @@
       <parameter type-id='64698d33' name='target'/>
       <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
     </function-decl>
     <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
       <parameter type-id='aa323ea4' name='target'/>
@@ -1182,6 +1186,12 @@
       <parameter type-id='ee1f298e' name='bits'/>
       <return type-id='ee1f298e'/>
     </function-decl>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='exp'/>
+      <parameter type-id='eaa32e2f' name='des'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
     <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
       <parameter type-id='aa323ea4' name='target'/>
       <parameter type-id='b96825af' name='exp'/>
@@ -1205,12 +1215,6 @@
       <parameter type-id='ee1f298e' name='exp'/>
       <parameter type-id='ee1f298e' name='des'/>
       <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='exp'/>
-      <parameter type-id='eaa32e2f' name='des'/>
-      <return type-id='eaa32e2f'/>
     </function-decl>
     <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
       <parameter type-id='aa323ea4' name='target'/>
@@ -3359,13 +3363,13 @@
     </function-decl>
     <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='fsname'/>
+      <parameter type-id='80f4b756' name='fsname'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='c19b74c3' name='noop'/>
-      <parameter type-id='26a90f95' name='alt_keylocation'/>
+      <parameter type-id='80f4b756' name='alt_keylocation'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
@@ -4080,9 +4084,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='libzfs_mount.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='f1bd64e2' size-in-bits='384' id='b2c36c9f'>
-      <subrange length='2' type-id='7359adad' id='52efc4ef'/>
-    </array-type-def>
     <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' id='803dac95'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='cb_handles' type-id='4507922a' visibility='default'/>
@@ -4095,24 +4096,8 @@
       </data-member>
     </class-decl>
     <typedef-decl name='get_all_cb_t' type-id='803dac95' id='9b293607'/>
-    <class-decl name='proto_table_t' size-in-bits='192' is-struct='yes' naming-typedef-id='f1bd64e2' visibility='default' id='f4c8e1ed'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_prop' type-id='58603c44' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_name' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_share_err' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='p_unshare_err' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='proto_table_t' type-id='f4c8e1ed' id='f1bd64e2'/>
     <pointer-type-def type-id='9b293607' size-in-bits='64' id='77bf1784'/>
     <pointer-type-def type-id='9200a744' size-in-bits='64' id='4507922a'/>
-    <var-decl name='proto_table' type-id='b2c36c9f' visibility='default'/>
     <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
       <parameter type-id='b0382bb3' name='zfs_hdl'/>
       <parameter type-id='80f4b756' name='special'/>
@@ -5337,6 +5322,17 @@
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='zfs_snapshot_mount_os' mangled-name='zfs_snapshot_mount_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_mount_os'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='options'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot_unmount_os' mangled-name='zfs_snapshot_unmount_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_unmount_os'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='os/linux/libzfs_pool_os.c' language='LANG_C99'>
     <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
@@ -5596,6 +5592,10 @@
     <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
       <parameter type-id='26a90f95' name='version'/>
       <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_rollback_os' mangled-name='zfs_rollback_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback_os'>
+      <parameter type-id='9200a744' name='zhp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -583,17 +583,19 @@ zfs_iter_mounted(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 			continue;
 
 		if ((mtab_zhp = zfs_open(zhp->zfs_hdl, entry.mnt_special,
-		    ZFS_TYPE_FILESYSTEM)) == NULL)
+		    ZFS_TYPE_FILESYSTEM|ZFS_TYPE_SNAPSHOT)) == NULL)
 			continue;
 
 		/* Ignore legacy mounts as they are user managed */
-		verify(zfs_prop_get(mtab_zhp, ZFS_PROP_MOUNTPOINT, mnt_prop,
-		    sizeof (mnt_prop), NULL, NULL, 0, B_FALSE) == 0);
-		if (strcmp(mnt_prop, "legacy") == 0) {
-			zfs_close(mtab_zhp);
-			continue;
+		if (mtab_zhp->zfs_type != ZFS_TYPE_SNAPSHOT) {
+			verify(zfs_prop_get(mtab_zhp, ZFS_PROP_MOUNTPOINT,
+			    mnt_prop, sizeof (mnt_prop), NULL, NULL, 0,
+			    B_FALSE) == 0);
+			if (strcmp(mnt_prop, "legacy") == 0) {
+				zfs_close(mtab_zhp);
+				continue;
+			}
 		}
-
 		err = func(mtab_zhp, data);
 	}
 

--- a/lib/libzfs/os/freebsd/libzfs_compat.c
+++ b/lib/libzfs/os/freebsd/libzfs_compat.c
@@ -362,3 +362,11 @@ zfs_version_kernel(char *version, int len)
 	return (sysctlbyname("vfs.zfs.version.module",
 	    version, &l, NULL, 0));
 }
+
+/* Called from the tail end of zfs_rollback() */
+int
+zfs_rollback_os(zfs_handle_t *zhp)
+{
+	(void) zhp;
+	return (0);
+}

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -148,3 +148,19 @@ zpool_disable_volume_os(const char *name)
 {
 	(void) name;
 }
+
+/* Called for manual "zfs mount snapshot" */
+int
+zfs_snapshot_mount_os(zfs_handle_t *zhp, const char *options, int flags)
+{
+	(void) zhp, (void) options, (void) flags;
+	return (0);
+}
+
+/* Called for manual "zfs unmount snapshot" */
+int
+zfs_snapshot_unmount_os(zfs_handle_t *zhp, int flags)
+{
+	(void) zhp, (void) flags;
+	return (0);
+}

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -427,3 +427,19 @@ zpool_disable_volume_os(const char *name)
 {
 	(void) name;
 }
+
+/* Called for manual "zfs mount snapshot" */
+int
+zfs_snapshot_mount_os(zfs_handle_t *zhp, const char *options, int flags)
+{
+	(void) zhp, (void) options, (void) flags;
+	return (0);
+}
+
+/* Called for manual "zfs unmount snapshot" */
+int
+zfs_snapshot_unmount_os(zfs_handle_t *zhp, int flags)
+{
+	(void) zhp, (void) flags;
+	return (0);
+}

--- a/lib/libzfs/os/linux/libzfs_util_os.c
+++ b/lib/libzfs/os/linux/libzfs_util_os.c
@@ -220,3 +220,11 @@ zfs_version_kernel(char *version, int len)
 
 	return (0);
 }
+
+/* Called from the tail end of zfs_rollback() */
+int
+zfs_rollback_os(zfs_handle_t *zhp)
+{
+	(void) zhp;
+	return (0);
+}


### PR DESCRIPTION

2 part.

Allow mount and unmount of snapshots using `zfs mount dataset@snapshot`. (and unmount).

Add `zfs_rollback_os()` call for post-rollback OS specific requirements.


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

"zfs mount dataset@snapshot" as mounting of snapshot has to be done
manually from userland in macOS. There simply is no way to handle it
within the kernel.

In a future PR we will add events to `zed` to run snapshot scripts
that issue `zfs mount snapshot`, so that kernel can "trigger" mounting
events, and simulate ".zfs" on macOS.

In addition, as it is the only other change in this source file;

Add `zfs_rollback_os()` call to the rollback logic, so platforms can
do specific requirements. In our case, we need to kick Finder into
refreshing after rollback, or it will (continue to) display the old content.

Here we should make a decision;

As this PR will show, all new code are currently in `#ifdef __APPLE__` as to not impact upstream platforms.

But, in the case of `zfs_rollback_os()` perhaps it is acceptable to simply define empty functions for Linux and FreeBSD instead. We already do that in some places. Thoughts?

Would Linux and FreeBSD be also amenable to `zfs mount dataset@snapshot` ? It seems a perfectly sane use-case for users, but it does change the command-line semantics.

Discuss?


### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
