### PR TITLE
config/libatomic: require -latomic iff atomic.c doesn't link without it

### DIFF
--- a/config/user-libatomic.m4
+++ b/config/user-libatomic.m4
@@ -1,33 +1,27 @@
 dnl #
-dnl # If -latomic exists, it's needed for __atomic intrinsics.
-dnl #
-dnl # Some systems (like FreeBSD 13) don't have a libatomic at all because
-dnl # their toolchain doesn't ship it – they obviously don't need it.
-dnl #
-dnl # Others (like sufficiently ancient CentOS) have one,
-dnl # but terminally broken or unlinkable (e.g. it's a dangling symlink,
-dnl # or a linker script that points to a nonexistent file) –
-dnl # most arches affected by this don't actually need -latomic (and if they do,
-dnl # then they should have libatomic that actually exists and links,
-dnl # so don't fall into this category).
-dnl #
-dnl # Technically, we could check if the platform *actually* needs -latomic,
-dnl # or if it has native support for all the intrinsics we use,
-dnl # but it /really/ doesn't matter, and C11 recommends to always link it.
+dnl # If -latomic exists and atomic.c doesn't link without it,
+dnl # it's needed for __atomic intrinsics.
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_USER_LIBATOMIC], [
-	AC_MSG_CHECKING([whether -latomic is present])
+	AC_MSG_CHECKING([whether -latomic is required])
 
 	saved_libs="$LIBS"
 	LIBS="$LIBS -latomic"
+	LIBATOMIC_LIBS=""
 
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])], [
-		LIBATOMIC_LIBS="-latomic"
-		AC_MSG_RESULT([yes])
-	], [
-		LIBATOMIC_LIBS=""
-		AC_MSG_RESULT([no])
+		LIBS="$saved_libs"
+		saved_cflags="$CFLAGS"
+		CFLAGS="$CFLAGS -isystem lib/libspl/include"
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "lib/libspl/atomic.c"], [])], [], [LIBATOMIC_LIBS="-latomic"])
+		CFLAGS="$saved_cflags"
 	])
+
+	if test -n "$LIBATOMIC_LIBS"; then
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_RESULT([no])
+	fi
 
 	LIBS="$saved_libs"
 	AC_SUBST([LIBATOMIC_LIBS])


### PR DESCRIPTION
### Motivation and Context
#12345

### Description
See commit message.

### How Has This Been Tested?
Requires `-latomic` on amd64 with a forced unresolved symbol, doesn't on plain amd64.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – as above
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
